### PR TITLE
feat(s3): embed production License_Authority public key

### DIFF
--- a/woodev/licensing/class-license-envelope-verifier.php
+++ b/woodev/licensing/class-license-envelope-verifier.php
@@ -15,12 +15,14 @@
 
 defined( 'ABSPATH' ) || exit;
 
-// The framework embeds the Woodev authority PUBLIC key (base64) here. Defined
-// with a placeholder so the file is self-contained; the production key is
-// injected post-deploy. An empty/undecodable key makes every verification fail,
-// which is the safe default (claims locked, commands rejected).
+// The Woodev authority PUBLIC key (base64, Ed25519/32 bytes) — the PRODUCTION
+// key captured from woodev.ru on 2026-06-12 (woodev-core License_Authority,
+// option woodev_license_authority_keys; capture procedure in the woodev-core
+// signing spec). Rotating the server key invalidates every issued claim and
+// command and REQUIRES updating this constant in lockstep. An empty or
+// undecodable value makes every verification fail — the safe default.
 if ( ! defined( 'WOODEV_LICENSE_AUTHORITY_PUBKEY' ) ) {
-	define( 'WOODEV_LICENSE_AUTHORITY_PUBKEY', '' );
+	define( 'WOODEV_LICENSE_AUTHORITY_PUBKEY', '6N6HaUIrqZMuyDTYjvazMoQjpHwdeyLbmz5Zu3Fh2rM=' );
 }
 
 if ( ! class_exists( 'Woodev_License_Envelope_Verifier' ) ) :


### PR DESCRIPTION
Embeds the PRODUCTION Ed25519 public key (captured from woodev.ru 12.06.2026 via the woodev-core spec's wp-eval snippet) as `WOODEV_LICENSE_AUTHORITY_PUBKEY`, replacing the fail-closed placeholder.

- Activates §4 signed-claim verification and S3.3 command-signature verification against the real server key.
- `test_production_pubkey_is_not_placeholder` un-skips and passes (strict base64, 32 bytes): sodium unit suite **600/600, zero skips** (was 1 by-design skip).
- `composer check` green; no other test depended on the placeholder (all crypto tests inject fixture keys explicitly).
- Captured value + rotation warning recorded in the woodev-core signing spec (woodev_theme local commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)