### PR TITLE
feat(licensing): send framework_version on every licensing API request

### DIFF
--- a/tests/unit/PlatformNeutralLicensingTest.php
+++ b/tests/unit/PlatformNeutralLicensingTest.php
@@ -216,6 +216,43 @@ class PlatformNeutralLicensingTest extends TestCase {
 	}
 
 	/**
+	 * get_body() merges framework_version into EVERY request's defaults — the
+	 * server-side "is this site webhook-capable?" signal (additive request param;
+	 * explicit caller params still win via wp_parse_args, url/author/email defaults
+	 * unchanged).
+	 *
+	 * @return void
+	 */
+	public function test_get_body_adds_framework_version_default(): void {
+		Functions\when( 'home_url' )->justReturn( 'https://example.com' );
+		Functions\when( 'get_option' )->justReturn( 'admin@example.com' );
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults ) {
+				return array_merge( $defaults, $args );
+			}
+		);
+
+		$plugin = new Testable_Platform_Neutral_Licensing_Plugin();
+		$api    = new \Woodev_Licensing_API( $plugin );
+
+		$method = new \ReflectionMethod( \Woodev_Licensing_API::class, 'get_body' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$body = $method->invoke( $api, array( 'edd_action' => 'check_license', 'license' => 'KEY' ) );
+
+		$this->assertSame( \Woodev_Plugin::VERSION, $body['framework_version'] );
+		$this->assertSame( 'https://example.com', $body['url'] );
+		$this->assertSame( 'Woodev', $body['author'] );
+		$this->assertSame( 'check_license', $body['edd_action'] );
+
+		// An explicit caller value must never be overridden by the default.
+		$body = $method->invoke( $api, array( 'framework_version' => 'caller-wins' ) );
+		$this->assertSame( 'caller-wins', $body['framework_version'] );
+	}
+
+	/**
 	 * License message date formatting should not require WooCommerce helpers in a platform-neutral unit context.
 	 *
 	 * This test's contract is the ABSENCE of WooCommerce/WP date helpers

--- a/woodev/licensing/api/class-licensing-api.php
+++ b/woodev/licensing/api/class-licensing-api.php
@@ -127,9 +127,15 @@ if ( ! class_exists( 'Woodev_Licensing_API' ) ) :
 			return wp_parse_args(
 				$api_params,
 				array(
-					'url'    => home_url(),
-					'author' => 'Woodev',
-					'email'  => get_option( 'admin_email' ),
+					'url'               => home_url(),
+					'author'            => 'Woodev',
+					'email'             => get_option( 'admin_email' ),
+					// Additive: tells the server which framework version the site runs —
+					// e.g. whether it is webhook-capable (the woodev/v1/license-command
+					// endpoint exists on framework >= 2.0.0). Every licensing request
+					// funnels through here (dispatch() AND the updater), so the server
+					// sees it on check_license, activate/deactivate and get_version.
+					'framework_version' => Woodev_Plugin::VERSION,
 				)
 			);
 		}


### PR DESCRIPTION
Adds `framework_version => Woodev_Plugin::VERSION` to the `get_body()` defaults in `Woodev_Licensing_API` — the single funnel every licensing request passes through (`dispatch()` and the updater's `get_version`).

**Why:** the server side (woodev-plugins-deactivator, spec in woodev_theme) needs to know per-site whether the framework is webhook-capable (≥ 2.0.0 has the `woodev/v1/license-command` endpoint) to gate the remote-deactivate button.

- Purely additive request param — existing keys byte-for-byte (test pins url/author + caller-wins semantics).
- 601 unit tests green (sodium: zero skips), composer check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)