### PR TITLE
feat(licensing): s12 remote-deactivation UX — clear notice on reactivation + WC inbox breadcrumb

### DIFF
--- a/tests/unit/LicenseCommandDeactivateTest.php
+++ b/tests/unit/LicenseCommandDeactivateTest.php
@@ -1042,6 +1042,98 @@ class LicenseCommandDeactivateTest extends TestCase {
 	}
 
 	/* ----------------------------------------------------------------------- *
+	 * Finding A (s12) — clear stale notice on (re)activation
+	 * ----------------------------------------------------------------------- */
+
+	/**
+	 * clear_remote_deactivation_artifacts() removes ONLY the target plugin's entry
+	 * from the notices option and rewrites the remainder (other plugins untouched).
+	 *
+	 * @return void
+	 */
+	public function test_clear_artifacts_removes_only_target_entry(): void {
+
+		$plugin = Mockery::mock( \Woodev_Plugin::class );
+		$plugin->shouldReceive( 'get_id' )->andReturn( self::PLUGIN_ID );
+		$plugin->shouldReceive( 'get_id_dasherized' )->andReturn( self::PLUGIN_ID );
+
+		$stored = array(
+			self::PLUGIN_ID => array( 'message' => 'stale', 'ts' => 1 ),
+			'other-plugin'  => array( 'message' => 'keep', 'ts' => 2 ),
+		);
+
+		Functions\when( 'get_option' )->justReturn( $stored );
+
+		$written = null;
+		Functions\expect( 'update_option' )
+			->once()
+			->with(
+				'woodev_license_remote_deactivation_notices',
+				Mockery::on(
+					static function ( $v ) use ( &$written ) {
+						$written = $v;
+						return is_array( $v );
+					}
+				),
+				'no'
+			)
+			->andReturn( true );
+		Functions\expect( 'delete_option' )->never();
+
+		\Woodev_License_Command_Deactivate_Plugin::clear_remote_deactivation_artifacts( $plugin );
+
+		$this->assertArrayNotHasKey( self::PLUGIN_ID, $written );
+		$this->assertArrayHasKey( 'other-plugin', $written );
+	}
+
+	/**
+	 * clear_remote_deactivation_artifacts() deletes the whole option when removing
+	 * the target leaves it empty (no orphan empty array left behind).
+	 *
+	 * @return void
+	 */
+	public function test_clear_artifacts_deletes_option_when_empty(): void {
+
+		$plugin = Mockery::mock( \Woodev_Plugin::class );
+		$plugin->shouldReceive( 'get_id' )->andReturn( self::PLUGIN_ID );
+		$plugin->shouldReceive( 'get_id_dasherized' )->andReturn( self::PLUGIN_ID );
+
+		Functions\when( 'get_option' )->justReturn(
+			array( self::PLUGIN_ID => array( 'message' => 'stale', 'ts' => 1 ) )
+		);
+
+		Functions\expect( 'delete_option' )
+			->once()
+			->with( 'woodev_license_remote_deactivation_notices' )
+			->andReturn( true );
+		Functions\expect( 'update_option' )->never();
+
+		\Woodev_License_Command_Deactivate_Plugin::clear_remote_deactivation_artifacts( $plugin );
+	}
+
+	/**
+	 * clear_remote_deactivation_artifacts() writes NOTHING when the plugin has no
+	 * pending entry (no needless option churn on every activation).
+	 *
+	 * @return void
+	 */
+	public function test_clear_artifacts_no_write_when_no_entry(): void {
+
+		$plugin = Mockery::mock( \Woodev_Plugin::class );
+		$plugin->shouldReceive( 'get_id' )->andReturn( self::PLUGIN_ID );
+		$plugin->shouldReceive( 'get_id_dasherized' )->andReturn( self::PLUGIN_ID );
+
+		Functions\when( 'get_option' )->justReturn(
+			array( 'other-plugin' => array( 'message' => 'keep', 'ts' => 2 ) )
+		);
+
+		Functions\expect( 'update_option' )->never();
+		Functions\expect( 'delete_option' )->never();
+
+		\Woodev_License_Command_Deactivate_Plugin::clear_remote_deactivation_artifacts( $plugin );
+	}
+
+	/* ----------------------------------------------------------------------- *
 	 * Helpers
 	 * ----------------------------------------------------------------------- */
 

--- a/tests/unit/NotesHelperTest.php
+++ b/tests/unit/NotesHelperTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for Woodev_Notes_Helper::add_note() (s12 — Finding B breadcrumb creator).
+ *
+ * The unit suite has no WooCommerce, so the WC Admin Notes API is absent. add_note()
+ * must self-guard and return false WITHOUT side effects in that case — this is what
+ * lets the heavily mocked remote-deactivation command call it unconditionally on the
+ * executed path without tripping any of its persistence-seam assertions.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace Woodev\Tests\Unit;
+
+require_once dirname( __DIR__, 2 ) . '/woodev/admin/class-notes-helper.php';
+
+/**
+ * Class NotesHelperTest.
+ */
+class NotesHelperTest extends TestCase {
+
+	/**
+	 * Without the WooCommerce Admin Notes API, add_note() is a no-op returning false.
+	 *
+	 * @return void
+	 */
+	public function test_add_note_returns_false_without_wc_admin(): void {
+
+		$this->assertFalse(
+			class_exists( '\Automattic\WooCommerce\Admin\Notes\Note' ),
+			'Guard precondition: the unit suite must NOT have the WC Admin Notes API.'
+		);
+
+		$this->assertFalse(
+			\Woodev_Notes_Helper::add_note(
+				'woodev-test-remote-deactivated',
+				'woodev-test',
+				'Плагин Test отключён',
+				'Лицензия недействительна для этого сайта.',
+				array(
+					array(
+						'name'  => 'support',
+						'label' => 'Связаться с нами',
+						'url'   => 'https://woodev.ru/support/',
+					),
+				)
+			),
+			'add_note() must return false (no-op) when WooCommerce Admin is unavailable.'
+		);
+	}
+}

--- a/tests/unit/PlatformNeutralLifecycleTest.php
+++ b/tests/unit/PlatformNeutralLifecycleTest.php
@@ -8,9 +8,13 @@
 namespace Woodev\Tests\Unit;
 
 use Brain\Monkey\Functions;
+use Brain\Monkey\Actions;
 use Mockery;
 
 require_once dirname( __DIR__, 2 ) . '/woodev/class-lifecycle.php';
+require_once dirname( __DIR__, 2 ) . '/woodev/class-plugin.php';
+require_once dirname( __DIR__, 2 ) . '/woodev/licensing/commands/interface-license-command.php';
+require_once dirname( __DIR__, 2 ) . '/woodev/licensing/commands/class-license-command-deactivate-plugin.php';
 
 /**
  * Test wpdb double for lifecycle event persistence.
@@ -169,6 +173,58 @@ class PlatformNeutralLifecycleTest extends TestCase {
 		$this->assertSame( '2.0.0', $stored_history[0]['version'] );
 		$this->assertSame( '1.9.0', $stored_history[0]['data']['from_version'] );
 		$this->assertSame( 'alert(1)ready', $stored_history[0]['data']['nested']['note'] );
+	}
+
+	/**
+	 * Finding A (s12): a genuine (re)activation transition clears this plugin's own
+	 * stale entry from the remote-deactivation notices option (other plugins kept)
+	 * so a reactivated plugin never shows a "you were disabled" banner.
+	 *
+	 * @return void
+	 */
+	public function test_handle_activation_clears_stale_remote_deactivation_notice(): void {
+
+		$id = 'platform-neutral-lifecycle';
+
+		$plugin = Mockery::mock( \Woodev_Plugin::class );
+		$plugin->shouldReceive( 'get_id' )->andReturn( $id );
+		$plugin->shouldReceive( 'get_id_dasherized' )->andReturn( $id );
+
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = false ) use ( $id ) {
+				if ( 'woodev_' . $id . '_is_active' === $name ) {
+					return false; // not yet active → genuine activation transition.
+				}
+				if ( 'woodev_license_remote_deactivation_notices' === $name ) {
+					return array(
+						$id      => array( 'message' => 'stale', 'ts' => 1 ),
+						'other'  => array( 'message' => 'keep', 'ts' => 2 ),
+					);
+				}
+				return $default;
+			}
+		);
+		Functions\when( 'wp_reschedule_event' )->justReturn( true );
+		Functions\when( 'delete_option' )->justReturn( true );
+
+		$writes = array();
+		Functions\when( 'update_option' )->alias(
+			static function ( $name, $value, $autoload = '' ) use ( &$writes ) {
+				$writes[ $name ] = $value;
+				return true;
+			}
+		);
+
+		Actions\expectDone( 'woodev_' . $id . '_activated' )->once();
+
+		$lifecycle = new Testable_Platform_Neutral_Lifecycle( $plugin );
+		$lifecycle->handle_activation();
+
+		$this->assertArrayHasKey( 'woodev_license_remote_deactivation_notices', $writes );
+		$notices = $writes[ 'woodev_license_remote_deactivation_notices' ];
+		$this->assertArrayNotHasKey( $id, $notices, 'The reactivated plugin\'s own stale notice must be removed.' );
+		$this->assertArrayHasKey( 'other', $notices, 'Other plugins\' notices must be preserved.' );
+		$this->assertSame( 'yes', $writes[ 'woodev_' . $id . '_is_active' ] );
 	}
 
 	/**

--- a/woodev/admin/class-notes-helper.php
+++ b/woodev/admin/class-notes-helper.php
@@ -160,9 +160,9 @@ if ( ! class_exists( 'Woodev_Notes_Helper' ) ) :
 					$note->add_action( $action['name'], $action['label'], $action['url'] ?? '' );
 				}
 
-				$note->save();
-
-				return true;
+				// WC_Data::save() returns the saved note id (> 0); cast so a silent
+				// non-throwing save failure (id 0) is reported as false per the contract.
+				return (bool) $note->save();
 
 			} catch ( \Throwable $exception ) {
 				return false;

--- a/woodev/admin/class-notes-helper.php
+++ b/woodev/admin/class-notes-helper.php
@@ -105,6 +105,69 @@ if ( ! class_exists( 'Woodev_Notes_Helper' ) ) :
 				}
 			}
 		}
+
+
+		/** Setter methods */
+
+
+		/**
+		 * Creates (or updates, by name) a single WooCommerce Admin inbox note.
+		 *
+		 * Best-effort and self-guarding: returns false without side effects when the
+		 * WooCommerce Admin Notes API is absent, so callers (incl. the heavily
+		 * unit-tested remote-deactivation command) can call it unconditionally in any
+		 * environment. An existing note with the same name is revived and updated
+		 * rather than duplicated. Each action is `[ 'name' => , 'label' => , 'url' => ]`.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string                                                       $name    Unique note name (used for dedup).
+		 * @param string                                                       $source  Note source (plugin id-dasherized).
+		 * @param string                                                       $title   Note title.
+		 * @param string                                                       $content Note content.
+		 * @param array<int, array{name: string, label: string, url?: string}> $actions Optional action buttons.
+		 * @return bool True when the note was saved, false when WC Admin is unavailable or saving failed.
+		 */
+		public static function add_note( string $name, string $source, string $title, string $content, array $actions = [] ): bool {
+
+			if ( ! class_exists( '\Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+				return false;
+			}
+
+			try {
+
+				$note = self::get_note_with_name( $name );
+
+				if ( ! $note ) {
+					$note = new Automattic\WooCommerce\Admin\Notes\Note();
+					$note->set_name( $name );
+				}
+
+				$note->set_source( $source );
+				$note->set_type( Automattic\WooCommerce\Admin\Notes\Note::E_WC_ADMIN_NOTE_ERROR );
+				$note->set_title( $title );
+				$note->set_content( $content );
+				$note->set_status( Automattic\WooCommerce\Admin\Notes\Note::E_WC_ADMIN_NOTE_UNACTIONED );
+
+				$note->set_actions( [] );
+
+				foreach ( $actions as $action ) {
+
+					if ( empty( $action['name'] ) || empty( $action['label'] ) ) {
+						continue;
+					}
+
+					$note->add_action( $action['name'], $action['label'], $action['url'] ?? '' );
+				}
+
+				$note->save();
+
+				return true;
+
+			} catch ( \Throwable $exception ) {
+				return false;
+			}
+		}
 	}
 
 endif;

--- a/woodev/class-lifecycle.php
+++ b/woodev/class-lifecycle.php
@@ -135,6 +135,14 @@ if ( ! class_exists( 'Woodev_Lifecycle' ) ) :
 
 				$this->activate();
 
+				// The plugin is active again — clear any stale "remotely deactivated"
+				// artifacts for it (Finding A, s12) so the admin never sees a "you were
+				// disabled" banner/inbox note for a plugin that is now running. Guarded
+				// so the core lifecycle never hard-depends on the licensing subsystem.
+				if ( class_exists( 'Woodev_License_Command_Deactivate_Plugin' ) ) {
+					Woodev_License_Command_Deactivate_Plugin::clear_remote_deactivation_artifacts( $this->get_plugin() );
+				}
+
 				// Reschedule weekly license check
 				wp_reschedule_event( time(), 'weekly', 'woodev_weekly_scheduled_events' );
 

--- a/woodev/licensing/commands/class-license-command-deactivate-plugin.php
+++ b/woodev/licensing/commands/class-license-command-deactivate-plugin.php
@@ -148,12 +148,18 @@ if ( ! class_exists( 'Woodev_License_Command_Deactivate_Plugin' ) ) :
 				}
 			}
 
-			// Remove the WC Admin inbox breadcrumb (Finding B), if WooCommerce Admin
-			// is present. class_exists keeps the core lifecycle free of any hard WC
-			// dependency — the deactivated plugin's note is rendered by WooCommerce,
-			// so it must also be cleared here on reactivation.
-			if ( class_exists( '\Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
-				\Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( self::get_breadcrumb_note_name( $plugin ) );
+			// Remove the WC Admin inbox breadcrumb (Finding B), if WooCommerce Admin is
+			// present. Guarded on the same Note marker the writer uses (the option path
+			// above is platform-neutral and intentionally runs without it), and wrapped
+			// so a WooCommerce/DB hiccup while deleting the inbox note can never abort
+			// the activation flow that called us — clearing the breadcrumb is best-effort.
+			if ( class_exists( '\Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+				try {
+					\Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( self::get_breadcrumb_note_name( $plugin ) );
+				} catch ( \Throwable $exception ) {
+					// Best-effort: the next admin_notices pass / dismissal still resolves it.
+					unset( $exception );
+				}
 			}
 		}
 

--- a/woodev/licensing/commands/class-license-command-deactivate-plugin.php
+++ b/woodev/licensing/commands/class-license-command-deactivate-plugin.php
@@ -115,6 +115,62 @@ if ( ! class_exists( 'Woodev_License_Command_Deactivate_Plugin' ) ) :
 		}
 
 		/**
+		 * Clears all pending remote-deactivation artifacts for a plugin that is
+		 * (again) active.
+		 *
+		 * Called from Woodev_Lifecycle::handle_activation() on a genuine
+		 * (re)activation transition (Finding A, s12): a plugin that is running must
+		 * not show a stale "you were disabled" banner — or WC Admin inbox note — for
+		 * itself. Removes the plugin's own entry from NOTICES_OPTION (deleting the
+		 * whole option when it becomes empty) and removes the WC Admin inbox
+		 * breadcrumb note when WooCommerce Admin is present. No-op when the plugin
+		 * has no pending entry, so it adds no option churn on routine activations.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Woodev_Plugin $plugin The plugin that has just (re)activated.
+		 * @return void
+		 */
+		public static function clear_remote_deactivation_artifacts( Woodev_Plugin $plugin ): void {
+
+			$plugin_id = (string) $plugin->get_id();
+
+			$notices = get_option( self::NOTICES_OPTION, array() );
+
+			if ( is_array( $notices ) && array_key_exists( $plugin_id, $notices ) ) {
+
+				unset( $notices[ $plugin_id ] );
+
+				if ( empty( $notices ) ) {
+					delete_option( self::NOTICES_OPTION );
+				} else {
+					update_option( self::NOTICES_OPTION, $notices, 'no' );
+				}
+			}
+
+			// Remove the WC Admin inbox breadcrumb (Finding B), if WooCommerce Admin
+			// is present. class_exists keeps the core lifecycle free of any hard WC
+			// dependency — the deactivated plugin's note is rendered by WooCommerce,
+			// so it must also be cleared here on reactivation.
+			if ( class_exists( '\Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
+				\Automattic\WooCommerce\Admin\Notes\Notes::delete_notes_with_name( self::get_breadcrumb_note_name( $plugin ) );
+			}
+		}
+
+		/**
+		 * Builds the deterministic WC Admin inbox note name for a plugin's remote
+		 * deactivation breadcrumb (Finding B, s12).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Woodev_Plugin $plugin The target plugin.
+		 * @return string
+		 */
+		private static function get_breadcrumb_note_name( Woodev_Plugin $plugin ): string {
+			return 'woodev-' . $plugin->get_id_dasherized() . '-remote-deactivated';
+		}
+
+		/**
 		 * Whether the WP plugin API needs loading before this command can run.
 		 *
 		 * Gates on the FULL set of plugin-API functions execute() calls — NOT just
@@ -198,6 +254,12 @@ if ( ! class_exists( 'Woodev_License_Command_Deactivate_Plugin' ) ) :
 			// was deactivated. autoload 'no' — only read on admin_notices, not on every
 			// page load.
 			$this->write_notice( $plugin_id, $plugin->get_plugin_name(), $plugin->get_support_url() );
+
+			// Also leave a WooCommerce Admin inbox breadcrumb (Finding B, s12).
+			// WooCommerce renders it independent of this plugin's active state, so the
+			// admin still learns why a SINGLE-v2-plugin site went dark — the
+			// admin_notices banner above can only be drawn by a still-active sibling.
+			$this->maybe_add_breadcrumb_note( $plugin );
 
 			/**
 			 * Fires after a remote deactivate_plugin command executes successfully.
@@ -286,6 +348,56 @@ if ( ! class_exists( 'Woodev_License_Command_Deactivate_Plugin' ) ) :
 			);
 
 			update_option( self::NOTICES_OPTION, $notices, 'no' );
+		}
+
+		/**
+		 * Leaves a WooCommerce Admin inbox breadcrumb for a remote deactivation.
+		 *
+		 * The admin_notices banner (NOTICES_OPTION) can only be drawn by an ACTIVE
+		 * Woodev_Plugins_License engine — on a site whose only v2 plugin is the one
+		 * just deactivated, NO framework code loads at all, so the banner never shows
+		 * (Finding B, s12). A WC Admin note is stored in WooCommerce's own table and
+		 * rendered by WooCommerce regardless of this plugin's state, so it survives
+		 * the deactivation. Cleared on reactivation by
+		 * clear_remote_deactivation_artifacts(). Best-effort: a no-op when WooCommerce
+		 * Admin is not present (e.g. a pure-WP plugin or the unit suite), which is why
+		 * the class_exists guard runs FIRST — before any plugin accessor — so the
+		 * heavily mocked command tests never reach the WC path.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Woodev_Plugin $plugin The plugin being remotely deactivated.
+		 * @return void
+		 */
+		private function maybe_add_breadcrumb_note( Woodev_Plugin $plugin ): void {
+
+			if ( ! class_exists( '\Automattic\WooCommerce\Admin\Notes\Note' ) || ! class_exists( 'Woodev_Notes_Helper' ) ) {
+				return;
+			}
+
+			$support_url = trim( (string) $plugin->get_support_url() );
+
+			$actions = array();
+
+			if ( '' !== $support_url ) {
+				$actions[] = array(
+					'name'  => 'woodev-remote-deactivated-support',
+					'label' => __( 'Связаться с нами', 'woodev-plugin-framework' ),
+					'url'   => $support_url,
+				);
+			}
+
+			Woodev_Notes_Helper::add_note(
+				self::get_breadcrumb_note_name( $plugin ),
+				$plugin->get_id_dasherized(),
+				sprintf(
+					/* translators: %s: plugin name */
+					__( 'Плагин %s отключён', 'woodev-plugin-framework' ),
+					$plugin->get_plugin_name()
+				),
+				__( 'Лицензия недействительна для этого сайта. Проверьте статус лицензии в личном кабинете на woodev.ru.', 'woodev-plugin-framework' ),
+				$actions
+			);
 		}
 	}
 


### PR DESCRIPTION
## Context

Fixes two UX gaps found in the s11 operator manual run of the live remote-deactivation cycle (findings doc `docs-internal/reviews/remote-deactivation-ux-findings-2026-06-13.md`). The happy path was already proven live on both channels in s11; these are lifecycle/UX gaps around it. No production plugin ships v2 yet, so this is v2-mechanism hardening only.

## Finding A — notice not cleared on (re)activation

The `woodev_license_remote_deactivation_notices` option entry (and the WC Admin inbox note) was never removed when the plugin was re-activated, so a "you were disabled" banner persisted after the admin re-enabled the plugin.

`Woodev_Lifecycle::handle_activation()` now clears the plugin's own artifacts on a **genuine (re)activation transition** via `Woodev_License_Command_Deactivate_Plugin::clear_remote_deactivation_artifacts()` — removes the option entry (deleting the option when empty), and deletes the WC inbox note. No-op when there is no pending entry (no option churn on routine activations).

## Finding B — banner cannot render on a single-v2-plugin site

The `admin_notices` banner can only be drawn by an **active** `Woodev_Plugins_License` engine. On a site whose only v2 plugin is the one just deactivated, **no framework code loads at all** (the vendored `bootstrap.php` is never included for an inactive plugin), so the banner never shows.

Per the operator''s direction, the remote-deactivation command now **also writes a WooCommerce Admin inbox note** (new `Woodev_Notes_Helper::add_note()`), which WooCommerce renders independent of this plugin''s active state. It is created **after** `handle_deactivation`''s source-based bulk note-cleanup (which fires during `deactivate_plugins()`), so it survives the deactivation, and is cleared on reactivation by Finding A. Additive to the banner (which still serves multi-plugin and non-WC sites). Guarded on the WC Admin Notes class so the unit suite and pure-WP plugins are unaffected.

> Note for review: the WC note is **additive** to the existing (shipped 2.0.1) admin_notices banner, not a replacement. On a multi-v2-plugin WC site both surfaces fire (top banner + inbox note). Flagged for the operator''s call; easy to make the note the sole channel later if preferred.

## Verification

- `composer check` green: PHPCS, PHPStan 0, **608 unit tests** (+5 new).
- **Rig-verified against real WooCommerce 10.8.1** (local stand, the single-v2-plugin case): `add_note` creates the note (type=error, 1 action button), is idempotent (no duplicate), **survives the real `execute()` path** after `handle_deactivation` bulk-deletes same-source notes, and `handle_activation()` clears both the note and the option entry on reactivation.

`@since 2.0.2` on new APIs; VERSION constant left at 2.0.1 (release deferred per s11 — not bumping to avoid auto-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)