### PR TITLE
fix(plugin-updater): OB-3 Step 2 — catch(Throwable) + F7 wiring-failure logging

### DIFF
--- a/tests/unit/UpdaterRobustnessTest.php
+++ b/tests/unit/UpdaterRobustnessTest.php
@@ -36,6 +36,7 @@ class UpdaterRobustnessTest extends TestCase {
 		$source = (string) file_get_contents(
 			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
 		);
+		$this->assertNotEmpty( $source, 'class-plugin-updater.php source file could not be read.' );
 		$this->assertStringNotContainsString(
 			'catch ( Exception $e ) {',
 			$source,
@@ -62,6 +63,7 @@ class UpdaterRobustnessTest extends TestCase {
 		$source = (string) file_get_contents(
 			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
 		);
+		$this->assertNotEmpty( $source, 'class-plugin-updater.php source file could not be read.' );
 		$this->assertStringContainsString(
 			"'Woodev updater: get_version_from_remote failed: '",
 			$source,
@@ -85,6 +87,7 @@ class UpdaterRobustnessTest extends TestCase {
 		$source = (string) file_get_contents(
 			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
 		);
+		$this->assertNotEmpty( $source, 'class-plugin-updater.php source file could not be read.' );
 		$this->assertStringContainsString(
 			"'Woodev updater: Woodev_License_Command_Acks not available",
 			$source,
@@ -106,6 +109,7 @@ class UpdaterRobustnessTest extends TestCase {
 		$source = (string) file_get_contents(
 			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
 		);
+		$this->assertNotEmpty( $source, 'class-plugin-updater.php source file could not be read.' );
 		$this->assertStringContainsString(
 			"'Woodev updater: Woodev_License_Command_Dispatcher not available",
 			$source,

--- a/tests/unit/UpdaterRobustnessTest.php
+++ b/tests/unit/UpdaterRobustnessTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * OB-3 Step 2 robustness tests (s16).
+ *
+ * Covers two robustness findings from the OB-3 updater review (2026-06-14, s14):
+ *   - F2:  catch(\Throwable) + error_log in get_version_from_remote()
+ *   - F7:  wiring-failure error_log when Acks/Dispatcher classes are absent
+ *
+ * @package Woodev\Framework\Tests
+ */
+
+namespace Woodev\Tests\Unit;
+
+use Brain\Monkey\Functions;
+
+require_once dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php';
+
+/**
+ * Class UpdaterRobustnessTest.
+ */
+class UpdaterRobustnessTest extends TestCase {
+
+	// ── F2: catch(\Throwable) + error_log ────────────────────────────────────
+
+	/**
+	 * The outer catch in get_version_from_remote() must catch \Throwable (not just
+	 * Exception) so that PHP Error subclasses (TypeError, etc.) are captured.
+	 *
+	 * Source assertion — fails RED when catch block still says "Exception $e".
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function test_f2_source_catches_throwable_not_just_exception(): void {
+		$source = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
+		);
+		$this->assertStringNotContainsString(
+			'catch ( Exception $e ) {',
+			$source,
+			'F2: the outer catch in get_version_from_remote() must not be "catch ( Exception $e )" — it must be \Throwable.'
+		);
+		$this->assertStringContainsString(
+			'catch ( \Throwable $e )',
+			$source,
+			'F2: the outer catch in get_version_from_remote() must be "catch ( \Throwable $e )" to capture PHP Error subclasses.'
+		);
+	}
+
+	/**
+	 * The outer catch in get_version_from_remote() must call error_log() with the
+	 * "get_version_from_remote failed" message so failures are diagnosable.
+	 *
+	 * Source assertion — fails RED when the catch block is still empty.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function test_f2_source_logs_throwable_message(): void {
+		$source = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
+		);
+		$this->assertStringContainsString(
+			"'Woodev updater: get_version_from_remote failed: '",
+			$source,
+			'F2: catch block in get_version_from_remote() must call error_log() with the "get_version_from_remote failed" prefix.'
+		);
+	}
+
+	// ── F7: wiring-failure logging ────────────────────────────────────────────
+
+	/**
+	 * When Woodev_License_Command_Acks class is absent, error_log() must emit a
+	 * diagnostic so wiring bugs are visible in the server log.
+	 *
+	 * Source assertion — fails RED when the null-ack-store branch has no log call.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function test_f7_source_logs_when_acks_class_missing(): void {
+		$source = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
+		);
+		$this->assertStringContainsString(
+			"'Woodev updater: Woodev_License_Command_Acks not available",
+			$source,
+			'F7: get_version_from_remote() must log a wiring-failure message when Woodev_License_Command_Acks class does not exist.'
+		);
+	}
+
+	/**
+	 * When Woodev_License_Command_Dispatcher class is absent, error_log() must emit
+	 * a diagnostic so wiring bugs are visible in the server log.
+	 *
+	 * Source assertion — fails RED when the else branch has no log call.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function test_f7_source_logs_when_dispatcher_class_missing(): void {
+		$source = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
+		);
+		$this->assertStringContainsString(
+			"'Woodev updater: Woodev_License_Command_Dispatcher not available",
+			$source,
+			'F7: get_version_from_remote() must log a wiring-failure message when Woodev_License_Command_Dispatcher class does not exist.'
+		);
+	}
+}

--- a/woodev/plugin-updater/class-plugin-updater.php
+++ b/woodev/plugin-updater/class-plugin-updater.php
@@ -538,6 +538,9 @@ if ( ! class_exists( 'Woodev_Plugin_Updater' ) ) :
 				// D-W3 / §3.2 pull-fallback: consume any license_commands delivered in
 				// the response and drain acks.
 				$ack_store = class_exists( 'Woodev_License_Command_Acks' ) ? new Woodev_License_Command_Acks() : null;
+				if ( null === $ack_store ) {
+					error_log( 'Woodev updater: Woodev_License_Command_Acks not available — ack transport disabled.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- wiring-failure diagnostic (OB-3 F7).
+				}
 
 				if ( class_exists( 'Woodev_License_Command_Dispatcher' ) ) {
 					try {
@@ -547,6 +550,8 @@ if ( ! class_exists( 'Woodev_Plugin_Updater' ) ) :
 						// bug must not break the update flow — loud-but-contained, never silent.
 						error_log( 'Woodev updater: pull-command consumption failed: ' . $throwable->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- ruled loud-but-contained boundary (s8-p5 #4b).
 					}
+				} else {
+					error_log( 'Woodev updater: Woodev_License_Command_Dispatcher not available — pull-command transport disabled.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- wiring-failure diagnostic (OB-3 F7).
 				}
 
 				// acks_received drain — ruled s8-p5 re-review #1: confirm ONLY the
@@ -591,8 +596,8 @@ if ( ! class_exists( 'Woodev_Plugin_Updater' ) ) :
 
 				return $response;
 
-			} catch ( Exception $e ) {
-
+			} catch ( \Throwable $e ) {
+				error_log( 'Woodev updater: get_version_from_remote failed: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- loud-but-contained boundary; the update flow must not break on API failure (OB-3 F2).
 			}
 
 			return false;


### PR DESCRIPTION
## Summary

- **F2**: Replace empty `catch ( Exception $e ) {}` in `get_version_from_remote()` with `catch ( \Throwable $e )` + `error_log()` — PHP `Error` subclasses (TypeError etc.) were silently swallowed; now loud-but-contained with diagnostic output.
- **F7**: Add `error_log()` wiring-failure diagnostics when `Woodev_License_Command_Acks` or `Woodev_License_Command_Dispatcher` are absent at the `class_exists()` guard site — these classes are required unconditionally via `includes()` so absence signals a deployment defect.
- 4 new source-level assertions in `UpdaterRobustnessTest.php` covering both findings; `assertNotEmpty` guard on every test (Codex critic MINOR fix).

**Not included** (scope control):
- F6 (backoff option write) — endpoint-wide key intent not confirmed; backoff remains dead code.
- F4 (idempotent construction) — `class-plugin.php`, separate step.
- F1/F3/F5 normalization, F8/F9/F10 contract-touching — future steps.

## Test plan

- [x] `./vendor/bin/phpunit tests/unit/UpdaterRobustnessTest.php` — 4 tests GREEN
- [x] `composer check` — phpcs 0, phpstan 0, 621/621 tests (65 skipped baseline)
- [x] Codex adversarial review — SHIP (1 MINOR applied: assertNotEmpty guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)