### PR TITLE
chore(autodev): per-task worker model tiering in the conductor loop

### DIFF
--- a/.autodev/queue/done/s7-t1-conductor-model-tiering.md
+++ b/.autodev/queue/done/s7-t1-conductor-model-tiering.md
@@ -1,0 +1,94 @@
+---
+id: s7-t1-conductor-model-tiering
+title: Wire per-task worker model tiering (haiku/sonnet/opus) into the autodev conductor loop
+phase: Autodev tooling — Fable 5 re-tiering (orchestrator prompt "After / housekeeping")
+type: tooling
+touches_contract_zone: false
+writes_guard: false
+file_set:
+  - tools/autodev/_common.ps1
+  - tools/autodev/invoke-worker.ps1
+  - tools/autodev/conductor.ps1
+  - docs-internal/fable5-autodev-orchestrator-prompt.md
+depends_on: []
+contract_zones_touched: []
+needs_guard: no
+acceptance:
+  - "Task frontmatter supports optional `model: haiku|sonnet|opus`; ConvertFrom-AutodevTask defaults it to $null (StrictMode-safe)"
+  - "invoke-worker.ps1 accepts -Model; ladder = WorkerLadder sub-ladder starting at the declared model (opus->sonnet->haiku, sonnet->haiku, haiku only); no declared model -> full ladder (current behavior preserved)"
+  - "Contract-zone pin UNCHANGED and wins over any declared model: -TouchesContractZone always pins to WorkerLadder[0] (opus) + logs a WARN if a weaker model was declared"
+  - "Invalid declared model -> WARN + fall back to full ladder (never crash the loop)"
+  - "conductor.ps1 passes -Model from the parsed task to invoke-worker"
+  - "DryRun output prints the declared model and resulting ladder"
+  - "Verified via invoke-worker -DryRun with temp task files (model: sonnet -> ladder 'sonnet -> haiku'; model: haiku + contract zone -> pinned 'opus'); scheduler.ps1 self-test still passes"
+---
+
+# Task
+
+The operator re-tiered the autodev loop (2026-06-10, s5): the orchestrator picks a worker
+model per task complexity (haiku = trivial/mechanical, sonnet = moderate, opus =
+complex/contract-adjacent). The operator-directed pattern already does this via the Agent
+tool; this task wires the SAME tiering into the automated conductor loop
+(`tools/autodev/`), per `docs-internal/fable5-autodev-orchestrator-prompt.md` →
+"After / housekeeping". The critic side (GPT-5.5 high) is already wired — do NOT touch
+invoke-critic.ps1.
+
+## 1. `tools/autodev/_common.ps1` — frontmatter field
+
+In `ConvertFrom-AutodevTask`, add `model = $null` to the `$obj` defaults (the generic
+`key: value` parser already fills it when present; the explicit default keeps
+`Set-StrictMode -Version Latest` property access safe for tasks without the key).
+Update the function docblock example to show the optional `model:` key.
+
+## 2. `tools/autodev/invoke-worker.ps1` — sub-ladder from declared model
+
+- Add `[string]$Model` to `param()`.
+- Ladder construction (replace the current one-liner, keep the `[string[]]` cast +
+  single-element comma trick — see the existing comment about scalar unwrapping):
+  1. `-TouchesContractZone` → ladder is `, $Config.WorkerLadder[0]` exactly as today.
+     If `$Model` is also set and differs from `WorkerLadder[0]`, log a WARN that the
+     contract-zone pin overrides the declared model. (A license-zone edit must never
+     run on haiku, even if the task spec mistakenly declares it.)
+  2. Else if `$Model` is set and present in `$Config.WorkerLadder` → ladder = the
+     sub-array of `WorkerLadder` from that model's index to the end (declared tier
+     first, then rate-limit step-downs to cheaper tiers only).
+  3. Else if `$Model` is set but NOT in `WorkerLadder` → `Write-AutodevLog -Level WARN`
+     ("unknown model '<x>', falling back to full ladder") and use the full ladder.
+  4. Else → full ladder (current behavior, byte-for-byte).
+- Extend the existing "Task ... ladder:" log line and the DryRun output to include the
+  declared model (or "(none)").
+- Update the `.SYNOPSIS`/`.DESCRIPTION` comment block: MODEL LADDER now starts at the
+  task-declared tier when present.
+
+## 3. `tools/autodev/conductor.ps1` — pass-through
+
+At the invoke-worker call site (~line 152), pass the parsed task's model:
+`-Model ([string]$task.model)` (cast so $null becomes ''). Do not change anything else.
+
+## 4. `docs-internal/fable5-autodev-orchestrator-prompt.md` — housekeeping
+
+In "## After / housekeeping", mark the conductor wiring item DONE with date 2026-06-10
+and one line describing the mechanism (frontmatter `model:` → invoke-worker sub-ladder;
+contract-zone pin unchanged). Keep the edit minimal.
+
+## What NOT to change
+- `invoke-critic.ps1` (critic tiering is mechanical and already correct; model already gpt-5.5).
+- `WorkerLadder` order/content in `_common.ps1` config.
+- The contract-zone pause-not-downgrade semantics on 429.
+- `scheduler.ps1`, `gate.ps1`, `watchdog.ps1`, `anti-drift.ps1`.
+- No PHP files; `composer check` not required (note why in the report).
+
+## Verification (run these, capture output in the report)
+1. Create a temp task file with `model: sonnet`, `touches_contract_zone: false` in
+   `.autodev/queue/active/`, run `tools/autodev/invoke-worker.ps1 -TaskId <id> -DryRun`
+   → printed ladder must be `sonnet -> haiku`.
+2. Same with `model: haiku` + `-TouchesContractZone` → pinned `opus`, WARN logged.
+3. No `model:` key → full ladder `opus -> sonnet -> haiku` (unchanged).
+4. `model: gpt-9` (unknown) → WARN + full ladder.
+5. `pwsh -File tools/autodev/scheduler.ps1 -SelfTest` (if that switch exists; otherwise
+   skip and say so) — frontmatter parser change must not break it.
+6. Clean up temp task files + any runtime dirs they created.
+
+## Reference
+- `docs-internal/fable5-autodev-orchestrator-prompt.md` — tiering policy table
+- `.autodev/queue/done/s5-p1-need-license-flag-and-seam.md` — frontmatter format example

--- a/docs-internal/fable5-autodev-orchestrator-prompt.md
+++ b/docs-internal/fable5-autodev-orchestrator-prompt.md
@@ -92,9 +92,12 @@
 
 ## After / housekeeping
 - Save any new Fable orchestrator review output to `docs-internal/reviews/`.
-- When `tools/autodev/conductor.ps1` (the automated loop) is used instead of the operator-directed
+- ~~When `tools/autodev/conductor.ps1` (the automated loop) is used instead of the operator-directed
   pattern, wire the same tiering there (worker model per task, GPT-5.5 critic) — a small tooling
-  change, separate from this prompt.
+  change, separate from this prompt.~~ **DONE 2026-06-10** — frontmatter `model: haiku|sonnet|opus`
+  parsed by `ConvertFrom-AutodevTask`; `invoke-worker.ps1` builds a sub-ladder starting at the
+  declared tier; `conductor.ps1` passes `-Model $task.model`; contract-zone pin (opus) unchanged
+  and overrides any weaker declared model with a WARN.
 
 ## Related
 - [reviews/fable5-architecture-review-2026-06-10.md](reviews/fable5-architecture-review-2026-06-10.md)

--- a/tools/autodev/_common.ps1
+++ b/tools/autodev/_common.ps1
@@ -186,6 +186,7 @@ function ConvertFrom-AutodevTask {
         type: guard
         touches_contract_zone: true
         writes_guard: true
+        model: sonnet        # optional: haiku | sonnet | opus (omit for full ladder)
         file_set:
           - path/one.php
           - path/two.json
@@ -203,6 +204,7 @@ function ConvertFrom-AutodevTask {
     $obj = [ordered]@{
         id = $null; title = $null; type = $null
         touches_contract_zone = $false; writes_guard = $false
+        model = $null
         file_set = @(); body = $body; path = $Path
     }
     $currentList = $null

--- a/tools/autodev/conductor.ps1
+++ b/tools/autodev/conductor.ps1
@@ -149,6 +149,7 @@ function Invoke-ConductorIteration {
     # 3. WORKER
     if (-not $AssumeWorkerDone) {
         $w = & (Join-Path $here 'invoke-worker.ps1') -TaskId $task.id `
+                -Model ([string]$task.model) `
                 -TouchesContractZone:([bool]$task.touches_contract_zone) -DryRun:$DryRunWorker
         if ($w.Status -eq 'RATE_LIMITED') {
             # A 429 is an EXTERNAL pause, not a failed attempt -- refund the attempt counter so

--- a/tools/autodev/invoke-worker.ps1
+++ b/tools/autodev/invoke-worker.ps1
@@ -4,10 +4,13 @@
 
 .DESCRIPTION
   Spawns a fresh `claude -p` worker for a single task in its worktree. Implements:
-    - MODEL LADDER: Opus -> Sonnet -> Haiku for ordinary tasks.
-    - CONTRACT-ZONE PIN: a task that touches a contract zone is pinned to Opus. On a
-      rate-limit it PAUSES (returns rate_limited) -- it is NEVER silently downgraded to
-      a weaker model. A license-zone edit must not land on Haiku just because Opus is busy.
+    - MODEL LADDER: starts at the task-declared tier when present (opus -> sonnet -> haiku
+      for 'opus', sonnet -> haiku for 'sonnet', haiku only for 'haiku'); full ladder when
+      no model is declared. Rate-limit step-downs only go to cheaper tiers.
+    - CONTRACT-ZONE PIN: a task that touches a contract zone is pinned to Opus regardless
+      of any declared model. On a rate-limit it PAUSES (returns rate_limited) -- it is
+      NEVER silently downgraded to a weaker model. A license-zone edit must not land on
+      Haiku just because Opus is busy.
     - WATCHDOG: the worker touches runtime/<id>/heartbeat; a stale heartbeat kills the
       hung process so the conductor can respawn (attempts++).
     - RATE-LIMIT DETECTION: 429/quota in exit code or stderr steps down the ladder
@@ -17,6 +20,12 @@
   Status in DONE-ish (the conductor then reads runtime/<id>/worker-report.md for the
   authoritative worker status) | RATE_LIMITED | TIMED_OUT | ERROR.
 
+.PARAMETER Model
+  Optional model declared in the task frontmatter (haiku|sonnet|opus). When set, the
+  ladder starts at that tier and steps down only to cheaper models on rate-limits.
+  Ignored (with a WARN) if -TouchesContractZone is set and the declared model is weaker
+  than opus. Unknown values fall back to the full ladder with a WARN.
+
 .PARAMETER DryRun
   Build and print the ladder + claude command(s) without spawning claude. Used to verify
   command construction and the contract-zone Opus pin in this bootstrap session.
@@ -25,6 +34,7 @@
 param(
     [Parameter(Mandatory)][string]$TaskId,
     [string]$Worktree,
+    [string]$Model,
     [switch]$TouchesContractZone,
     [switch]$DryRun
 )
@@ -84,13 +94,35 @@ $taskBody
 
 # Build the ladder. Cast to [string[]] so a single-element ladder is NOT unwrapped to a
 # scalar string (which would make $ladder[0] index a character instead of the model name).
-[string[]]$ladder = if ($TouchesContractZone) { , $Config.WorkerLadder[0] } else { $Config.WorkerLadder }
-Write-AutodevLog -Level WORKER -Message "Task $TaskId ladder: $($ladder -join ' -> ')$(if ($TouchesContractZone) { ' (CONTRACT-ZONE: pinned to ' + $ladder[0] + ', pause-not-downgrade on 429)' })" -Config $Config
+# Priority: (1) contract-zone pin always wins; (2) declared model starts a sub-ladder;
+# (3) unknown declared model -> WARN + full ladder; (4) no model -> full ladder (unchanged).
+$declaredModel = if ($Model) { $Model.Trim().ToLower() } else { '' }
+[string[]]$ladder = @()
+if ($TouchesContractZone) {
+    $ladder = , $Config.WorkerLadder[0]
+    if ($declaredModel -and $declaredModel -ne $Config.WorkerLadder[0]) {
+        Write-AutodevLog -Level WARN -Message "Task $TaskId declares model '$declaredModel' but touches a contract zone -- pinned to $($Config.WorkerLadder[0]) (contract-zone pin overrides declared model)." -Config $Config
+    }
+} elseif ($declaredModel) {
+    $idx = [array]::IndexOf($Config.WorkerLadder, $declaredModel)
+    if ($idx -ge 0) {
+        # Sub-ladder: declared tier first, then cheaper tiers only (rate-limit step-down).
+        $ladder = [string[]]($Config.WorkerLadder[$idx..($Config.WorkerLadder.Length - 1)])
+    } else {
+        Write-AutodevLog -Level WARN -Message "Task $TaskId declares unknown model '$declaredModel' -- falling back to full ladder." -Config $Config
+        $ladder = $Config.WorkerLadder
+    }
+} else {
+    $ladder = $Config.WorkerLadder
+}
+$declaredLabel = if ($declaredModel) { $declaredModel } else { '(none)' }
+Write-AutodevLog -Level WORKER -Message "Task $TaskId declared-model: $declaredLabel  ladder: $($ladder -join ' -> ')$(if ($TouchesContractZone) { ' (CONTRACT-ZONE: pinned to ' + $ladder[0] + ', pause-not-downgrade on 429)' })" -Config $Config
 
 $prompt = Build-WorkerPrompt -TaskId $TaskId -Worktree $Worktree
 
 if ($DryRun) {
     Write-Host "=== invoke-worker DRY RUN (task $TaskId) ==="
+    Write-Host "DeclaredModel: $declaredLabel"
     Write-Host "TouchesContractZone: $([bool]$TouchesContractZone)"
     Write-Host "Ladder: $($ladder -join ' -> ')"
     foreach ($model in $ladder) {


### PR DESCRIPTION
## What
Wires the s5 operator re-tiering decision into the automated autodev loop (`tools/autodev/`), per `docs-internal/fable5-autodev-orchestrator-prompt.md` → After/housekeeping:

- Task frontmatter gains optional `model: haiku|sonnet|opus`.
- `invoke-worker.ps1` builds the rate-limit ladder as the `WorkerLadder` sub-ladder starting at the declared tier (`sonnet → haiku`; `haiku` only, no downgrade target).
- **Contract-zone pin unchanged and wins**: contract-zone tasks always pin to opus, a weaker declared model is overridden with a WARN. Pause-not-downgrade on 429 preserved.
- No declared model → full ladder, byte-for-byte current behavior.
- Critic side untouched (already GPT-5.5 high).

## Verification
- DryRun: `model: sonnet` → ladder `sonnet -> haiku`; `model: haiku` + contract zone → pinned `opus` + WARN; unknown model → WARN + full ladder; no model → `opus -> sonnet -> haiku`.
- `scheduler.ps1 -SelfTest` PASS.
- No PHP touched → `composer check` unaffected.

## Review
GPT-5.5 high (codex, read-only): initial BLOCK must-fix verified **false-positive** (every task object is built by `ConvertFrom-AutodevTask`, which now defaults `model = $null`); re-verdict **SHIP, zero must-fix**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)