### PR TITLE
fix(pickup): filter payment_methods/photos instead of strval-coercing them

### DIFF
--- a/tests/unit/Shipping/Pickup/PickupPointTest.php
+++ b/tests/unit/Shipping/Pickup/PickupPointTest.php
@@ -247,6 +247,23 @@ final class PickupPointTest extends TestCase {
 		$this->assertSame( [ 'Наличные' ], $point->to_array()['payment_methods'] );
 	}
 
+	/**
+	 * Pins a deliberate behaviour change (issue #154 follow-up, 2026-08-07): the pre-fix
+	 * `array_map( 'strval', ... )` coerced scalars, so an integer element used to SURVIVE as
+	 * its stringified form ('5'). `sanitize_string_list()` requires `is_string()` and drops
+	 * it instead. See that method's docblock for why: neither reference carrier
+	 * (`plugins-reference/woocommerce-edostavka`, `plugins-reference/woocommerce-yandex-delivery`)
+	 * nor any in-repo fixture ever produces a numeric `payment_methods` element, so this is not
+	 * a real shape to accommodate — it is far more likely a broken adapter leaking an internal
+	 * id, and displaying that id as a payment method would be exactly the "Array" bug's failure
+	 * mode wearing a different number.
+	 */
+	public function test_integer_payment_methods_are_dropped_not_stringified(): void {
+		$point = $this->make_point( [ 'payment_methods' => [ 'Наличные', 5 ] ] );
+
+		$this->assertSame( [ 'Наличные' ], $point->to_array()['payment_methods'] );
+	}
+
 	public function test_non_string_photos_are_dropped(): void {
 		$point = $this->make_point( [ 'photos' => [ 'https://example.test/a.jpg', [ 'x' ], null, 5 ] ] );
 
@@ -267,6 +284,20 @@ final class PickupPointTest extends TestCase {
 
 	public function test_whitespace_only_photos_are_dropped(): void {
 		$point = $this->make_point( [ 'photos' => [ 'https://example.test/a.jpg', '   ', '' ] ] );
+
+		$this->assertSame( [ 'https://example.test/a.jpg' ], $point->to_array()['photos'] );
+	}
+
+	/**
+	 * Pins the same deliberate change as
+	 * {@see self::test_integer_payment_methods_are_dropped_not_stringified()} for `photos`: an
+	 * integer element is dropped, not `strval()`-coerced into a fabricated "URL". No reference
+	 * carrier populates `photos` at all yet (always `[]` in every in-repo fixture), so there is
+	 * no real shape being narrowed here — only a hypothetical one that would be equally wrong to
+	 * accommodate silently.
+	 */
+	public function test_integer_photos_are_dropped_not_stringified(): void {
+		$point = $this->make_point( [ 'photos' => [ 'https://example.test/a.jpg', 5 ] ] );
 
 		$this->assertSame( [ 'https://example.test/a.jpg' ], $point->to_array()['photos'] );
 	}

--- a/tests/unit/Shipping/Pickup/PickupPointTest.php
+++ b/tests/unit/Shipping/Pickup/PickupPointTest.php
@@ -224,4 +224,50 @@ final class PickupPointTest extends TestCase {
 
 		$this->assertSame( [ '0' ], $point->to_array()['services'] );
 	}
+
+	public function test_non_string_payment_methods_are_dropped(): void {
+		$point = $this->make_point( [ 'payment_methods' => [ 'Наличные', [ 'x' ], null, 5 ] ] );
+
+		$this->assertSame( [ 'Наличные' ], $point->to_array()['payment_methods'] );
+	}
+
+	public function test_surviving_payment_methods_are_reindexed_from_zero(): void {
+		// Same array_filter()-preserves-keys trap as services (see the note on that field's
+		// fixture): every other case here happens to keep key 0, so this is the one that
+		// kills the mutant that would drop array_values() and leave a sparse array.
+		$point = $this->make_point( [ 'payment_methods' => [ [ 'x' ], 'Наличные', null, 'Картой' ] ] );
+
+		$this->assertSame( [ 0, 1 ], array_keys( $point->to_array()['payment_methods'] ) );
+		$this->assertSame( [ 'Наличные', 'Картой' ], $point->to_array()['payment_methods'] );
+	}
+
+	public function test_whitespace_only_payment_methods_are_dropped(): void {
+		$point = $this->make_point( [ 'payment_methods' => [ 'Наличные', '   ', '' ] ] );
+
+		$this->assertSame( [ 'Наличные' ], $point->to_array()['payment_methods'] );
+	}
+
+	public function test_non_string_photos_are_dropped(): void {
+		$point = $this->make_point( [ 'photos' => [ 'https://example.test/a.jpg', [ 'x' ], null, 5 ] ] );
+
+		$this->assertSame( [ 'https://example.test/a.jpg' ], $point->to_array()['photos'] );
+	}
+
+	public function test_surviving_photos_are_reindexed_from_zero(): void {
+		$point = $this->make_point(
+			[ 'photos' => [ [ 'x' ], 'https://example.test/a.jpg', null, 'https://example.test/b.jpg' ] ]
+		);
+
+		$this->assertSame( [ 0, 1 ], array_keys( $point->to_array()['photos'] ) );
+		$this->assertSame(
+			[ 'https://example.test/a.jpg', 'https://example.test/b.jpg' ],
+			$point->to_array()['photos']
+		);
+	}
+
+	public function test_whitespace_only_photos_are_dropped(): void {
+		$point = $this->make_point( [ 'photos' => [ 'https://example.test/a.jpg', '   ', '' ] ] );
+
+		$this->assertSame( [ 'https://example.test/a.jpg' ], $point->to_array()['photos'] );
+	}
 }

--- a/woodev/shipping-method/pickup/class-pickup-point.php
+++ b/woodev/shipping-method/pickup/class-pickup-point.php
@@ -133,6 +133,23 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Point' ) ) :
 		 * re-indexes so `wp_json_encode()` emits a JSON array, not an object, the moment any
 		 * record is dropped (see gotcha: php-stdlib-traps-that-survive-tests).
 		 *
+		 * DELIBERATELY STRICT, not just non-empty-after-cast: an `int`, `float`, or `bool`
+		 * element is DROPPED, not `strval()`-coerced into a string that happens to look
+		 * plausible. This narrows the old `payment_methods`/`photos` behaviour (which used
+		 * `array_map( 'strval', ... )` and so kept a coerced `5` as `'5'`) rather than merely
+		 * closing the "Array" hole while leaving scalar coercion in place — checked against
+		 * both reference carriers in `plugins-reference/` (issue #154 follow-up, 2026-08-07):
+		 * CDEK (`woocommerce-edostavka`) never emits a `payment_methods` list at all — its API
+		 * reports `have_cashless`/`have_cash`/`allowed_cod` booleans, which an adapter targeting
+		 * this contract would map to STRING codes, not carry through as numbers; Yandex Delivery
+		 * (`woocommerce-yandex-delivery`) emits string codes directly (`'cash_on_receipt'`,
+		 * `'card_on_receipt'`). Every in-repo pickup fixture agrees (`'card'`, `'cod'`; `photos`
+		 * always `[]` — no real carrier this framework targets populates it yet). A numeric
+		 * element here is therefore not a plausible carrier shape to accommodate; it is far more
+		 * likely a broken adapter leaking an internal id/enum, and silently stringifying it would
+		 * put a meaningless "5" in front of the customer exactly as confusingly as "Array" did —
+		 * dropping it is the correct failure mode, matching `services`, which never coerced.
+		 *
 		 * @since 2.0.2
 		 *
 		 * @param array<int|string, mixed> $list Raw list from a carrier payload.

--- a/woodev/shipping-method/pickup/class-pickup-point.php
+++ b/woodev/shipping-method/pickup/class-pickup-point.php
@@ -81,31 +81,15 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Point' ) ) :
 			}
 
 			$payment_methods = isset( $payload['payment_methods'] )
-				? array_map( 'strval', (array) $payload['payment_methods'] )
+				? self::sanitize_string_list( (array) $payload['payment_methods'] )
 				: [];
 
 			$photos = isset( $payload['photos'] )
-				? array_map( 'strval', (array) $payload['photos'] )
+				? self::sanitize_string_list( (array) $payload['photos'] )
 				: [];
 
-			// Unlike payment_methods/photos above (which strval-cast every element), services
-			// are filtered rather than coerced: a non-string element (an un-flattened object, an
-			// array a carrier adapter forgot to map) is dropped instead of becoming the literal
-			// string "Array" — esc_html() in to_browser_array() would fatal on an actual array.
-			// A whitespace-only entry ('   ') is treated as absent and dropped via trim(); the
-			// string '0' is a legitimate service label and is deliberately kept — it is truthy
-			// via trim() !== '' but would be silently eaten by a naive `if ( $service )` filter.
-			// array_values() re-indexes so wp_json_encode() emits a JSON array, not an object
-			// (see gotcha: php-stdlib-traps-that-survive-tests).
 			$services = isset( $payload['services'] )
-				? array_values(
-					array_filter(
-						(array) $payload['services'],
-						static function ( $service ): bool {
-							return is_string( $service ) && '' !== trim( $service );
-						}
-					)
-				)
+				? self::sanitize_string_list( (array) $payload['services'] )
 				: [];
 
 			return new self(
@@ -131,6 +115,38 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Point' ) ) :
 					'accepts_cod'     => isset( $payload['accepts_cod'] ) ? (bool) $payload['accepts_cod'] : null,
 					'max_weight'      => isset( $payload['max_weight'] ) ? (int) $payload['max_weight'] : null,
 				]
+			);
+		}
+
+		/**
+		 * Filters a raw carrier list down to non-empty strings, re-indexed from zero.
+		 *
+		 * Shared by `payment_methods`, `photos`, and `services`. Elements are FILTERED, not
+		 * coerced: a non-string element (an un-flattened carrier object, a nested array a
+		 * carrier adapter forgot to map) is dropped instead of becoming the literal string
+		 * "Array" — `strval()`/`(string)` on an array in PHP 8 does not fatal, it emits a
+		 * warning and returns "Array", which would otherwise reach the customer as a payment
+		 * method or photo literally named "Array" (see issue #154). A whitespace-only entry
+		 * ('   ') is treated as absent and dropped via `trim()`; the string '0' is a
+		 * legitimate label and is deliberately kept — it is truthy via `trim() !== ''` but
+		 * would be silently eaten by a naive `if ( $value )` filter. `array_values()`
+		 * re-indexes so `wp_json_encode()` emits a JSON array, not an object, the moment any
+		 * record is dropped (see gotcha: php-stdlib-traps-that-survive-tests).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<int|string, mixed> $list Raw list from a carrier payload.
+		 *
+		 * @return string[] Non-empty string values, re-indexed from zero.
+		 */
+		private static function sanitize_string_list( array $list ): array {
+			return array_values(
+				array_filter(
+					$list,
+					static function ( $value ): bool {
+						return is_string( $value ) && '' !== trim( $value );
+					}
+				)
 			);
 		}
 


### PR DESCRIPTION
`payment_methods` and `photos` were normalized with `array_map( 'strval', … )`. An
un-flattened element from a carrier adapter does not fatal on PHP 8 — it emits a warning
and returns the literal string `"Array"`, which reaches the customer as a payment method
named "Array".

Both now use the same filter the newer `services` field already used, extracted into a
shared `Pickup_Point::sanitize_string_list()`: keep non-empty strings, drop everything
else, `array_values()` to re-index. The re-index is required, not cosmetic — these fields
cross the REST boundary and `array_filter()` preserves keys, so `wp_json_encode()` would
emit a JSON object the moment one entry was dropped (gotcha
`php-stdlib-traps-that-survive-tests`).

### The behaviour change, decided deliberately

`strval()` also coerced scalars, so an integer element used to survive as `'1'`; the
filter drops it. That was checked against reality rather than inherited from the
`services` precedent: CDEK's API exposes no `payment_methods` list at all (it returns
`have_cashless`/`have_cash`/`allowed_cod` booleans), Yandex.Delivery emits string codes
(`cash_on_receipt`, `card_on_receipt`), and every fixture uses strings. No carrier this
framework targets sends a number here, so an integer arriving in this field indicates a
broken adapter leaking an internal id — surfacing `"5"` as a payment method is the same
customer-facing defect as `"Array"`, just quieter. Dropping is now documented as
deliberate and pinned by tests in both directions.

`photos` keeps "non-empty string" rather than URL validation on purpose:
`to_browser_array()` already applies `esc_url_raw()` at the browser edge, and stricter
validation here would reject legitimate relative URLs.

1426 unit tests, phpcs clean, PHPStan clean.

Closes #154
