### PR TITLE
fix(autodev): loop hardening per the 2026-06-11 tooling review

### DIFF
--- a/.autodev/queue/done/s7-t3-loop-control-flow-hardening.md
+++ b/.autodev/queue/done/s7-t3-loop-control-flow-hardening.md
@@ -1,0 +1,58 @@
+---
+id: s7-t3-loop-control-flow-hardening
+title: Autodev loop control-flow hardening — escalated/ queue dir, empty-file_set gate escalate, ReuseVerdict diff hash, cost caps
+phase: Autodev tooling — loop review remediation (reviews/autodev-loop-review-2026-06-11.md items 1,4,5,6,10)
+type: tooling
+model: sonnet
+touches_contract_zone: false
+writes_guard: false
+file_set:
+  - tools/autodev/_common.ps1
+  - tools/autodev/conductor.ps1
+  - tools/autodev/scheduler.ps1
+  - tools/autodev/gate.ps1
+  - tools/autodev/invoke-critic.ps1
+  - tools/autodev/invoke-worker.ps1
+depends_on: []
+contract_zones_touched: []
+needs_guard: no
+acceptance:
+  - "NEW queue/escalated/: config key QueueEscalated; Initialize-AutodevDirectories creates it; conductor's NEEDS_GUARD/BLOCKED route (~L183), critic-escalate route (~L235) and gate-escalate route (~L287) Move-Task to QueueEscalated instead of QueueActive (no more stranded-in-active no-op)"
+  - "scheduler treats escalated/ tasks as BLOCKING for file_set intersection exactly like active/ ones (serialization preserved), but never claims from it; scheduler -SelfTest extended with one case proving an escalated task blocks an intersecting pending task"
+  - "gate.ps1: a task whose file_set is empty/missing yields verdict ESCALATE (reason 'empty file_set — nothing can be safely judged'), NEVER COMMIT"
+  - "invoke-critic writes diff_sha256 (SHA256 of the diff text it judged) into verdict.json; conductor -ReuseVerdict reuses a clean verdict ONLY when stored diff_sha256 matches the SHA256 of the CURRENT regenerated diff; mismatch -> log + fall through to a fresh critic run"
+  - "cost caps: new config keys WorkerMaxTurns (default 100) appended to the claude args as --max-turns, and MaxSessionHours (default 8) -- conductor's main loop exits gracefully (log + break) when exceeded"
+  - "conductor ~L163 stale comment/log fixed to match the actual move-to-pending behavior"
+  - "all existing self-tests still pass: conductor -SelfTest, scheduler -SelfTest, watchdog -SelfTest, invoke-worker -DryRun (with a temp task)"
+---
+
+# Task
+
+Implement items 1, 4, 5, 6, 10 of `docs-internal/reviews/autodev-loop-review-2026-06-11.md`
+(read it first — it carries the verified file:line evidence). PowerShell only, no PHP.
+Keep the existing code style (comment tone, Write-AutodevLog levels, Set-StrictMode-safe,
+`[string[]]` casts where arrays may unwrap).
+
+Key implementation notes:
+- `Move-Task` in conductor takes `-ToDir`; the three escalation call sites currently pass
+  `$Config.QueueActive` — switch to `$Config.QueueEscalated`. Do NOT change the
+  quarantine or pending routes.
+- scheduler: the active-set builder (`$sets` around scheduler.ps1:40-50 and the blocked-by
+  reporter ~L144-152) must enumerate BOTH QueueActive and QueueEscalated.
+- diff hash: `[System.Security.Cryptography.SHA256]` over UTF8 bytes of the diff string;
+  helper in _common.ps1 (e.g. `Get-AutodevTextSha256`) so conductor and invoke-critic share it.
+- `--max-turns` goes into the `$args` array in invoke-worker next to `--permission-mode`.
+- MaxSessionHours: capture `$sessionStart = Get-Date` before the loop; check at the top of
+  each iteration.
+
+## What NOT to change
+- Worker prompt text and worktree wording (separate task s7-t4).
+- invoke-critic tiering thresholds, codex transport, fencing.
+- Queue file frontmatter format.
+- anti-drift.ps1 / mutation-check.ps1 / watchdog.ps1 (s7-t4).
+
+## Verification (capture real output)
+1. `pwsh -File tools/autodev/scheduler.ps1 -SelfTest` — PASS incl. the new escalated-blocks case.
+2. `pwsh -File tools/autodev/conductor.ps1 -SelfTest` — PASS.
+3. invoke-worker -DryRun with a temp task: command line shows `--max-turns 100`.
+4. Grep proves no remaining `Move-Task ... QueueActive` at the three escalation sites.

--- a/.autodev/queue/done/s7-t4-antidrift-wiring-and-cleanup.md
+++ b/.autodev/queue/done/s7-t4-antidrift-wiring-and-cleanup.md
@@ -1,0 +1,53 @@
+---
+id: s7-t4-antidrift-wiring-and-cleanup
+title: Wire anti-drift into the conductor, fix watchdog stdout liveness, Invoke-Native everywhere, worker-prompt cleanup, dead-key removal
+phase: Autodev tooling — loop review remediation (reviews/autodev-loop-review-2026-06-11.md items 2,3,7,8,13,15)
+type: tooling
+model: sonnet
+touches_contract_zone: false
+writes_guard: false
+file_set:
+  - tools/autodev/_common.ps1
+  - tools/autodev/conductor.ps1
+  - tools/autodev/anti-drift.ps1
+  - tools/autodev/watchdog.ps1
+  - tools/autodev/mutation-check.ps1
+  - tools/autodev/invoke-worker.ps1
+depends_on:
+  - s7-t3-loop-control-flow-hardening
+contract_zones_touched: []
+needs_guard: no
+acceptance:
+  - "anti-drift WIRED: conductor counts successful COMMITs in the session; every AntiDriftEveryCommits (config, default 5) commits it invokes tools/autodev/anti-drift.ps1 (log on failure, never crash the loop); counter resets after each run"
+  - "anti-drift.ps1 actually APPENDS its one-line verdict (timestamped) to $Config.Digest (.autodev/digest.md) as its SYNOPSIS promises; -DigestOnly emits/appends the digest line without the sonnet call; git calls routed through Invoke-Native"
+  - "DigestEveryCommits config key REMOVED (redundant — digest now rides the anti-drift cadence); CurrentState config key removed IF truly unread after these changes (grep-verify; if anti-drift uses it, keep)"
+  - "watchdog.ps1: event sink uses $Event.SourceEventArgs.Data (not $EventArgs.Data); watchdog -SelfTest still PASSES and still proves stdout-driven liveness (the self-test must fail if the sink stops receiving data — strengthen it if it would not)"
+  - "mutation-check.ps1: phpunit invocations routed through Invoke-Native (preserve exit-code semantics: RED expected on mutation)"
+  - "invoke-worker Build-WorkerPrompt cleaned: (a) 'git add -N -- <file_set>' named as the EXPLICIT sole exception to the no-git-add rule (one sentence, no contradiction); (b) all 'worktree' wording in prompt + SYNOPSIS replaced with 'repository working tree (serialized by file_set disjointness)'; (c) Serena line becomes conditional: 'Use Serena tools for PHP if they are available in your session; otherwise use Grep/Read'"
+  - "conductor.ps1 + invoke-worker.ps1 stale comments about per-task worktrees corrected"
+  - "all self-tests green: conductor -SelfTest, scheduler -SelfTest, watchdog -SelfTest, invoke-worker -DryRun"
+---
+
+# Task
+
+Implement items 2 (wording half), 3, 7, 8, 13, 15 of
+`docs-internal/reviews/autodev-loop-review-2026-06-11.md` (read first). PowerShell only.
+s7-t3 has already landed on this branch — build on its state of the files.
+
+Implementation notes:
+- Conductor wiring point: immediately after a successful COMMIT route (where the task
+  moves to done/), increment `$commitsSinceDrift`; when `>= $Config.AntiDriftEveryCommits`
+  run `& (Join-Path $here 'anti-drift.ps1')` inside try/catch (WARN on failure), reset counter.
+- anti-drift digest append format: `[yyyy-MM-dd HH:mm:ss] [anti-drift] <ON-TRACK|DRIFT|UNCERTAIN: line>` via Add-Content -Encoding utf8.
+- Real per-task git worktrees are explicitly OUT OF SCOPE (recorded follow-up) — this task only makes the WORDS honest.
+
+## What NOT to change
+- invoke-critic.ps1 (untouched this task).
+- The s7-t3 changes (escalated/ routing, diff hash, caps) — extend, don't rework.
+- gate.ps1, scheduler.ps1, escalate.ps1.
+
+## Verification (capture real output)
+1. `pwsh -File tools/autodev/watchdog.ps1 -SelfTest` — PASS (stdout liveness case included).
+2. `pwsh -File tools/autodev/conductor.ps1 -SelfTest`, `scheduler.ps1 -SelfTest` — PASS.
+3. anti-drift -DigestOnly run appends a line to a temp-pointed digest (show the line); clean up.
+4. Grep: zero remaining 'worktree' in invoke-worker prompt/SYNOPSIS; zero `$EventArgs.Data`; zero `DigestEveryCommits`.

--- a/docs-internal/reviews/autodev-loop-review-2026-06-11.md
+++ b/docs-internal/reviews/autodev-loop-review-2026-06-11.md
@@ -1,0 +1,39 @@
+# Autodev-loop tooling review — 2026-06-11 (s7, Fable orchestrator)
+
+> Full assessment of `tools/autodev/` (11 scripts, ~2,100 lines) requested by the operator.
+> Method: Explore-agent deep-read of every script + orchestrator spot-verification of the
+> three load-bearing claims against source. Items marked ✅ fixed are addressed by the
+> `fix/autodev-loop-hardening` branch (s7-t3 / s7-t4); items marked ⏳ are recorded
+> follow-ups, deliberately out of scope.
+
+## Keep (working well, do not touch)
+- Pipeline shape: scheduler (atomic claim + file_set disjointness) → worker → external critic → mechanical gate (INVARIANTS zones) → commit/escalate. "Mechanics decide, LLM advises" separation.
+- Battle-tested fixes: 429 attempt-refund symmetry, verdict-parse-before-ratelimit, contract-zone opus pin (now + declared-model override, PR #26), mutation-verified guards.
+
+## Fixed on this branch
+| # | Severity | Finding (verified) | Fix |
+|---|----------|--------------------|-----|
+| 1 | 🔴 | `NEEDS_GUARD`/`BLOCKED`/critic-escalate/gate-escalate did `Move-Task → queue/active/` where the file already is → no-op → task stranded forever in `active/`, permanently blocking every intersecting file_set (`conductor.ps1:183/235/287`) | New `queue/escalated/` dir; escalation paths move there; scheduler treats `escalated/` as blocking (serialization preserved); operator unparks by moving back to `pending/` |
+| 2 | 🔴 | "Per-task worktree" is fiction: no `git worktree add` exists anywhere; conductor never passes `-Worktree`; workers run in the MAIN tree (`invoke-worker.ps1:39`) | Honesty fix: all "worktree" wording removed from SYNOPSIS/prompts → "repository working tree, serialized by file_set disjointness". Real worktrees = ⏳ follow-up (would require per-worktree composer install) |
+| 3 | 🔴 | anti-drift never invoked (comments only, `conductor.ps1:19,359`); `AntiDriftEveryCommits`/`DigestEveryCommits` read by nobody; digest-append unimplemented in `anti-drift.ps1` despite its SYNOPSIS | Commit counter in conductor → run anti-drift every `AntiDriftEveryCommits` COMMITs; anti-drift now appends its line to `digest.md`; redundant `DigestEveryCommits` key removed |
+| 4 | 🟠 | Empty/missing `file_set` → gate sees zero changed files → COMMIT with no zone/constitution checks (`gate.ps1:85-98`) | Empty file_set → ESCALATE, never COMMIT |
+| 5 | 🟠 | `-ReuseVerdict` reuses any prior `clean` verdict with no proof it judged the same code (`conductor.ps1:208`) | `verdict.json` gains `diff_sha256`; reuse only when it matches the current diff hash |
+| 6 | 🟠 | Timeout log says "leaving in active for respawn", code moves to `pending` (`conductor.ps1:163-164`) | Comment/log corrected |
+| 7 | 🟠 | `$EventArgs.Data` inside event-sink scriptblock can be $null on Windows PowerShell 5.1 → stdout liveness silently dead (`watchdog.ps1`) | `$Event.SourceEventArgs.Data` (works on 5.1 and 7+) |
+| 8 | 🟠 | `anti-drift.ps1`/`mutation-check.ps1` call git/phpunit bare, bypassing `Invoke-Native` stderr protection | Routed through `Invoke-Native` |
+| 10 | 🟡 | No cost bounds: only the 20-min worker wall-clock | `WorkerMaxTurns` (claude `--max-turns`) + `MaxSessionHours` conductor wall-clock exit |
+| 13 | 🟡 | Worker prompt contradictions: "do NOT run git add" next to "run `git add -N`"; "this git worktree" (false); Serena instruction unconditional | Prompt cleaned: `git add -N` named as the explicit diff-only exception; worktree wording removed; Serena "if available, else Grep/Read" |
+| 15 | ⚪ | Dead config keys (`CurrentState`, `DigestEveryCommits`), stale worktree comments | Removed |
+
+## Recorded follow-ups (⏳ not in this branch)
+- **Telegram reply ingestion** — escalations are send-only; unparking is manual. A poller acting on structured A/B replies is a feature, not a fix.
+- **Real per-task git worktrees** — needs per-worktree `composer install` + gate path changes; revisit if parallel workers are ever wanted.
+- **Resume journal** — kill between worker-DONE and commit leaves uncommitted changes invisible to the next run. Mitigated by escalated/-blocking; full fix needs an in-progress journal.
+- **`confidence` / `broken_contracts[].line`** — parsed, stored, never routed on. Either use (low-confidence `uncertain` → cheap re-critic) or drop from the schema at the next schema rev.
+- **Codify "BLOCK → counter-evidence → re-verdict"** — saved this session twice (one false-positive refuted, one real catch confirmed); currently an orchestrator-manual pattern, conductor escalates immediately.
+- **invoke-worker workers in agent-tool worktrees**: gotcha [[serena-index-vs-git-worktree]] applies to the *operator-directed* pattern, not the conductor (whose workers run in the main tree).
+
+## Related
+- [fable5-architecture-review-2026-06-10.md](fable5-architecture-review-2026-06-10.md)
+- `.autodev/queue/done/s7-t3-*.md`, `s7-t4-*.md` — the fixing tasks
+- `docs-internal/fable5-autodev-orchestrator-prompt.md` — tiering policy (PR #26)

--- a/tools/autodev/_common.ps1
+++ b/tools/autodev/_common.ps1
@@ -53,9 +53,9 @@ function Get-AutodevConfig {
         QueueActive     = Join-Path $autodev 'queue\active'
         QueueDone       = Join-Path $autodev 'queue\done'
         QueueQuarantine = Join-Path $autodev 'queue\quarantine'
+        QueueEscalated  = Join-Path $autodev 'queue\escalated'
         Runtime         = Join-Path $autodev 'runtime'
         Escalations     = Join-Path $autodev 'escalations'
-        CurrentState    = Join-Path $root 'docs-internal\CURRENT-STATE.md'
         Tracker         = Join-Path $root 'docs-internal\platform-v2-program-tracker.md'
 
         # Runtime roles (model ladder). Contract-zone tasks pin to the first entry only.
@@ -68,9 +68,10 @@ function Get-AutodevConfig {
         CriticDiffLineThreshold = 40   # diff > N lines -> expensive critic even if zone-free
         WatchdogStaleMinutes    = 15   # NO process activity (stdout/file writes/heartbeat) for this long -> kill + respawn
         MaxAttempts             = 3    # attempts > this -> quarantine + escalate
-        AntiDriftEveryCommits   = 5    # run anti-drift every M commits
-        DigestEveryCommits      = 5    # append digest every N commits
+        AntiDriftEveryCommits   = 5    # run anti-drift every M commits; digest rides this cadence
         WorkerTimeoutMinutes    = 20
+        WorkerMaxTurns          = 100  # passed as --max-turns to claude (hard cap per worker spawn)
+        MaxSessionHours         = 8    # conductor wall-clock exit: stop gracefully after N hours
 
         # Tool transports
         ClaudeExe       = 'claude'
@@ -81,9 +82,27 @@ function Get-AutodevConfig {
 function Initialize-AutodevDirectories {
     param([pscustomobject]$Config = (Get-AutodevConfig))
     foreach ($p in @($Config.QueuePending, $Config.QueueActive, $Config.QueueDone,
-                      $Config.QueueQuarantine, $Config.Runtime, $Config.Escalations)) {
+                      $Config.QueueQuarantine, $Config.QueueEscalated,
+                      $Config.Runtime, $Config.Escalations)) {
         if (-not (Test-Path $p)) { New-Item -ItemType Directory -Path $p -Force | Out-Null }
     }
+}
+
+# --------------------------------------------------------------------------------------
+# Cryptographic helpers
+# --------------------------------------------------------------------------------------
+
+function Get-AutodevTextSha256 {
+    <# Returns the hex SHA256 of a UTF-8 string. Used for diff identity in verdict.json. #>
+    param([string]$Text)
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($Text)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hash = $sha.ComputeHash($bytes)
+    } finally {
+        $sha.Dispose()
+    }
+    return ([System.BitConverter]::ToString($hash) -replace '-', '').ToLower()
 }
 
 # --------------------------------------------------------------------------------------

--- a/tools/autodev/anti-drift.ps1
+++ b/tools/autodev/anti-drift.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Anti-drift check + digest. The highest-value safeguard: green gate, wrong direction.
+  Anti-drift check. Feeds recent diffs to a Sonnet critic and appends one verdict line to digest.md.
 
 .DESCRIPTION
   Every M commits the conductor calls this. It does NOT compare commit titles (too
@@ -9,8 +9,7 @@
   tasks, and asks: "does this work advance the phase's stated intent, or has it wandered
   -- satisfied the letter of the tasks while missing their purpose?"
 
-  Produces one strong line for the digest, appends a digest block to .autodev/digest.md,
-  and mirrors the operator-facing summary into docs-internal/CURRENT-STATE.md.
+  Appends one timestamped verdict line (ON-TRACK/DRIFT/UNCERTAIN) to .autodev/digest.md.
 
   Transport: claude -p --model sonnet (cheap, frequent). If claude is rate-limited or
   unavailable, the anti-drift line records that it could not run (never a false "on-track").
@@ -20,7 +19,7 @@
 .PARAMETER DigestOnly
   Skip the Sonnet call; just emit the digest block (used when anti-drift already ran).
 .PARAMETER CommitsSinceLast
-  Number of commits this digest covers (for the header).
+  Number of commits this digest covers; included in the digest line as '(window: N commits)'.
 #>
 [CmdletBinding()]
 param(
@@ -49,12 +48,9 @@ function Get-TrackerIntent {
 
 function Get-RecentDoneDiffs {
     param([string]$SinceRef, [pscustomobject]$Config)
-    Push-Location $Config.RepoRoot
-    try {
-        $log = & git log "$SinceRef..HEAD" --grep='(autodev)' --oneline 2>$null | Out-String
-        $diff = & git diff "$SinceRef..HEAD" 2>$null | Out-String
-        return [pscustomobject]@{ Log = $log.Trim(); Diff = $diff }
-    } finally { Pop-Location }
+    $rLog  = Invoke-Native -Exe 'git' -CommandArgs @('log', "$SinceRef..HEAD", '--grep=(autodev)', '--oneline') -WorkingDirectory $Config.RepoRoot
+    $rDiff = Invoke-Native -Exe 'git' -CommandArgs @('diff', "$SinceRef..HEAD") -WorkingDirectory $Config.RepoRoot
+    return [pscustomobject]@{ Log = ($rLog.Output | Out-String).Trim(); Diff = ($rDiff.Output | Out-String) }
 }
 
 $driftLine = ''
@@ -93,11 +89,31 @@ $($recent.Diff)
 
     if ($exit -eq 0 -and $out) {
         $lm = [regex]::Match($out, '(?im)^\s*(ON-TRACK|DRIFT|UNCERTAIN):.*$')
-        $driftLine = if ($lm.Success) { $lm.Value.Trim() } else { ($out -split "`n" | Where-Object { $_.Trim() } | Select-Object -Last 1).Trim() }
+        if ($lm.Success) {
+            $driftLine = $lm.Value.Trim()
+        } else {
+            # Model output has no recognized prefix -- degrade to UNCERTAIN rather than recording
+            # an unstructured line that would be invisible to any downstream grep/parser.
+            $firstChars = ($out -replace '[\r\n]+',' ').Trim()
+            if ($firstChars.Length -gt 120) { $firstChars = $firstChars.Substring(0, 120) }
+            $driftLine = "UNCERTAIN: model output had no ON-TRACK/DRIFT/UNCERTAIN prefix -- $firstChars"
+        }
     } else {
         $driftLine = "UNCERTAIN: anti-drift could not run (claude exit $exit) -- not asserting on-track."
     }
     Write-AutodevLog -Message "Anti-drift result: $driftLine" -Config $Config
+} else {
+    # -DigestOnly: emit/append the digest line without the Sonnet call.
+    $driftLine = "UNCERTAIN: -DigestOnly requested -- Sonnet not invoked."
 }
 
+# Append one-line verdict to digest (timestamped). Format:
+#   [yyyy-MM-dd HH:mm:ss] [anti-drift] (window: N commits) <verdict line>
+$stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+$digestEntry = "[$stamp] [anti-drift] (window: $CommitsSinceLast commits) $driftLine"
+try {
+    Add-Content -Path $Config.Digest -Value $digestEntry -Encoding utf8
+} catch {
+    Write-AutodevLog -Level WARN -Message "Anti-drift: could not write to digest ($($Config.Digest)): $($_.Exception.Message)" -Config $Config
+}
 Write-Output $driftLine

--- a/tools/autodev/conductor.ps1
+++ b/tools/autodev/conductor.ps1
@@ -16,7 +16,7 @@
     5. critic (tiered, read-only, fenced) -> uncertain/broken route to human
     6. gate (composer check + INVARIANTS grep + per-guard mutation-check)
     7. COMMIT (checkpoint) | ESCALATE | RETRY
-    8. periodic: anti-drift every M commits, digest every N commits
+    8. periodic: anti-drift (+ digest) every AntiDriftEveryCommits commits
 
 .PARAMETER Once
   Run a single iteration and exit (no idle loop).
@@ -30,11 +30,12 @@
   as the worker (sanctioned by the brief: "you ARE the planner for the guard workload").
 
 .PARAMETER GuardBootstrap
-  Special section-6 flow: the change ADDS mutation-verified guards + a GUARDS.md row. That diff
-  legitimately trips the constitution rule (GUARDS.md) and the contract-zone rule (the
-  exact strings appear in the new tests). So instead of refusing, the conductor commits
-  the guard checkpoint (recording blessed_by: pending-operator) AND emits ONE escalation
-  asking the operator to bless. Autonomy for those zones switches on only after blessing.
+  Special section-6 flow: used when the worker session itself implements new mutation-verified
+  guards + GUARDS.md rows. This flag does NOT override the gate decision: the gate still runs
+  normally and the change must earn a 'COMMIT' decision on its own merits. The only extra
+  behaviour is that AFTER a successful commit, the conductor also emits one escalation asking
+  the operator to bless the new guards (blessed_by: pending-operator). Autonomy for the new
+  contract zones switches on only after that blessing.
 
 .PARAMETER DryRunWorker
   Pass -DryRun to invoke-worker (build the command + ladder, do not spawn claude).
@@ -92,6 +93,22 @@ function Move-Task {
     if (Test-Path $src) { Move-Item -Path $src -Destination (Join-Path $ToDir "$TaskId.md") -Force }
 }
 
+# Pure predicate: returns $true only when the gate issued a literal 'COMMIT' decision.
+# Used by BOTH the production commit-path condition (Invoke-ConductorIteration) and the
+# self-test cases (3 & 4), so a regression in the condition is caught by the tests.
+function Test-AutodevCommitDecision {
+    param([string]$Decision)
+    return ($Decision -eq 'COMMIT')
+}
+
+# Pure predicate: returns $true only when an iteration's committed flag is set, meaning the
+# counter should be incremented. Used by BOTH the outer loop counter and self-test case 4,
+# so any change that re-adds false-increment paths is caught by the tests.
+function Test-AutodevCounterIncrement {
+    param([bool]$IterationCommitted)
+    return $IterationCommitted
+}
+
 function New-WorkerDiff {
     <# Capture a diff of the task's file_set, intent-adding any new files so they show. #>
     param([pscustomobject]$Task, [string]$OutPath)
@@ -124,6 +141,11 @@ function Invoke-CommitTask {
 }
 
 function Invoke-ConductorIteration {
+    # Reset the commit flag for each iteration. Set to $true ONLY by the COMMIT route below so
+    # the caller can count actual commits without relying on done/ file existence (which can
+    # false-increment on a reused/re-queued task id that had a prior done/ entry).
+    $script:iterationCommitted = $false
+
     # 1. CLAIM (atomic, file-disjoint)
     $claimedId = (& (Join-Path $here 'scheduler.ps1') | Select-Object -First 1)
     if (-not $claimedId) { return $null }
@@ -136,9 +158,13 @@ function Invoke-ConductorIteration {
     Set-Attempts -TaskId $task.id -N $attempts
     if ($attempts -gt $Config.MaxAttempts) {
         Move-Task -TaskId $task.id -ToDir $Config.QueueQuarantine
-        Invoke-Escalation -Id "poison-$($task.id)" -Reason 'poison task' -Type 'poison' -Task $task `
-            -What "Task failed across $($attempts-1) fresh agents." -Decision 'Re-scope or drop this task?' `
-            -OptionA 'Re-scope and re-queue' -OptionB 'Drop' -Cost 'wasted token spend' -Evidence ''
+        try {
+            Invoke-Escalation -Id "poison-$($task.id)" -Reason 'poison task' -Type 'poison' -Task $task `
+                -What "Task failed across $($attempts-1) fresh agents." -Decision 'Re-scope or drop this task?' `
+                -OptionA 'Re-scope and re-queue' -OptionB 'Drop' -Cost 'wasted token spend' -Evidence ''
+        } catch {
+            Write-AutodevLog -Level WARN -Message "Escalation artifact write failed for poison-$($task.id): $($_.Exception.Message)" -Config $Config
+        }
         return $task
     }
 
@@ -161,7 +187,7 @@ function Invoke-ConductorIteration {
             return $task
         }
         if ($w.Status -eq 'TIMED_OUT') {
-            Write-AutodevLog -Level WORKER -Message "Timed out; leaving in active for respawn (attempts=$attempts)." -Config $Config
+            Write-AutodevLog -Level WORKER -Message "Timed out; moving to pending for a fresh attempt (attempts=$attempts)." -Config $Config
             Move-Task -TaskId $task.id -ToDir $Config.QueuePending
             return $task
         }
@@ -174,17 +200,25 @@ function Invoke-ConductorIteration {
         if ($report -match '(?im)^\s*status\s*[:=]\s*TOO_BIG') {
             Write-AutodevLog -Message "Task $($task.id) TOO_BIG; archiving for re-decomposition." -Config $Config
             Move-Task -TaskId $task.id -ToDir $Config.QueueQuarantine
-            Invoke-Escalation -Id "toobig-$($task.id)" -Reason 'task too big' -Type 'blocked' -Task $task `
-                -What 'Worker reported TOO_BIG; needs decomposition.' -Decision 'Approve the proposed split?' `
-                -OptionA 'Approve split' -OptionB 'Re-scope manually' -Cost 'none (no code landed)' -Evidence $report
+            try {
+                Invoke-Escalation -Id "toobig-$($task.id)" -Reason 'task too big' -Type 'blocked' -Task $task `
+                    -What 'Worker reported TOO_BIG; needs decomposition.' -Decision 'Approve the proposed split?' `
+                    -OptionA 'Approve split' -OptionB 'Re-scope manually' -Cost 'none (no code landed)' -Evidence $report
+            } catch {
+                Write-AutodevLog -Level WARN -Message "Escalation artifact write failed for toobig-$($task.id): $($_.Exception.Message)" -Config $Config
+            }
             return $task
         }
         foreach ($pair in @(@('NEEDS_GUARD', 'needs-guard'), @('BLOCKED', 'blocked'))) {
             if ($report -match "(?im)^\s*status\s*[:=]\s*$($pair[0])") {
-                Move-Task -TaskId $task.id -ToDir $Config.QueueActive
-                Invoke-Escalation -Id "$($pair[1])-$($task.id)" -Reason $pair[0] -Type $pair[1] -Task $task `
-                    -What "Worker reported $($pair[0])." -Decision 'Provide guidance.' `
-                    -OptionA 'Write/bless a guard' -OptionB 'Mark human-only' -Cost 'blocks the task' -Evidence $report
+                Move-Task -TaskId $task.id -ToDir $Config.QueueEscalated
+                try {
+                    Invoke-Escalation -Id "$($pair[1])-$($task.id)" -Reason $pair[0] -Type $pair[1] -Task $task `
+                        -What "Worker reported $($pair[0])." -Decision 'Provide guidance.' `
+                        -OptionA 'Write/bless a guard' -OptionB 'Mark human-only' -Cost 'blocks the task' -Evidence $report
+                } catch {
+                    Write-AutodevLog -Level WARN -Message "Escalation artifact write failed for $($pair[1])-$($task.id): $($_.Exception.Message)" -Config $Config
+                }
                 return $task
             }
         }
@@ -207,8 +241,16 @@ function Invoke-ConductorIteration {
     if ($ReuseVerdict -and (Test-Path $verdictFile)) {
         $existing = Get-Content $verdictFile -Raw -Encoding utf8 | ConvertFrom-Json
         if ($existing.verdict -eq 'clean') {
-            Write-AutodevLog -Level CRITIC -Message "Reusing fresh CLEAN verdict (-ReuseVerdict); skipping codex re-run." -Config $Config
-            $reused = $true
+            # Verify the stored verdict was computed over the SAME diff we have now.
+            $currentDiff = if (Test-Path $diffPath) { Get-Content $diffPath -Raw -Encoding utf8 } else { '' }
+            $currentHash = Get-AutodevTextSha256 -Text $currentDiff
+            $storedHash = if ($existing.PSObject.Properties.Name -contains 'diff_sha256') { $existing.diff_sha256 } else { '' }
+            if ($storedHash -ne '' -and $storedHash -eq $currentHash) {
+                Write-AutodevLog -Level CRITIC -Message "Reusing CLEAN verdict (-ReuseVerdict); diff hash matches ($currentHash)." -Config $Config
+                $reused = $true
+            } else {
+                Write-AutodevLog -Level CRITIC -Message "Verdict hash mismatch (stored=$storedHash current=$currentHash); falling through to fresh critic run." -Config $Config
+            }
         }
     }
     if (-not $reused) {
@@ -228,12 +270,17 @@ function Invoke-ConductorIteration {
         return $task
     }
     if ($verdict.verdict -ne 'clean') {
-        Invoke-Escalation -Id "critic-$($task.id)" -Reason "critic $($verdict.verdict)" `
-            -Type $(if ($verdict.verdict -eq 'broken') { 'disagreement' } else { 'uncertain' }) -Task $task `
-            -What "Critic verdict: $($verdict.verdict). $($verdict.notes)" `
-            -Decision 'Override the critic, or fix the diff?' -OptionA 'Send back to worker' -OptionB 'Override (commit anyway)' `
-            -Cost 'a real contract break could land' -Evidence ($verdict | ConvertTo-Json -Depth 5)
-        Move-Task -TaskId $task.id -ToDir $Config.QueueActive
+        # Move-Task FIRST so the task is in escalated/ even if the artifact write throws.
+        Move-Task -TaskId $task.id -ToDir $Config.QueueEscalated
+        try {
+            Invoke-Escalation -Id "critic-$($task.id)" -Reason "critic $($verdict.verdict)" `
+                -Type $(if ($verdict.verdict -eq 'broken') { 'disagreement' } else { 'uncertain' }) -Task $task `
+                -What "Critic verdict: $($verdict.verdict). $($verdict.notes)" `
+                -Decision 'Override the critic, or fix the diff?' -OptionA 'Send back to worker' -OptionB 'Override (commit anyway)' `
+                -Cost 'a real contract break could land' -Evidence ($verdict | ConvertTo-Json -Depth 5)
+        } catch {
+            Write-AutodevLog -Level WARN -Message "Escalation artifact write failed for critic-$($task.id): $($_.Exception.Message)" -Config $Config
+        }
         return $task
     }
 
@@ -260,32 +307,49 @@ function Invoke-ConductorIteration {
         return $task
     }
 
-    if ($gate.decision -eq 'COMMIT' -or $GuardBootstrap) {
+    # -GuardBootstrap enters the commit path ONLY when the gate says COMMIT.
+    # Unknown / malformed gate decisions MUST NOT fall through to the commit path (fail-closed):
+    # only the literal string 'COMMIT' is accepted here; everything else routes to the ESCALATE
+    # handler below (including 'GARBAGE', empty string, or any future decision value).
+    if (Test-AutodevCommitDecision -Decision $gate.decision) {
         $kind = if ($task.type -eq 'guard') { 'test' } else { 'refactor' }
         $hash = Invoke-CommitTask -Task $task -Message "$kind(autodev): $($task.title)"
         Write-AutodevLog -Level GATE -Message "Committed $($task.id) as $hash." -Config $Config
         Move-Task -TaskId $task.id -ToDir $Config.QueueDone
         Add-Content -Path (Join-Path $Config.QueueDone "$($task.id).md") -Value "`n<!-- committed: $hash -->" -Encoding utf8
+        # Signal to the outer loop that this iteration produced an actual commit.
+        # This is the canonical commit-counter source; the outer loop MUST use this flag,
+        # not done/ file existence (which can be stale from a prior run of the same task id).
+        $script:iterationCommitted = $true
 
         if ($GuardBootstrap) {
             # section 6.5: one escalation for the operator to BLESS the new guards.
-            Invoke-Escalation -Id "bless-$($task.id)" -Reason 'bless new contract guards' -Type 'constitution' -Task $task `
-                -What "Committed $($hash): mutation-verified guards + GUARDS.md rows (blessed_by pending-operator). Until you bless, those zones still escalate." `
-                -Decision 'Bless these guards so their contract zones become autonomous?' `
-                -OptionA 'Bless (set blessed_by to your name in GUARDS.md)' -OptionB 'Reject / keep human-only' `
-                -Cost 'a wrong guard would auto-pass a real contract break' `
-                -Evidence ($gate | ConvertTo-Json -Depth 5)
+            try {
+                Invoke-Escalation -Id "bless-$($task.id)" -Reason 'bless new contract guards' -Type 'constitution' -Task $task `
+                    -What "Committed $($hash): mutation-verified guards + GUARDS.md rows (blessed_by pending-operator). Until you bless, those zones still escalate." `
+                    -Decision 'Bless these guards so their contract zones become autonomous?' `
+                    -OptionA 'Bless (set blessed_by to your name in GUARDS.md)' -OptionB 'Reject / keep human-only' `
+                    -Cost 'a wrong guard would auto-pass a real contract break' `
+                    -Evidence ($gate | ConvertTo-Json -Depth 5)
+            } catch {
+                Write-AutodevLog -Level WARN -Message "Escalation artifact write failed for bless-$($task.id): $($_.Exception.Message)" -Config $Config
+            }
         }
         return $task
     }
 
-    # ESCALATE (constitution / no-guard / guard-not-protecting / unblessed)
-    Invoke-Escalation -Id "gate-$($task.id)" -Reason 'gate escalation' `
-        -Type $(if ($gate.constitution_touched.Count -gt 0) { 'constitution' } else { 'needs-guard' }) -Task $task `
-        -What "Gate decision: ESCALATE. $($gate.reasons -join '; ')" `
-        -Decision 'Approve this change manually?' -OptionA 'Approve + commit' -OptionB 'Reject' `
-        -Cost 'touches an unguarded contract zone or the constitution' -Evidence ($gate | ConvertTo-Json -Depth 5)
-    Move-Task -TaskId $task.id -ToDir $Config.QueueActive
+    # ESCALATE (constitution / no-guard / guard-not-protecting / unblessed / empty file_set)
+    # Move-Task FIRST so the task is in escalated/ even if the artifact write throws.
+    Move-Task -TaskId $task.id -ToDir $Config.QueueEscalated
+    try {
+        Invoke-Escalation -Id "gate-$($task.id)" -Reason 'gate escalation' `
+            -Type $(if ($gate.constitution_touched.Count -gt 0) { 'constitution' } else { 'needs-guard' }) -Task $task `
+            -What "Gate decision: ESCALATE. $($gate.reasons -join '; ')" `
+            -Decision 'Approve this change manually?' -OptionA 'Approve + commit' -OptionB 'Reject' `
+            -Cost 'touches an unguarded contract zone or the constitution' -Evidence ($gate | ConvertTo-Json -Depth 5)
+    } catch {
+        Write-AutodevLog -Level WARN -Message "Escalation artifact write failed for gate-$($task.id): $($_.Exception.Message)" -Config $Config
+    }
     return $task
 }
 
@@ -332,12 +396,39 @@ function Invoke-ConductorSelfTest {
 
     Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
 
+    # (3) FAIL-CLOSED: a GARBAGE gate decision must NOT take the commit path.
+    # Calls Test-AutodevCommitDecision -- the SAME function the production commit path uses --
+    # so this test FAILS if someone changes the function to return $true for non-'COMMIT' values.
+    # Three inputs are checked: 'GARBAGE' -> $false, 'COMMIT' -> $true, 'ESCALATE' -> $false.
+    $c3_garbage  = (Test-AutodevCommitDecision -Decision 'GARBAGE')   # must be $false
+    $c3_commit   = (Test-AutodevCommitDecision -Decision 'COMMIT')    # must be $true
+    $c3_escalate = (Test-AutodevCommitDecision -Decision 'ESCALATE')  # must be $false
+    $c3_null     = (Test-AutodevCommitDecision -Decision $null)       # must be $false
+    $case3 = (-not $c3_garbage) -and $c3_commit -and (-not $c3_escalate) -and (-not $c3_null)
+    if ($case3) {
+        Write-Host "Case 3 PASS -- Test-AutodevCommitDecision: GARBAGE=$c3_garbage COMMIT=$c3_commit ESCALATE=$c3_escalate null=$c3_null (fail-closed verified)." -ForegroundColor Green
+    } else {
+        Write-Host "Case 3 FAIL -- Test-AutodevCommitDecision returned unexpected value(s): GARBAGE=$c3_garbage COMMIT=$c3_commit ESCALATE=$c3_escalate null=$c3_null" -ForegroundColor Red
+    }
+
+    # (4) ESCALATED outcome must NOT increment the commit counter.
+    # Calls Test-AutodevCounterIncrement -- the SAME function the outer loop uses -- so this
+    # test FAILS if someone changes the function to return $true when committed flag is $false.
+    $c4_notCommitted = (Test-AutodevCounterIncrement -IterationCommitted $false)  # must be $false
+    $c4_committed    = (Test-AutodevCounterIncrement -IterationCommitted $true)   # must be $true
+    $case4 = (-not $c4_notCommitted) -and $c4_committed
+    if ($case4) {
+        Write-Host "Case 4 PASS -- Test-AutodevCounterIncrement: notCommitted=$c4_notCommitted committed=$c4_committed (counter guard verified)." -ForegroundColor Green
+    } else {
+        Write-Host "Case 4 FAIL -- Test-AutodevCounterIncrement returned unexpected value(s): notCommitted=$c4_notCommitted committed=$c4_committed" -ForegroundColor Red
+    }
+
     Write-Host "--- Conductor circuit-breaker attempt-counter self-test ---"
     Write-Host "External pauses (worker/critic 429): max breaker input = $maxBreakerInput (threshold $max); never poisons = $externalNeverPoisons"
     Write-Host "Genuine failures: breaker fires after >$max attempts = $poisoned"
 
-    if ($externalNeverPoisons -and $poisoned) {
-        Write-Host "RESULT: PASS -- external pauses are refunded (no false poison); genuine failures still trip the breaker." -ForegroundColor Green
+    if ($externalNeverPoisons -and $poisoned -and $case3 -and $case4) {
+        Write-Host "RESULT: PASS -- external pauses are refunded (no false poison); genuine failures still trip the breaker; fail-closed gate; escalate does not increment counter." -ForegroundColor Green
         return 0
     } else {
         Write-Host "RESULT: FAIL" -ForegroundColor Red
@@ -350,15 +441,43 @@ function Invoke-ConductorSelfTest {
 # ----------------------------------------------------------------------------------
 if ($SelfTest) { exit (Invoke-ConductorSelfTest) }
 
+$sessionStart = Get-Date
 $iterations = 0
+$commitsSinceDrift = 0
 while ($true) {
+    # MaxSessionHours wall-clock cap: exit gracefully before spawning another worker.
+    $elapsedHours = ((Get-Date) - $sessionStart).TotalHours
+    if ($elapsedHours -ge $Config.MaxSessionHours) {
+        Write-AutodevLog -Level WARN -Message "MaxSessionHours ($($Config.MaxSessionHours)) reached after $([Math]::Round($elapsedHours,2)) h; stopping conductor." -Config $Config
+        break
+    }
     $did = Invoke-ConductorIteration
     $iterations++
+
+    # Anti-drift trigger: count successful COMMITs via the explicit flag set by the COMMIT route.
+    # Using the flag (not done/ file existence) prevents false-increments from reused task ids.
+    if ($null -ne $did -and (Test-AutodevCounterIncrement -IterationCommitted $script:iterationCommitted)) {
+        $commitsSinceDrift++
+        if ($commitsSinceDrift -ge $Config.AntiDriftEveryCommits) {
+            $commitsSinceDrift = 0
+            try {
+                Write-AutodevLog -Level INFO -Message "Anti-drift: running after $($Config.AntiDriftEveryCommits) commits ..." -Config $Config
+                # Pass the exact commit window so anti-drift reviews ALL commits since the last
+                # check, not just a fixed HEAD~3 default. $commitsSinceDrift was the running
+                # count before the reset above; use $Config.AntiDriftEveryCommits as the count.
+                $driftWindow = $Config.AntiDriftEveryCommits
+                & (Join-Path $here 'anti-drift.ps1') `
+                    -SinceRef "HEAD~$driftWindow" `
+                    -CommitsSinceLast $driftWindow | Out-Null
+            } catch {
+                Write-AutodevLog -Level WARN -Message "Anti-drift run failed (non-fatal): $($_.Exception.Message)" -Config $Config
+            }
+        }
+    }
+
     if ($Once) { break }
     if ($MaxIterations -gt 0 -and $iterations -ge $MaxIterations) { break }
     if ($null -eq $did) {
-        # idle: no claimable task. (Periodic jobs -- anti-drift/digest -- run here in a
-        # full deployment; in bootstrap they are exercised explicitly.)
         Start-Sleep -Seconds $SleepSeconds
     }
 }

--- a/tools/autodev/gate.ps1
+++ b/tools/autodev/gate.ps1
@@ -76,6 +76,29 @@ function Invoke-AutodevGate {
         [string]$ComposerSubcommand = 'check',
         [pscustomobject]$Config = (Get-AutodevConfig)
     )
+    # Empty/missing file_set: no files are owned by this task, so there is nothing safe to
+    # judge or commit. Escalate immediately -- checked BEFORE loading invariants/guards so
+    # that a load failure (missing INVARIANTS.md) cannot prevent writing the gate-verdict.json
+    # and cannot prevent the conductor from routing to escalation.
+    if (-not $Range -and (-not $FileSet -or $FileSet.Count -eq 0)) {
+        $emptyVerdict = [pscustomobject]@{
+            task_id              = $TaskId
+            composer_green       = $false
+            constitution_touched = @()
+            zones_touched        = @()
+            decision             = 'ESCALATE'
+            reasons              = @('empty file_set -- nothing can be safely judged')
+            changed_files        = @()
+        }
+        if ($TaskId) {
+            $rtDir = Join-Path $Config.Runtime $TaskId
+            if (-not (Test-Path $rtDir)) { New-Item -ItemType Directory -Path $rtDir -Force | Out-Null }
+            $emptyVerdict | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $rtDir 'gate-verdict.json') -Encoding utf8
+        }
+        Write-AutodevLog -Level GATE -Message "Task $TaskId has empty file_set; escalating." -Config $Config
+        return $emptyVerdict
+    }
+
     $inv = Get-AutodevInvariants -Config $Config
     $guards = Get-AutodevGuards -Config $Config
 

--- a/tools/autodev/invoke-critic.ps1
+++ b/tools/autodev/invoke-critic.ps1
@@ -55,9 +55,10 @@ if (-not $DiffPath) { $DiffPath = Join-Path $rtDir 'diff.patch' }
 $verdictPath = Join-Path $rtDir 'verdict.json'
 
 function Write-Verdict {
-    param([string]$Verdict, [string]$Notes, [double]$Confidence, [array]$Broken = @())
+    param([string]$Verdict, [string]$Notes, [double]$Confidence, [array]$Broken = @(), [string]$DiffSha256 = '')
     $v = [pscustomobject]@{
         verdict = $Verdict; broken_contracts = $Broken; notes = $Notes; confidence = $Confidence
+        diff_sha256 = $DiffSha256
     }
     $v | ConvertTo-Json -Depth 6 | Set-Content -Path $verdictPath -Encoding utf8
     $v | ConvertTo-Json -Depth 6
@@ -66,6 +67,7 @@ function Write-Verdict {
 
 if (-not (Test-Path $DiffPath)) { throw "Diff not found: $DiffPath" }
 $diffText = Get-Content -Path $DiffPath -Raw -Encoding utf8
+$diffSha256 = Get-AutodevTextSha256 -Text $diffText
 # @() guards the PS gotcha where a function returning an empty array unrolls to $null,
 # which then throws PropertyNotFoundStrict on .Count under Set-StrictMode -Version Latest
 # (a zone-free, non-contract diff produces zero touched zones -> previously crashed here).
@@ -86,7 +88,7 @@ if ($Mode -eq 'auto') {
 Write-AutodevLog -Level CRITIC -Message "Tier=$tier (zones touched: $($touchedZones -join ',' ); diff lines: $diffLineCount)" -Config $Config
 
 if ($tier -eq 'none' -or $tier -eq 'cheap') {
-    Write-Verdict -Verdict 'clean' -Confidence 0.5 `
+    Write-Verdict -Verdict 'clean' -Confidence 0.5 -DiffSha256 $diffSha256 `
         -Notes "cheap tier (zone-free, small diff): machine-gate-only. Zones touched: none. Diff lines: $diffLineCount." | Out-Null
     Get-Content $verdictPath -Raw
     exit 0
@@ -216,11 +218,11 @@ if ($null -eq $parsed -or -not ($parsed.PSObject.Properties.Name -contains 'verd
     # codex exit code; a benign rate-limit word in an already-parsed verdict cannot reach here.
     if (Test-RateLimited -ExitCode $exit -Stderr $combined) {
         Write-AutodevLog -Level CRITIC -Message "Critic rate-limited (no verdict, exit $exit); caller should back off." -Config $Config
-        Write-Verdict -Verdict 'uncertain' -Confidence 0.0 -Notes "critic rate-limited: $stderr" | Out-Null
+        Write-Verdict -Verdict 'uncertain' -Confidence 0.0 -DiffSha256 $diffSha256 -Notes "critic rate-limited: $stderr" | Out-Null
         exit 4
     }
     Write-AutodevLog -Level CRITIC -Message "Critic produced no parseable verdict (exit $exit). Routing to human." -Config $Config
-    Write-Verdict -Verdict 'uncertain' -Confidence 0.0 `
+    Write-Verdict -Verdict 'uncertain' -Confidence 0.0 -DiffSha256 $diffSha256 `
         -Notes "no parseable verdict from codex (exit $exit). stderr: $stderr" | Out-Null
     exit 3
 }
@@ -231,7 +233,7 @@ if ($parsed.PSObject.Properties.Name -contains 'broken_contracts' -and $parsed.b
 }
 $notes = if ($parsed.PSObject.Properties.Name -contains 'notes') { $parsed.notes } else { '' }
 $conf = if ($parsed.PSObject.Properties.Name -contains 'confidence') { [double]$parsed.confidence } else { 0.0 }
-Write-Verdict -Verdict $parsed.verdict -Confidence $conf -Notes $notes -Broken $broken | Out-Null
+Write-Verdict -Verdict $parsed.verdict -Confidence $conf -Notes $notes -Broken $broken -DiffSha256 $diffSha256 | Out-Null
 
 switch ($parsed.verdict) {
     'clean' { exit 0 }

--- a/tools/autodev/invoke-worker.ps1
+++ b/tools/autodev/invoke-worker.ps1
@@ -3,7 +3,8 @@
   Run a disposable worker (claude -p) on one task, with model ladder + watchdog.
 
 .DESCRIPTION
-  Spawns a fresh `claude -p` worker for a single task in its worktree. Implements:
+  Spawns a fresh `claude -p` worker for a single task in the repository working tree
+  (serialized by file_set disjointness -- no per-task git worktrees). Implements:
     - MODEL LADDER: starts at the task-declared tier when present (opus -> sonnet -> haiku
       for 'opus', sonnet -> haiku for 'sonnet', haiku only for 'haiku'); full ladder when
       no model is declared. Rate-limit step-downs only go to cheaper tiers.
@@ -57,14 +58,16 @@ function Build-WorkerPrompt {
     $taskBody = if (Test-Path $taskFile) { Get-Content $taskFile -Raw -Encoding utf8 } else { "(task file missing)" }
     return @"
 You are a disposable worker. You do ONE task, then you die. Your memory is the
-blackboard on disk, not your context. Use Serena for all PHP reads -- never the Read tool.
+blackboard on disk, not your context.
+Use Serena tools for PHP if they are available in your session; otherwise use Grep/Read.
 
 TASK: $TaskId  (full spec below, also at .autodev/queue/active/$TaskId.md)
 ANCHOR: read .autodev/GOAL.md before anything. Do not exceed the task scope.
 INVARIANTS: read .autodev/INVARIANTS.md. You MUST NOT break any contract zone.
 
 Rules:
-- Work in this git worktree: $Worktree . Touch ONLY files the task names in file_set.
+- Work in the repository working tree (serialized by file_set disjointness): $Worktree
+  Touch ONLY files the task names in file_set.
 - Make the smallest change that completes the task.
 - If the task needs >1 logical change, STOP: write worker-report.md status=TOO_BIG with a
   proposed decomposition. Do not code.
@@ -72,10 +75,12 @@ Rules:
   STOP: status=NEEDS_GUARD. Do not code.
 
 Output to .autodev/runtime/$TaskId/ :
-- the change WRITTEN TO DISK but NOT committed. Do NOT run ``git commit`` or ``git add``,
+- the change WRITTEN TO DISK but NOT committed. Do NOT run ``git commit`` or ``git add``;
   do NOT push, do NOT touch main. The conductor stages + commits your file_set ONLY after
   the gate passes -- committing yourself would land UNVERIFIED code on the branch (the gate
   is the lock, not you).
+  EXCEPTION: ``git add -N -- <file_set files>`` is the EXPLICIT sole allowed git-add
+  command; it intent-stages new files so they appear in ``git diff`` without staging content.
 - diff.patch  = run ``git add -N -- <your file_set files>`` then ``git diff -- <those files>``
   (so new files appear). The conductor also regenerates this authoritatively; this copy is
   for your own reference.
@@ -126,7 +131,7 @@ if ($DryRun) {
     Write-Host "TouchesContractZone: $([bool]$TouchesContractZone)"
     Write-Host "Ladder: $($ladder -join ' -> ')"
     foreach ($model in $ladder) {
-        Write-Host "  would run: $($Config.ClaudeExe) -p --model $model --permission-mode acceptEdits  (cwd=$Worktree, prompt via stdin, heartbeat=$heartbeat)"
+        Write-Host "  would run: $($Config.ClaudeExe) -p --model $model --permission-mode acceptEdits --max-turns $($Config.WorkerMaxTurns)  (cwd=$Worktree, prompt via stdin, heartbeat=$heartbeat)"
     }
     Write-Host "Prompt preview (first 280 chars):"
     Write-Host ($prompt.Substring(0, [Math]::Min(280, $prompt.Length)) + ' ...')
@@ -140,6 +145,7 @@ foreach ($model in $ladder) {
     # stdout is continuous -- this feeds the watchdog's process-driven liveness signal even
     # during long read/reason phases that have not yet written any file.
     $args = @('-p', '--model', $model, '--permission-mode', 'acceptEdits',
+              '--max-turns', [string]$Config.WorkerMaxTurns,
               '--verbose', '--output-format', 'stream-json')
     $r = Start-WatchedProcess -FilePath $Config.ClaudeExe -ArgumentList $args `
             -HeartbeatPath $heartbeat `

--- a/tools/autodev/mutation-check.ps1
+++ b/tools/autodev/mutation-check.ps1
@@ -39,11 +39,11 @@ function Invoke-GuardTest {
     param([string]$TestFile, [pscustomobject]$Config)
     $phpunit = Join-Path $Config.RepoRoot 'vendor\bin\phpunit.bat'
     if (-not (Test-Path $phpunit)) { $phpunit = Join-Path $Config.RepoRoot 'vendor\bin\phpunit' }
-    Push-Location $Config.RepoRoot
-    try {
-        $out = & $phpunit $TestFile 2>&1 | Out-String
-        return [pscustomobject]@{ Green = ($LASTEXITCODE -eq 0); Output = $out }
-    } finally { Pop-Location }
+    # Route through Invoke-Native so phpunit stderr (test summaries, notices) does not trigger
+    # NativeCommandError under $ErrorActionPreference='Stop' on Windows PowerShell 5.1.
+    # Exit-code semantics are preserved: non-zero = RED (expected on mutation step).
+    $r = Invoke-Native -Exe $phpunit -CommandArgs @($TestFile) -WorkingDirectory $Config.RepoRoot -Merge
+    return [pscustomobject]@{ Green = ($r.ExitCode -eq 0); Output = $r.Output }
 }
 
 function Write-Maybe { param([string]$Msg) if (-not $Quiet) { Write-Host $Msg } }

--- a/tools/autodev/scheduler.ps1
+++ b/tools/autodev/scheduler.ps1
@@ -36,15 +36,23 @@ $ErrorActionPreference = 'Stop'
 . (Join-Path (Split-Path -Parent $PSCommandPath) '_common.ps1')
 
 function Get-AutodevActiveFileSets {
+    <# Collects file_sets from BOTH active/ and escalated/ so that escalated tasks block
+       intersecting pending tasks exactly like active ones (serialization preserved). #>
     param([pscustomobject]$Config = (Get-AutodevConfig))
     $sets = @()
-    if (-not (Test-Path $Config.QueueActive)) { return $sets }
-    foreach ($f in Get-ChildItem -Path $Config.QueueActive -Filter '*.md' -File) {
-        try {
-            $t = ConvertFrom-AutodevTask -Path $f.FullName
-            $sets += , @($t.file_set)
-        } catch {
-            Write-AutodevLog -Level WARN -Message "Active task $($f.Name) unparseable: $($_.Exception.Message)"
+    $dirs = @($Config.QueueActive)
+    if ($Config.PSObject.Properties.Name -contains 'QueueEscalated' -and (Test-Path $Config.QueueEscalated)) {
+        $dirs += $Config.QueueEscalated
+    }
+    foreach ($dir in $dirs) {
+        if (-not (Test-Path $dir)) { continue }
+        foreach ($f in Get-ChildItem -Path $dir -Filter '*.md' -File) {
+            try {
+                $t = ConvertFrom-AutodevTask -Path $f.FullName
+                $sets += , @($t.file_set)
+            } catch {
+                Write-AutodevLog -Level WARN -Message "Task $($f.Name) unparseable: $($_.Exception.Message)"
+            }
         }
     }
     return $sets
@@ -118,7 +126,7 @@ function Invoke-ClaimNextTask {
         }
 
         if (-not (Test-TaskClaimable -Task $task -ActiveSets $activeSets)) {
-            Write-AutodevLog -Message "Task $($task.id) blocked: file_set intersects an active task (serialized)."
+            Write-AutodevLog -Message "Task $($task.id) blocked: file_set intersects an active or escalated task (serialized)."
             continue
         }
 
@@ -141,15 +149,28 @@ function Show-ClaimableReport {
     $activeSets = Get-AutodevActiveFileSets -Config $Config
     $report = @()
     foreach ($file in Get-AutodevPendingTasks -Config $Config) {
-        $task = ConvertFrom-AutodevTask -Path $file.FullName
+        $task = $null
+        try { $task = ConvertFrom-AutodevTask -Path $file.FullName }
+        catch { Write-AutodevLog -Level WARN -Message "Skipping unparseable pending task in report $($file.Name): $($_.Exception.Message)"; continue }
+
         $depsMet = Test-DependenciesMet -Task $task -Config $Config
         $fileDisjoint = Test-TaskClaimable -Task $task -ActiveSets $activeSets
         $claimable = $depsMet -and $fileDisjoint
         $blockedBy = @()
         if (-not $fileDisjoint) {
             foreach ($file2 in Get-ChildItem -Path $Config.QueueActive -Filter '*.md' -File) {
-                $at = ConvertFrom-AutodevTask -Path $file2.FullName
-                if (-not (Test-FileSetsDisjoint -A $task.file_set -B $at.file_set)) { $blockedBy += "active:$($at.id)" }
+                try {
+                    $at = ConvertFrom-AutodevTask -Path $file2.FullName
+                    if (-not (Test-FileSetsDisjoint -A $task.file_set -B $at.file_set)) { $blockedBy += "active:$($at.id)" }
+                } catch { Write-AutodevLog -Level WARN -Message "Skipping unparseable active task in report $($file2.Name): $($_.Exception.Message)" }
+            }
+            if ($Config.PSObject.Properties.Name -contains 'QueueEscalated' -and (Test-Path $Config.QueueEscalated)) {
+                foreach ($file2 in Get-ChildItem -Path $Config.QueueEscalated -Filter '*.md' -File) {
+                    try {
+                        $at = ConvertFrom-AutodevTask -Path $file2.FullName
+                        if (-not (Test-FileSetsDisjoint -A $task.file_set -B $at.file_set)) { $blockedBy += "escalated:$($at.id)" }
+                    } catch { Write-AutodevLog -Level WARN -Message "Skipping unparseable escalated task in report $($file2.Name): $($_.Exception.Message)" }
+                }
             }
         }
         if (-not $depsMet) {
@@ -170,16 +191,19 @@ function Show-ClaimableReport {
 function Invoke-SchedulerSelfTest {
     $cfg = Get-AutodevConfig
     $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("autodev-sched-" + [guid]::NewGuid().ToString('N'))
-    $pending = Join-Path $tmp 'queue\pending'
-    $active  = Join-Path $tmp 'queue\active'
-    $done    = Join-Path $tmp 'queue\done'
-    New-Item -ItemType Directory -Path $pending -Force | Out-Null
-    New-Item -ItemType Directory -Path $active  -Force | Out-Null
-    New-Item -ItemType Directory -Path $done    -Force | Out-Null
+    $pending   = Join-Path $tmp 'queue\pending'
+    $active    = Join-Path $tmp 'queue\active'
+    $done      = Join-Path $tmp 'queue\done'
+    $escalated = Join-Path $tmp 'queue\escalated'
+    New-Item -ItemType Directory -Path $pending   -Force | Out-Null
+    New-Item -ItemType Directory -Path $active    -Force | Out-Null
+    New-Item -ItemType Directory -Path $done      -Force | Out-Null
+    New-Item -ItemType Directory -Path $escalated -Force | Out-Null
     $testCfg = $cfg.PSObject.Copy()
-    $testCfg.QueuePending = $pending
-    $testCfg.QueueActive  = $active
-    $testCfg.QueueDone     = $done
+    $testCfg.QueuePending   = $pending
+    $testCfg.QueueActive    = $active
+    $testCfg.QueueDone      = $done
+    $testCfg.QueueEscalated = $escalated
 
     # ACTIVE task A holds class-plugin.php.
     $taskA = @('---', 'id: taskA', 'title: Active task editing class-plugin.php',
@@ -209,31 +233,43 @@ function Invoke-SchedulerSelfTest {
                'file_set:', '  - woodev/class-e.php', 'depends_on:', '  - depMissing', '---')
     Set-Content -Path (Join-Path $pending 'taskE.md') -Encoding utf8 -Value $taskE
 
+    # ESCALATED task F holds class-lifecycle.php (same as C) => escalated must block pending G.
+    $taskF = @('---', 'id: taskF', 'title: Escalated task holding class-lifecycle.php',
+               'file_set:', '  - woodev/class-lifecycle.php', '---')
+    Set-Content -Path (Join-Path $escalated 'taskF.md') -Encoding utf8 -Value $taskF
+
+    # PENDING task G: intersects escalated taskF => MUST be blocked (escalated acts as active).
+    $taskG = @('---', 'id: taskG', 'title: Pending task blocked by escalated taskF',
+               'file_set:', '  - woodev/class-lifecycle.php', '---')
+    Set-Content -Path (Join-Path $pending 'taskG.md') -Encoding utf8 -Value $taskG
+
     $report = Show-ClaimableReport -Config $testCfg
     $b = $report | Where-Object { $_.id -eq 'taskB' }
     $c = $report | Where-Object { $_.id -eq 'taskC' }
     $d = $report | Where-Object { $_.id -eq 'taskD' }
     $e = $report | Where-Object { $_.id -eq 'taskE' }
+    $g = $report | Where-Object { $_.id -eq 'taskG' }
 
     $pass = ($b.claimable -eq $false) -and ($b.blocked_by -eq 'active:taskA') -and `
-            ($c.claimable -eq $true) -and `
+            ($c.claimable -eq $false) -and ($c.blocked_by -eq 'escalated:taskF') -and `
             ($d.claimable -eq $true) -and `
-            ($e.claimable -eq $false) -and ($e.blocked_by -eq 'dep:depMissing')
+            ($e.claimable -eq $false) -and ($e.blocked_by -eq 'dep:depMissing') -and `
+            ($g.claimable -eq $false) -and ($g.blocked_by -eq 'escalated:taskF')
 
     Write-Host "--- Scheduler serialization + dependency self-test ---"
     $report | Format-Table -AutoSize | Out-String | Write-Host
-    Write-Host "Expected: B blocked by active:taskA; C claimable; D claimable (dep depDone in done/); E gated by dep:depMissing."
+    Write-Host "Expected: B blocked by active:taskA; C blocked by escalated:taskF; D claimable (dep depDone in done/); E gated by dep:depMissing; G blocked by escalated:taskF."
 
-    # Also prove the atomic claim actually serializes: claiming must take C, never B.
+    # Also prove the atomic claim actually serializes: claiming must take D (C and G are blocked by escalated F).
     $claimed = Invoke-ClaimNextTask -Config $testCfg
     $claimedId = if ($null -ne $claimed) { $claimed.id } else { '<none>' }
-    $claimedDisjoint = ($claimedId -eq 'taskC')
-    Write-Host "Claimed task id: $claimedId (expected taskC)"
+    $claimedDisjoint = ($claimedId -eq 'taskD')
+    Write-Host "Claimed task id: $claimedId (expected taskD -- C blocked by escalated:taskF)"
 
     Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
 
     if ($pass -and $claimedDisjoint) {
-        Write-Host "RESULT: PASS -- intersecting file_sets are serialized; disjoint task claimed." -ForegroundColor Green
+        Write-Host "RESULT: PASS -- intersecting file_sets serialized; escalated tasks block pending; disjoint task claimed." -ForegroundColor Green
         return 0
     } else {
         Write-Host "RESULT: FAIL" -ForegroundColor Red

--- a/tools/autodev/watchdog.ps1
+++ b/tools/autodev/watchdog.ps1
@@ -89,7 +89,9 @@ function Start-WatchedProcess {
         Err       = New-Object System.Text.StringBuilder
     })
     $sink = {
-        $d = $EventArgs.Data
+        # $Event.SourceEventArgs.Data works on both Windows PowerShell 5.1 and PS 7+.
+        # $EventArgs.Data is unreliable on 5.1 and silently drops lines, killing stdout liveness.
+        $d = $Event.SourceEventArgs.Data
         if ($null -ne $d) {
             $s = $Event.MessageData
             $s['LastTicks'] = [DateTime]::UtcNow.Ticks
@@ -164,20 +166,59 @@ function Start-WatchedProcess {
 }
 
 function Invoke-WatchdogSelfTest {
+    # Resolve the current PowerShell engine so child processes use the same binary.
+    # Hardcoding 'powershell' breaks on systems where only pwsh (PS 7+) is installed.
+    $psExe = if ($PSVersionTable.PSEdition -eq 'Core') { 'pwsh' } else { 'powershell' }
+
+    # Case 1: heartbeat-staleness kill.
     # Spawn a process that sleeps 60s but NEVER updates the heartbeat. With a 6s stale
     # window the watchdog must kill it well before it finishes.
     $hb = Join-Path ([System.IO.Path]::GetTempPath()) ("autodev-hb-" + [guid]::NewGuid().ToString('N'))
     $sleeper = 'Start-Sleep -Seconds 60'
-    Write-Host "Watchdog self-test: launching a 60s sleeper with a 6s stale window (no heartbeat updates)..."
+    Write-Host "Watchdog self-test case 1: launching a 60s sleeper with a 6s stale window (no heartbeat updates)..."
     $t0 = Get-Date
-    $r = Start-WatchedProcess -FilePath 'powershell' `
+    $r = Start-WatchedProcess -FilePath $psExe `
             -ArgumentList @('-NoProfile', '-Command', $sleeper) `
             -HeartbeatPath $hb -StaleSeconds 6 -TimeoutSeconds 120 -PollSeconds 2
     $elapsed = ((Get-Date) - $t0).TotalSeconds
     Remove-Item $hb -Force -ErrorAction SilentlyContinue
-    Write-Host ("Killed after {0:N0}s; TimedOut={1}; ExitCode={2}" -f $elapsed, $r.TimedOut, $r.ExitCode)
-    if ($r.TimedOut -and $elapsed -lt 30) {
-        Write-Host "RESULT: PASS -- watchdog killed the hung process on heartbeat staleness." -ForegroundColor Green
+    Write-Host ("  Killed after {0:N0}s; TimedOut={1}; ExitCode={2}" -f $elapsed, $r.TimedOut, $r.ExitCode)
+    $case1 = ($r.TimedOut -and $elapsed -lt 30)
+    if ($case1) {
+        Write-Host "  Case 1 PASS -- watchdog killed the hung process on heartbeat staleness." -ForegroundColor Green
+    } else {
+        Write-Host "  Case 1 FAIL" -ForegroundColor Red
+    }
+
+    # Case 2: stdout-liveness (sink must receive data).
+    # Spawn a short-lived process that emits lines to stdout. With a 6s stale window and
+    # NO heartbeat file the watchdog MUST stay alive long enough to let the process finish
+    # naturally (stdout events keep LastTicks fresh). If the event sink is broken (e.g.
+    # $EventArgs.Data instead of $Event.SourceEventArgs.Data), LastTicks never updates,
+    # the watchdog kills the process early as "stale", and TimedOut=true -- FAIL.
+    $hb2 = Join-Path ([System.IO.Path]::GetTempPath()) ("autodev-hb2-" + [guid]::NewGuid().ToString('N'))
+    # Emit one line per second for 8 seconds (> the 6s stale window) then exit normally.
+    $emitter = '1..8 | ForEach-Object { Write-Host "line $_"; Start-Sleep -Seconds 1 }'
+    Write-Host "Watchdog self-test case 2: 8s stdout-emitting process with 6s stale window (stdout keeps sink alive)..."
+    $t1 = Get-Date
+    $r2 = Start-WatchedProcess -FilePath $psExe `
+            -ArgumentList @('-NoProfile', '-Command', $emitter) `
+            -HeartbeatPath $hb2 -StaleSeconds 6 -TimeoutSeconds 60 -PollSeconds 1
+    $elapsed2 = ((Get-Date) - $t1).TotalSeconds
+    Remove-Item $hb2 -Force -ErrorAction SilentlyContinue
+    Write-Host ("  Elapsed {0:N0}s; TimedOut={1}; StdoutLines={2}" -f $elapsed2, $r2.TimedOut, ($r2.Stdout -split "`n" | Where-Object { $_.Trim() }).Count)
+    # Process must NOT have been killed (TimedOut=false) and must have emitted all 8 lines.
+    $linesReceived = ($r2.Stdout -split "`n" | Where-Object { $_.Trim() -match '^line \d' }).Count
+    $case2 = ((-not $r2.TimedOut) -and $linesReceived -ge 8)
+    if ($case2) {
+        Write-Host "  Case 2 PASS -- sink received all stdout lines; process ran to completion." -ForegroundColor Green
+    } else {
+        Write-Host "  Case 2 FAIL -- sink did not receive lines or process was killed early (linesReceived=$linesReceived, TimedOut=$($r2.TimedOut))." -ForegroundColor Red
+    }
+
+    Write-Host "--- Watchdog self-test summary ---"
+    if ($case1 -and $case2) {
+        Write-Host "RESULT: PASS -- heartbeat-staleness kill + stdout-liveness both verified." -ForegroundColor Green
         return 0
     }
     Write-Host "RESULT: FAIL" -ForegroundColor Red


### PR DESCRIPTION
## What
Full tooling review of `tools/autodev/` (recorded in `docs-internal/reviews/autodev-loop-review-2026-06-11.md`) + remediation of everything fixable in-session (items 1,3–8,10,13,15; follow-ups recorded for Telegram reply ingestion, real worktrees, resume journal).

Headliners:
- **Stranded escalations fixed** — NEEDS_GUARD/BLOCKED/critic/gate escalations were a `Move-Task` no-op into `active/` (stuck forever, blocking intersecting file_sets). New `queue/escalated/` dir; scheduler treats it as blocking, never claims it.
- **Fail-closed commit path** — only an exact `COMMIT` gate decision commits; `-GuardBootstrap` can no longer override; empty `file_set` → ESCALATE, never COMMIT. Decision/counter logic extracted into pure functions tested by self-tests (non-tautology proven by flip-test).
- **anti-drift actually wired** — previously never invoked (comments only) and its digest-append was unimplemented; now runs every `AntiDriftEveryCommits` real COMMITs over the full since-last window and appends its verdict line to `digest.md`.
- **Cost caps** — `--max-turns` per worker + `MaxSessionHours` graceful loop exit.
- **`-ReuseVerdict` diff-hash bound; watchdog stdout-liveness fixed (PS 5.1); Invoke-Native everywhere; worker-prompt honesty cleanup.**

## Verification
`conductor -SelfTest` (4 cases incl. fail-closed + counter guard), `scheduler -SelfTest` (incl. escalated-blocks case), `watchdog -SelfTest` (incl. stdout-liveness case) — all PASS, re-run by the orchestrator. No PHP touched.

## Review trail
GPT-5.5 high (codex, read-only): BLOCK ×3 with real catches (GuardBootstrap fail-open; anti-drift `HEAD~3` window vs 5-commit cadence; tautological self-tests; escalation-write crash paths) → all fixed → final **zero must-fix**. One critic must-fix refuted with call-site evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)