### PR TITLE
ci: run the JS suite in CI and bound every job with a timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
   version:
     name: Read version
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       current: ${{ steps.read.outputs.current }}
       previous: ${{ steps.read.outputs.previous }}
@@ -55,6 +56,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: version
 
     steps:
@@ -88,7 +90,7 @@ jobs:
         run: ./vendor/bin/phpcs --warning-severity=0
 
       - name: Run PHPStan
-        run: ./vendor/bin/phpstan analyse --memory-limit=2G
+        run: ./vendor/bin/phpstan analyse --memory-limit=4G
 
   # ===========================================================================
   # PHP Compatibility check (7.4 → 8.2)
@@ -96,6 +98,7 @@ jobs:
   compat:
     name: PHP Compat (${{ matrix.php }})
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: lint
 
     strategy:
@@ -133,6 +136,7 @@ jobs:
   unit-tests:
     name: Unit Tests (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: lint
 
     strategy:
@@ -169,12 +173,46 @@ jobs:
         run: composer test:unit
 
   # ===========================================================================
+  # JS-тесты (wp-scripts test-unit-js — jsdom, наш jest owner).
+  # НИКОГДА не подменять на `npx jest` — без конфига wp-scripts jest падает
+  # обратно на node-окружение и теряет jsdom (см.
+  # docs-internal/gotchas/npx-jest-bypasses-wp-scripts-jsdom.md).
+  #
+  # timeout-minutes низкий и намеренный: баг из SP-5 (s46) в
+  # map-provider-yandex.js вызывал неограниченную рекурсию по микрозадачам,
+  # которая забивала очередь макрозадач настолько, что не срабатывал даже
+  # собственный таймаут теста в jest — набор просто висел вечно без вывода.
+  # Без job-таймаута такое зависание сжигает весь лимит джобы впустую.
+  # ===========================================================================
+  test-js:
+    name: JS Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run JS tests
+        run: npm run test:js
+
+  # ===========================================================================
   # Сборка JS-бандла и проверка паритета с закоммиченным woodev/assets/build/
   # Независимый job: node-сбой не должен маскировать PHP-матрицу
   # ===========================================================================
   assets:
     name: Assets build parity
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -224,7 +262,8 @@ jobs:
   release:
     name: Publish Release v${{ needs.version.outputs.current }}
     runs-on: ubuntu-latest
-    needs: [version, lint, unit-tests, assets]
+    timeout-minutes: 15
+    needs: [version, lint, unit-tests, test-js, assets]
     permissions:
       contents: write
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,6 +20,7 @@ jobs:
   auto-merge:
     name: Merge Dependabot PR when all checks pass
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     # Only proceed if the triggering workflow succeeded and the actor is Dependabot.
     if: >

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     name: Build MkDocs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -53,6 +54,7 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,6 +21,7 @@ jobs:
   integration:
     name: WP ${{ matrix.wp }} / WC ${{ matrix.wc }} / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       WP_ENV_HOME: /tmp/wp-env
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,6 +18,7 @@ jobs:
   markdownlint:
     name: Markdown Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -8,6 +8,7 @@ jobs:
   label-pr:
     name: Label PR
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "scripts": {
         "phpcs":       "./vendor/bin/phpcs",
         "phpcbf":      "./vendor/bin/phpcbf",
-        "phpstan":     "./vendor/bin/phpstan analyse --memory-limit=2G",
+        "phpstan":     "./vendor/bin/phpstan analyse --memory-limit=4G",
         "test":        "./vendor/bin/phpunit --testsuite=Unit",
         "test:unit":   "./vendor/bin/phpunit --testsuite=Unit",
         "test:integration": "./vendor/bin/phpunit --testsuite=Integration",


### PR DESCRIPTION
## #146 — the JS suite never ran in CI

701 jest tests existed that CI never executed: the Node job only built bundles, and
`npm run test:js` was invoked by no workflow. Any frontend regression could reach `main`
with every PHP job green.

Adds a "JS Tests" job to `ci.yml` mirroring the existing "Assets build parity" setup
(same `.nvmrc`-driven node, same `npm ci`), running `npm run test:js` — never `npx jest`,
which has no config here and reports phantom failures with a wrong total (gotcha
`npx-jest-bypasses-wp-scripts-jsdom`). Also added to the `release` job's `needs:` so a
release cannot ship on a broken JS layer.

## #146, second half — no timeouts anywhere

No workflow set `timeout-minutes`. That matters specifically here: a microtask-recursion
regression in the map provider hangs jest so hard that even its own per-test timeout does
not fire — the job would burn its full limit with an empty log. Every job in every
workflow now has a timeout, set to a generous multiple of observed runtimes rather than a
tight bound, so this does not become a source of flaky red.

## #164 — `composer phpstan` OOMs on 2G

Raised to 4G. `check` aliases `@phpstan` so it inherits the fix.

Two findings beyond the issue:
- `ci.yml`'s `lint` job invokes `phpstan analyse --memory-limit=2G` directly, not through
  the composer script — the same OOM, in a second place. Also raised.
- `phpstan.neon` already sets `maximumNumberOfProcesses: 1`, so capping workers (the
  issue's suggested cheaper alternative) was already done and is not available as a lever.

Verified: before, `2G` crashes the parallel worker; after, `[OK] No errors` across 193
files. Locally `npm run test:js` reports 701/701 passing in 8 suites.

Closes #146
Closes #164
