### PR TITLE
test(fixture): close the picker on a confirmed selection

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/fixture-points.php
+++ b/tests/_fixtures/woodev-test-shipping-method/fixture-points.php
@@ -350,12 +350,18 @@ $long_address_point = [
 // SP-5 Task 13: three points wired to the fixture's
 // `woodev_shipping_pickup_point_selection` filter (see the plugin init callback in
 // woodev-test-shipping-method.php) — DEMO-PVZ-REFUSE always refuses on confirmation
-// (the rig's remembered-refusal path), DEMO-PVZ-FAST forces an immediate close,
-// overriding this fixture's own two-step default (close_on_select is left at the
-// Pickup_Handler constructor's own `false` — the fixture never passes that
-// argument), and DEMO-PVZ-REFRESH asks for a checkout refresh. Coordinates are
-// distinct from every point above at well past 4 decimal places so all three are
-// individually clickable on the rig map.
+// (the rig's remembered-refusal path), DEMO-PVZ-STAY refuses to CLOSE against a
+// config that says close (the fixture now passes `close_on_select = true`, so every
+// ordinary point closes on confirmation and this one deliberately does not), and
+// DEMO-PVZ-REFRESH asks for a checkout refresh. Coordinates are distinct from every
+// point above at well past 4 decimal places so all three are individually clickable
+// on the rig map.
+// DEMO-PVZ-STAY replaced the earlier DEMO-PVZ-FAST, which did the opposite (config
+// `false`, point answering `true`). That direction demonstrated the override without
+// TESTING it: the browser reads `resolveFlag( result.close, defaults.close )`, whose
+// contract is `??` and never `||`, and for `false`-config/`true`-point the two
+// operators return the same value. The reversed direction separates them — `??` keeps
+// this point's picker open, `||` would close it.
 // `accepts_cod` is deliberately `true` and `max_weight` is deliberately `null` on
 // all three: the demo behaviour comes from the domain filter overriding the verdict,
 // not from Constraint_Checker independently refusing them for an unrelated reason.
@@ -388,8 +394,8 @@ $domain_seam_points = [
 		'services'        => [],
 	],
 	[
-		'id'              => 'DEMO-PVZ-FAST',
-		'name'            => 'ПВЗ «Люсиновская — мгновенное закрытие»',
+		'id'              => 'DEMO-PVZ-STAY',
+		'name'            => 'ПВЗ «Люсиновская — карта остаётся открытой»',
 		'lat'             => 55.6900,
 		'lng'             => 37.5450,
 		'address'         => 'Москва, Люсиновская улица, д. 4',

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -471,6 +471,28 @@ function woodev_test_shipping_method_plugin_init(): void {
 					],
 				];
 
+				// `close_on_select` (13th argument) is the CONFIG half of the two-level close
+				// contract, and until now the rig only ever exercised the other half. The
+				// framework's own default is `false` — a confirmed point leaves the customer in
+				// the map with the CTA relabelled «Продолжить оформление заказа» — so the config
+				// path had no live coverage at all: everything on the rig went through a domain
+				// filter answering `close => true` per point.
+				//
+				// Turning it on here is not only "what the rig should demo". It is what makes the
+				// override direction TESTABLE. The browser reads
+				// `resolveFlag( result.close, defaults.close )`, whose contract is `??` and
+				// explicitly NEVER `||`: an explicit `false` from the domain is a DECISION ("do
+				// not close THIS one") and must beat a `true` config. With the config at `false`
+				// and a point answering `true`, `??` and `||` return the SAME value — so the
+				// fixture could not have caught that regression. With the config at `true`, a
+				// point answering `false` separates them: `??` keeps the picker open, `||` closes
+				// it. See DEMO-PVZ-STAY in fixture-points.php, which is that point.
+				//
+				// Arguments 10-12 are the framework's own defaults, restated only because the
+				// constructor is positional and PHP 7.4 (which CI checks) has no named arguments.
+				// The accent colour is duplicated as a literal because `DEFAULT_ACCENT_COLOR` is
+				// a `private const` the fixture cannot reference — exactly the friction issue
+				// #170 tracks.
 				$this->pickup_handler = new \Woodev\Framework\Shipping\Pickup\Pickup_Handler(
 					self::PLUGIN_ID,
 					'carrier_pickup_point',
@@ -480,7 +502,11 @@ function woodev_test_shipping_method_plugin_init(): void {
 					null,
 					null,
 					true,
-					$point_icons
+					$point_icons,
+					'#06aedd',
+					'',
+					true,
+					true
 				);
 				$this->pickup_handler->register();
 			}
@@ -732,12 +758,23 @@ function woodev_test_shipping_method_plugin_init(): void {
 				return $result;
 			}
 
-			// A point that closes immediately, overriding the fixture's two-step default
-			// (Pickup_Handler is constructed above without a `close_on_select` argument, so
-			// it keeps the constructor's own `false`) — the rig's way to see `close` actually
-			// override the config.
-			if ( 'DEMO-PVZ-FAST' === $id ) {
-				$result['close'] = true;
+			// A point that REFUSES to close, against a config that says close (the handler is
+			// constructed above with `close_on_select = true`). This is the direction that
+			// actually proves something.
+			//
+			// The browser resolves the flag as `resolveFlag( result.close, defaults.close )`,
+			// whose contract is `??` and explicitly never `||`, because an explicit `false`
+			// from the domain is a DECISION — "do not close THIS one" — and has to beat a
+			// `true` config. Under the previous arrangement (config `false`, point answering
+			// `true`) both operators return the same value, so the rig could not tell a correct
+			// implementation from a regressed one. Here they diverge: `??` keeps the picker
+			// open, `||` closes it.
+			//
+			// A real carrier reaches this branch whenever confirmation returns something the
+			// customer still has to see — a point that needs a code collected at the counter,
+			// say — which is why the framework offers the per-point override at all.
+			if ( 'DEMO-PVZ-STAY' === $id ) {
+				$result['close'] = false;
 
 				return $result;
 			}


### PR DESCRIPTION
The rig only ever exercised the **response** half of the two-level close contract.
`Pickup_Handler` was constructed without `close_on_select`, so it kept the framework's own
`false` default and every close seen on the rig came from a per-point domain filter — the
config path had no live coverage at all.

The fixture now passes `close_on_select = true`: an ordinary point closes as soon as the
server confirms it.

## The demo point is reversed, because the old direction could not fail

The browser resolves the flag as `resolveFlag( result.close, defaults.close )`, whose
contract is `??` and explicitly **never** `||` — an explicit `false` from the domain is a
decision ("do not close THIS one") and has to beat a `true` config.

With the config at `false` and a point answering `true`, `??` and `||` return the same
value. So `DEMO-PVZ-FAST` demonstrated the override without testing it: a regression from
`??` to `||` would have looked identical on the rig.

It is now `DEMO-PVZ-STAY`, answering `false` against a `true` config. There the two
operators diverge: `??` keeps its picker open, `||` closes it.

## Rig-verified, both directions

- ordinary point → `selection.close: true` reaches the browser, picker closes on the first
  click after success, field written
- `DEMO-PVZ-STAY` → picker stays open, CTA relabels to «Продолжить оформление заказа»,
  field written `DEMO-PVZ-STAY`

## One wart worth naming

Arguments 10-12 are the framework's own defaults, restated only because the constructor is
positional and CI checks PHP 7.4, which has no named arguments. The accent colour is a
duplicated `'#06aedd'` literal because `DEFAULT_ACCENT_COLOR` is a `private const` the
fixture cannot reference. Both are exactly the friction #170 tracks.

1430 unit tests, phpcs clean.
