### PR TITLE
feat(admin): OB-8 — Woodev marketplace tab on plugin-install.php

### DIFF
--- a/tests/unit/PluginInstallTabTest.php
+++ b/tests/unit/PluginInstallTabTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Woodev\Tests\Unit;
+
+// Load the class under test so the behavioral test can instantiate it.
+require_once dirname( __DIR__, 2 ) . '/woodev/admin/class-plugin-install-tab.php';
+
+/**
+ * Tests for Woodev_Plugin_Install_Tab (OB-8).
+ *
+ * Source-level assertions verify structural contracts (hook wiring, view wiring).
+ * The behavioral test verifies register_tab() actually inserts the 'woodev' key.
+ *
+ * @since 2.0.2
+ */
+class PluginInstallTabTest extends TestCase {
+
+	/** @var string */
+	private string $source;
+
+	/** @var string */
+	private string $admin_pages_source;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->source             = (string) file_get_contents( dirname( __DIR__, 2 ) . '/woodev/admin/class-plugin-install-tab.php' );
+		$this->admin_pages_source = (string) file_get_contents( dirname( __DIR__, 2 ) . '/woodev/admin/class-admin-pages.php' );
+	}
+
+	// ── File existence ────────────────────────────────────────────────────────
+
+	public function test_class_file_exists(): void {
+		self::assertFileExists( dirname( __DIR__, 2 ) . '/woodev/admin/class-plugin-install-tab.php' );
+	}
+
+	public function test_view_file_exists(): void {
+		self::assertFileExists( dirname( __DIR__, 2 ) . '/woodev/admin/pages/views/html-plugin-install-tab.php' );
+	}
+
+	// ── Hook wiring (source-level) ────────────────────────────────────────────
+
+	public function test_source_hooks_install_plugins_tabs_filter(): void {
+		self::assertNotEmpty( $this->source, 'class-plugin-install-tab.php must not be empty' );
+		self::assertStringContainsString( "'install_plugins_tabs'", $this->source );
+	}
+
+	public function test_source_hooks_install_plugins_pre_woodev_action(): void {
+		self::assertNotEmpty( $this->source, 'class-plugin-install-tab.php must not be empty' );
+		self::assertStringContainsString( "'install_plugins_pre_woodev'", $this->source );
+	}
+
+	public function test_source_enqueues_styles_via_admin_enqueue_scripts(): void {
+		self::assertNotEmpty( $this->source, 'class-plugin-install-tab.php must not be empty' );
+		self::assertStringContainsString( "'admin_enqueue_scripts'", $this->source );
+	}
+
+	public function test_source_registers_woodev_tab_key(): void {
+		self::assertNotEmpty( $this->source, 'class-plugin-install-tab.php must not be empty' );
+		self::assertStringContainsString( "'woodev'", $this->source );
+	}
+
+	// ── Admin pages integration (source-level) ────────────────────────────────
+
+	public function test_admin_pages_wires_plugin_install_tab(): void {
+		self::assertNotEmpty( $this->admin_pages_source, 'class-admin-pages.php must not be empty' );
+		self::assertStringContainsString( 'Woodev_Plugin_Install_Tab', $this->admin_pages_source );
+	}
+
+	public function test_admin_pages_calls_init_plugin_install_tab(): void {
+		self::assertNotEmpty( $this->admin_pages_source, 'class-admin-pages.php must not be empty' );
+		self::assertStringContainsString( 'init_plugin_install_tab', $this->admin_pages_source );
+	}
+
+	// ── Behavioral: register_tab() ────────────────────────────────────────────
+
+	/**
+	 * register_tab() must insert a 'woodev' => string entry into the tabs array.
+	 *
+	 * Uses newInstanceWithoutConstructor() to avoid the Woodev_Plugin dependency
+	 * (constructor type is not checked when bypassed via Reflection).
+	 *
+	 * @since 2.0.2
+	 */
+	public function test_register_tab_adds_woodev_key(): void {
+		$ref    = new \ReflectionClass( \Woodev_Plugin_Install_Tab::class );
+		$inst   = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod( 'register_tab' );
+
+		$result = $method->invoke( $inst, [] );
+
+		self::assertIsArray( $result );
+		self::assertArrayHasKey( 'woodev', $result );
+		self::assertIsString( $result['woodev'] );
+	}
+}

--- a/woodev/admin/class-admin-pages.php
+++ b/woodev/admin/class-admin-pages.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Woodev_Admin_Pages' ) ) :
 		 *
 		 * @return void
 		 */
-		public function instance( Woodev_Plugin $woodev_plugin ) {
+		public function instance( Woodev_Plugin $woodev_plugin ): void {
 
 			$this->woodev_plugin = $woodev_plugin;
 
@@ -41,6 +41,19 @@ if ( ! class_exists( 'Woodev_Admin_Pages' ) ) :
 			}
 
 			add_filter( 'menu_order', array( $this, 'menu_order' ) );
+
+			$this->init_plugin_install_tab();
+		}
+
+		/**
+		 * Register the Woodev tab on the plugin-install.php screen.
+		 *
+		 * @since 2.0.2
+		 * @return void
+		 */
+		private function init_plugin_install_tab(): void {
+			include_once $this->woodev_plugin->get_framework_path() . '/admin/class-plugin-install-tab.php';
+			( new Woodev_Plugin_Install_Tab( $this->woodev_plugin ) )->init();
 		}
 
 		public function admin_menu() {

--- a/woodev/admin/class-plugin-install-tab.php
+++ b/woodev/admin/class-plugin-install-tab.php
@@ -1,0 +1,112 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Woodev_Plugin_Install_Tab' ) ) :
+
+	/**
+	 * Adds a "Woodev" tab to /wp-admin/plugin-install.php,
+	 * rendering the Woodev marketplace when the tab is active.
+	 *
+	 * @since 2.0.2
+	 */
+	class Woodev_Plugin_Install_Tab {
+
+		/**
+		 * Main plugin instance.
+		 *
+		 * @since 2.0.2
+		 * @var Woodev_Plugin
+		 */
+		private Woodev_Plugin $plugin;
+
+		/**
+		 * @since 2.0.2
+		 *
+		 * @param Woodev_Plugin $plugin Main plugin instance.
+		 */
+		public function __construct( Woodev_Plugin $plugin ) {
+			$this->plugin = $plugin;
+		}
+
+		/**
+		 * Register WordPress hooks.
+		 *
+		 * @since 2.0.2
+		 * @return void
+		 */
+		public function init(): void {
+			add_filter( 'install_plugins_tabs', [ $this, 'register_tab' ] );
+			add_action( 'admin_enqueue_scripts', [ $this, 'maybe_enqueue_styles' ] );
+			add_action( 'install_plugins_pre_woodev', [ $this, 'render' ] );
+		}
+
+		/**
+		 * Append the Woodev tab to the plugin-install.php tab list.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<string, string> $tabs Tab slug => label map.
+		 * @return array<string, string>
+		 */
+		public function register_tab( array $tabs ): array {
+			$tabs['woodev'] = __( 'Woodev', 'woodev-plugin-framework' );
+			return $tabs;
+		}
+
+		/**
+		 * Enqueue marketplace CSS when on the Woodev plugin-install tab.
+		 *
+		 * Fires on admin_enqueue_scripts so the stylesheet lands in <head>.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $hook Current admin page hook suffix.
+		 * @return void
+		 */
+		public function maybe_enqueue_styles( string $hook ): void {
+			$tab = sanitize_key( $_GET['tab'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only tab slug check, no state change.
+
+			if ( 'plugin-install.php' !== $hook || 'woodev' !== $tab ) {
+				return;
+			}
+
+			wp_enqueue_style(
+				'woodev-plugin-install-tab',
+				$this->plugin->get_framework_assets_url() . '/css/admin/woodev-plugins-page.css',
+				[],
+				$this->plugin->get_version()
+			);
+		}
+
+		/**
+		 * Render the Woodev marketplace content and exit cleanly.
+		 *
+		 * Fires via install_plugins_pre_woodev, after admin-header.php has been printed.
+		 * We output our page content, include admin-footer.php, then exit so the native
+		 * plugin list table is never displayed.
+		 *
+		 * @since 2.0.2
+		 * @return void
+		 */
+		public function render(): void {
+			if ( ! class_exists( 'Woodev_Admin_Plugins' ) ) {
+				include_once $this->plugin->get_framework_path() . '/admin/pages/class-admin-plugins.php';
+			}
+
+			$section  = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$search   = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$sections = Woodev_Admin_Plugins::get_sections();
+			$addons   = ( 'all' === $section && '' === $search )
+				? ( Woodev_Admin_Plugins::get_all_extension() ?: [] )
+				: ( Woodev_Admin_Plugins::get_extension_by_query() ?: [] );
+			$base_url = admin_url( 'plugin-install.php?tab=woodev' );
+
+			include __DIR__ . '/pages/views/html-plugin-install-tab.php';
+
+			require_once ABSPATH . 'wp-admin/admin-footer.php';
+			exit;
+		}
+	}
+
+endif;

--- a/woodev/admin/pages/views/html-plugin-install-tab.php
+++ b/woodev/admin/pages/views/html-plugin-install-tab.php
@@ -1,0 +1,107 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Variables passed from Woodev_Plugin_Install_Tab::render():
+ *
+ * @var array<int, object> $addons   Product objects from the Woodev store API.
+ * @var string             $base_url Base URL for tab navigation (plugin-install.php?tab=woodev).
+ * @var string             $search   Current search query.
+ * @var string             $section  Current section/category slug.
+ * @var array<int, object> $sections Category objects from the Woodev store API.
+ */
+?>
+<div class="woodev-extension-wrap">
+	<div class="woodev-extension-header">
+		<h1 class="woodev-extension-header__title"><?php esc_html_e( 'Woodev Plugins', 'woodev-plugin-framework' ); ?></h1>
+		<p class="woodev-extension-header__description"><?php esc_html_e( 'Improve your WordPress website with our extensions.', 'woodev-plugin-framework' ); ?></p>
+		<form method="GET" class="woodev-extension-header__search-form" action="<?php echo esc_url( admin_url( 'plugin-install.php' ) ); ?>">
+			<input
+				type="text"
+				name="search"
+				value="<?php echo esc_attr( $search ); ?>"
+				placeholder="<?php esc_attr_e( 'Search for extensions', 'woodev-plugin-framework' ); ?>"
+			/>
+			<button type="submit">
+				<span class="dashicons dashicons-search"></span>
+			</button>
+			<input type="hidden" name="tab" value="woodev">
+		</form>
+	</div>
+
+	<div class="wrap">
+		<div class="woodev-extension-content-wrapper">
+
+			<div class="woodev-extension-content-categories">
+				<ul>
+					<li <?php echo ( 'all' === $section ) ? 'class="current"' : ''; ?>>
+						<a href="<?php echo esc_url( $base_url ); ?>">
+							<?php esc_html_e( 'All', 'woodev-plugin-framework' ); ?>
+						</a>
+					</li>
+					<?php foreach ( (array) $sections as $category ) : ?>
+						<li <?php echo ( $category->slug === $section ) ? 'class="current"' : ''; ?>>
+							<a href="<?php echo esc_url( add_query_arg( 'section', $category->slug, $base_url ) ); ?>">
+								<?php echo esc_html( $category->label ); ?>
+							</a>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+
+			<div class="woodev-extension-content-list">
+				<?php foreach ( (array) $addons as $addon ) : ?>
+					<div class="woodev-extension-content-item">
+						<div class="details">
+							<div class="picture">
+								<a href="<?php echo esc_url( Woodev_Admin_Plugins::generate_utm_url( $addon->info->permalink ?: $addon->info->link, $addon->info->slug ) ); ?>" target="_blank" rel="noopener noreferrer">
+									<img
+										src="<?php echo esc_url( isset( $addon->info->thumbnails, $addon->info->thumbnails->small ) ? $addon->info->thumbnails->small : $addon->info->thumbnail ); ?>"
+										alt="<?php echo esc_attr( $addon->info->title ); ?>"
+									/>
+								</a>
+							</div>
+							<div class="description">
+								<h3 class="name">
+									<a href="<?php echo esc_url( Woodev_Admin_Plugins::generate_utm_url( $addon->info->permalink ?: $addon->info->link, $addon->info->slug ) ); ?>" target="_blank" rel="noopener noreferrer">
+										<?php echo esc_html( $addon->info->title ); ?>
+									</a>
+								</h3>
+								<div class="excerpt">
+									<?php echo wp_kses_post( $addon->info->excerpt ); ?>
+								</div>
+							</div>
+						</div>
+						<div class="footer">
+							<div class="info">
+								<?php
+								if ( isset( $addon->rating ) ) {
+									wp_star_rating(
+										[
+											'rating' => $addon->rating,
+											'type'   => 'percent',
+										]
+									);
+								}
+								?>
+							</div>
+							<div class="action-button">
+								<?php
+								$amount      = isset( $addon->pricing->amount ) ? intval( $addon->pricing->amount ) : 0;
+								$button_text = $amount > 0
+									? sprintf( __( 'Buy by %d RUB', 'woodev-plugin-framework' ), intval( $addon->pricing->amount ) )
+									: __( 'Free download', 'woodev-plugin-framework' );
+								?>
+								<a href="<?php echo esc_url( Woodev_Admin_Plugins::generate_utm_url( $addon->info->permalink ?: $addon->info->link, $addon->info->slug ) ); ?>" class="button">
+									<?php echo esc_html( $button_text ); ?>
+								</a>
+							</div>
+						</div>
+					</div>
+				<?php endforeach; ?>
+			</div>
+
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Summary

- Adds a **Woodev** tab to `/wp-admin/plugin-install.php` (mirrors WooCommerce's `?tab=woo` pattern)
- New class `Woodev_Plugin_Install_Tab` hooks into `install_plugins_tabs` (tab registration), `admin_enqueue_scripts` (CSS), and `install_plugins_pre_woodev` (render + early exit)
- Marketplace content rendered via the existing `Woodev_Admin_Plugins` API (sections, products) with a new dedicated view that uses plugin-install.php URLs (`?tab=woodev&section=…`)
- Also fixes `Woodev_Admin_Pages::instance()` missing `: void` return type (M-1 from Codex review)

## Test plan

- [ ] 9 new tests (8 source-level assertions + 1 behavioral `register_tab()` via ReflectionClass): `composer test:unit` green locally (633 tests)
- [ ] `composer check` clean (phpcs + phpstan L3 + unit)
- [ ] CI green before merge
- [ ] Manual verification on rig: `/wp-admin/plugin-install.php` should show a "Woodev" tab that renders the marketplace grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)