### PR TITLE
test(fixture): draw 2GIS tiles through the D-8 layers/copyrights seam

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -387,6 +387,34 @@ function woodev_test_shipping_method_plugin_init(): void {
 					? new \Woodev_Test_Viewport_Point_Source()
 					: new \Woodev_Test_Bulk_Point_Source();
 
+				// D-8: custom tile layers + their attribution are a PLUGIN decision, and
+				// this fixture exercises that seam on purpose. Before this, `layers` and
+				// `copyrights` were reachable only from unit tests — no rig traffic ever
+				// went through `_addLayers()`/`_addCopyrights()`, and a fixture poorer
+				// than production is exactly how s49 hid two of its four map defects.
+				//
+				// The 2GIS tile source and its `sphericalMercator` projection are copied
+				// from the reference plugin (`plugins-reference/woocommerce-edostavka`,
+				// `assets/js/frontend/woodev-yandex-map-plugin.js`), which is the real
+				// consumer this seam was designed for. `projection` travels as the STRING
+				// name — `_addLayers()` resolves it against `ymaps.projection.*` and
+				// silently omits it if unrecognised, so the descriptor stays JSON-safe.
+				//
+				// The copyright line is NOT decoration and not optional in practice:
+				// swapping the base tiles away from Yandex without attributing whoever
+				// actually served them is a terms-of-use problem for both parties. The
+				// framework deliberately ENABLES this rather than enforcing it (nothing
+				// requires a plugin passing `layers` to also pass `copyrights`), so the
+				// fixture demonstrates the correct pairing rather than the minimum.
+				$map_layers = [
+					[
+						'url'        => 'https://tile%d|4.maps.2gis.com/tiles?%c&v=4.png',
+						'projection' => 'sphericalMercator',
+					],
+				];
+
+				$map_copyrights = [ '© 2ГИС' ];
+
 				// The Yandex Maps fallback key is a PLUGIN obligation, never the
 				// framework's (spec §10.6) — Yandex_Map_Provider's constructor REQUIRES
 				// one. This value is an obviously-fake placeholder that only works
@@ -394,7 +422,13 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// PHPUnit; a real shipping plugin shipping this to production supplies
 				// its OWN key here (obtained from the Yandex developer console), not a
 				// copy of this placeholder.
-				$map_provider = new \Woodev\Framework\Shipping\Map\Yandex_Map_Provider( 'FIXTURE-FAKE-YANDEX-KEY' );
+				$map_provider = new \Woodev\Framework\Shipping\Map\Yandex_Map_Provider(
+					'FIXTURE-FAKE-YANDEX-KEY',
+					'',
+					'',
+					$map_layers,
+					$map_copyrights
+				);
 
 				// SP-5 Task 8 (D-7): a hardcoded default viewport is now a REQUIRED
 				// constructor argument — Moscow, matching every point this fixture serves,


### PR DESCRIPTION
## The handoff's premise was wrong, and that is the interesting part

The queue item read: "the seam exists in the provider, but `Pickup_Handler` does not emit
it — a plugin physically cannot pass tiles." Checked against the code, that is not so.
`Yandex_Map_Provider` already takes `$layers` and `$copyrights` as constructor arguments,
sanitizes both (non-array layer entries and non-string copyrights dropped, re-indexed so
`wp_json_encode()` cannot emit an object), and `get_js_config()` emits them;
`Pickup_Handler`'s `mapConfig` is a pass-through of whatever the provider returns. It has
worked since #149, with unit tests.

So there was no PHP work to do. What was actually missing was **live coverage**: no rig
traffic had ever gone through `_addLayers()`/`_addCopyrights()`. This repo has been bitten
by precisely that before — a fixture poorer than production hid two of the four map
defects found in s49.

## What this does

The fixture now passes the 2GIS tile source and its attribution, taken from the reference
plugin the seam was designed for (`plugins-reference/woocommerce-edostavka`). `projection`
travels as the string `'sphericalMercator'`, which `_addLayers()` resolves against
`ymaps.projection.*` and omits if unrecognised, so the descriptor stays JSON-safe.

The copyright is paired with the layer on purpose. The framework deliberately *enables*
attribution rather than enforcing it — nothing requires a plugin passing `layers` to also
pass `copyrights` — so the fixture should model the correct pairing, not the minimum.
Swapping base tiles away from Yandex without attributing who actually served them is a
terms-of-use problem for both parties.

## Verified on the rig, not inferred

- PHP shipped it: `mapConfig.layers` = the 2GIS descriptor, `mapConfig.copyrights` = `["© 2ГИС"]`
- Tiles actually load: `GET https://tile1.maps.2gis.com/tiles?x=2476&y=1280&z=12&v=4.png` → 200
  (ymaps resolved the `%d`/`%c` templates)
- The copyright pane reads **«© Yandex, © 2ГИС»** — ours added alongside Yandex's, not replacing it

Side effect worth knowing: 2GIS serves Russian labels, so the rig map now reads Russian
even though the rig's WordPress locale is `en-US` and ymaps therefore loads `lang=en_US`.

1430 unit tests, phpcs clean.
