### PR TITLE
test(fixture): filter rig points by locality and draw the real carrier icons

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/postamat-active.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/postamat-active.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 70" width="50" height="70">
-	<path d="M25 68C25 68 45 42 45 25A20 20 0 0 0 5 25C5 42 25 68 25 68Z" fill="#1937ff" stroke="#fff" stroke-width="3"/>
-	<rect x="17" y="15" width="16" height="20" rx="1.5" fill="none" stroke="#fff" stroke-width="2.5"/>
-	<path d="M17 22h16M17 28h16" stroke="#fff" stroke-width="2"/>
-</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/postamat.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/postamat.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 45" width="45" height="45">
-	<circle cx="22.5" cy="22.5" r="20" fill="#1937ff" stroke="#fff" stroke-width="3"/>
-	<rect x="14" y="13" width="17" height="20" rx="1.5" fill="none" stroke="#fff" stroke-width="2.5"/>
-	<path d="M14 20h17M14 26h17" stroke="#fff" stroke-width="2"/>
-</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/pvz-active.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/pvz-active.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 70" width="50" height="70">
-	<path d="M25 68C25 68 45 42 45 25A20 20 0 0 0 5 25C5 42 25 68 25 68Z" fill="#0a8c37" stroke="#fff" stroke-width="3"/>
-	<path d="M16 21h18v13H16z" fill="none" stroke="#fff" stroke-width="2.5"/>
-	<path d="M16 21l9-6 9 6" fill="none" stroke="#fff" stroke-width="2.5" stroke-linejoin="round"/>
-</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/pvz.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/pvz.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 45" width="45" height="45">
-	<circle cx="22.5" cy="22.5" r="20" fill="#0a8c37" stroke="#fff" stroke-width="3"/>
-	<path d="M13 19h19v13H13z" fill="none" stroke="#fff" stroke-width="2.5"/>
-	<path d="M13 19l9.5-6 9.5 6" fill="none" stroke="#fff" stroke-width="2.5" stroke-linejoin="round"/>
-</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-office-active.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-office-active.svg
@@ -1,0 +1,27 @@
+<!-- Issue #162 companion (Task B): copied from plugins-reference/woocommerce-yandex-delivery/assets/images/yandex-delivery-map-pin-office-active.svg — WooDev's own map-pin icon for its "Яндекс доставка для Woocommerce" plugin (Yandex.Delivery integration), not a Yandex LLC brand asset. Used here, unmodified, as the rig's real PVZ (office) marker ACTIVE-state icon in place of the previous framework-drawn placeholder. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" fill="none">
+ <defs>
+  <clipPath id="clip0">
+   <path d="m0,0l42,0l0,42l-42,0l0,-42z" fill="#fff"/>
+  </clipPath>
+  <filter color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse" height="42.53" id="filter0_d" width="35.28" x="3.36" y="0">
+   <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+   <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+   <feOffset dy="1.68"/>
+   <feGaussianBlur stdDeviation="0.84"/>
+   <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+   <feBlend in2="BackgroundImageFix"/>
+   <feBlend in="SourceGraphic" in2="effect1_dropShadow"/>
+  </filter>
+ </defs>
+ <g clip-path="url(#clip0)">
+   <g filter="url(#filter0_d)">
+    <path clip-rule="evenodd" d="m23.41,32.74a15.96,15.96 0 1 0 -4.83,0l1.6,6.78c0.2,0.87 1.43,0.87 1.64,0l1.6,-6.78l-0.01,0z" fill="#fb4513" fill-rule="evenodd"/>
+   </g>
+   <g>
+    <path d="m22.99,18.54c-0.46,0 -0.84,0.38 -0.84,0.84l0,5.88c0,0.46 0.38,0.84 0.84,0.84l5.88,0c0.46,0 0.84,-0.38 0.84,-0.84l0,-5.88c0,-0.46 -0.38,-0.84 -0.84,-0.84l-5.88,0z" fill="#FFF" opacity="0.5" transform="translate(-1 -3)"/>
+    <path d="m19.91,13.15c1.35,0 2.44,-0.94 2.44,-2.4c0,-0.13 -0.01,-0.27 -0.03,-0.39l0.37,-0.06c0.54,-0.09 0.96,-0.5 1.07,-1.02l0.09,-0.42l-2.33,0.01c-0.43,-0.38 -1,-0.59 -1.62,-0.59c-1.35,0 -2.45,1.02 -2.45,2.48c0,1.46 1.1,2.4 2.45,2.4z" fill="#FFF"/>
+    <path d="m18.86,13.84c-1.19,-0.29 -2.38,0.45 -2.66,1.64l-1.65,6.96l-0.05,0.06l-1.65,0c-0.2,0 -0.37,0.17 -0.37,0.37l0,0.57c0,0.21 0.17,0.38 0.37,0.38l16.26,0c0.21,0 0.38,-0.17 0.38,-0.38l0,-0.57c0,-0.2 -0.17,-0.37 -0.38,-0.37l-10.19,0l0.73,-2.55l0.01,0.02c0.11,0.39 0.4,0.65 0.76,0.76c0.06,0.03 0.13,0.05 0.19,0.07l5.06,1.22c0.25,-0.86 -0.21,-1.76 -1.06,-2.06l-2.95,-1.02l-0.85,-3.83c-0.03,-0.18 -0.11,-0.34 -0.22,-0.48c-0.14,-0.25 -0.39,-0.45 -0.71,-0.53l-1.05,-0.24z" fill="#FFF" />
+   </g>
+  </g>
+</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-office.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-office.svg
@@ -1,0 +1,27 @@
+<!-- Issue #162 companion (Task B): copied from plugins-reference/woocommerce-yandex-delivery/assets/images/yandex-delivery-map-pin-office.svg — WooDev's own map-pin icon for its "Яндекс доставка для Woocommerce" plugin (Yandex.Delivery integration), not a Yandex LLC brand asset. Used here, unmodified, as the rig's real PVZ (office) marker icon in place of the previous framework-drawn placeholder. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" fill="none">
+ <defs>
+  <clipPath id="clip0">
+   <path d="m0,0l42,0l0,42l-42,0l0,-42z" fill="#fff"/>
+  </clipPath>
+  <filter color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse" height="42.53" id="filter0_d" width="35.28" x="3.36" y="0">
+   <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+   <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+   <feOffset dy="1.68"/>
+   <feGaussianBlur stdDeviation="0.84"/>
+   <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+   <feBlend in2="BackgroundImageFix"/>
+   <feBlend in="SourceGraphic" in2="effect1_dropShadow"/>
+  </filter>
+ </defs>
+ <g clip-path="url(#clip0)">
+   <g filter="url(#filter0_d)">
+    <path clip-rule="evenodd" d="m23.41,32.74a15.96,15.96 0 1 0 -4.83,0l1.6,6.78c0.2,0.87 1.43,0.87 1.64,0l1.6,-6.78l-0.01,0z" fill="#FCE000" fill-rule="evenodd"/>
+   </g>
+   <g>
+    <path d="m22.99,18.54c-0.46,0 -0.84,0.38 -0.84,0.84l0,5.88c0,0.46 0.38,0.84 0.84,0.84l5.88,0c0.46,0 0.84,-0.38 0.84,-0.84l0,-5.88c0,-0.46 -0.38,-0.84 -0.84,-0.84l-5.88,0z" fill="#222" opacity="0.5" transform="translate(-1 -3)"/>
+    <path d="m19.91,13.15c1.35,0 2.44,-0.94 2.44,-2.4c0,-0.13 -0.01,-0.27 -0.03,-0.39l0.37,-0.06c0.54,-0.09 0.96,-0.5 1.07,-1.02l0.09,-0.42l-2.33,0.01c-0.43,-0.38 -1,-0.59 -1.62,-0.59c-1.35,0 -2.45,1.02 -2.45,2.48c0,1.46 1.1,2.4 2.45,2.4z" fill="#222"/>
+    <path d="m18.86,13.84c-1.19,-0.29 -2.38,0.45 -2.66,1.64l-1.65,6.96l-0.05,0.06l-1.65,0c-0.2,0 -0.37,0.17 -0.37,0.37l0,0.57c0,0.21 0.17,0.38 0.37,0.38l16.26,0c0.21,0 0.38,-0.17 0.38,-0.38l0,-0.57c0,-0.2 -0.17,-0.37 -0.38,-0.37l-10.19,0l0.73,-2.55l0.01,0.02c0.11,0.39 0.4,0.65 0.76,0.76c0.06,0.03 0.13,0.05 0.19,0.07l5.06,1.22c0.25,-0.86 -0.21,-1.76 -1.06,-2.06l-2.95,-1.02l-0.85,-3.83c-0.03,-0.18 -0.11,-0.34 -0.22,-0.48c-0.14,-0.25 -0.39,-0.45 -0.71,-0.53l-1.05,-0.24z" fill="#222" />
+   </g>
+  </g>
+</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-terminal-active.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-terminal-active.svg
@@ -1,0 +1,30 @@
+<!-- Issue #162 companion (Task B): copied from plugins-reference/woocommerce-yandex-delivery/assets/images/yandex-delivery-map-pin-terminal-active.svg — WooDev's own map-pin icon for its "Яндекс доставка для Woocommerce" plugin (Yandex.Delivery integration), not a Yandex LLC brand asset. Used here, unmodified, as the rig's real POSTAMAT (terminal) marker ACTIVE-state icon in place of the previous framework-drawn placeholder. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" fill="none">
+ <defs>
+  <clipPath id="clip0">
+   <path d="m0,0l42,0l0,42l-42,0l0,-42z" fill="#fff"/>
+  </clipPath>
+  <filter color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse" height="42.53" id="filter0_d" width="35.28" x="3.36" y="0">
+   <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+   <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+   <feOffset dy="1.68"/>
+   <feGaussianBlur stdDeviation="0.84"/>
+   <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+   <feBlend in2="BackgroundImageFix"/>
+   <feBlend in="SourceGraphic" in2="effect1_dropShadow"/>
+  </filter>
+ </defs>
+ <g clip-path="url(#clip0)">
+   <g filter="url(#filter0_d)">
+    <path clip-rule="evenodd" d="m23.41,32.24a15.96,15.96 0 1 0 -4.83,0l1.6,6.78c0.2,0.87 1.43,0.87 1.64,0l1.6,-6.78l-0.01,0z" fill="#fb4513" fill-rule="evenodd"/>
+   </g>
+   <g>
+    <g opacity="0.5">
+     <path d="m26.53,9.25c0.4,0 0.72,0.33 0.72,0.74l0,5.19l-13,0l0,-5.19c0,-0.41 0.33,-0.74 0.72,-0.74l11.55,0z" fill="#FFF" />
+     <path d="m15.7,16.67l-1.45,0l0,5.93l5.02,3.71l1.48,0l0,-5.92c0,-0.54 -0.28,-1.04 -0.75,-1.3l-4.31,-2.42z" fill="#FFF" />
+    </g>
+    <path d="m25.08,11.48l-2.88,0l0,1.49l2.88,0l0,-1.49z" fill="#FFF"/>
+    <path d="m15.7,16.67l11.55,0l0,5.19c0,0.41 -0.33,0.74 -0.72,0.74l-5.78,0l0,-2.21c0,-0.54 -0.28,-1.04 -0.75,-1.3l-4.31,-2.42z" fill="#FFF" />
+   </g>
+  </g>
+</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-terminal.svg
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/images/yandex-delivery-map-pin-terminal.svg
@@ -1,0 +1,30 @@
+<!-- Issue #162 companion (Task B): copied from plugins-reference/woocommerce-yandex-delivery/assets/images/yandex-delivery-map-pin-terminal.svg — WooDev's own map-pin icon for its "Яндекс доставка для Woocommerce" plugin (Yandex.Delivery integration), not a Yandex LLC brand asset. Used here, unmodified, as the rig's real POSTAMAT (terminal) marker icon in place of the previous framework-drawn placeholder. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" fill="none">
+ <defs>
+  <clipPath id="clip0">
+   <path d="m0,0l42,0l0,42l-42,0l0,-42z" fill="#fff"/>
+  </clipPath>
+  <filter color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse" height="42.53" id="filter0_d" width="35.28" x="3.36" y="0">
+   <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+   <feColorMatrix in="SourceAlpha" result="hardAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+   <feOffset dy="1.68"/>
+   <feGaussianBlur stdDeviation="0.84"/>
+   <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+   <feBlend in2="BackgroundImageFix"/>
+   <feBlend in="SourceGraphic" in2="effect1_dropShadow"/>
+  </filter>
+ </defs>
+ <g clip-path="url(#clip0)">
+   <g filter="url(#filter0_d)">
+    <path clip-rule="evenodd" d="m23.41,32.24a15.96,15.96 0 1 0 -4.83,0l1.6,6.78c0.2,0.87 1.43,0.87 1.64,0l1.6,-6.78l-0.01,0z" fill="#FCE000" fill-rule="evenodd"/>
+   </g>
+   <g>
+    <g opacity="0.5">
+     <path d="m26.53,9.25c0.4,0 0.72,0.33 0.72,0.74l0,5.19l-13,0l0,-5.19c0,-0.41 0.33,-0.74 0.72,-0.74l11.55,0z" fill="#222" />
+     <path d="m15.7,16.67l-1.45,0l0,5.93l5.02,3.71l1.48,0l0,-5.92c0,-0.54 -0.28,-1.04 -0.75,-1.3l-4.31,-2.42z" fill="#222" />
+    </g>
+    <path d="m25.08,11.48l-2.88,0l0,1.49l2.88,0l0,-1.49z" fill="#222"/>
+    <path d="m15.7,16.67l11.55,0l0,5.19c0,0.41 -0.33,0.74 -0.72,0.74l-5.78,0l0,-2.21c0,-0.54 -0.28,-1.04 -0.75,-1.3l-4.31,-2.42z" fill="#222" />
+   </g>
+  </g>
+</svg>

--- a/tests/_fixtures/woodev-test-shipping-method/class-test-bulk-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-bulk-point-source.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Woodev_Test_Bulk_Point_Source — the rig's STRATEGY_BULK fixture Point_Source.
+ *
+ * Extracted to its own file (unlike `Woodev_Test_Viewport_Point_Source`, still declared
+ * inline in `woodev-test-shipping-method.php`) so a PHPUnit unit test can `require_once`
+ * it directly, right after the `Point_Source` interface, WITHOUT going through the
+ * fixture plugin's full Platform v2 load path: `Woodev_Plugin_Bootstrap`'s resolver is a
+ * process-wide singleton with a one-shot `load_plugins()` latch (see
+ * `Woodev_Plugin_Bootstrap::instance()`/`Framework_Resolver::$loaded`), so once any other
+ * test in the same PHPUnit run (e.g. `BootstrapTest`) has loaded it, a second
+ * registration+load attempt from this fixture is silently a no-op — order-dependent and
+ * unusable as a unit-test seam.
+ *
+ * `woodev_test_shipping_method_plugin_init()` requires this file the same way it used to
+ * declare the class inline, at the same point in its own execution — the `Point_Source`
+ * interface is guaranteed autoloadable by the time that callback runs (see its own
+ * docblock), so production behaviour is unchanged by this split.
+ *
+ * @package Woodev_Test_Shipping_Method
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Woodev_Test_Bulk_Point_Source' ) ) {
+
+	/**
+	 * Class Woodev_Test_Bulk_Point_Source
+	 *
+	 * STRATEGY_BULK fixture source (Yandex/CDEK shape): every point for the
+	 * requested locality is returned in one call, every field populated up front.
+	 * Two of the five points are deliberately named so a human driving the rig can
+	 * find them on the live map: one refuses cash on delivery (COD gating), one
+	 * caps the accepted parcel weight at 1 kg (weight-limit gating).
+	 */
+	class Woodev_Test_Bulk_Point_Source implements \Woodev\Framework\Shipping\Pickup\Point_Source {
+
+		/** Point id that refuses cash on delivery — exercises COD gating on the rig. */
+		public const COD_REFUSING_POINT_ID = 'FIX-BULK-2';
+
+		/** Point id capped at 1000 g — exercises the weight-limit rule on the rig. */
+		public const WEIGHT_LIMITED_POINT_ID = 'FIX-BULK-4';
+
+		/**
+		 * The fixture's one static "city" — every fixture point's own `locality` field
+		 * (see fixture-points.php) is this exact string.
+		 */
+		private const FIXTURE_LOCALITY = 'Москва';
+
+		/**
+		 * @inheritDoc
+		 */
+		public function get_strategy(): string {
+			return self::STRATEGY_BULK;
+		}
+
+		/**
+		 * Returns every fixture point when the requested locality is this fixture's own
+		 * city, or an empty list otherwise (issue #162).
+		 *
+		 * The framework guarantees `$query->get_locality()` is non-null for a
+		 * STRATEGY_BULK source (see the Point_Source interface docblock); a real
+		 * carrier would filter server-side by that locality. Matching is
+		 * case-/surrounding-whitespace-insensitive — a browser city input or a
+		 * REST client is not guaranteed to send back the exact casing this fixture
+		 * emits — but otherwise exact: no transliteration, no fuzzy/partial matching.
+		 * Without this the checkout's `emptyLocality` state (spec V-5) could never be
+		 * seen on the rig, only in unit/jest tests — a real carrier integration
+		 * would filter server-side the same way, just against its own city list
+		 * instead of this one hardcoded string.
+		 *
+		 * @inheritDoc
+		 */
+		public function fetch_points( \Woodev\Framework\Shipping\Pickup\Point_Query $query ): array {
+			if ( ! $this->locality_matches( $query->get_locality() ) ) {
+				return [];
+			}
+
+			return array_values( array_filter( array_map(
+				[ \Woodev\Framework\Shipping\Pickup\Pickup_Point::class, 'from_array' ],
+				$this->all_points()
+			) ) );
+		}
+
+		/**
+		 * Whether the requested locality names this fixture's own city, ignoring case
+		 * and surrounding whitespace.
+		 *
+		 * @param string|null $locality Requested locality, guaranteed non-null by the
+		 *                               framework for a STRATEGY_BULK source (see
+		 *                               {@see self::fetch_points()}); the null-coalesce
+		 *                               below is defensive only.
+		 *
+		 * @return bool
+		 */
+		private function locality_matches( ?string $locality ): bool {
+			return mb_strtolower( trim( $locality ?? '' ) ) === mb_strtolower( self::FIXTURE_LOCALITY );
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function fetch_details( string $point_id ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
+			foreach ( $this->all_points() as $payload ) {
+				if ( $point_id === $payload['id'] ) {
+					return \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array( $payload );
+				}
+			}
+
+			return null;
+		}
+
+		/**
+		 * The fixture's Moscow points — every field populated.
+		 *
+		 * SP-map Task 1: the fixture was grown from the original 5 static points
+		 * (still present, ids included, as the first 5 entries) to ~49 points
+		 * across 2 types, including a co-located pair on identical coordinates —
+		 * see the docblock in fixture-points.php for why. Delegated to a standalone
+		 * data file so the unit suite can assert on its shape without loading the
+		 * whole plugin.
+		 *
+		 * @return array<int, array<string, mixed>>
+		 */
+		private function all_points(): array {
+			return require __DIR__ . '/fixture-points.php';
+		}
+	}
+}

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -181,88 +181,20 @@ function woodev_test_shipping_method_plugin_init(): void {
 	// exercising both loading strategies (§4.5). A real shipping plugin talks to
 	// its carrier's API here instead of returning hardcoded arrays.
 	//
-	// Declared HERE (inside this callback), not at file top level: this
+	// Required/declared HERE (inside this callback), not at file top level: this
 	// callback runs only once the bootstrap has selected the highest-version
 	// framework copy and its autoloader is registered — declaring a class that
 	// `implements \Woodev\Framework\Shipping\Pickup\Point_Source` any earlier
 	// than that fails with "Interface ... not found", the same reason the main
 	// plugin class below is declared inside this callback rather than at file
 	// top level.
+	//
+	// Woodev_Test_Bulk_Point_Source lives in its own file (see the docblock there)
+	// specifically so a unit test can `require_once` it directly, bypassing the
+	// Woodev_Plugin_Bootstrap singleton's process-wide, one-shot load latch.
 	// -----------------------------------------------------------------------
 
-	if ( ! class_exists( 'Woodev_Test_Bulk_Point_Source' ) ) {
-
-		/**
-		 * Class Woodev_Test_Bulk_Point_Source
-		 *
-		 * STRATEGY_BULK fixture source (Yandex/CDEK shape): every point for the
-		 * requested locality is returned in one call, every field populated up front.
-		 * Two of the five points are deliberately named so a human driving the rig can
-		 * find them on the live map: one refuses cash on delivery (COD gating), one
-		 * caps the accepted parcel weight at 1 kg (weight-limit gating).
-		 */
-		class Woodev_Test_Bulk_Point_Source implements \Woodev\Framework\Shipping\Pickup\Point_Source {
-
-			/** Point id that refuses cash on delivery — exercises COD gating on the rig. */
-			public const COD_REFUSING_POINT_ID = 'FIX-BULK-2';
-
-			/** Point id capped at 1000 g — exercises the weight-limit rule on the rig. */
-			public const WEIGHT_LIMITED_POINT_ID = 'FIX-BULK-4';
-
-			/**
-			 * @inheritDoc
-			 */
-			public function get_strategy(): string {
-				return self::STRATEGY_BULK;
-			}
-
-			/**
-			 * Returns all 5 fixture points regardless of the requested locality string.
-			 *
-			 * The framework guarantees `$query->get_locality()` is non-null for a
-			 * STRATEGY_BULK source (see the Point_Source interface docblock); a real
-			 * carrier would filter server-side by that locality. The fixture has only
-			 * one static "city", so it returns the same 5 points for any locality.
-			 *
-			 * @inheritDoc
-			 */
-			public function fetch_points( \Woodev\Framework\Shipping\Pickup\Point_Query $query ): array {
-				return array_values( array_filter( array_map(
-					[ \Woodev\Framework\Shipping\Pickup\Pickup_Point::class, 'from_array' ],
-					$this->all_points()
-				) ) );
-			}
-
-			/**
-			 * @inheritDoc
-			 */
-			public function fetch_details( string $point_id ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
-				foreach ( $this->all_points() as $payload ) {
-					if ( $point_id === $payload['id'] ) {
-						return \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array( $payload );
-					}
-				}
-
-				return null;
-			}
-
-			/**
-			 * The fixture's Moscow points — every field populated.
-			 *
-			 * SP-map Task 1: the fixture was grown from the original 5 static points
-			 * (still present, ids included, as the first 5 entries) to ~49 points
-			 * across 2 types, including a co-located pair on identical coordinates —
-			 * see the docblock in fixture-points.php for why. Delegated to a standalone
-			 * data file so the unit suite can assert on its shape without loading the
-			 * whole plugin.
-			 *
-			 * @return array<int, array<string, mixed>>
-			 */
-			private function all_points(): array {
-				return require __DIR__ . '/fixture-points.php';
-			}
-		}
-	}
+	require_once __DIR__ . '/class-test-bulk-point-source.php';
 
 	if ( ! class_exists( 'Woodev_Test_Viewport_Point_Source' ) ) {
 
@@ -470,9 +402,10 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// whole world.
 				$default_location = [ 'center' => [ 55.76, 37.64 ], 'zoom' => 12 ];
 
-				// SP-5 Task 8 (D-5), re-pointed by the live-review fix (D7, 05.08.2026): both
-				// fixture types now supply BOTH states — `pvz` mirrors the Yandex reference's
-				// two-image shape, `postamat` its own — so the rig always has at least one type
+				// SP-5 Task 8 (D-5), re-pointed by the live-review fix (D7, 05.08.2026), and
+				// swapped for the REAL reference icons by issue #162's companion task: both
+				// fixture types supply BOTH states — `PVZ` mirrors the Yandex reference's
+				// two-image shape, `POSTAMAT` its own — so the rig always has at least one type
 				// showing what a real two-image active state looks like. The framework's
 				// one-image fallback (`active` mirrors `default` when a plugin supplies only one
 				// image, the CDEK shape) is still real and still covered — see
@@ -486,16 +419,21 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// URLs are real files served by this plugin, not a placeholder host: an icon that
 				// 404s renders as a broken image, which looks identical to "the framework never
 				// applied the icon" and makes rig verification prove nothing.
+				// The four SVGs themselves are copies of `plugins-reference/woocommerce-yandex-delivery`'s
+				// own `yandex-delivery-map-pin-{office,terminal}[-active].svg` (WooDev's own
+				// icons for its Yandex.Delivery integration, not hotlinked — see each file's own
+				// attribution comment) — "office" is this fixture's `PVZ`, "terminal" its
+				// `POSTAMAT`.
 				$icons_url = plugins_url( 'assets/images', __FILE__ );
 
 				$point_icons = [
 					'PVZ'      => [
-						'default' => $icons_url . '/pvz.svg',
-						'active'  => $icons_url . '/pvz-active.svg',
+						'default' => $icons_url . '/yandex-delivery-map-pin-office.svg',
+						'active'  => $icons_url . '/yandex-delivery-map-pin-office-active.svg',
 					],
 					'POSTAMAT' => [
-						'default' => $icons_url . '/postamat.svg',
-						'active'  => $icons_url . '/postamat-active.svg',
+						'default' => $icons_url . '/yandex-delivery-map-pin-terminal.svg',
+						'active'  => $icons_url . '/yandex-delivery-map-pin-terminal-active.svg',
 					],
 				];
 

--- a/tests/integration/Shipping/PickupRouteTest.php
+++ b/tests/integration/Shipping/PickupRouteTest.php
@@ -111,6 +111,35 @@ class PickupRouteTest extends TestCase {
 		);
 	}
 
+	/**
+	 * A locality OTHER than the fixture's own city ("Москва") must return zero
+	 * points, HTTP 200 — issue #162. Before this fix, `Woodev_Test_Bulk_Point_Source`
+	 * ignored `locality` entirely and returned every fixture point regardless, so the
+	 * checkout's `emptyLocality` state (spec V-5) could never be seen on the rig by
+	 * setting the checkout city to e.g. «Новосибирск», only exercised in unit/jest
+	 * tests.
+	 *
+	 * @return void
+	 */
+	public function test_a_foreign_locality_returns_no_points(): void {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request(
+			'GET',
+			'/woodev/v1/shipping/pickup/woodev-test-shipping-method/points'
+		);
+		$request->set_param( 'locality', 'Новосибирск' );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			[],
+			$response->get_data()['points'],
+			'A locality other than the fixture\'s own city must yield zero points.'
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// 3. Unusable query still 200s
 	// -------------------------------------------------------------------------

--- a/tests/unit/Shipping/Pickup/TestShippingMethodFixtureLocalityTest.php
+++ b/tests/unit/Shipping/Pickup/TestShippingMethodFixtureLocalityTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Unit tests for issue #162: the rig's `woodev-test-shipping-method` fixture must
+ * actually filter `Woodev_Test_Bulk_Point_Source::fetch_points()` by the requested
+ * `locality`, so the checkout's `emptyLocality` state (spec V-5) is reachable on the
+ * rig, not just in tests — previously it returned every fixture point regardless of
+ * what locality was requested.
+ *
+ * `Woodev_Test_Bulk_Point_Source` lives in its own file,
+ * `tests/_fixtures/woodev-test-shipping-method/class-test-bulk-point-source.php` (split
+ * out of `woodev-test-shipping-method.php` for exactly this reason — see that file's
+ * docblock), so it can be `require_once`d directly here, after the interfaces/value
+ * objects it depends on, the same pattern {@see \Woodev\Tests\Unit\Shipping\Rest_Api\PickupControllerTest}
+ * and {@see \Woodev\Tests\Unit\Shipping\Pickup\PickupHandlerTest} already use for their
+ * own `Point_Source` test doubles — WITHOUT going through the fixture plugin's full
+ * Platform v2 load path. That path runs through `Woodev_Plugin_Bootstrap`'s singleton
+ * resolver, which is process-wide and load-once (`Framework_Resolver::$loaded`); once
+ * any other test in the same PHPUnit run has loaded it (e.g. `BootstrapTest`), a second
+ * registration+load from this fixture would silently no-op.
+ *
+ * @package Woodev\Tests\Unit\Shipping\Pickup
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Pickup;
+
+use Woodev\Framework\Shipping\Pickup\Point_Query;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-point.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-point-query.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/interface-point-source.php';
+require_once dirname( __DIR__, 4 ) . '/tests/_fixtures/woodev-test-shipping-method/class-test-bulk-point-source.php';
+
+/**
+ * @covers \Woodev_Test_Bulk_Point_Source
+ */
+final class TestShippingMethodFixtureLocalityTest extends TestCase {
+
+	/**
+	 * A locality matching the fixture's own city ("Москва") must return points —
+	 * the fixture's baseline behaviour, unchanged by this fix.
+	 */
+	public function test_matching_locality_returns_points(): void {
+		$source = new \Woodev_Test_Bulk_Point_Source();
+
+		$query = Point_Query::from_request( [ 'locality' => 'Москва' ] );
+
+		$this->assertNotEmpty( $source->fetch_points( $query ) );
+	}
+
+	/**
+	 * A locality that is NOT the fixture's own city ("Новосибирск") must return zero
+	 * points — this is what makes the checkout's `emptyLocality` state (spec V-5)
+	 * reachable on the rig (issue #162), where it was previously unreachable: every
+	 * locality returned all 49 fixture points.
+	 */
+	public function test_foreign_locality_returns_no_points(): void {
+		$source = new \Woodev_Test_Bulk_Point_Source();
+
+		$query = Point_Query::from_request( [ 'locality' => 'Новосибирск' ] );
+
+		$this->assertSame( [], $source->fetch_points( $query ) );
+	}
+
+	/**
+	 * Matching is forgiving of case and surrounding whitespace — a browser city input
+	 * or a REST client is not guaranteed to send back the fixture's own exact casing —
+	 * but that forgiveness must not itself cause a false negative on the fixture's own
+	 * city.
+	 */
+	public function test_locality_matching_ignores_case_and_surrounding_whitespace(): void {
+		$source = new \Woodev_Test_Bulk_Point_Source();
+
+		$query = Point_Query::from_request( [ 'locality' => '  МОСКВА  ' ] );
+
+		$this->assertNotEmpty( $source->fetch_points( $query ) );
+	}
+
+	/**
+	 * A locality that merely CONTAINS the fixture's city as a substring must still be
+	 * rejected — matching is exact (after case-folding/trimming), never partial or
+	 * fuzzy, per the fix's own explicit decision.
+	 */
+	public function test_locality_matching_rejects_partial_match(): void {
+		$source = new \Woodev_Test_Bulk_Point_Source();
+
+		$query = Point_Query::from_request( [ 'locality' => 'Москва область' ] );
+
+		$this->assertSame( [], $source->fetch_points( $query ) );
+	}
+}


### PR DESCRIPTION
Two fixture changes, given to one branch because they touch the same files.

## #162 — the fixture ignored `locality`

`Woodev_Test_Bulk_Point_Source::fetch_points()` returned the same points for any city, so
the `emptyLocality` state (spec V-5) was fully unit/jest-covered yet impossible to see on
the rig — setting the checkout city to «Новосибирск» still returned all 49 points.

It now matches the requested locality against the fixture's own city, tolerant of case and
surrounding whitespace, exact otherwise — no transliteration, no fuzzy matching. Covered
by unit tests (match, foreign city, case/whitespace, and rejection of the partial
«Москва область») plus an integration test mirroring the issue's own REST repro.

The viewport/bbox source is deliberately left alone: `Point_Source` guarantees a
`STRATEGY_VIEWPORT` query carries bounds and never guarantees `locality`, and that source
already filters on the axis meaningful to it.

### Why `Woodev_Test_Bulk_Point_Source` moved to its own file

It was declared inside `woodev_test_shipping_method_plugin_init()`, which only runs
through `Framework_Resolver`'s process-wide one-shot `load_plugins()` latch. Once any
earlier test in the same PHPUnit run has tripped that latch, a second registration
silently no-ops — so testing the class through the real plugin-load path is
order-dependent. Extracting it lets a unit test `require_once` it directly, the same
pattern `PickupHandlerTest`/`PickupControllerTest` already use. No behaviour change for
the rig.

## Real point icons in the fixture

The rig drew our own placeholder pins. It now uses the four real ones from the reference
plugin — office/terminal x default/active — mapped onto `PVZ` and `POSTAMAT`.

The existing `point_icons` shape already matched the framework contract
(`array<string type_code, array{default?, active?}>`, `active` falling back to `default`),
so only the URLs changed.

**Attribution correction:** these are not Yandex LLC brand assets. The reference plugin's
header shows `Author: WooDev` — they are WooDev's own icons, drawn in Yandex's brand
colours for its Yandex.Delivery integration. Copied unmodified, each carrying an
attribution comment.

phpcs clean, PHPStan clean.

Closes #162
