### PR TITLE
test(licensing): fix red unit matrix on main (stub get_support_url on dispatcher test mock)

### DIFF
--- a/tests/unit/LicenseCommandDispatcherTest.php
+++ b/tests/unit/LicenseCommandDispatcherTest.php
@@ -2107,6 +2107,7 @@ class LicenseCommandDispatcherTest extends TestCase {
 		$plugin->shouldReceive( 'get_id' )->andReturn( 'test_plugin' );
 		$plugin->shouldReceive( 'get_plugin_file' )->andReturn( 'test-plugin/test-plugin.php' );
 		$plugin->shouldReceive( 'get_plugin_name' )->andReturn( 'Test Plugin' );
+		$plugin->shouldReceive( 'get_support_url' )->andReturn( null );
 
 		$engine = Mockery::mock( \Woodev_Plugins_License::class );
 		$engine->shouldReceive( 'get_plugin' )->andReturn( $plugin );


### PR DESCRIPTION
Follow-up to #41. `execute()` now calls `$plugin->get_support_url()` for the 2.0.1 notice link, but the strict plugin mock in `test_hook_failure_then_redelivery_converges_to_already` lacked the stub → dispatcher caught the `BadMethodCallException` → `'failed'` → hook never fired → `InvalidCountException`. The test skips in isolation, so it only surfaced in the full-suite matrix order, landing red on main after #41 merged.

One-line fix: stub `get_support_url` like the other execute-path mocks. Restores the green unit matrix → unblocks the 2.0.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)