### PR TITLE
perf(pickup): do not rebuild the point list for an unchanged selection

### DIFF
--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -383,6 +383,104 @@ describe( 'selected row highlight (Task 10)', () => {
 } );
 
 // -----------------------------------------------------------------------
+// #172: `setSelectedId()` used to rebuild the whole list (`renderListBody()` — up to LIST_CAP
+// DOM nodes recreated, every row's click listener re-attached) EVERY time it was called, even
+// when the id it was handed is the exact one already recorded. `pickup-mount.js`'s restore pass
+// does exactly that on session open under `strategy: 'viewport'`: `alreadySelected` seeds
+// `_selectedId` before the first fetch, then `restoreSelection()` calls `setSelectedId()` again
+// with the SAME value once the map is ready — a second full rebuild that moves no class and
+// changes nothing on screen. Reproduced here at the row-identity level (a real rebuild replaces
+// every row with a fresh node; an unchanged id must leave the existing ones alone), the smallest
+// place the redundant work is directly observable — `pickup-mount.js`'s own tests use a
+// `StubPanels` double that records calls onto plain properties, never real DOM, so the
+// duplicate rebuild is invisible from there.
+// -----------------------------------------------------------------------
+
+describe( 'setSelectedId does not rebuild the list for an unchanged id (#172)', () => {
+	it( 'leaves the existing row nodes alone when called twice with the same id', () => {
+		const panels = new Panels( document.createElement( 'div' ), config );
+		panels.render();
+		panels.setVisible( [ group( 'p1', 55.75, 37.61, 'ПВЗ 1' ), group( 'p2', 55.76, 37.61, 'ПВЗ 2' ) ] );
+		panels.setSelectedId( 'p2' );
+
+		const before = [ ...panels.root.querySelectorAll( '.woodev-pickup-list__item' ) ];
+
+		// The exact scenario #172 traces: a second call with the id already in force — nothing
+		// about the selection changed, so nothing about the list should either.
+		panels.setSelectedId( 'p2' );
+
+		const after = [ ...panels.root.querySelectorAll( '.woodev-pickup-list__item' ) ];
+
+		// `renderListBody()` always does `empty( self._listBodyEl )` then rebuilds every row from
+		// scratch — a real rebuild therefore hands back BRAND NEW nodes, never the same
+		// references. Same references here is exactly "the second call did no list work".
+		expect( after ).toHaveLength( before.length );
+		expect( after[ 0 ] ).toBe( before[ 0 ] );
+		expect( after[ 1 ] ).toBe( before[ 1 ] );
+	} );
+
+	it( 'still rebuilds the list body the FIRST time an id is recorded, even with no group data yet', () => {
+		// Mirrors `pickup-mount.js`'s own opening sequence: `setSelectedId()` is seeded before
+		// `setVisible()` ever runs (session open, before the first fetch). `_selectedId` moves
+		// from `null` to a real value here — a genuine change — so this must NOT be skipped, or
+		// a customer reopening the picker on an already-chosen point would never get the
+		// highlight once the real groups do arrive without ANOTHER unrelated change first.
+		const panels = new Panels( document.createElement( 'div' ), config );
+		panels.render();
+
+		expect( () => panels.setSelectedId( 'p2' ) ).not.toThrow();
+
+		panels.setVisible( [ group( 'p1', 55.75, 37.61, 'ПВЗ 1' ), group( 'p2', 55.76, 37.61, 'ПВЗ 2' ) ] );
+
+		const rows = panels.root.querySelectorAll( '.woodev-pickup-list__item' );
+
+		expect( rows[ 1 ].classList.contains( 'is-selected' ) ).toBe( true );
+	} );
+
+	it( 'still rebuilds the list body when the id actually changes', () => {
+		// Regression guard alongside the skip above — normal customer-driven reselection (a
+		// different sidebar row, a different marker) must keep rebuilding exactly as before.
+		const panels = new Panels( document.createElement( 'div' ), config );
+		panels.render();
+		panels.setVisible( [ group( 'p1', 55.75, 37.61, 'ПВЗ 1' ), group( 'p2', 55.76, 37.61, 'ПВЗ 2' ) ] );
+		panels.setSelectedId( 'p1' );
+
+		const before = [ ...panels.root.querySelectorAll( '.woodev-pickup-list__item' ) ];
+
+		panels.setSelectedId( 'p2' );
+
+		const after = [ ...panels.root.querySelectorAll( '.woodev-pickup-list__item' ) ];
+
+		expect( after[ 0 ] ).not.toBe( before[ 0 ] );
+		expect( after[ 1 ] ).not.toBe( before[ 1 ] );
+		expect( after[ 1 ].classList.contains( 'is-selected' ) ).toBe( true );
+	} );
+
+	it( 'still updates the open card\'s CTA when setSelectedId is called with the unchanged id', () => {
+		// The trap the brief calls out: `setSelectedId()` also drives `renderCard()` (the CTA's
+		// `continueCheckout`/`select` label). Gating the LIST rebuild on "id changed" must not
+		// gate the card too — proven by opening a card, THEN calling `setSelectedId()` again with
+		// the id already in force, and checking the CTA still reflects it correctly.
+		const cfg = {
+			...config,
+			i18n: { ...config.i18n, select: 'Забрать здесь', continueCheckout: 'Продолжить оформление заказа' },
+		};
+		const panels = new Panels( document.createElement( 'div' ), cfg );
+		panels.render();
+		panels.setSelectedId( 'p1' );
+		panels.openCard( { key: 'g1', size: 1, points: [ { id: 'p1', name: 'ПВЗ 1', short_address: 'x' } ] } );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__cta' ).textContent )
+			.toBe( 'Продолжить оформление заказа' );
+
+		panels.setSelectedId( 'p1' );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__cta' ).textContent )
+			.toBe( 'Продолжить оформление заказа' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
 // Round 2 (D6): `openCard( group, pointId, origin )` — `origin` is what lets the mount tell a
 // marker click (pan only) apart from every other route (zoom in), now that the original V-10
 // "must behave identically" claim has been overruled (see the file docblock's revised

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -2699,11 +2699,47 @@
 	 * only runs once `render()` exists (`this.root`); called before that, this method still only
 	 * updates `_selectedId` and, if a card is open, `renderCard()`.
 	 *
+	 * SKIPS THAT REBUILD WHEN THE NORMALIZED ID HASN'T ACTUALLY CHANGED (#172).
+	 * `pickup-mount.js`'s restore pass (spec D-15) calls this method TWICE with the exact same
+	 * value for one session open under `strategy: 'viewport'`: `alreadySelected` seeds
+	 * `_selectedId` before the first fetch even starts, and `restoreSelection()` calls this again,
+	 * once the map is ready, with the SAME id read off the SAME field — nothing about the
+	 * selection moved between the two calls, so the second `renderListBody()` recreates every row
+	 * only to reproduce the identical `is-selected` class the first render already painted. Every
+	 * OTHER reason the list might need rebuilding already goes through its own method
+	 * (`setVisible()` when the groups change, `setAnchor()` when the sort anchor moves, the type
+	 * filter's own handler) — this method's contract is "reflect a selection CHANGE", and a
+	 * repeated call carrying the CHANGED id (a customer picking a different row, or the mount's
+	 * own restore call finding a DIFFERENT current value than what was seeded) still rebuilds
+	 * exactly as before; only the no-op repeat is now free.
+	 *
+	 * `renderCard()` stays UNCONDITIONAL, gated only on `this._activeGroup`, never on whether the
+	 * id changed — it is NOT redundant work the way the list rebuild is. Two real call paths rely
+	 * on it running even when `_selectedId` itself did not just move in THIS call:
+	 *
+	 * - `pickup-mount.js`'s `finishSelection()` (a confirmed selection) clears the busy lock via
+	 *   `setSelectionBusy( false )` — which reruns `renderCard()` against the STILL-OLD
+	 *   `_selectedId` — BEFORE this method ever runs with the point's real id. This call is
+	 *   therefore the one that actually flips the CTA from `confirming` to `continueCheckout`; it
+	 *   never sees an "unchanged id" in that flow (the id is genuinely new), but the causality
+	 *   matters here: it is proof this method's OWN `renderCard()` call, not
+	 *   `setSelectionBusy()`'s, is what paints the label a customer actually sees, so it cannot be
+	 *   the one gated.
+	 * - `restoreSelection()` itself calls this method with a value already seeded, then opens the
+	 *   card on that SAME id via `openCard()` — which calls `renderCard()` unconditionally on its
+	 *   own, so the card is covered there regardless of what this method does. But a caller that
+	 *   re-asserts the CTA state without going through `openCard()` (an already-open card, e.g. a
+	 *   confirmation that lands while the customer is still looking at the same point) must not
+	 *   silently stop working just because the id happens to already match.
+	 *
 	 * @param {string|number|null} id
 	 * @returns {void}
 	 */
 	Panels.prototype.setSelectedId = function( id ) {
-		this._selectedId = ( undefined !== id && null !== id ) ? String( id ) : null;
+		var normalized = ( undefined !== id && null !== id ) ? String( id ) : null;
+		var changed = normalized !== this._selectedId;
+
+		this._selectedId = normalized;
 
 		// The list carries the highlight too now (Task 10), so it must be rebuilt as well — not
 		// only the card, which is all this method used to touch when `_selectedId` affected
@@ -2711,8 +2747,10 @@
 		// `handleFilterCheckboxChange()` guard their own `renderList()` call: `self._listBodyEl`
 		// does not exist before `render()` builds it, and `renderListBody()`'s `empty()` call has
 		// no null-check, so an unconditional call here would throw for a caller that sets the
-		// selection before the list has ever been rendered.
-		if ( this.root ) {
+		// selection before the list has ever been rendered. `changed` is checked FIRST (see this
+		// method's own docblock on #172) so a repeat call carrying the same id neither throws nor
+		// rebuilds — both guards independently gate the SAME call, not two alternatives.
+		if ( changed && this.root ) {
 			renderList( this );
 		}
 


### PR DESCRIPTION
`Panels.setSelectedId()` always ran a full `renderListBody()` — up to `LIST_CAP` (300) rows
recreated with a fresh click listener on each — even when called with the id it already
held. Restoring a previous selection did exactly that: the list had already been built
with the correct `_selectedId`, and the restore call rebuilt all of it to move one class.

Now the list rebuild is gated on the normalized id actually changing.

### The trap, and why `renderCard()` stayed unconditional

`setSelectedId()` also drives the open card, and that call is load-bearing: during
`finishSelection()`, `setSelectionBusy(false)` re-renders the card while `_selectedId` is
still the OLD value (clearing «Проверяем…»), and it is `setSelectedId()`'s own
`renderCard()` that then flips the CTA to «Продолжить оформление заказа», because only
then does `isSelected` become true. So only the list rebuild is gated; the card render is
not. A test pins the CTA still updating on an unchanged id.

### A correction to issue #172

The issue traces the order as `setPoints()` → `setVisible()` → `renderList()`, then
`restoreSelection()`. That sequence is stale: the s52 fix for the ymaps marker-parking
race already reordered `restoreSelection()` to run BEFORE `provider.setPoints()` when the
restored point is found. The underlying diagnosis — a redundant `setSelectedId()` with an
unchanged id forcing a wasted rebuild — still holds, and was reproduced at the `Panels`
level rather than taken from the narration.

The fix sits in `Panels`, not at the `restoreSelection()` call site, so the `bulk`
strategy's real work through that same path is untouched; `setVisible()` (which rebuilds
when the group data genuinely changes) is not gated at all. `bulk` restore coverage
confirmed still green.

Proven by DOM node identity: a real rebuild always returns fresh nodes, so identical row
references prove no rebuild occurred. jest 701 -> 705 passing.

Closes #172
