### PR TITLE
feat(bootstrap): B-1 mixed v1/v2 fleet hard-gate (probe + tombstone)

### DIFF
--- a/.autodev/queue/done/s7-t2-b1-mixed-fleet-bootstrap-gate.md
+++ b/.autodev/queue/done/s7-t2-b1-mixed-fleet-bootstrap-gate.md
@@ -1,0 +1,118 @@
+---
+id: s7-t2-b1-mixed-fleet-bootstrap-gate
+title: B-1 mixed v1/v2 fleet hard-gate — soft-fail probe in the v2 entry template + register_plugin() tombstone on the v2 bootstrap
+phase: Fable 5 review B-1 (Critical) — site-availability armor before the first production plugin rewrite
+type: feature
+model: opus
+touches_contract_zone: true
+writes_guard: false
+file_set:
+  - woodev/bootstrap.php
+  - tests/_fixtures/woodev-test-plugin/woodev-test-plugin.php
+  - tests/_fixtures/woodev-test-payment-gateway/woodev-test-payment-gateway.php
+  - tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+  - tests/unit/MixedFleetBootstrapGateTest.php
+depends_on: []
+contract_zones_touched: []
+needs_guard: no
+acceptance:
+  - composer check green (PHPCS, PHPStan 0, all unit tests pass)
+  - "Direction A (v2 plugin on a v1 bootstrap): every fixture entry file probes method_exists( $bootstrap, 'register_loader_definition' ) after the class_exists/require rendezvous; when absent it hooks an admin_notices warning ('update plugin X / framework outdated') and returns — plugin stays dormant, NO fatal"
+  - "Direction B (v1 plugin on the v2 bootstrap): Woodev_Plugin_Bootstrap gains a register_plugin() tombstone that NEVER initializes the legacy plugin and NEVER calls the v1 callback; it records the plugin (name/path when extractable) into an incompatible list rendered through the existing bootstrap admin-notice path; accepts ANY legacy argument shape without throwing (v1 signature was register_plugin( $framework_version, $plugin_name, $path, $callback, $args = [] ) — see `git show platform-v2-pre-refactor:woodev/bootstrap.php`)"
+  - "New MixedFleetBootstrapGateTest covers BOTH directions: (A) separate-process test defines a v1-shaped stub Woodev_Plugin_Bootstrap (instance() + register_plugin() only, NO register_loader_definition), includes a fixture entry file -> no Error, loader definition NOT registered, notice hooked; (B) calls register_plugin() on the real v2 bootstrap with v1-shaped positional args -> no Error, callback NOT invoked, plugin recorded + notice path engaged"
+  - "No existing behavior changes for a pure-v2 fleet: all existing tests still green; register_loader_definition path untouched"
+  - "No installed-site contract strings changed (option keys, hooks, ids). The tombstone is ADDITIVE armor; clean-break ADR-005 not violated (site-availability, not internal-API nostalgia)"
+---
+
+# Task
+
+Implement Fable 5 review finding **B-1** (Critical, verified against source — see
+`docs-internal/reviews/fable5-architecture-review-2026-06-10.md` §B-1). Problem: WP loads
+plugins directory-alphabetically, so on a site mixing one v2-rewritten plugin with one
+v1 plugin, whichever vendored copy defines `Woodev_Plugin_Bootstrap` first wins the
+rendezvous. v1 exposes `register_plugin()`, v2 exposes `register_loader_definition()` —
+each side calling the other's missing method is an uncaught `Error` → site-wide WSOD.
+Two ~30-line guards fix both directions.
+
+## 1. Direction A — soft-fail probe in the v2 entry-file template
+
+The 3 fixture entry files are the canonical v2 entry template (review evidence cites
+them). In each, the current shape is:
+
+```php
+if ( ! class_exists( 'Woodev_Plugin_Bootstrap' ) ) { require_once $framework_bootstrap; }
+...
+Woodev_Plugin_Bootstrap::instance()->register_loader_definition( ... );
+```
+
+Insert the probe between rendezvous and registration:
+
+```php
+$bootstrap = Woodev_Plugin_Bootstrap::instance();
+if ( ! method_exists( $bootstrap, 'register_loader_definition' ) ) {
+    // A legacy (v1) framework copy won the class rendezvous: stay dormant, warn, never fatal.
+    add_action( 'admin_notices', <closure rendering an error-class notice naming this plugin> );
+    return;
+}
+$bootstrap->register_loader_definition( ... );
+```
+
+Keep the probe identical across the 3 files (it IS the template future rewrites copy).
+Notice text: Russian, i18n'd with text domain `woodev-plugin-framework`, matching the
+style of existing bootstrap notices.
+
+## 2. Direction B — `register_plugin()` tombstone on the v2 bootstrap
+
+Add a public `register_plugin()` method to `Woodev_Plugin_Bootstrap`
+(`woodev/bootstrap.php`). Requirements:
+
+- Tolerates ANY argument shape (the legacy caller is unknown-version code; nothing it
+  passes may cause a TypeError). A variadic `( ...$args )` with best-effort extraction
+  of the plugin name (string at index 1) and path (string at index 2) is acceptable —
+  document WHY the signature is intentionally loose (robustness beats the type-decl
+  convention here; say so in the docblock).
+- NEVER invokes the v1 `$callback` (index 3) and never initializes the plugin.
+- Records the plugin into the bootstrap's incompatible-plugin machinery so the EXISTING
+  admin-notice render path surfaces "plugin X is built for an older framework version —
+  update it". Reuse `$incompatible_framework_plugins` + `render_deactivation_notice()` /
+  `maybe_deactivate_framework_plugins()` if their record shape fits; if their shape does
+  not fit, add a dedicated list + hook the notice the same way the existing ones are
+  hooked. Read the existing code first (Grep/Read in THIS worktree) and pick the
+  smallest correct reuse.
+- Docblock: `@since 2.0.0`, explains the mixed-fleet rationale and references B-1.
+
+## 3. Tests — `tests/unit/MixedFleetBootstrapGateTest.php`
+
+Brain Monkey unit tests, both directions:
+
+- **A:** `@runInSeparateProcess` + `@preserveGlobalState disabled`: define a v1-shaped
+  stub `Woodev_Plugin_Bootstrap` (only `instance()` returning a singleton with a
+  `register_plugin()` method) BEFORE including
+  `tests/_fixtures/woodev-test-plugin/woodev-test-plugin.php`; stub the WP functions the
+  entry file calls (Brain Monkey `Functions\when`). Assert: include completes (no Error),
+  `register_loader_definition` was never called (stub lacks it — reaching it would
+  fatal), and an `admin_notices` callback was added (Brain Monkey `Actions\expectAdded`).
+- **B:** instantiate/obtain the real v2 bootstrap (see how BootstrapRegistrationTest
+  does it), call `register_plugin( '1.4.1', 'Legacy Plugin', '/path/legacy.php',
+  function() { $GLOBALS['b1_cb'] = true; }, [] )`. Assert: no exception, callback global
+  NOT set, the plugin appears in the incompatible list (reflection — mind the
+  `reflection-setaccessible-version-guard` gotcha: `setAccessible(true)` guarded by
+  `PHP_VERSION_ID < 80100`), notice hook engaged. Also call it with garbage
+  (`register_plugin( null )`, `register_plugin()`) — still no exception.
+- Mind the `brain-monkey-function-pollution` gotcha for anything needing separate process.
+
+## What NOT to change
+- `register_loader_definition()` / resolver / `load_plugins()` arbitration — out of scope (that is B-2, NOT this task).
+- No installed-site contract strings (option keys, hook names, ids). Additive only.
+- No deprecation shims for internal APIs (ADR-005) — the tombstone is not a shim: it never delegates, it quarantines.
+- Do NOT touch the realistic/pilot fixtures (they register from test code, not entry files).
+- Coding conventions: WPCS tabs, Yoda, short arrays, `@since 2.0.0`, English comments, Russian user-facing strings.
+
+## Verification
+- `composer check` green in THIS worktree (vendor/ already installed).
+- New tests fail if the probe or tombstone is removed (state in the report how you spot-checked that, e.g. temporarily reverting one guard).
+
+## Reference
+- `docs-internal/reviews/fable5-architecture-review-2026-06-10.md` §B-1
+- `git show platform-v2-pre-refactor:woodev/bootstrap.php` — v1 register_plugin signature
+- `tests/unit/BootstrapRegistrationTest.php` — existing bootstrap test scaffolding

--- a/tests/_fixtures/woodev-test-payment-gateway/woodev-test-payment-gateway.php
+++ b/tests/_fixtures/woodev-test-payment-gateway/woodev-test-payment-gateway.php
@@ -68,8 +68,33 @@ function woodev_test_payment_gateway_plugin_loader_definition(): array {
 
 /**
  * Регистрируем тестовый плагин в бутстрапе фреймворка.
+ *
+ * Mixed-fleet probe (B-1): на сайте, где соседствуют v2-переписанный и ещё-v1 плагин,
+ * WordPress грузит плагины по алфавиту, и первая vendored-копия, определившая
+ * Woodev_Plugin_Bootstrap, выигрывает rendezvous. Если выиграла легаси (v1) копия — у неё
+ * нет register_loader_definition(). Зондируем метод: если его нет, остаёмся в спячке,
+ * показываем предупреждение и выходим — никакого фатала.
  */
-Woodev_Plugin_Bootstrap::instance()->register_loader_definition( woodev_test_payment_gateway_plugin_loader_definition() );
+$woodev_test_payment_gateway_bootstrap = Woodev_Plugin_Bootstrap::instance();
+if ( ! method_exists( $woodev_test_payment_gateway_bootstrap, 'register_loader_definition' ) ) {
+	add_action(
+		'admin_notices',
+		static function (): void {
+			echo '<div class="error"><p>';
+			echo wp_kses(
+				sprintf(
+					/* translators: %s — plugin name. */
+					esc_html__( 'Плагин %s не запущен: загруженная версия фреймворка устарела. Обновите плагин или фреймворк.', 'woodev-plugin-framework' ),
+					'<strong>' . esc_html__( 'Woodev Test Payment Gateway Plugin', 'woodev-plugin-framework' ) . '</strong>'
+				),
+				[ 'strong' => [] ]
+			);
+			echo '</p></div>';
+		}
+	);
+	return;
+}
+$woodev_test_payment_gateway_bootstrap->register_loader_definition( woodev_test_payment_gateway_plugin_loader_definition() );
 
 function woodev_test_payment_gateway_plugin_init(): void {
 

--- a/tests/_fixtures/woodev-test-plugin/woodev-test-plugin.php
+++ b/tests/_fixtures/woodev-test-plugin/woodev-test-plugin.php
@@ -69,8 +69,33 @@ function woodev_test_plugin_loader_definition(): array {
 
 /**
  * Регистрируем тестовый плагин в бутстрапе фреймворка.
+ *
+ * Mixed-fleet probe (B-1): на сайте, где соседствуют v2-переписанный и ещё-v1 плагин,
+ * WordPress грузит плагины по алфавиту, и первая vendored-копия, определившая
+ * Woodev_Plugin_Bootstrap, выигрывает rendezvous. Если выиграла легаси (v1) копия — у неё
+ * нет register_loader_definition(). Зондируем метод: если его нет, остаёмся в спячке,
+ * показываем предупреждение и выходим — никакого фатала.
  */
-Woodev_Plugin_Bootstrap::instance()->register_loader_definition( woodev_test_plugin_loader_definition() );
+$woodev_test_plugin_bootstrap = Woodev_Plugin_Bootstrap::instance();
+if ( ! method_exists( $woodev_test_plugin_bootstrap, 'register_loader_definition' ) ) {
+	add_action(
+		'admin_notices',
+		static function (): void {
+			echo '<div class="error"><p>';
+			echo wp_kses(
+				sprintf(
+					/* translators: %s — plugin name. */
+					esc_html__( 'Плагин %s не запущен: загруженная версия фреймворка устарела. Обновите плагин или фреймворк.', 'woodev-plugin-framework' ),
+					'<strong>' . esc_html__( 'Woodev Framework Test Plugin', 'woodev-plugin-framework' ) . '</strong>'
+				),
+				[ 'strong' => [] ]
+			);
+			echo '</p></div>';
+		}
+	);
+	return;
+}
+$woodev_test_plugin_bootstrap->register_loader_definition( woodev_test_plugin_loader_definition() );
 
 /**
  * Фабричная функция — инициализирует тестовый плагин.

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -68,8 +68,33 @@ function woodev_test_shipping_method_plugin_loader_definition(): array {
 
 /**
  * Регистрируем тестовый плагин метода доставки в бутстрапе фреймворка.
+ *
+ * Mixed-fleet probe (B-1): на сайте, где соседствуют v2-переписанный и ещё-v1 плагин,
+ * WordPress грузит плагины по алфавиту, и первая vendored-копия, определившая
+ * Woodev_Plugin_Bootstrap, выигрывает rendezvous. Если выиграла легаси (v1) копия — у неё
+ * нет register_loader_definition(). Зондируем метод: если его нет, остаёмся в спячке,
+ * показываем предупреждение и выходим — никакого фатала.
  */
-Woodev_Plugin_Bootstrap::instance()->register_loader_definition( woodev_test_shipping_method_plugin_loader_definition() );
+$woodev_test_shipping_method_bootstrap = Woodev_Plugin_Bootstrap::instance();
+if ( ! method_exists( $woodev_test_shipping_method_bootstrap, 'register_loader_definition' ) ) {
+	add_action(
+		'admin_notices',
+		static function (): void {
+			echo '<div class="error"><p>';
+			echo wp_kses(
+				sprintf(
+					/* translators: %s — plugin name. */
+					esc_html__( 'Плагин %s не запущен: загруженная версия фреймворка устарела. Обновите плагин или фреймворк.', 'woodev-plugin-framework' ),
+					'<strong>' . esc_html__( 'Woodev Test Shipping Method Plugin', 'woodev-plugin-framework' ) . '</strong>'
+				),
+				[ 'strong' => [] ]
+			);
+			echo '</p></div>';
+		}
+	);
+	return;
+}
+$woodev_test_shipping_method_bootstrap->register_loader_definition( woodev_test_shipping_method_plugin_loader_definition() );
 
 /**
  * Фабричная функция — инициализирует тестовый плагин метода доставки.

--- a/tests/unit/MixedFleetBootstrapGateTest.php
+++ b/tests/unit/MixedFleetBootstrapGateTest.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Mixed-fleet bootstrap gate test (B-1).
+ *
+ * Covers both directions of the mixed v1/v2 fleet hard-gate:
+ *  - Direction A: a v2 plugin entry file loaded against a legacy (v1) bootstrap that
+ *    lacks register_loader_definition() must stay dormant + warn, never fatal.
+ *  - Direction B: a legacy (v1) plugin calling register_plugin() on the real v2 bootstrap
+ *    must be quarantined — callback never invoked, plugin recorded, notice path engaged,
+ *    and any garbage argument shape tolerated without throwing.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace Woodev\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use ReflectionClass;
+
+/**
+ * Class MixedFleetBootstrapGateTest
+ */
+class MixedFleetBootstrapGateTest extends TestCase {
+
+	/**
+	 * Reset the real bootstrap singleton before each test to avoid pollution.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->reset_bootstrap_singleton();
+	}
+
+	/**
+	 * Tear down: reset the singleton to leave a clean state.
+	 */
+	protected function tearDown(): void {
+		$this->reset_bootstrap_singleton();
+		parent::tearDown();
+	}
+
+	/**
+	 * Resets the real Woodev_Plugin_Bootstrap singleton via reflection, if the real class is loaded.
+	 *
+	 * @return void
+	 */
+	private function reset_bootstrap_singleton(): void {
+		if ( ! class_exists( \Woodev_Plugin_Bootstrap::class, false ) ) {
+			return;
+		}
+
+		$reflection = new ReflectionClass( \Woodev_Plugin_Bootstrap::class );
+
+		// Skip the v1-shaped stub defined inside the Direction A separate process.
+		if ( ! $reflection->hasMethod( 'register_loader_definition' ) ) {
+			return;
+		}
+
+		$instance = $reflection->getProperty( 'instance' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance->setAccessible( true );
+		}
+		$instance->setValue( null, null );
+	}
+
+	/**
+	 * Reads a protected property from the bootstrap via reflection.
+	 *
+	 * @param \Woodev_Plugin_Bootstrap $bootstrap The bootstrap instance.
+	 * @param string                   $name      Property name.
+	 * @return mixed
+	 */
+	private function get_protected_property( \Woodev_Plugin_Bootstrap $bootstrap, string $name ) {
+		$reflection = new ReflectionClass( $bootstrap );
+		$property   = $reflection->getProperty( $name );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+
+		return $property->getValue( $bootstrap );
+	}
+
+	/**
+	 * Direction A: a v2 entry file on a legacy (v1) bootstrap must stay dormant + warn, never fatal.
+	 *
+	 * A v1-shaped stub Woodev_Plugin_Bootstrap (instance() + register_plugin(), but NO
+	 * register_loader_definition()) is defined BEFORE including the fixture entry file. Reaching
+	 * register_loader_definition() on the stub would be a fatal Error, so completing the include
+	 * proves the probe short-circuited.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_direction_a_v2_entry_file_stays_dormant_on_legacy_bootstrap(): void {
+		// Legacy (v1) bootstrap stub — wins the class rendezvous, lacks register_loader_definition().
+		// eval() defines a test-only stub class in this isolated process (no untrusted input); this
+		// mirrors the established FeaturesUtil-stub pattern in BootstrapRegistrationTest.
+		eval(
+			'class Woodev_Plugin_Bootstrap {
+				private static $instance;
+				public static function instance() { return self::$instance ??= new self(); }
+				public function register_plugin( $framework_version, $plugin_name, $path, $callback, $args = [] ) {}
+			}'
+		);
+
+		Functions\stubEscapeFunctions();
+		Functions\when( 'wp_kses' )->returnArg();
+
+		// Point the fixture at the real framework root so its file_exists() guard passes; the
+		// stub already defines Woodev_Plugin_Bootstrap, so the real bootstrap.php is never required.
+		if ( ! defined( 'WOODEV_FRAMEWORK_DIR' ) ) {
+			define( 'WOODEV_FRAMEWORK_DIR', dirname( __DIR__, 2 ) );
+		}
+
+		$added = [];
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, $callback ) use ( &$added ): void {
+				$added[] = [ $hook, $callback ];
+			}
+		);
+
+		require __DIR__ . '/../_fixtures/woodev-test-plugin/woodev-test-plugin.php';
+
+		// register_loader_definition() was never reached (the stub lacks it — reaching it would fatal).
+		$this->assertFalse(
+			method_exists( \Woodev_Plugin_Bootstrap::instance(), 'register_loader_definition' ),
+			'The legacy stub must remain the loaded bootstrap.'
+		);
+
+		$admin_notice_hooks = array_filter(
+			$added,
+			static function ( array $hook ): bool {
+				return 'admin_notices' === $hook[0];
+			}
+		);
+
+		$this->assertCount( 1, $admin_notice_hooks, 'The probe must hook exactly one admin_notices warning.' );
+	}
+
+	/**
+	 * Direction B: a legacy (v1) register_plugin() call on the real v2 bootstrap is quarantined.
+	 *
+	 * The callback must never fire, the plugin must be recorded, the notice path must engage, and
+	 * the hooked callback must be the bootstrap render method. The render-purity assertion (the
+	 * renderer touches no framework runtime class) lives in its own separate-process test below,
+	 * because it requires a clean class table to mean anything.
+	 */
+	public function test_direction_b_legacy_register_plugin_is_quarantined(): void {
+		Functions\stubs( [ 'add_action' ] );
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\stubEscapeFunctions();
+		Functions\when( 'wp_kses' )->returnArg();
+		Functions\when( '_x' )->returnArg();
+
+		unset( $GLOBALS['b1_cb'] );
+
+		$added = [];
+		Functions\when( 'has_action' )->justReturn( false );
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, $callback ) use ( &$added ): void {
+				$added[] = [ $hook, $callback ];
+			}
+		);
+
+		$bootstrap = \Woodev_Plugin_Bootstrap::instance();
+
+		// v1 positional signature: register_plugin( $framework_version, $plugin_name, $path, $callback, $args ).
+		$bootstrap->register_plugin(
+			'1.4.1',
+			'Legacy Plugin',
+			'/path/legacy.php',
+			static function (): void {
+				$GLOBALS['b1_cb'] = true;
+			},
+			[]
+		);
+
+		$this->assertArrayNotHasKey( 'b1_cb', $GLOBALS, 'The legacy v1 callback must never be invoked.' );
+
+		$recorded = $this->get_protected_property( $bootstrap, 'mixed_fleet_incompatible_plugins' );
+		$this->assertCount( 1, $recorded, 'The legacy plugin must be recorded in the mixed-fleet list.' );
+		$this->assertSame( 'Legacy Plugin', $recorded[0]['plugin_name'] );
+		$this->assertSame( '/path/legacy.php', $recorded[0]['path'] );
+
+		$admin_notice_hooks = array_filter(
+			$added,
+			static function ( array $hook ): bool {
+				return 'admin_notices' === $hook[0];
+			}
+		);
+		$this->assertCount( 1, $admin_notice_hooks, 'The tombstone must engage the admin_notices path.' );
+
+		$render_callback = $admin_notice_hooks[ array_key_first( $admin_notice_hooks ) ][1];
+		$this->assertSame(
+			[ $bootstrap, 'render_mixed_fleet_notice' ],
+			$render_callback,
+			'The hooked callback must be the bootstrap render method.'
+		);
+	}
+
+	/**
+	 * Direction B: registering a second legacy plugin must NOT add admin_notices hook twice.
+	 *
+	 * The bootstrap uses a private flag $mixed_fleet_notice_hooked to ensure the admin_notices hook
+	 * is registered exactly once, even when multiple legacy v1 plugins are quarantined.
+	 */
+	public function test_direction_b_second_legacy_plugin_does_not_re_hook_admin_notices(): void {
+		Functions\stubs( [ 'add_action' ] );
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\stubEscapeFunctions();
+		Functions\when( 'wp_kses' )->returnArg();
+		Functions\when( '_x' )->returnArg();
+
+		$added = [];
+		Functions\when( 'has_action' )->justReturn( false );
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, $callback ) use ( &$added ): void {
+				$added[] = [ $hook, $callback ];
+			}
+		);
+
+		$bootstrap = \Woodev_Plugin_Bootstrap::instance();
+
+		// Register first legacy plugin.
+		$bootstrap->register_plugin(
+			'1.4.1',
+			'Legacy Plugin One',
+			'/path/legacy-one.php',
+			static function (): void {},
+			[]
+		);
+
+		// Register second legacy plugin.
+		$bootstrap->register_plugin(
+			'1.4.0',
+			'Legacy Plugin Two',
+			'/path/legacy-two.php',
+			static function (): void {},
+			[]
+		);
+
+		$recorded = $this->get_protected_property( $bootstrap, 'mixed_fleet_incompatible_plugins' );
+		$this->assertCount( 2, $recorded, 'Both legacy plugins must be recorded.' );
+		$this->assertSame( 'Legacy Plugin One', $recorded[0]['plugin_name'] );
+		$this->assertSame( 'Legacy Plugin Two', $recorded[1]['plugin_name'] );
+
+		$admin_notice_hooks = array_filter(
+			$added,
+			static function ( array $hook ): bool {
+				return 'admin_notices' === $hook[0];
+			}
+		);
+		$this->assertCount( 1, $admin_notice_hooks, 'The admin_notices hook must be added exactly once, not twice.' );
+	}
+
+	/**
+	 * Direction B (render purity): the quarantine renderer must NOT touch any framework runtime class.
+	 *
+	 * "Not loaded" is exactly the mixed-fleet scenario the tombstone serves — in production the framework
+	 * runtime (e.g. \Woodev_Helper) is genuinely unavailable, so the old
+	 * \Woodev_Helper::list_array_items() call fatals. Under the classmap autoloader a reference here would
+	 * instead SILENTLY load the class, so we snapshot the declared framework classes around the render call
+	 * and assert the set did not grow.
+	 *
+	 * This runs in a SEPARATE PROCESS with global state disabled so the class table is provably clean: no
+	 * earlier test can have preloaded \Woodev_Helper, which means the hard assertFalse() below can never be
+	 * a false skip — a present class is a real regression, never test pollution. The autoloader is inherited
+	 * by the child process, so referencing \Woodev_Plugin_Bootstrap still resolves via the classmap.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_direction_b_render_notice_loads_no_framework_class(): void {
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\stubEscapeFunctions();
+		Functions\when( 'wp_kses' )->returnArg();
+		Functions\when( '__' )->returnArg();
+		Functions\when( '_x' )->returnArg();
+		Functions\when( 'has_action' )->justReturn( false );
+
+		$added = [];
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, $callback ) use ( &$added ): void {
+				$added[] = [ $hook, $callback ];
+			}
+		);
+
+		$bootstrap = \Woodev_Plugin_Bootstrap::instance();
+
+		$bootstrap->register_plugin( '1.4.1', 'Legacy Plugin', '/path/legacy.php', static function (): void {}, [] );
+
+		$admin_notice_hooks = array_filter(
+			$added,
+			static function ( array $hook ): bool {
+				return 'admin_notices' === $hook[0];
+			}
+		);
+		$render_callback = $admin_notice_hooks[ array_key_first( $admin_notice_hooks ) ][1];
+
+		// Hard guard, not a skip: in a separate process the class table is clean, so a present Woodev_Helper
+		// here means a real regression (the renderer or something it touched loaded it), never test pollution.
+		$this->assertFalse(
+			class_exists( 'Woodev_Helper', false ),
+			'Woodev_Helper must not be loaded before the renderer runs — the separate process guarantees a clean class table.'
+		);
+
+		$framework_classes_before = $this->loaded_framework_classes();
+
+		ob_start();
+		( $bootstrap->{$render_callback[1]}() );
+		$output = (string) ob_get_clean();
+
+		$framework_classes_after = $this->loaded_framework_classes();
+
+		$this->assertStringContainsString( 'Legacy Plugin', $output, 'The rendered notice must name the quarantined plugin.' );
+		$this->assertStringContainsString( '<div class="error">', $output, 'The rendered notice must produce the admin-notice markup.' );
+		$this->assertSame(
+			$framework_classes_before,
+			$framework_classes_after,
+			'The renderer must not load any Woodev_* framework runtime class — it has to survive the no-framework mixed-fleet case.'
+		);
+	}
+
+	/**
+	 * Snapshot of currently-declared framework runtime classes (Woodev_* and Woodev\Framework\*).
+	 *
+	 * Used to prove the mixed-fleet renderer pulls in NO framework class as a side effect — in a real
+	 * mixed-fleet site those classes are unavailable and any reference fatals; here the classmap
+	 * autoloader would silently load them on reference, so a grown snapshot reveals the regression.
+	 *
+	 * @return array<int,string>
+	 */
+	private function loaded_framework_classes(): array {
+		$framework = array_filter(
+			get_declared_classes(),
+			static function ( string $class ): bool {
+				return 0 === strpos( $class, 'Woodev_' ) || 0 === strpos( $class, 'Woodev\\Framework\\' );
+			}
+		);
+
+		sort( $framework );
+
+		return $framework;
+	}
+
+	/**
+	 * Direction B (XSS guard): the quarantine renderer must escape plugin names in output.
+	 *
+	 * A legacy plugin with a malicious name like '<script>alert(1)</script>' must be rendered
+	 * as plain text, not executed. This guard ensures the renderer never outputs unescaped data.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_direction_b_render_escapes_plugin_names(): void {
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\stubEscapeFunctions();
+		Functions\when( 'esc_html' )->alias(
+			static function ( string $text ): string {
+				return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+			}
+		);
+		Functions\when( 'wp_kses' )->returnArg();
+		Functions\when( '__' )->returnArg();
+		Functions\when( '_x' )->returnArg();
+		Functions\when( 'has_action' )->justReturn( false );
+
+		$added = [];
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, $callback ) use ( &$added ): void {
+				$added[] = [ $hook, $callback ];
+			}
+		);
+
+		$bootstrap = \Woodev_Plugin_Bootstrap::instance();
+
+		$bootstrap->register_plugin(
+			'1.4.1',
+			'<script>alert(1)</script>Plugin',
+			'/path/malicious.php',
+			static function (): void {},
+			[]
+		);
+
+		$admin_notice_hooks = array_filter(
+			$added,
+			static function ( array $hook ): bool {
+				return 'admin_notices' === $hook[0];
+			}
+		);
+		$render_callback = $admin_notice_hooks[ array_key_first( $admin_notice_hooks ) ][1];
+
+		ob_start();
+		( $bootstrap->{$render_callback[1]}() );
+		$output = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'<script>',
+			$output,
+			'The rendered output must not contain unescaped <script> tags — plugin name must be escaped.'
+		);
+		$this->assertStringContainsString(
+			'alert(1)',
+			$output,
+			'The plugin name text must appear in output (escaped), not be stripped.'
+		);
+	}
+
+	/**
+	 * Direction B: the tombstone tolerates ANY argument shape without throwing.
+	 */
+	public function test_direction_b_tombstone_tolerates_garbage_arguments(): void {
+		Functions\stubs( [ 'add_action', 'has_action' ] );
+		Functions\when( 'is_admin' )->justReturn( false );
+
+		$bootstrap = \Woodev_Plugin_Bootstrap::instance();
+
+		// None of these may raise a TypeError — the caller is unknown-version legacy code.
+		$bootstrap->register_plugin();
+		$bootstrap->register_plugin( null );
+		$bootstrap->register_plugin( 42, [ 'not-a-string' ], new \stdClass() );
+
+		$recorded = $this->get_protected_property( $bootstrap, 'mixed_fleet_incompatible_plugins' );
+		$this->assertCount( 3, $recorded, 'Every garbage call must still be recorded without throwing.' );
+		$this->assertSame( '', $recorded[2]['path'] ?? 'unset', 'A non-string path argument falls back to an empty string.' );
+		// A non-string plugin_name argument falls back to the localized placeholder. Brain Monkey stubs __()
+		// to echo its source string, so the recorded name must equal the Russian source verbatim.
+		$this->assertSame( 'Неизвестный плагин', $recorded[2]['plugin_name'] ?? 'unset', 'A non-string plugin-name argument falls back to the localized placeholder.' );
+	}
+}

--- a/woodev/bootstrap.php
+++ b/woodev/bootstrap.php
@@ -38,6 +38,12 @@ if ( ! class_exists( 'Woodev_Plugin_Bootstrap' ) ) :
 		/** @var array invalid explicit loader definitions */
 		protected array $invalid_loader_definitions = [];
 
+		/** @var array<int,array<string,string>> Legacy (v1) plugins quarantined by the mixed-fleet tombstone — see B-1. */
+		protected array $mixed_fleet_incompatible_plugins = [];
+
+		/** @var bool Whether the mixed-fleet admin notice has already been hooked — idempotency guard (B-1). */
+		private bool $mixed_fleet_notice_hooked = false;
+
 		/**
 		 * Hidden constructor.
 		 */
@@ -78,6 +84,95 @@ if ( ! class_exists( 'Woodev_Plugin_Bootstrap' ) ) :
 			$this->sync_resolver_state();
 
 			return $accepted;
+		}
+
+		/**
+		 * Tombstone for the legacy v1 registration entry point — mixed-fleet armor (B-1).
+		 *
+		 * On a site mixing one v2-rewritten plugin with one still-v1 plugin, WordPress loads
+		 * plugins directory-alphabetically and the first vendored copy to define
+		 * `Woodev_Plugin_Bootstrap` wins the class rendezvous. When this v2 copy wins, a v1
+		 * plugin entry file still calls `register_plugin()` (the v1 API). Without this method
+		 * that call is an uncaught `Error` -> site-wide WSOD. This tombstone quarantines the
+		 * legacy plugin instead: it NEVER invokes the v1 callback and NEVER initializes the
+		 * plugin, it only records it so the existing admin-notice path tells the merchant to
+		 * update the outdated plugin.
+		 *
+		 * The signature is intentionally variadic and untyped: the caller is unknown-version
+		 * legacy code and nothing it passes (the v1 shape was
+		 * `register_plugin( string $framework_version, string $plugin_name, string $path, callable $callback, array $args = [] )`,
+		 * but a still-older copy may differ) may trip a TypeError — robustness for
+		 * site-availability beats the project's type-declaration convention here. Name and path
+		 * are best-effort extracted from the v1 positional shape (name at index 1, path at index 2).
+		 *
+		 * This is NOT a deprecation shim (ADR-005): it never delegates to a real implementation,
+		 * it permanently quarantines the legacy registration.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param mixed ...$args Legacy v1 registration arguments, any shape.
+		 * @return void
+		 */
+		public function register_plugin( ...$args ): void {
+			$plugin_name = isset( $args[1] ) && is_string( $args[1] ) && '' !== $args[1] ? $args[1] : __( 'Неизвестный плагин', 'woodev-plugin-framework' );
+			$plugin_path = isset( $args[2] ) && is_string( $args[2] ) ? $args[2] : '';
+
+			$this->mixed_fleet_incompatible_plugins[] = [
+				'plugin_name' => $plugin_name,
+				'path'        => $plugin_path,
+			];
+
+			if ( ! $this->mixed_fleet_notice_hooked && is_admin() && ! defined( 'DOING_AJAX' ) ) {
+				$this->mixed_fleet_notice_hooked = true;
+				add_action( 'admin_notices', [ $this, 'render_mixed_fleet_notice' ] );
+			}
+		}
+
+		/**
+		 * Renders the mixed-fleet quarantine notice for legacy (v1) plugins (B-1).
+		 *
+		 * @since 2.0.0
+		 *
+		 * @return void
+		 */
+		public function render_mixed_fleet_notice(): void {
+			if ( empty( $this->mixed_fleet_incompatible_plugins ) ) {
+				return;
+			}
+
+			// Build the plugin-name list with ONLY WordPress core functions + plain PHP. This runs in
+			// the mixed-fleet scenario where the framework runtime (e.g. Woodev_Helper) may NOT be loaded,
+			// so it must never reference a framework class — see B-1.
+			$names = array_map(
+				static function ( array $plugin ): string {
+					return sprintf( '<strong>%s</strong>', esc_html( $plugin['plugin_name'] ) );
+				},
+				$this->mixed_fleet_incompatible_plugins
+			);
+
+			$count = count( $names );
+
+			if ( $count > 1 ) {
+				$last_name  = (string) array_pop( $names );
+				$conjunction = _x( 'и', 'coordinating conjunction for a list of items: a, b и c', 'woodev-plugin-framework' );
+				$name_list  = implode( ', ', $names ) . ' ' . $conjunction . ' ' . $last_name;
+			} else {
+				$name_list = (string) reset( $names );
+			}
+
+			echo '<div class="error"><p>';
+			echo wp_kses(
+				sprintf(
+					/* translators: %s — list of plugin names. */
+					__(
+						'Следующие плагины собраны для устаревшей версии фреймворка Woodev и поэтому были отключены: %s. Пожалуйста, обновите их.',
+						'woodev-plugin-framework'
+					),
+					$name_list
+				),
+				[ 'strong' => [] ]
+			);
+			echo '</p></div>';
 		}
 
 		/**


### PR DESCRIPTION
## What (Fable 5 review B-1, Critical)
On a customer site mixing one v2-rewritten plugin with one v1 plugin (the normal state during a staggered fleet rollout), the directory-alphabetical `class_exists` rendezvous lets either framework copy win — and each side then calls a method the other copy doesn''t have → uncaught `Error` → WSOD on every request. This is the hard gate required **before the first production plugin rewrite ships**.

- **Direction A (v2 plugin, v1 bootstrap won):** the canonical v2 entry template (3 fixture entry files) probes `method_exists( $bootstrap, 'register_loader_definition' )`; on a v1 winner the plugin stays dormant + admin notice. No fatal.
- **Direction B (v1 plugin, v2 bootstrap won):** `Woodev_Plugin_Bootstrap::register_plugin()` tombstone — tolerates any legacy argument shape, never invokes the v1 callback, records into a dedicated mixed-fleet incompatible list, renders an admin notice using **WP-core functions only** (framework runtime classes may be absent in exactly this scenario).

Additive site-availability armor — no installed-site contract strings touched, ADR-005 clean-break intact (the tombstone quarantines, it never delegates).

## Tests
`MixedFleetBootstrapGateTest` — 6 tests: both directions, separate-process render-purity detector (FAILS, not skips, in CI if a framework-class call regresses into the renderer), notice-hook idempotency, XSS escaping of legacy plugin names. Suite: PHPCS 152/152, PHPStan 0, **281 tests / 852 assertions**.

## Review trail
GPT-5.5 high (codex, read-only), adversarial: **BLOCK ×2 with real catches** (renderer fataled when `Woodev_Helper` absent; `_n()` Russian-plural misuse without a catalog; detector self-skipped in full-suite CI) → all fixed by opus fix-workers → final **SHIP-WITH-NITS**, all 4 nits applied.

Known follow-up (critic nit, out of scope): fixture local-dev path fallback `dirname(__DIR__, 2)` resolves to `tests/` in unit context — masked by `WOODEV_FRAMEWORK_DIR` in wp-env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)