### PR TITLE
feat(bootstrap): name conflicting v1 plugin in mixed-fleet dormant notice (OB-1)

### DIFF
--- a/tests/_fixtures/woodev-test-payment-gateway/woodev-test-payment-gateway.php
+++ b/tests/_fixtures/woodev-test-payment-gateway/woodev-test-payment-gateway.php
@@ -67,6 +67,57 @@ function woodev_test_payment_gateway_plugin_loader_definition(): array {
 }
 
 /**
+ * Best-effort resolves the display name of the plugin whose outdated (v1) framework
+ * copy won the Woodev_Plugin_Bootstrap class rendezvous (B-1 / OB-1).
+ *
+ * Runs only on the mixed-fleet dormant path, so it relies on WordPress core +
+ * reflection alone and never references a framework class — the loaded runtime is the
+ * legacy v1 copy. Returns '' when the owner cannot be determined; the caller then
+ * falls back to generic wording.
+ *
+ * @return string Conflicting plugin display name, or '' if undeterminable.
+ */
+function woodev_test_payment_gateway_conflicting_framework_plugin_name(): string {
+	if ( ! class_exists( 'Woodev_Plugin_Bootstrap', false ) || ! defined( 'WP_PLUGIN_DIR' ) || ! function_exists( 'wp_normalize_path' ) || ! function_exists( 'get_plugins' ) ) {
+		return '';
+	}
+
+	try {
+		$framework_file = ( new ReflectionClass( 'Woodev_Plugin_Bootstrap' ) )->getFileName();
+	} catch ( ReflectionException $e ) {
+		return '';
+	}
+
+	$plugins_dir = constant( 'WP_PLUGIN_DIR' );
+
+	if ( ! is_string( $framework_file ) || '' === $framework_file || ! is_string( $plugins_dir ) || '' === $plugins_dir ) {
+		return '';
+	}
+
+	$framework_file = wp_normalize_path( $framework_file );
+	$plugins_dir    = wp_normalize_path( $plugins_dir );
+
+	if ( 0 !== strpos( $framework_file, $plugins_dir . '/' ) ) {
+		return '';
+	}
+
+	$relative = ltrim( substr( $framework_file, strlen( $plugins_dir ) ), '/' );
+	$slug     = strstr( $relative . '/', '/', true );
+
+	if ( ! is_string( $slug ) || '' === $slug ) {
+		return '';
+	}
+
+	foreach ( get_plugins() as $plugin_file => $plugin_data ) {
+		if ( 0 === strpos( (string) $plugin_file, $slug . '/' ) && ! empty( $plugin_data['Name'] ) ) {
+			return (string) $plugin_data['Name'];
+		}
+	}
+
+	return '';
+}
+
+/**
  * Регистрируем тестовый плагин в бутстрапе фреймворка.
  *
  * Mixed-fleet probe (B-1): на сайте, где соседствуют v2-переписанный и ещё-v1 плагин,
@@ -80,15 +131,30 @@ if ( ! method_exists( $woodev_test_payment_gateway_bootstrap, 'register_loader_d
 	add_action(
 		'admin_notices',
 		static function (): void {
+			$this_plugin_name = esc_html__( 'Woodev Test Payment Gateway Plugin', 'woodev-plugin-framework' );
+
+			// Best-effort: name the plugin whose outdated (v1) framework copy won the class
+			// rendezvous. Uses ONLY WordPress core + reflection — never a framework class,
+			// because here the loaded framework runtime is the legacy v1 copy (B-1 / OB-1).
+			$conflicting_plugin_name = woodev_test_payment_gateway_conflicting_framework_plugin_name();
+
+			if ( '' !== $conflicting_plugin_name ) {
+				$message = sprintf(
+					/* translators: 1: this plugin name, 2: the conflicting plugin name. */
+					esc_html__( 'Плагин %1$s не запущен: на сайте активен плагин %2$s с устаревшей версией фреймворка Woodev, которая мешает его загрузке. Обновите плагин %2$s до последней версии.', 'woodev-plugin-framework' ),
+					'<strong>' . $this_plugin_name . '</strong>',
+					'<strong>' . esc_html( $conflicting_plugin_name ) . '</strong>'
+				);
+			} else {
+				$message = sprintf(
+					/* translators: %s — this plugin name. */
+					esc_html__( 'Плагин %s не запущен: на сайте активен другой плагин Woodev с устаревшей версией фреймворка. Обновите все плагины Woodev до последней версии.', 'woodev-plugin-framework' ),
+					'<strong>' . $this_plugin_name . '</strong>'
+				);
+			}
+
 			echo '<div class="error"><p>';
-			echo wp_kses(
-				sprintf(
-					/* translators: %s — plugin name. */
-					esc_html__( 'Плагин %s не запущен: загруженная версия фреймворка устарела. Обновите плагин или фреймворк.', 'woodev-plugin-framework' ),
-					'<strong>' . esc_html__( 'Woodev Test Payment Gateway Plugin', 'woodev-plugin-framework' ) . '</strong>'
-				),
-				[ 'strong' => [] ]
-			);
+			echo wp_kses( $message, [ 'strong' => [] ] );
 			echo '</p></div>';
 		}
 	);

--- a/tests/_fixtures/woodev-test-plugin/woodev-test-plugin.php
+++ b/tests/_fixtures/woodev-test-plugin/woodev-test-plugin.php
@@ -68,6 +68,57 @@ function woodev_test_plugin_loader_definition(): array {
 }
 
 /**
+ * Best-effort resolves the display name of the plugin whose outdated (v1) framework
+ * copy won the Woodev_Plugin_Bootstrap class rendezvous (B-1 / OB-1).
+ *
+ * Runs only on the mixed-fleet dormant path, so it relies on WordPress core +
+ * reflection alone and never references a framework class — the loaded runtime is the
+ * legacy v1 copy. Returns '' when the owner cannot be determined; the caller then
+ * falls back to generic wording.
+ *
+ * @return string Conflicting plugin display name, or '' if undeterminable.
+ */
+function woodev_test_plugin_conflicting_framework_plugin_name(): string {
+	if ( ! class_exists( 'Woodev_Plugin_Bootstrap', false ) || ! defined( 'WP_PLUGIN_DIR' ) || ! function_exists( 'wp_normalize_path' ) || ! function_exists( 'get_plugins' ) ) {
+		return '';
+	}
+
+	try {
+		$framework_file = ( new ReflectionClass( 'Woodev_Plugin_Bootstrap' ) )->getFileName();
+	} catch ( ReflectionException $e ) {
+		return '';
+	}
+
+	$plugins_dir = constant( 'WP_PLUGIN_DIR' );
+
+	if ( ! is_string( $framework_file ) || '' === $framework_file || ! is_string( $plugins_dir ) || '' === $plugins_dir ) {
+		return '';
+	}
+
+	$framework_file = wp_normalize_path( $framework_file );
+	$plugins_dir    = wp_normalize_path( $plugins_dir );
+
+	if ( 0 !== strpos( $framework_file, $plugins_dir . '/' ) ) {
+		return '';
+	}
+
+	$relative = ltrim( substr( $framework_file, strlen( $plugins_dir ) ), '/' );
+	$slug     = strstr( $relative . '/', '/', true );
+
+	if ( ! is_string( $slug ) || '' === $slug ) {
+		return '';
+	}
+
+	foreach ( get_plugins() as $plugin_file => $plugin_data ) {
+		if ( 0 === strpos( (string) $plugin_file, $slug . '/' ) && ! empty( $plugin_data['Name'] ) ) {
+			return (string) $plugin_data['Name'];
+		}
+	}
+
+	return '';
+}
+
+/**
  * Регистрируем тестовый плагин в бутстрапе фреймворка.
  *
  * Mixed-fleet probe (B-1): на сайте, где соседствуют v2-переписанный и ещё-v1 плагин,
@@ -81,15 +132,30 @@ if ( ! method_exists( $woodev_test_plugin_bootstrap, 'register_loader_definition
 	add_action(
 		'admin_notices',
 		static function (): void {
+			$this_plugin_name = esc_html__( 'Woodev Framework Test Plugin', 'woodev-plugin-framework' );
+
+			// Best-effort: name the plugin whose outdated (v1) framework copy won the class
+			// rendezvous. Uses ONLY WordPress core + reflection — never a framework class,
+			// because here the loaded framework runtime is the legacy v1 copy (B-1 / OB-1).
+			$conflicting_plugin_name = woodev_test_plugin_conflicting_framework_plugin_name();
+
+			if ( '' !== $conflicting_plugin_name ) {
+				$message = sprintf(
+					/* translators: 1: this plugin name, 2: the conflicting plugin name. */
+					esc_html__( 'Плагин %1$s не запущен: на сайте активен плагин %2$s с устаревшей версией фреймворка Woodev, которая мешает его загрузке. Обновите плагин %2$s до последней версии.', 'woodev-plugin-framework' ),
+					'<strong>' . $this_plugin_name . '</strong>',
+					'<strong>' . esc_html( $conflicting_plugin_name ) . '</strong>'
+				);
+			} else {
+				$message = sprintf(
+					/* translators: %s — this plugin name. */
+					esc_html__( 'Плагин %s не запущен: на сайте активен другой плагин Woodev с устаревшей версией фреймворка. Обновите все плагины Woodev до последней версии.', 'woodev-plugin-framework' ),
+					'<strong>' . $this_plugin_name . '</strong>'
+				);
+			}
+
 			echo '<div class="error"><p>';
-			echo wp_kses(
-				sprintf(
-					/* translators: %s — plugin name. */
-					esc_html__( 'Плагин %s не запущен: загруженная версия фреймворка устарела. Обновите плагин или фреймворк.', 'woodev-plugin-framework' ),
-					'<strong>' . esc_html__( 'Woodev Framework Test Plugin', 'woodev-plugin-framework' ) . '</strong>'
-				),
-				[ 'strong' => [] ]
-			);
+			echo wp_kses( $message, [ 'strong' => [] ] );
 			echo '</p></div>';
 		}
 	);

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -67,6 +67,57 @@ function woodev_test_shipping_method_plugin_loader_definition(): array {
 }
 
 /**
+ * Best-effort resolves the display name of the plugin whose outdated (v1) framework
+ * copy won the Woodev_Plugin_Bootstrap class rendezvous (B-1 / OB-1).
+ *
+ * Runs only on the mixed-fleet dormant path, so it relies on WordPress core +
+ * reflection alone and never references a framework class — the loaded runtime is the
+ * legacy v1 copy. Returns '' when the owner cannot be determined; the caller then
+ * falls back to generic wording.
+ *
+ * @return string Conflicting plugin display name, or '' if undeterminable.
+ */
+function woodev_test_shipping_method_conflicting_framework_plugin_name(): string {
+	if ( ! class_exists( 'Woodev_Plugin_Bootstrap', false ) || ! defined( 'WP_PLUGIN_DIR' ) || ! function_exists( 'wp_normalize_path' ) || ! function_exists( 'get_plugins' ) ) {
+		return '';
+	}
+
+	try {
+		$framework_file = ( new ReflectionClass( 'Woodev_Plugin_Bootstrap' ) )->getFileName();
+	} catch ( ReflectionException $e ) {
+		return '';
+	}
+
+	$plugins_dir = constant( 'WP_PLUGIN_DIR' );
+
+	if ( ! is_string( $framework_file ) || '' === $framework_file || ! is_string( $plugins_dir ) || '' === $plugins_dir ) {
+		return '';
+	}
+
+	$framework_file = wp_normalize_path( $framework_file );
+	$plugins_dir    = wp_normalize_path( $plugins_dir );
+
+	if ( 0 !== strpos( $framework_file, $plugins_dir . '/' ) ) {
+		return '';
+	}
+
+	$relative = ltrim( substr( $framework_file, strlen( $plugins_dir ) ), '/' );
+	$slug     = strstr( $relative . '/', '/', true );
+
+	if ( ! is_string( $slug ) || '' === $slug ) {
+		return '';
+	}
+
+	foreach ( get_plugins() as $plugin_file => $plugin_data ) {
+		if ( 0 === strpos( (string) $plugin_file, $slug . '/' ) && ! empty( $plugin_data['Name'] ) ) {
+			return (string) $plugin_data['Name'];
+		}
+	}
+
+	return '';
+}
+
+/**
  * Регистрируем тестовый плагин метода доставки в бутстрапе фреймворка.
  *
  * Mixed-fleet probe (B-1): на сайте, где соседствуют v2-переписанный и ещё-v1 плагин,
@@ -80,15 +131,30 @@ if ( ! method_exists( $woodev_test_shipping_method_bootstrap, 'register_loader_d
 	add_action(
 		'admin_notices',
 		static function (): void {
+			$this_plugin_name = esc_html__( 'Woodev Test Shipping Method Plugin', 'woodev-plugin-framework' );
+
+			// Best-effort: name the plugin whose outdated (v1) framework copy won the class
+			// rendezvous. Uses ONLY WordPress core + reflection — never a framework class,
+			// because here the loaded framework runtime is the legacy v1 copy (B-1 / OB-1).
+			$conflicting_plugin_name = woodev_test_shipping_method_conflicting_framework_plugin_name();
+
+			if ( '' !== $conflicting_plugin_name ) {
+				$message = sprintf(
+					/* translators: 1: this plugin name, 2: the conflicting plugin name. */
+					esc_html__( 'Плагин %1$s не запущен: на сайте активен плагин %2$s с устаревшей версией фреймворка Woodev, которая мешает его загрузке. Обновите плагин %2$s до последней версии.', 'woodev-plugin-framework' ),
+					'<strong>' . $this_plugin_name . '</strong>',
+					'<strong>' . esc_html( $conflicting_plugin_name ) . '</strong>'
+				);
+			} else {
+				$message = sprintf(
+					/* translators: %s — this plugin name. */
+					esc_html__( 'Плагин %s не запущен: на сайте активен другой плагин Woodev с устаревшей версией фреймворка. Обновите все плагины Woodev до последней версии.', 'woodev-plugin-framework' ),
+					'<strong>' . $this_plugin_name . '</strong>'
+				);
+			}
+
 			echo '<div class="error"><p>';
-			echo wp_kses(
-				sprintf(
-					/* translators: %s — plugin name. */
-					esc_html__( 'Плагин %s не запущен: загруженная версия фреймворка устарела. Обновите плагин или фреймворк.', 'woodev-plugin-framework' ),
-					'<strong>' . esc_html__( 'Woodev Test Shipping Method Plugin', 'woodev-plugin-framework' ) . '</strong>'
-				),
-				[ 'strong' => [] ]
-			);
+			echo wp_kses( $message, [ 'strong' => [] ] );
 			echo '</p></div>';
 		}
 	);

--- a/tests/unit/MixedFleetBootstrapGateTest.php
+++ b/tests/unit/MixedFleetBootstrapGateTest.php
@@ -134,6 +134,188 @@ class MixedFleetBootstrapGateTest extends TestCase {
 		);
 
 		$this->assertCount( 1, $admin_notice_hooks, 'The probe must hook exactly one admin_notices warning.' );
+
+		// The dormant notice must render actionable wording. With an eval'd stub the conflicting
+		// plugin can't be resolved (eval'd classes have no file, and WP_PLUGIN_DIR is undefined),
+		// so the generic still-actionable fallback must appear: it names this dormant plugin and
+		// tells the merchant exactly what to do (OB-1).
+		$render_callback = $admin_notice_hooks[ array_key_first( $admin_notice_hooks ) ][1];
+		ob_start();
+		$render_callback();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Woodev Framework Test Plugin', $output, 'The notice must name this dormant plugin.' );
+		$this->assertStringContainsString( 'Обновите все плагины Woodev', $output, 'The generic fallback must give an actionable update instruction.' );
+		$this->assertStringContainsString( '<div class="error">', $output, 'The notice must produce the admin-notice markup.' );
+	}
+
+	/**
+	 * Direction A (OB-1): when the conflicting v1 plugin can be resolved, the dormant notice names
+	 * it explicitly and tells the merchant to update that plugin.
+	 *
+	 * A file-based v1-shaped stub Woodev_Plugin_Bootstrap is written under a fake WP_PLUGIN_DIR so
+	 * ReflectionClass::getFileName() yields a real plugins-dir path; a stubbed get_plugins() maps
+	 * that plugin slug to a display name. Including the fixture entry file then exercises the real
+	 * probe + resolver boilerplate end to end.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_direction_a_notice_names_resolved_conflicting_plugin(): void {
+		$base       = sys_get_temp_dir() . '/woodev_mf_' . uniqid( '', true );
+		$plugin_dir = $base . '/legacy-woodev-plugin/woodev';
+		mkdir( $plugin_dir, 0777, true );
+		$stub_file = $plugin_dir . '/bootstrap.php';
+
+		$stub_source  = "<?php\n";
+		$stub_source .= 'class Woodev_Plugin_Bootstrap {' . "\n";
+		$stub_source .= "\tprivate static \$instance;\n";
+		$stub_source .= "\tpublic static function instance() { return self::\$instance ??= new self(); }\n";
+		$stub_source .= "\tpublic function register_plugin( ...\$args ) {}\n";
+		$stub_source .= "}\n";
+		file_put_contents( $stub_file, $stub_source );
+
+		require $stub_file; // Defines the legacy stub from a real file so getFileName() resolves.
+
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			define( 'WP_PLUGIN_DIR', $base );
+		}
+		if ( ! defined( 'WOODEV_FRAMEWORK_DIR' ) ) {
+			define( 'WOODEV_FRAMEWORK_DIR', dirname( __DIR__, 2 ) );
+		}
+
+		Functions\stubEscapeFunctions();
+		Functions\when( 'wp_kses' )->returnArg();
+		Functions\when( 'wp_normalize_path' )->alias(
+			static function ( string $path ): string {
+				return str_replace( '\\', '/', $path );
+			}
+		);
+		Functions\when( 'get_plugins' )->justReturn(
+			[ 'legacy-woodev-plugin/legacy-woodev-plugin.php' => [ 'Name' => 'Legacy Woodev Plugin' ] ]
+		);
+
+		$added = [];
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, $callback ) use ( &$added ): void {
+				$added[] = [ $hook, $callback ];
+			}
+		);
+
+		require __DIR__ . '/../_fixtures/woodev-test-plugin/woodev-test-plugin.php';
+
+		// The resolver must map the winning v1 framework file back to its plugin display name.
+		$this->assertSame(
+			'Legacy Woodev Plugin',
+			woodev_test_plugin_conflicting_framework_plugin_name(),
+			'The resolver must map the winning v1 framework file to its owning plugin display name.'
+		);
+
+		$admin_notice_hooks = array_filter(
+			$added,
+			static function ( array $hook ): bool {
+				return 'admin_notices' === $hook[0];
+			}
+		);
+		$this->assertCount( 1, $admin_notice_hooks, 'The probe must hook exactly one admin_notices warning (named path).' );
+
+		$render_callback = $admin_notice_hooks[ array_key_first( $admin_notice_hooks ) ][1];
+		ob_start();
+		$render_callback();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Legacy Woodev Plugin', $output, 'The notice must name the conflicting v1 plugin.' );
+		$this->assertStringContainsString( 'Woodev Framework Test Plugin', $output, 'The notice must also name this dormant plugin.' );
+
+		if ( is_file( $stub_file ) ) {
+			unlink( $stub_file );
+		}
+		foreach ( [ $plugin_dir, dirname( $plugin_dir ), $base ] as $dir ) {
+			if ( is_dir( $dir ) ) {
+				rmdir( $dir );
+			}
+		}
+	}
+
+	/**
+	 * Direction A (OB-1, XSS guard): a hostile conflicting-plugin name must be escaped in the notice.
+	 *
+	 * The resolved name comes from another plugin's header (get_plugins()), so a plugin named
+	 * '<script>…</script>…' must render as inert text — esc_html() + wp_kses() must strip the script.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_direction_a_notice_escapes_hostile_conflicting_plugin_name(): void {
+		$base       = sys_get_temp_dir() . '/woodev_mf_' . uniqid( '', true );
+		$plugin_dir = $base . '/legacy-woodev-plugin/woodev';
+		mkdir( $plugin_dir, 0777, true );
+		$stub_file = $plugin_dir . '/bootstrap.php';
+
+		$stub_source  = "<?php\n";
+		$stub_source .= 'class Woodev_Plugin_Bootstrap {' . "\n";
+		$stub_source .= "\tprivate static \$instance;\n";
+		$stub_source .= "\tpublic static function instance() { return self::\$instance ??= new self(); }\n";
+		$stub_source .= "\tpublic function register_plugin( ...\$args ) {}\n";
+		$stub_source .= "}\n";
+		file_put_contents( $stub_file, $stub_source );
+
+		require $stub_file;
+
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			define( 'WP_PLUGIN_DIR', $base );
+		}
+		if ( ! defined( 'WOODEV_FRAMEWORK_DIR' ) ) {
+			define( 'WOODEV_FRAMEWORK_DIR', dirname( __DIR__, 2 ) );
+		}
+
+		Functions\stubEscapeFunctions();
+		Functions\when( 'esc_html' )->alias(
+			static function ( string $text ): string {
+				return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+			}
+		);
+		Functions\when( 'wp_kses' )->returnArg();
+		Functions\when( 'wp_normalize_path' )->alias(
+			static function ( string $path ): string {
+				return str_replace( '\\', '/', $path );
+			}
+		);
+		Functions\when( 'get_plugins' )->justReturn(
+			[ 'legacy-woodev-plugin/legacy-woodev-plugin.php' => [ 'Name' => '<script>alert(1)</script>Legacy' ] ]
+		);
+
+		$added = [];
+		Functions\when( 'add_action' )->alias(
+			static function ( string $hook, $callback ) use ( &$added ): void {
+				$added[] = [ $hook, $callback ];
+			}
+		);
+
+		require __DIR__ . '/../_fixtures/woodev-test-plugin/woodev-test-plugin.php';
+
+		$admin_notice_hooks = array_filter(
+			$added,
+			static function ( array $hook ): bool {
+				return 'admin_notices' === $hook[0];
+			}
+		);
+		$render_callback = $admin_notice_hooks[ array_key_first( $admin_notice_hooks ) ][1];
+		ob_start();
+		$render_callback();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString( '<script>', $output, 'The hostile conflicting-plugin name must be escaped.' );
+		$this->assertStringContainsString( 'alert(1)', $output, 'The escaped name text must still appear.' );
+
+		if ( is_file( $stub_file ) ) {
+			unlink( $stub_file );
+		}
+		foreach ( [ $plugin_dir, dirname( $plugin_dir ), $base ] as $dir ) {
+			if ( is_dir( $dir ) ) {
+				rmdir( $dir );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## OB-1 — Bootstrap silently yields to a v1-framework plugin (notice)

**Backlog:** `docs-internal/FUTURE-BACKLOG.md` → OB-1. The reverse of the B-1 tombstone case.

### Problem
When a plugin bundling framework **v1** wins the `Woodev_Plugin_Bootstrap` class rendezvous, the loaded bootstrap lacks the v2-only `register_loader_definition()`. The v2 plugin's entry-file probe (shipped with B-1) already stays dormant and shows an admin notice — so it never *fails silently*. But that notice only named the v2 plugin (Y) and said "framework outdated" generically.

### Change
The dormant-probe notice is now **actionable**: it best-effort names the conflicting **v1** plugin (X) and tells the merchant to update it, degrading to robust generic wording ("update all Woodev plugins") when X can't be resolved.

- Resolution = a uniquely-named **per-plugin helper** in the entry-file template → no new shared global symbol, so no B-2 first-wins rendezvous hazard.
- **Mixed-fleet pure:** WordPress core + reflection only; never references a framework runtime class (the loaded runtime is the legacy v1 copy).
- **Never-fatal by construction:** returns `''` (generic wording) whenever `WP_PLUGIN_DIR`/`get_plugins`/`wp_normalize_path` are unavailable or reflection yields no file. No file is ever loaded on this path.

Applied to all three entry-file fixtures (the canonical template plugins copy).

### Tests
- Resolved-name (X) path — file-based v1 stub under a fake `WP_PLUGIN_DIR` + stubbed `get_plugins()`.
- Generic fallback wording.
- Hostile-name XSS regression.

`MixedFleetBootstrapGateTest`: 8 tests / 30 assertions. `composer check` green: PHPCS 162/162, PHPStan 0, PHPUnit **609**, 65 baseline-skips.

### Review
GPT-5.5 adversarial critic (inline-bundle, read-only): round 1 **BLOCK** (an `ABSPATH` include could fatal) → fixed (return `''` if `get_plugins()` unavailable; type-guard `WP_PLUGIN_DIR`) → round 2 **SHIP**.

> Note: real plugins ship their own entry files; they should adopt this enriched probe when migrated onto v2 (per their data-preservation checklists). This PR updates the canonical fixture template + test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)