### PR TITLE
fix(plugin-updater): OB-3 F5 — remove unused string action param from api_request()

### DIFF
--- a/tests/unit/UpdaterNormalizationF5Test.php
+++ b/tests/unit/UpdaterNormalizationF5Test.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * OB-3 Step 3 — F5 normalization test (s16).
+ *
+ * Covers F5 from the OB-3 updater review (2026-06-14, s14):
+ *   - F5: api_request() was a false multi-action abstraction; $_action was unused
+ *         and every call resolved to get_version. The parameter has been removed.
+ *
+ * @package Woodev\Framework\Tests
+ */
+
+namespace Woodev\Tests\Unit;
+
+require_once dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php';
+
+/**
+ * Class UpdaterNormalizationF5Test.
+ */
+class UpdaterNormalizationF5Test extends TestCase {
+
+	// ── F5: api_request() no longer accepts a string action ───────────────────
+
+	/**
+	 * api_request() must not declare a string first parameter — the former
+	 * $_action was unused (every call resolved to get_version). Source assertion.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function test_f5_api_request_has_no_action_string_parameter(): void {
+		$source = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
+		);
+		$this->assertNotEmpty( $source, 'class-plugin-updater.php source file could not be read.' );
+		$this->assertStringNotContainsString(
+			'private function api_request( string $_action',
+			$source,
+			'F5: api_request() must not have a string $_action parameter — it was unused; every call resolves to get_version.'
+		);
+	}
+
+	/**
+	 * api_request() must still accept an array parameter (the slug-guard data).
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function test_f5_api_request_accepts_array_data_parameter(): void {
+		$source = (string) file_get_contents(
+			dirname( __DIR__, 2 ) . '/woodev/plugin-updater/class-plugin-updater.php'
+		);
+		$this->assertNotEmpty( $source, 'class-plugin-updater.php source file could not be read.' );
+		$this->assertStringContainsString(
+			'private function api_request( array $_data )',
+			$source,
+			'F5: api_request() must accept array $_data as its only parameter after removing the unused $_action.'
+		);
+	}
+
+	/**
+	 * api_request() signature must be reflected via ReflectionMethod — confirms the
+	 * method exists with exactly ONE parameter (no leftover action arg).
+	 *
+	 * @since 2.0.2
+	 *
+	 * @return void
+	 */
+	public function test_f5_api_request_has_exactly_one_parameter(): void {
+		$r = new \ReflectionMethod( \Woodev_Plugin_Updater::class, 'api_request' );
+		$this->assertCount(
+			1,
+			$r->getParameters(),
+			'F5: api_request() must have exactly one parameter (array $_data) after removing the unused string $_action.'
+		);
+	}
+}

--- a/woodev/plugin-updater/class-plugin-updater.php
+++ b/woodev/plugin-updater/class-plugin-updater.php
@@ -131,7 +131,6 @@ if ( ! class_exists( 'Woodev_Plugin_Updater' ) ) :
 			if ( false === $version_info || ( $this->api_handler->is_debug_enabled() && isset( $_GET['force-check'] ) ) ) {
 
 				$version_info = $this->api_request(
-					'plugin_latest_version',
 					array(
 						'slug' => $this->slug,
 						'beta' => $this->beta,
@@ -352,7 +351,7 @@ if ( ! class_exists( 'Woodev_Plugin_Updater' ) ) :
 			// If we have no transient-saved value, run the API, set a fresh transient with the API value, and return that value too right now.
 			if ( empty( $edd_api_request_transient ) ) {
 
-				$api_response = $this->api_request( 'plugin_information', $to_send );
+				$api_response = $this->api_request( $to_send );
 
 				// Expires in 3 hours
 				$this->set_version_info_cache( $api_response );
@@ -416,17 +415,20 @@ if ( ! class_exists( 'Woodev_Plugin_Updater' ) ) :
 		}
 
 		/**
-		 * Calls the API and, if successfull, returns the object delivered by the API.
+		 * Fetches version info from the remote store.
 		 *
-		 * @param string $_action The requested action.
-		 * @param array  $_data   Parameters for the API action.
+		 * All callers issue the same `get_version` action (OB-3 F5: the former
+		 * `$_action` parameter was unused — every call resolved to `get_version`).
+		 * The slug guard is a containment sanity-check: both call sites always pass
+		 * `$this->slug`, so this returns false only on an internal wiring mistake.
+		 *
+		 * @since 1.2.1
+		 *
+		 * @param array $_data Parameters that must contain a `slug` key matching this plugin.
 		 *
 		 * @return false|object
-		 * @uses get_bloginfo()
-		 * @uses wp_remote_get()
-		 * @uses is_wp_error()
 		 */
-		private function api_request( string $_action, array $_data ) {
+		private function api_request( array $_data ) {
 			$data = array_merge( $this->api_data, $_data );
 
 			if ( $data['slug'] !== $this->slug ) {

--- a/woodev/plugin-updater/class-plugin-updater.php
+++ b/woodev/plugin-updater/class-plugin-updater.php
@@ -419,8 +419,9 @@ if ( ! class_exists( 'Woodev_Plugin_Updater' ) ) :
 		 *
 		 * All callers issue the same `get_version` action (OB-3 F5: the former
 		 * `$_action` parameter was unused — every call resolved to `get_version`).
-		 * The slug guard is a containment sanity-check: both call sites always pass
-		 * `$this->slug`, so this returns false only on an internal wiring mistake.
+		 * Returns false in two cases: (a) slug mismatch (containment sanity-check —
+		 * both call sites always pass `$this->slug`, so this only fires on a wiring
+		 * mistake); (b) a recent request failure recorded by request_recently_failed().
 		 *
 		 * @since 1.2.1
 		 *


### PR DESCRIPTION
## Summary

**F5** from OB-3 review: `api_request()` accepted a `string $_action` parameter that was never read — both callers passed different strings (`'plugin_latest_version'`, `'plugin_information'`) but both resolved to the same `get_version` wire call via `get_version_from_remote()`. The parameter is dead abstraction.

Changes:
- Remove `string $_action` from `api_request()` signature; update docblock to reflect single responsibility
- Update both call sites (`get_repo_api_data()` and `plugins_api_filter()`) — remove the action string argument
- 3 new assertions in `UpdaterNormalizationF5Test.php`: source-level (no old signature, correct new signature) + ReflectionMethod parameter count

**Wire contract unchanged**: `edd_action='get_version'` in `get_api_params()` is untouched; slug guard and backoff guard preserved byte-for-byte.

**Not included**: F1 (sections normalization) and F3 (cache key isolation) require verifying the store's actual payload shape first — deferred per OB-3 review step ordering.

## Test plan

- [x] `./vendor/bin/phpunit tests/unit/UpdaterNormalizationF5Test.php` — 3 tests GREEN
- [x] `composer check` — phpcs 0, phpstan 0, 624/624 tests (65 skipped baseline)
- [ ] Codex adversarial review — pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)