### PR TITLE
fix(setup): WP_Error in complete() @return (PHPStan L3 — fixes red main)

### DIFF
--- a/woodev/rest-api/controllers/class-rest-api-setup.php
+++ b/woodev/rest-api/controllers/class-rest-api-setup.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'Woodev_REST_API_Setup' ) ) :
 		 * @since 2.0.2
 		 *
 		 * @param \WP_REST_Request $request request.
-		 * @return \WP_REST_Response|array<string,mixed>
+		 * @return \WP_REST_Response|\WP_Error|array<string,mixed>
 		 */
 		public function complete( $request ) {
 			$state = 'skipped' === $request->get_param( 'state' ) ? 'skipped' : 'completed';


### PR DESCRIPTION
Hotfix: #81 added a WP_Error return to `Woodev_REST_API_Setup::complete()` but its `@return` docblock omitted `\WP_Error`, so PHPStan L3 failed on main (931d38c). One-line docblock alignment with `save_step()`. phpcs clean, unit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)