### PR TITLE
feat!: bump framework version to 2.0.0

### DIFF
--- a/docs-internal/FUTURE-BACKLOG.md
+++ b/docs-internal/FUTURE-BACKLOG.md
@@ -26,6 +26,20 @@
 
 ## Technical Debt
 
+### Big consistency review: @since annotations + long array() syntax (operator request, 12.06.2026)
+- **What's wrong:** (1) v2-era code carries `@since 1.4.1` (and other stale versions) — the
+  framework was bumped to 2.0.0 on 12.06.2026, every symbol ADDED during the v2 program
+  must say `@since 2.0.0`; (2) agents keep writing `array()` where the project convention
+  is short `[]` (CLAUDE.md → Coding Conventions) — the codebase is inconsistent.
+- **Action when triggered:** one dedicated review session: (a) sweep `@since`/`@version`
+  tags against git history (symbols introduced on the v2 branch → `2.0.0`); (b) convert
+  long array syntax to `[]` across `woodev/` and `tests/`; (c) ENFORCE both going forward —
+  add `Generic.Arrays.DisallowLongArraySyntax` to phpcs.xml so phpcbf auto-fixes and CI
+  pins the convention (no more agent drift).
+- **Why deferred:** pure mechanical churn — schedule between feature blocks; the phpcs rule
+  makes the fix one `composer phpcbf` run plus a docblock sweep.
+- **When:** operator-scheduled "большое ревью" session (after the deactivator deployment).
+
 ### PHPStan Baseline Cleanup
 - **What's done:** 50+ errors baselined in phpstan-baseline.neon
 - **What's missing:** Fix or properly type-annotate each ignored error

--- a/tests/_fixtures/woodev-edostavka-pilot-plugin/woodev-edostavka-pilot-plugin.php
+++ b/tests/_fixtures/woodev-edostavka-pilot-plugin/woodev-edostavka-pilot-plugin.php
@@ -24,7 +24,7 @@ function woodev_edostavka_pilot_plugin_loader_definition(): array {
 		'plugin_id'         => 'woodev-edostavka-pilot',
 		'plugin_name'       => 'Woodev Edostavka Pilot Fixture',
 		'plugin_version'    => WOODEV_EDOSTAVKA_PILOT_VERSION,
-		'framework_version' => '1.4.1',
+		'framework_version' => '2.0.0',
 		'plugin_file'       => WOODEV_EDOSTAVKA_PILOT_FILE,
 		'platform'          => \Woodev\Framework\Framework_Plugin_Loader_Definition::PLATFORM_WOOCOMMERCE,
 		'requirements'      => [

--- a/tests/_fixtures/woodev-realistic-payment-plugin/woodev-realistic-payment-plugin.php
+++ b/tests/_fixtures/woodev-realistic-payment-plugin/woodev-realistic-payment-plugin.php
@@ -24,7 +24,7 @@ function woodev_realistic_payment_plugin_loader_definition(): array {
 		'plugin_id'         => 'woodev-realistic-payment',
 		'plugin_name'       => 'Woodev Realistic Payment Fixture',
 		'plugin_version'    => WOODEV_REALISTIC_PAYMENT_VERSION,
-		'framework_version' => '1.4.1',
+		'framework_version' => '2.0.0',
 		'plugin_file'       => WOODEV_REALISTIC_PAYMENT_FILE,
 		'platform'          => \Woodev\Framework\Framework_Plugin_Loader_Definition::PLATFORM_WOOCOMMERCE,
 		'requirements'      => [

--- a/tests/_fixtures/woodev-realistic-shipping-plugin/woodev-realistic-shipping-plugin.php
+++ b/tests/_fixtures/woodev-realistic-shipping-plugin/woodev-realistic-shipping-plugin.php
@@ -24,7 +24,7 @@ function woodev_realistic_shipping_plugin_loader_definition(): array {
 		'plugin_id'         => 'woodev-realistic-shipping',
 		'plugin_name'       => 'Woodev Realistic Shipping Fixture',
 		'plugin_version'    => WOODEV_REALISTIC_SHIPPING_VERSION,
-		'framework_version' => '1.4.1',
+		'framework_version' => '2.0.0',
 		'plugin_file'       => WOODEV_REALISTIC_SHIPPING_FILE,
 		'platform'          => \Woodev\Framework\Framework_Plugin_Loader_Definition::PLATFORM_WOOCOMMERCE,
 		'requirements'      => [

--- a/tests/_fixtures/woodev-yandex-pilot-plugin/woodev-yandex-pilot-plugin.php
+++ b/tests/_fixtures/woodev-yandex-pilot-plugin/woodev-yandex-pilot-plugin.php
@@ -28,7 +28,7 @@ function woodev_yandex_pilot_plugin_loader_definition(): array {
 		'plugin_id'         => 'yandex_delivery',
 		'plugin_name'       => 'Woodev Yandex Pilot Fixture',
 		'plugin_version'    => WOODEV_YANDEX_PILOT_VERSION,
-		'framework_version' => '1.4.1',
+		'framework_version' => '2.0.0',
 		'plugin_file'       => WOODEV_YANDEX_PILOT_FILE,
 		'platform'          => \Woodev\Framework\Framework_Plugin_Loader_Definition::PLATFORM_WOOCOMMERCE,
 		'requirements'      => [

--- a/woodev/class-plugin.php
+++ b/woodev/class-plugin.php
@@ -12,12 +12,12 @@ if ( ! class_exists( 'Woodev_Plugin' ) ) :
 	 * plugin.  This class handles all the "non-feature" support tasks such
 	 * as verifying dependencies are met, loading the text domain, etc.
 	 *
-	 * @version 1.4.1
+	 * @version 2.0.0
 	 */
 	abstract class Woodev_Plugin {
 
 		/** Plugin Framework Version */
-		const VERSION = '1.4.1';
+		const VERSION = '2.0.0';
 
 		/** @var object single instance of plugin */
 		protected static $instance;


### PR DESCRIPTION
Bumps `Woodev_Plugin::VERSION` 1.4.1 → 2.0.0 (+ `@version` docblock + v2 fixture loader definitions; MixedFleet legacy-simulation values deliberately untouched).

**Why now:** the webhook-capability signal was lying — `framework_version` (PR #38) reported 1.4.1 while the deactivator gating (D-PD5) checks ≥ 2.0.0. After this bump a site on current main correctly reports itself webhook-capable. All `@since 2.0.0` annotations now match reality.

**Note:** merging triggers the automatic release pipeline → tag `v2.0.0` + GitHub release.

Also records the operator-requested consistency-review backlog item (@since sweep + `array()`→`[]` + phpcs enforcement).

- 601 unit tests green (sodium: zero skips), 41/41 integration in wp-env, composer check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)