### PR TITLE
refactor(licensing): cheap-check-first condition + ?? over isset

### DIFF
--- a/woodev/licensing/class-plugin-license.php
+++ b/woodev/licensing/class-plugin-license.php
@@ -530,7 +530,7 @@ if ( ! class_exists( 'Woodev_Plugins_License' ) ) :
 					)
 				);
 
-				if ( $this->woodev_license->success && ! empty( $this->woodev_license->license ) ) {
+				if ( ! empty( $this->woodev_license->license ) && $this->woodev_license->success ) {
 
 					$this->woodev_license->save( $license_data->get_response_data() );
 					// Clean plugins cache
@@ -743,7 +743,7 @@ if ( ! class_exists( 'Woodev_Plugins_License' ) ) :
 		 * @return object|string|null
 		 */
 		public function get_license_data() {
-			return isset( $this->woodev_license->data ) ? $this->woodev_license->data : null;
+			return $this->woodev_license->data ?? null;
 		}
 
 		/**


### PR DESCRIPTION
Two cosmetic cleanups in `Woodev_Plugins_License` (operator IDE edits from the s8 pre-rebase stash, not superseded by s6-p1 as previously assumed):

- license-save guard reordered to short-circuit on the cheap `! empty()` check first;
- `get_license_data()` uses `?? null` instead of `isset() ? : null` (project convention).

No behavior change. `composer check` green locally: PHPCS, PHPStan 0, 337 tests / 1107 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)