### PR TITLE
test(pickup): drive the rig from real Yandex.Delivery pickup points

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
@@ -1,0 +1,581 @@
+<?php
+/**
+ * Woodev_Test_Live_Yandex_Point_Source — OPT-IN STRATEGY_BULK fixture Point_Source that
+ * calls the REAL Yandex.Delivery `pickup-points/list` endpoint on Yandex's own TEST host,
+ * proving the framework's `Point_Source` contract against a live carrier response instead
+ * of a static array (issue #185).
+ *
+ * ACTIVATION: never on by default. `woodev-test-shipping-method.php` only constructs this
+ * class when `WOODEV_TEST_PICKUP_LIVE_YANDEX` is truthy (defined near
+ * `WOODEV_TEST_PICKUP_STRATEGY` at the top of that file, default `false`). Neither
+ * `composer test:unit` nor `composer test:integration` nor CI ever set that constant, so
+ * this class is declared (cheap — no I/O happens merely by `require_once`ing or
+ * `class_exists`-guarding it) but never INSTANTIATED, and therefore never makes a network
+ * call, in either suite. An operator flips it on the same way as the strategy switch — a
+ * `define( 'WOODEV_TEST_PICKUP_LIVE_YANDEX', true );` in wp-config.php or the `.wp-env.json`
+ * `config` block — to drive the rig's map off real Yandex sandbox data.
+ *
+ * TOKEN — NOT IN THIS FILE, AND NOT IN THIS REPOSITORY. The bearer token is read at request
+ * time from the constant named by `self::TOKEN_CONSTANT`
+ * (`WOODEV_TEST_YANDEX_SANDBOX_TOKEN`); when it is undefined the source throws instead of
+ * calling out, so the failure names its own cause.
+ *
+ * It is deliberately not a literal here. The value lives in the reference plugin
+ * (`plugins-reference/woocommerce-yandex-delivery/woocommerce-yandex-delivery.php`, the
+ * `is_test_environment()` branch), and that directory is gitignored — so committing the
+ * literal would have moved a THIRD PARTY's credential into a PUBLIC repository's history for
+ * the first time. That it is only a sandbox token, and that it ships inside every install of
+ * that plugin already, lowers the impact but does not make publishing it ours to do: a
+ * credential scanner hitting a public repo is a plausible route to that token being revoked,
+ * which would break the reference plugin's test mode for its actual customers.
+ *
+ * Define it alongside the activation constant — in `wp-config.php`, or in the GITIGNORED
+ * `.wp-env.override.json` rather than the tracked `.wp-env.json`:
+ *
+ *     define( 'WOODEV_TEST_YANDEX_SANDBOX_TOKEN', '…' );
+ *
+ * A real shipping plugin supplies ITS OWN token, from its own Yandex.Delivery cabinet, and
+ * likewise never commits it.
+ *
+ * PAYLOAD, verified by hand 07.08.2026 (not taken from documentation — see the "reference
+ * is not enough" lesson this project has been burned by before): four live calls against
+ * `POST /api/b2b/platform/pickup-points/list` with `geo_id: 213` (Moscow):
+ *  - `{}` (no `type`)         -> HTTP 200, 812 points: 808 `pickup_point` + 4 `terminal`.
+ *  - `{"type":"pickup_point"}` -> HTTP 200, 808 points, all `pickup_point` (type DOES filter
+ *     server-side, contrary to an earlier, unverified assumption that an unrecognised/any
+ *     `type` value is ignored).
+ *  - `{"type":"terminal"}`     -> HTTP 200, 4 points, all `terminal`.
+ *  - `{"type":"bogus_type"}`   -> HTTP 400, `{"code":"400","message":"Value of 'type' (bogus_type)
+ *     is not parseable into enum"}` — an unrecognised type ERRORS, it is not ignored.
+ * This class therefore omits `type` entirely and fetches BOTH shapes in one call, mapping
+ * each raw record's own `type` field client-side (see `TYPE_MAP`) — one HTTP round trip and
+ * one cache entry serves every marker on the map, and the interface docblock explicitly
+ * permits a STRATEGY_BULK source to ignore `Point_Query::get_types()` and let the framework
+ * filter client-side.
+ *
+ * Observed record shape (both `pickup_point` and `terminal`): `id`, `operator_station_id`,
+ * `operator_id`, `name`, `type`, `position{latitude,longitude}`,
+ * `address{geoId,country,region,subRegion,locality,street,house,housing,apartment,building,
+ * comment,full_address,postal_code}`, `instruction`, `payment_methods[]`, `contact{phone}`,
+ * `schedule{time_zone,restrictions[{days[],time_from{hours,minutes},time_to{...}}]}`,
+ * `is_yandex_branded`, `is_market_partner`, `is_dark_store`, `is_post_office`, `dayoffs[]`,
+ * `deactivation_date`, `deactivation_date_predicted_debt`, `available_for_dropoff`,
+ * `available_for_c2c_dropoff`, `pickup_services{is_fitting_allowed,is_partial_refuse_allowed,
+ * is_paperless_pickup_allowed,is_unboxing_allowed}`. No `max_weight`/weight-limit field
+ * anywhere in the payload, so `Pickup_Point::get_max_weight()` stays null for every live
+ * point — this is an honest "the carrier did not say", not a mapping gap.
+ *
+ * SCOPE: like `Woodev_Test_Bulk_Point_Source`, this fixture serves exactly one city
+ * (Moscow, Yandex `geo_id` 213) — `MOSCOW_GEO_ID` is hardcoded rather than resolved from
+ * the requested locality string, because building a real locality->geo_id resolver
+ * (Yandex's own `location/detect` endpoint) is a second live integration this card never
+ * asked for. `fetch_points()` still gates on the requested locality matching this fixture's
+ * own city string, exactly like the static bulk source, so the rig's `emptyLocality` state
+ * stays reachable.
+ *
+ * FAIL SOFT: the `Point_Source` interface REQUIRES a transport/auth/API failure to surface
+ * as a thrown `\Woodev_API_Exception`, never as a silently empty list (see the interface's
+ * own `@throws` docblock) — and the REST layer (`class-pickup-controller.php`) already
+ * catches exactly that exception and turns it into a `502 WP_Error` the browser's
+ * error/retry UI understands (see `upstream_error()` there). So "fail soft" here means:
+ * throw on every real failure (transport, non-200, unparseable/unexpected body) and let the
+ * framework's EXISTING retry surface handle it — reinventing a bespoke fallback (e.g.
+ * silently returning stale/empty data) would both violate the interface contract and hide a
+ * real sandbox outage as "this city has no pickup points". `wp_safe_remote_post()` is used
+ * (not the unsafe variant) with an explicit `REQUEST_TIMEOUT` so a hung sandbox degrades to
+ * a bounded error, not an indefinitely blocked picker. NOTE: unlike the local-issuer case in
+ * `docs-internal/gotchas/wp-safe-remote-request-local-rig.md`, no `http_request_host_is_external`
+ * / `http_allowed_safe_ports` workaround is needed here — Yandex's TEST host is a PUBLIC
+ * host on the standard port 443, exactly what `wp_safe_remote_request()`'s validator allows;
+ * that gotcha only bites a PRIVATE/loopback host or a non-standard port.
+ *
+ * CACHING: one transient covers the whole Moscow point list (both types), refreshed once
+ * per `CACHE_TTL`. The value matches this framework's own established convention for
+ * cacheable API responses — `Woodev_Cacheable_Request_Trait::$cache_lifetime` (see
+ * `woodev/api/traits/cacheable-request-trait.php`) defaults to `86400` (one day) — rather
+ * than inventing a fixture-specific number. A day is long enough that a rig session never
+ * re-hits the sandbox on every map open/reload (the whole point of caching here), and short
+ * enough that the next day's session sees a genuinely fresh pull rather than a
+ * week-stale one. Real pickup-point lists do not churn minute-to-minute, and this is a
+ * manually-opted-in dev/demo path, not a production freshness guarantee.
+ *
+ * SCHEDULE: `Pickup_Point::work_time` is a plain string; Yandex's `schedule` is structured
+ * (per-weekday time restrictions). `flatten_schedule()` groups consecutive weekdays sharing
+ * an identical time range into readable spans ("Пн–Вс 00:00–23:59"). This is a flattening,
+ * not a redesign of the point contract for structured schedules — that is issue #152,
+ * explicitly out of scope here. `dayoffs`/`deactivation_date` (specific calendar exceptions)
+ * have no home in a flat string either and are dropped rather than mushed in.
+ *
+ * PAYMENT METHODS: raw API codes (`already_paid`, `card_on_receipt`, `bound_card`,
+ * `postpay` — confirmed live, matching the brief) are display text once they reach the
+ * customer (issue #154), so `PAYMENT_METHOD_LABELS` maps each known code to a Russian
+ * label; an unrecognised code is DROPPED rather than shown as a raw English string to the
+ * customer, the same "drop, do not coerce" rule `Pickup_Point::sanitize_string_list()`
+ * already applies to a non-string element.
+ *
+ * Declared inside the plugin's init callback (`require_once`d from
+ * `woodev-test-shipping-method.php`, same arrangement as `class-test-bulk-point-source.php`
+ * — see that file's own docblock and
+ * `docs-internal/gotchas/fixture-classes-must-live-inside-plugin-init.md`): a class naming a
+ * `Woodev\Framework\*` interface in `implements` fatals if declared before the bootstrap has
+ * selected a framework copy and registered its autoloader.
+ *
+ * @package Woodev_Test_Shipping_Method
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Woodev_Test_Live_Yandex_Point_Source' ) ) {
+
+	/**
+	 * Class Woodev_Test_Live_Yandex_Point_Source
+	 *
+	 * Live Yandex.Delivery sandbox Point_Source — see the file-level docblock for the full
+	 * rationale (activation gate, verified payload shape, caching, fail-soft behaviour).
+	 */
+	class Woodev_Test_Live_Yandex_Point_Source implements \Woodev\Framework\Shipping\Pickup\Point_Source {
+
+		/**
+		 * Name of the constant supplying the sandbox bearer token — see the file docblock's
+		 * TOKEN section. The token itself is deliberately NOT in this file: this repository
+		 * is PUBLIC, and the value is a third party's credential, not ours to publish.
+		 */
+		private const TOKEN_CONSTANT = 'WOODEV_TEST_YANDEX_SANDBOX_TOKEN';
+
+		/** Yandex's TEST host — never the production `b2b-authproxy.taxi.yandex.net`. */
+		private const TEST_HOST = 'https://b2b.taxi.tst.yandex.net';
+
+		/** Verified live 07.08.2026 — see the file docblock's PAYLOAD section. */
+		private const LIST_PATH = '/api/b2b/platform/pickup-points/list';
+
+		/** Yandex `geo_id` for Moscow — see the file docblock's SCOPE section. */
+		private const MOSCOW_GEO_ID = 213;
+
+		/**
+		 * The fixture's one static "city" — mirrors
+		 * `Woodev_Test_Bulk_Point_Source::FIXTURE_LOCALITY` so the rig's locality gating
+		 * behaves identically regardless of which bulk source is active.
+		 */
+		private const FIXTURE_LOCALITY = 'Москва';
+
+		/** Bounded so a hung sandbox degrades to an error, not an indefinite wait. */
+		private const REQUEST_TIMEOUT = 8;
+
+		/** One transient covers both point types for the one city this fixture serves. */
+		private const CACHE_TRANSIENT_KEY = 'woodev_test_live_yandex_points_213';
+
+		/** One day — matches `Woodev_Cacheable_Request_Trait`'s own default; see file docblock. */
+		private const CACHE_TTL = DAY_IN_SECONDS;
+
+		/**
+		 * Maps Yandex's raw `type` values onto the fixture's existing type codes so the
+		 * existing point icons (registered in `woodev-test-shipping-method.php` under
+		 * exactly these `PVZ`/`POSTAMAT` keys) keep working — the framework compares type
+		 * codes case-sensitively.
+		 */
+		private const TYPE_MAP = [
+			'pickup_point' => [
+				'code'  => 'PVZ',
+				'label' => 'Пункт выдачи заказов',
+			],
+			'terminal'     => [
+				'code'  => 'POSTAMAT',
+				'label' => 'Постамат',
+			],
+		];
+
+		/** Russian display labels for the raw API payment-method codes — see file docblock. */
+		private const PAYMENT_METHOD_LABELS = [
+			'already_paid'    => 'Товар уже оплачен',
+			'card_on_receipt' => 'Оплата картой при получении',
+			'bound_card'      => 'Привязанная карта',
+			'postpay'         => 'Постоплата',
+		];
+
+		/** Russian weekday abbreviations, Yandex's 1 (Monday) .. 7 (Sunday). */
+		private const DAY_LABELS = [
+			1 => 'Пн',
+			2 => 'Вт',
+			3 => 'Ср',
+			4 => 'Чт',
+			5 => 'Пт',
+			6 => 'Сб',
+			7 => 'Вс',
+		];
+
+		/**
+		 * @inheritDoc
+		 */
+		public function get_strategy(): string {
+			return self::STRATEGY_BULK;
+		}
+
+		/**
+		 * Returns every live Moscow point when the requested locality is this fixture's own
+		 * city, or an empty list otherwise — mirrors
+		 * `Woodev_Test_Bulk_Point_Source::fetch_points()` (issue #162).
+		 *
+		 * @inheritDoc
+		 *
+		 * @throws \Woodev_API_Exception On a sandbox transport, HTTP, or payload-shape
+		 *                                 failure — see the file docblock's FAIL SOFT section.
+		 */
+		public function fetch_points( \Woodev\Framework\Shipping\Pickup\Point_Query $query ): array {
+			if ( ! $this->locality_matches( $query->get_locality() ) ) {
+				return [];
+			}
+
+			return array_values( array_filter( array_map(
+				[ $this, 'map_point' ],
+				$this->fetch_all_points_cached()
+			) ) );
+		}
+
+		/**
+		 * @inheritDoc
+		 *
+		 * @throws \Woodev_API_Exception On a sandbox transport, HTTP, or payload-shape
+		 *                                 failure — see the file docblock's FAIL SOFT section.
+		 */
+		public function fetch_details( string $point_id ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
+			foreach ( $this->fetch_all_points_cached() as $raw_point ) {
+				if ( is_array( $raw_point ) && isset( $raw_point['id'] ) && $point_id === (string) $raw_point['id'] ) {
+					return $this->map_point( $raw_point );
+				}
+			}
+
+			return null;
+		}
+
+		/**
+		 * Whether the requested locality names this fixture's own city, ignoring case and
+		 * surrounding whitespace — identical rule to `Woodev_Test_Bulk_Point_Source`.
+		 *
+		 * @param string|null $locality Requested locality, guaranteed non-null by the
+		 *                               framework for a STRATEGY_BULK source; the
+		 *                               null-coalesce below is defensive only.
+		 *
+		 * @return bool
+		 */
+		private function locality_matches( ?string $locality ): bool {
+			return mb_strtolower( trim( $locality ?? '' ) ) === mb_strtolower( self::FIXTURE_LOCALITY );
+		}
+
+		/**
+		 * Returns the raw Yandex point list (both types, unmapped), from cache when fresh.
+		 *
+		 * Only a SUCCESSFUL fetch is cached — a thrown exception never reaches
+		 * `set_transient()`, so a sandbox outage is retried on the very next request rather
+		 * than being remembered as empty for a full day.
+		 *
+		 * @return array<int, mixed> Raw point records as decoded from the API's `points` array.
+		 *
+		 * @throws \Woodev_API_Exception On a sandbox transport, HTTP, or payload-shape failure.
+		 */
+		private function fetch_all_points_cached(): array {
+			$cached = get_transient( self::CACHE_TRANSIENT_KEY );
+
+			if ( is_array( $cached ) ) {
+				return $cached;
+			}
+
+			$points = $this->request_points_from_yandex();
+
+			set_transient( self::CACHE_TRANSIENT_KEY, $points, self::CACHE_TTL );
+
+			return $points;
+		}
+
+		/**
+		 * Performs the live call to Yandex's TEST sandbox and returns the raw `points` array.
+		 *
+		 * `type` is deliberately omitted from the request body — see the file docblock's
+		 * PAYLOAD section for why an omitted `type` (both shapes in one call) is preferred
+		 * over filtering server-side.
+		 *
+		 * @return array<int, mixed>
+		 *
+		 * @throws \Woodev_API_Exception On a transport failure (`wp_safe_remote_post()`
+		 *                                 returning a `WP_Error`), a non-200 HTTP response, or
+		 *                                 a body that does not decode to `{ "points": [...] }`.
+		 */
+		private function request_points_from_yandex(): array {
+			$token = defined( self::TOKEN_CONSTANT ) ? (string) constant( self::TOKEN_CONSTANT ) : '';
+
+			// Fail with the same exception type as every other failure here, so the REST layer
+			// turns it into the existing 502 + retry UI rather than a bespoke path. The message
+			// names the constant, because "no points" with a silent cause is exactly the kind of
+			// thing that reads as a broken picker.
+			if ( '' === $token ) {
+				throw new \Woodev_API_Exception(
+					sprintf(
+						'Yandex.Delivery sandbox token missing: define %s to use the live point source.',
+						self::TOKEN_CONSTANT
+					)
+				);
+			}
+
+			$response = wp_safe_remote_post(
+				self::TEST_HOST . self::LIST_PATH,
+				[
+					'timeout' => self::REQUEST_TIMEOUT,
+					'headers' => [
+						'Authorization'   => 'Bearer ' . $token,
+						'Content-Type'    => 'application/json',
+						'Accept-Language' => 'ru',
+					],
+					'body'    => wp_json_encode( [ 'geo_id' => self::MOSCOW_GEO_ID ] ),
+				]
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new \Woodev_API_Exception(
+					sprintf( 'Yandex.Delivery sandbox transport failure: %s', $response->get_error_message() )
+				);
+			}
+
+			$code = (int) wp_remote_retrieve_response_code( $response );
+
+			if ( 200 !== $code ) {
+				throw new \Woodev_API_Exception(
+					sprintf( 'Yandex.Delivery sandbox returned HTTP %d.', $code ),
+					$code
+				);
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( ! is_array( $body ) || ! isset( $body['points'] ) || ! is_array( $body['points'] ) ) {
+				throw new \Woodev_API_Exception( 'Yandex.Delivery sandbox returned an unexpected payload shape.' );
+			}
+
+			return $body['points'];
+		}
+
+		/**
+		 * Maps one raw Yandex record onto the framework's normalized payload shape and
+		 * builds a {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point} from it.
+		 *
+		 * Returns null (skips the point) for a non-array record or an unrecognised `type` —
+		 * one bad/foreign-shaped record must not empty the whole map (interface contract),
+		 * and a type outside `TYPE_MAP` has no matching marker icon anyway (file docblock).
+		 * Every other validation (required fields, coordinate range) is delegated to
+		 * `Pickup_Point::from_array()`, the framework's single source of truth for what a
+		 * valid point looks like.
+		 *
+		 * @param mixed $raw_point One element of the API's `points` array.
+		 *
+		 * @return \Woodev\Framework\Shipping\Pickup\Pickup_Point|null
+		 */
+		private function map_point( $raw_point ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
+			if ( ! is_array( $raw_point ) ) {
+				return null;
+			}
+
+			$type = self::TYPE_MAP[ (string) ( $raw_point['type'] ?? '' ) ] ?? null;
+
+			if ( null === $type ) {
+				return null;
+			}
+
+			$position = is_array( $raw_point['position'] ?? null ) ? $raw_point['position'] : [];
+			$address  = is_array( $raw_point['address'] ?? null ) ? $raw_point['address'] : [];
+			$contact  = is_array( $raw_point['contact'] ?? null ) ? $raw_point['contact'] : [];
+			$schedule = is_array( $raw_point['schedule'] ?? null ) ? $raw_point['schedule'] : [];
+			$services = is_array( $raw_point['pickup_services'] ?? null ) ? $raw_point['pickup_services'] : [];
+
+			return \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array(
+				[
+					'id'              => $raw_point['id'] ?? '',
+					'name'            => $raw_point['name'] ?? '',
+					'lat'             => $position['latitude'] ?? null,
+					'lng'             => $position['longitude'] ?? null,
+					'address'         => $address['full_address'] ?? '',
+					'type'            => $type,
+					'locality'        => $address['locality'] ?? '',
+					'postal_code'     => $address['postal_code'] ?? '',
+					'phone'           => $contact['phone'] ?? '',
+					'instruction'     => $raw_point['instruction'] ?? '',
+					'work_time'       => $this->flatten_schedule( $schedule ),
+					'payment_methods' => $this->map_payment_methods(
+						is_array( $raw_point['payment_methods'] ?? null ) ? $raw_point['payment_methods'] : []
+					),
+					'services'        => $this->map_services( $services ),
+					'photos'          => [],
+				]
+			);
+		}
+
+		/**
+		 * Maps raw API payment-method codes to Russian display labels, dropping any code
+		 * this fixture does not recognise — see the file docblock's PAYMENT METHODS section.
+		 *
+		 * @param array<int, mixed> $codes Raw `payment_methods` values from the API.
+		 *
+		 * @return string[]
+		 */
+		private function map_payment_methods( array $codes ): array {
+			$labels = [];
+
+			foreach ( $codes as $code ) {
+				if ( is_string( $code ) && isset( self::PAYMENT_METHOD_LABELS[ $code ] ) ) {
+					$labels[] = self::PAYMENT_METHOD_LABELS[ $code ];
+				}
+			}
+
+			return $labels;
+		}
+
+		/**
+		 * Maps the `pickup_services` boolean flags to Russian display labels.
+		 *
+		 * @param array<string, mixed> $flags Raw `pickup_services` object from the API.
+		 *
+		 * @return string[]
+		 */
+		private function map_services( array $flags ): array {
+			$labels = [];
+
+			if ( ! empty( $flags['is_fitting_allowed'] ) ) {
+				$labels[] = 'Примерка';
+			}
+
+			if ( ! empty( $flags['is_partial_refuse_allowed'] ) ) {
+				$labels[] = 'Частичный отказ от заказа';
+			}
+
+			if ( ! empty( $flags['is_unboxing_allowed'] ) ) {
+				$labels[] = 'Вскрытие упаковки';
+			}
+
+			if ( ! empty( $flags['is_paperless_pickup_allowed'] ) ) {
+				$labels[] = 'Выдача без бумажных документов';
+			}
+
+			return $labels;
+		}
+
+		/**
+		 * Flattens Yandex's structured `schedule.restrictions` into a readable string —
+		 * see the file docblock's SCHEDULE section for why this stays a flattening rather
+		 * than a redesign of `Pickup_Point::work_time` (issue #152).
+		 *
+		 * Consecutive weekdays sharing an identical time range are grouped into one span
+		 * (e.g. every day 00:00-23:59 becomes "Пн–Вс 00:00–23:59" instead of seven repeated
+		 * entries); non-consecutive or differing spans are joined with "; ".
+		 *
+		 * @param array<string, mixed> $schedule Raw `schedule` object from the API.
+		 *
+		 * @return string
+		 */
+		private function flatten_schedule( array $schedule ): string {
+			$restrictions = is_array( $schedule['restrictions'] ?? null ) ? $schedule['restrictions'] : [];
+
+			$range_by_day = [];
+
+			foreach ( $restrictions as $restriction ) {
+				if ( ! is_array( $restriction ) ) {
+					continue;
+				}
+
+				$range = $this->format_time_range( $restriction );
+
+				if ( '' === $range ) {
+					continue;
+				}
+
+				foreach ( (array) ( $restriction['days'] ?? [] ) as $day ) {
+					$day = (int) $day;
+
+					if ( isset( self::DAY_LABELS[ $day ] ) ) {
+						$range_by_day[ $day ] = $range;
+					}
+				}
+			}
+
+			if ( [] === $range_by_day ) {
+				return '';
+			}
+
+			ksort( $range_by_day );
+
+			return implode( '; ', $this->group_consecutive_days( $range_by_day ) );
+		}
+
+		/**
+		 * Groups a day => time-range map into "Пн–Пт HH:MM–HH:MM"-style spans, merging
+		 * consecutive weekday numbers that share an identical range.
+		 *
+		 * @param array<int, string> $range_by_day Sorted by day number; day => "HH:MM–HH:MM".
+		 *
+		 * @return string[]
+		 */
+		private function group_consecutive_days( array $range_by_day ): array {
+			$groups       = [];
+			$group_start  = null;
+			$group_range  = null;
+			$previous_day = null;
+
+			foreach ( $range_by_day as $day => $range ) {
+				$is_contiguous = ( null !== $previous_day && $day === $previous_day + 1 && $range === $group_range );
+
+				if ( ! $is_contiguous ) {
+					if ( null !== $group_start ) {
+						$groups[] = $this->format_day_group( $group_start, $previous_day, $group_range );
+					}
+
+					$group_start = $day;
+					$group_range = $range;
+				}
+
+				$previous_day = $day;
+			}
+
+			$groups[] = $this->format_day_group( $group_start, $previous_day, $group_range );
+
+			return $groups;
+		}
+
+		/**
+		 * Formats one grouped day span, e.g. "Пн–Пт 09:00–21:00" or "Вс 10:00–18:00".
+		 *
+		 * @param int    $start First day number of the span.
+		 * @param int    $end   Last day number of the span.
+		 * @param string $range Already-formatted "HH:MM–HH:MM" time range.
+		 *
+		 * @return string
+		 */
+		private function format_day_group( int $start, int $end, string $range ): string {
+			$label = ( $start === $end )
+				? self::DAY_LABELS[ $start ]
+				: self::DAY_LABELS[ $start ] . '–' . self::DAY_LABELS[ $end ];
+
+			return $label . ' ' . $range;
+		}
+
+		/**
+		 * Formats one `{time_from, time_to}` restriction as "HH:MM–HH:MM", or '' when either
+		 * side is missing its `hours`/`minutes`.
+		 *
+		 * @param array<string, mixed> $restriction One raw restriction entry.
+		 *
+		 * @return string
+		 */
+		private function format_time_range( array $restriction ): string {
+			$from = is_array( $restriction['time_from'] ?? null ) ? $restriction['time_from'] : [];
+			$to   = is_array( $restriction['time_to'] ?? null ) ? $restriction['time_to'] : [];
+
+			if ( ! isset( $from['hours'], $from['minutes'], $to['hours'], $to['minutes'] ) ) {
+				return '';
+			}
+
+			return sprintf(
+				'%02d:%02d–%02d:%02d',
+				(int) $from['hours'],
+				(int) $from['minutes'],
+				(int) $to['hours'],
+				(int) $to['minutes']
+			);
+		}
+	}
+}

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -28,6 +28,20 @@ if ( ! defined( 'WOODEV_TEST_PICKUP_STRATEGY' ) ) {
 }
 
 /**
+ * Issue #185: opt-in switch to the LIVE Yandex.Delivery sandbox Point_Source
+ * (`Woodev_Test_Live_Yandex_Point_Source`, calling Yandex's own TEST host) instead of the
+ * static fixture data. Defaults to `false` — neither the unit suite, the integration suite,
+ * nor CI ever defines this, so no test makes a network call. Flip via
+ * `define( 'WOODEV_TEST_PICKUP_LIVE_YANDEX', true );` in wp-config.php or the `.wp-env.json`
+ * `config` block, same idiom as `WOODEV_TEST_PICKUP_STRATEGY` above. Yandex only exposes a
+ * bulk/geo_id-addressed endpoint, so when this is on it WINS over `WOODEV_TEST_PICKUP_STRATEGY`
+ * regardless of that constant's value — see the point-source selection below.
+ */
+if ( ! defined( 'WOODEV_TEST_PICKUP_LIVE_YANDEX' ) ) {
+	define( 'WOODEV_TEST_PICKUP_LIVE_YANDEX', false );
+}
+
+/**
  * Определяем корневую директорию фреймворка.
  *
  * В wp-env контейнере: WOODEV_FRAMEWORK_DIR задаётся через config в .wp-env.json
@@ -195,6 +209,11 @@ function woodev_test_shipping_method_plugin_init(): void {
 	// -----------------------------------------------------------------------
 
 	require_once __DIR__ . '/class-test-bulk-point-source.php';
+
+	// Issue #185: declared unconditionally, same reasoning as Woodev_Test_Viewport_Point_Source
+	// just below — declaring a class is free (no I/O), only INSTANTIATING it below does
+	// anything, and that only happens when WOODEV_TEST_PICKUP_LIVE_YANDEX is truthy.
+	require_once __DIR__ . '/class-test-live-yandex-point-source.php';
 
 	if ( ! class_exists( 'Woodev_Test_Viewport_Point_Source' ) ) {
 
@@ -382,10 +401,20 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// SP-5 Task 18: WOODEV_TEST_PICKUP_STRATEGY (defined near the top of this
 				// file) selects which fixture Point_Source is active, so the rig can
 				// switch loading strategy without a code edit.
+				//
+				// Issue #185: WOODEV_TEST_PICKUP_LIVE_YANDEX (also defined near the top of
+				// this file, default false) wins over WOODEV_TEST_PICKUP_STRATEGY when
+				// truthy — Yandex only offers a bulk/geo_id-addressed endpoint, so "live"
+				// and "viewport" are not a combination that exists to choose between.
 				$viewport_strategy = \Woodev\Framework\Shipping\Pickup\Point_Source::STRATEGY_VIEWPORT;
-				$point_source      = ( $viewport_strategy === WOODEV_TEST_PICKUP_STRATEGY )
-					? new \Woodev_Test_Viewport_Point_Source()
-					: new \Woodev_Test_Bulk_Point_Source();
+
+				if ( WOODEV_TEST_PICKUP_LIVE_YANDEX ) {
+					$point_source = new \Woodev_Test_Live_Yandex_Point_Source();
+				} else {
+					$point_source = ( $viewport_strategy === WOODEV_TEST_PICKUP_STRATEGY )
+						? new \Woodev_Test_Viewport_Point_Source()
+						: new \Woodev_Test_Bulk_Point_Source();
+				}
 
 				// D-8: custom tile layers + their attribution are a PLUGIN decision, and
 				// this fixture exercises that seam on purpose. Before this, `layers` and

--- a/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
+++ b/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Unit tests for issue #185: `Woodev_Test_Live_Yandex_Point_Source`, the rig's OPT-IN
+ * Point_Source that calls the real Yandex.Delivery sandbox instead of a static array.
+ *
+ * HARD REQUIREMENT this file exists to prove: the unit suite must never make a network
+ * call. Every transport function (`wp_safe_remote_post`, `is_wp_error`,
+ * `wp_remote_retrieve_response_code`, `wp_remote_retrieve_body`, `get_transient`,
+ * `set_transient`) is stubbed via Brain Monkey below — `wp_safe_remote_post` is never the
+ * real WordPress HTTP client here, and {@see self::test_foreign_locality_never_touches_the_network()}
+ * additionally asserts it is not even CALLED for the (very common) case where the requested
+ * locality is not this fixture's own city.
+ *
+ * The canned payloads below are not invented — they are trimmed, byte-preserved copies of
+ * TWO records from a real 07.08.2026 `curl` against
+ * `POST https://b2b.taxi.tst.yandex.net/api/b2b/platform/pickup-points/list` (`geo_id: 213`):
+ * one `pickup_point` ("ГиперПВЗ-2") and one `terminal` ("Постамат Яндекс.Маркет"), so the
+ * mapping assertions below are checked against the REAL observed shape, not a guess at the
+ * documented one.
+ *
+ * `Woodev_Test_Live_Yandex_Point_Source` lives in its own file for the same reason as
+ * `Woodev_Test_Bulk_Point_Source` (see that class's own docblock and
+ * {@see \Woodev\Tests\Unit\Shipping\Pickup\TestShippingMethodFixtureLocalityTest}, whose
+ * `require_once` list this test mirrors): it can be pulled in directly, bypassing
+ * `Woodev_Plugin_Bootstrap`'s process-wide, load-once singleton.
+ *
+ * @package Woodev\Tests\Unit\Shipping\Pickup
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Pickup;
+
+use Brain\Monkey\Functions;
+use Woodev\Framework\Shipping\Pickup\Point_Query;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/class-plugin-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/api/class-api-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-point.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-point-query.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/interface-point-source.php';
+require_once dirname( __DIR__, 4 ) . '/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php';
+
+/**
+ * @covers \Woodev_Test_Live_Yandex_Point_Source
+ */
+final class TestLiveYandexPointSourceTest extends TestCase {
+
+	/**
+	 * The source reads its bearer token from a constant rather than a literal, because this
+	 * repository is public and the real value is a third party's credential (see the source's
+	 * own TOKEN docblock). Every test that exercises a SUCCESSFUL fetch therefore has to get
+	 * past that guard first, so a dummy is defined once for the whole process.
+	 *
+	 * Deliberately not the real token: nothing here reaches the network — the transport is
+	 * stubbed in every test — so the value only has to be non-empty.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WOODEV_TEST_YANDEX_SANDBOX_TOKEN' ) ) {
+			define( 'WOODEV_TEST_YANDEX_SANDBOX_TOKEN', 'dummy-token-for-tests' );
+		}
+	}
+
+	/**
+	 * A real `pickup_point` record, trimmed to the fields this class reads, captured live
+	 * 07.08.2026 (id/name/coordinates/address/schedule/payment_methods are byte-preserved).
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function real_pickup_point_record(): array {
+		return [
+			'id'               => '019373a0ecd97151922149c5094feaf6',
+			'operator_station_id' => '10001218535',
+			'name'             => 'ГиперПВЗ-2',
+			'type'             => 'pickup_point',
+			'position'         => [ 'latitude' => 55.740522, 'longitude' => 37.855554 ],
+			'address'          => [
+				'locality'     => 'Москва',
+				'postal_code'  => '111673',
+				'full_address' => 'Москва Новокосинская 17 к6',
+			],
+			'instruction'      => '',
+			'payment_methods'  => [ 'already_paid', 'card_on_receipt' ],
+			'contact'          => [ 'phone' => '+74951570020' ],
+			'schedule'         => [
+				'time_zone'    => 3,
+				'restrictions' => [
+					[ 'days' => [ 1 ], 'time_from' => [ 'hours' => 0, 'minutes' => 0 ], 'time_to' => [ 'hours' => 23, 'minutes' => 59 ] ],
+					[ 'days' => [ 2 ], 'time_from' => [ 'hours' => 0, 'minutes' => 0 ], 'time_to' => [ 'hours' => 23, 'minutes' => 59 ] ],
+					[ 'days' => [ 3 ], 'time_from' => [ 'hours' => 0, 'minutes' => 0 ], 'time_to' => [ 'hours' => 23, 'minutes' => 59 ] ],
+					[ 'days' => [ 4 ], 'time_from' => [ 'hours' => 0, 'minutes' => 0 ], 'time_to' => [ 'hours' => 23, 'minutes' => 59 ] ],
+					[ 'days' => [ 5 ], 'time_from' => [ 'hours' => 0, 'minutes' => 0 ], 'time_to' => [ 'hours' => 23, 'minutes' => 59 ] ],
+					[ 'days' => [ 6 ], 'time_from' => [ 'hours' => 0, 'minutes' => 0 ], 'time_to' => [ 'hours' => 23, 'minutes' => 59 ] ],
+					[ 'days' => [ 7 ], 'time_from' => [ 'hours' => 0, 'minutes' => 0 ], 'time_to' => [ 'hours' => 23, 'minutes' => 59 ] ],
+				],
+			],
+			'is_yandex_branded' => true,
+			'pickup_services'   => [
+				'is_fitting_allowed'          => true,
+				'is_partial_refuse_allowed'   => true,
+				'is_paperless_pickup_allowed' => false,
+				'is_unboxing_allowed'         => true,
+			],
+		];
+	}
+
+	/**
+	 * A real `terminal` record, trimmed the same way, captured live 07.08.2026.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function real_terminal_record(): array {
+		return [
+			'id'              => '5a6879c2-7910-44c1-a134-3de32d35e10c',
+			'name'            => 'Постамат Яндекс.Маркет',
+			'type'            => 'terminal',
+			'position'        => [ 'latitude' => 55.75130844116211, 'longitude' => 37.58462142944336 ],
+			'address'         => [
+				'locality'     => 'Москва',
+				'postal_code'  => '121099',
+				'full_address' => 'Москва Новинский бульвар 8',
+			],
+			'instruction'     => '',
+			'payment_methods' => [ 'already_paid', 'card_on_receipt' ],
+			'contact'         => [ 'phone' => '+74951570020' ],
+			'schedule'        => [
+				'time_zone'    => 3,
+				'restrictions' => [
+					[ 'days' => [ 1 ], 'time_from' => [ 'hours' => 8, 'minutes' => 0 ], 'time_to' => [ 'hours' => 22, 'minutes' => 0 ] ],
+					[ 'days' => [ 2 ], 'time_from' => [ 'hours' => 8, 'minutes' => 0 ], 'time_to' => [ 'hours' => 22, 'minutes' => 0 ] ],
+					[ 'days' => [ 3 ], 'time_from' => [ 'hours' => 8, 'minutes' => 0 ], 'time_to' => [ 'hours' => 22, 'minutes' => 0 ] ],
+					[ 'days' => [ 4 ], 'time_from' => [ 'hours' => 8, 'minutes' => 0 ], 'time_to' => [ 'hours' => 22, 'minutes' => 0 ] ],
+					[ 'days' => [ 5 ], 'time_from' => [ 'hours' => 8, 'minutes' => 0 ], 'time_to' => [ 'hours' => 22, 'minutes' => 0 ] ],
+					[ 'days' => [ 6 ], 'time_from' => [ 'hours' => 8, 'minutes' => 0 ], 'time_to' => [ 'hours' => 22, 'minutes' => 0 ] ],
+					[ 'days' => [ 7 ], 'time_from' => [ 'hours' => 8, 'minutes' => 0 ], 'time_to' => [ 'hours' => 22, 'minutes' => 0 ] ],
+				],
+			],
+			'is_yandex_branded' => false,
+			'pickup_services'   => [
+				'is_fitting_allowed'          => false,
+				'is_partial_refuse_allowed'   => false,
+				'is_paperless_pickup_allowed' => false,
+				'is_unboxing_allowed'         => false,
+			],
+		];
+	}
+
+	/**
+	 * Stubs a successful transport returning the given raw `points` array.
+	 *
+	 * @param array<int, mixed> $points Raw points array to embed as the JSON body.
+	 *
+	 * @return void
+	 */
+	private function stub_successful_transport( array $points ): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( json_encode( [ 'points' => $points ] ) );
+	}
+
+	public function test_strategy_is_bulk(): void {
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+
+		$this->assertSame( 'bulk', $source->get_strategy() );
+	}
+
+	/**
+	 * The most common miss case (a locality that is not Moscow) must resolve without
+	 * ever touching the transport — proves the network gate sits BEFORE the HTTP call,
+	 * not just around the class as a whole.
+	 */
+	public function test_foreign_locality_never_touches_the_network(): void {
+		Functions\expect( 'wp_safe_remote_post' )->never();
+		Functions\expect( 'get_transient' )->never();
+		Functions\expect( 'set_transient' )->never();
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$query  = Point_Query::from_request( [ 'locality' => 'Новосибирск' ] );
+
+		$this->assertSame( [], $source->fetch_points( $query ) );
+	}
+
+	public function test_locality_matching_ignores_case_and_surrounding_whitespace(): void {
+		$this->stub_successful_transport( [ $this->real_pickup_point_record() ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$query  = Point_Query::from_request( [ 'locality' => '  МОСКВА  ' ] );
+
+		$this->assertNotEmpty( $source->fetch_points( $query ) );
+	}
+
+	public function test_maps_both_pickup_point_and_terminal_onto_fixture_type_codes(): void {
+		$this->stub_successful_transport( [ $this->real_pickup_point_record(), $this->real_terminal_record() ] );
+		Functions\expect( 'set_transient' )->once()->with(
+			'woodev_test_live_yandex_points_213',
+			$this->anything(),
+			DAY_IN_SECONDS
+		)->andReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$query  = Point_Query::from_request( [ 'locality' => 'Москва' ] );
+		$points = $source->fetch_points( $query );
+
+		$this->assertCount( 2, $points );
+
+		$by_id = [];
+		foreach ( $points as $point ) {
+			$by_id[ $point->get_id() ] = $point;
+		}
+
+		$pvz = $by_id['019373a0ecd97151922149c5094feaf6'];
+		$this->assertSame( [ 'code' => 'PVZ', 'label' => 'Пункт выдачи заказов' ], $pvz->to_array()['type'] );
+		$this->assertSame( 55.740522, $pvz->get_lat() );
+		$this->assertSame( 37.855554, $pvz->get_lng() );
+
+		$postamat = $by_id['5a6879c2-7910-44c1-a134-3de32d35e10c'];
+		$this->assertSame( [ 'code' => 'POSTAMAT', 'label' => 'Постамат' ], $postamat->to_array()['type'] );
+	}
+
+	public function test_unrecognised_type_is_skipped_not_fatal(): void {
+		$foreign_type_record         = $this->real_pickup_point_record();
+		$foreign_type_record['type'] = 'a_future_yandex_type_this_fixture_does_not_know';
+
+		$this->stub_successful_transport( [ $foreign_type_record, $this->real_terminal_record() ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		// The unknown-typed record is dropped; the terminal survives — one bad record must
+		// not empty the whole map.
+		$this->assertCount( 1, $points );
+		$this->assertSame( 'POSTAMAT', $points[0]->to_array()['type']['code'] );
+	}
+
+	public function test_payment_methods_map_to_russian_labels_and_drop_unknown_codes(): void {
+		$record                     = $this->real_pickup_point_record();
+		$record['payment_methods'][] = 'a_future_code_this_fixture_does_not_know';
+
+		$this->stub_successful_transport( [ $record ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertSame(
+			[ 'Товар уже оплачен', 'Оплата картой при получении' ],
+			$points[0]->to_array()['payment_methods']
+		);
+	}
+
+	public function test_schedule_flattens_seven_identical_days_into_one_span(): void {
+		$this->stub_successful_transport( [ $this->real_pickup_point_record() ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertSame( 'Пн–Вс 00:00–23:59', $points[0]->to_array()['work_time'] );
+	}
+
+	public function test_schedule_flattens_differing_span_from_the_terminal_record(): void {
+		$this->stub_successful_transport( [ $this->real_terminal_record() ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertSame( 'Пн–Вс 08:00–22:00', $points[0]->to_array()['work_time'] );
+	}
+
+	public function test_pickup_services_flags_map_to_russian_service_labels(): void {
+		$this->stub_successful_transport( [ $this->real_pickup_point_record() ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertSame(
+			[ 'Примерка', 'Частичный отказ от заказа', 'Вскрытие упаковки' ],
+			$points[0]->to_array()['services']
+		);
+	}
+
+	public function test_cached_response_never_hits_the_transport(): void {
+		Functions\when( 'get_transient' )->justReturn( [ $this->real_pickup_point_record() ] );
+		Functions\expect( 'wp_safe_remote_post' )->never();
+		Functions\expect( 'set_transient' )->never();
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertCount( 1, $points );
+	}
+
+	public function test_fetch_details_finds_a_point_by_id_from_the_cached_list(): void {
+		Functions\when( 'get_transient' )->justReturn( [ $this->real_pickup_point_record(), $this->real_terminal_record() ] );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$point  = $source->fetch_details( '5a6879c2-7910-44c1-a134-3de32d35e10c' );
+
+		$this->assertNotNull( $point );
+		$this->assertSame( 'Постамат Яндекс.Маркет', $point->to_array()['name'] );
+	}
+
+	public function test_fetch_details_returns_null_for_an_unknown_id(): void {
+		Functions\when( 'get_transient' )->justReturn( [ $this->real_pickup_point_record() ] );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+
+		$this->assertNull( $source->fetch_details( 'no-such-id' ) );
+	}
+
+	/**
+	 * `wp_safe_remote_post()` returning a `WP_Error` (a real transport failure — blocked
+	 * host, DNS failure, timeout) must surface as `\Woodev_API_Exception`, matching the
+	 * `Point_Source` interface's own `@throws` contract, never as a silently empty list.
+	 */
+	public function test_transport_failure_throws_api_exception(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( new \WP_Error( 'http_request_failed', 'Connection timed out' ) );
+		Functions\when( 'is_wp_error' )->alias( static fn( $t ) => $t instanceof \WP_Error );
+		Functions\expect( 'set_transient' )->never();
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Yandex_Point_Source() )->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+	}
+
+	/**
+	 * A non-200 HTTP response (rate limit, auth failure, sandbox 5xx) must throw, not
+	 * report zero points for a city that in fact has points.
+	 */
+	public function test_non_200_response_throws_api_exception(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 429 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"code":"429","message":"rate limited"}' );
+		Functions\expect( 'set_transient' )->never();
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Yandex_Point_Source() )->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+	}
+
+	/**
+	 * A 200 response whose body is not `{ "points": [...] }` (HTML error page, truncated
+	 * JSON, a shape the sandbox changed underneath us) must throw rather than being
+	 * silently treated as zero points.
+	 */
+	public function test_unexpected_body_shape_throws_api_exception(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"unexpected":true}' );
+		Functions\expect( 'set_transient' )->never();
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Yandex_Point_Source() )->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+	}
+}

--- a/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTokenGuardTest.php
+++ b/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTokenGuardTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Guards the live Yandex source's refusal to call out without a bearer token.
+ *
+ * WHY THIS IS ITS OWN FILE: the behaviour under test is "the token constant is NOT
+ * defined", and a PHP constant cannot be un-defined once set. Its sibling
+ * `TestLiveYandexPointSourceTest` defines a dummy token for the whole class, so asserting
+ * the absent-token path from inside that class is impossible, and asserting it from any
+ * class in the same process would be order-dependent — passing or failing according to
+ * which test file PHPUnit happened to load first. Hence a separate file plus
+ * `@runInSeparateProcess` / `@preserveGlobalState disabled`, the same isolation idiom
+ * `BootstrapRegistrationTest` uses, and the one
+ * `docs-internal/gotchas/brain-monkey-function-pollution.md` prescribes for
+ * "this thing is absent" assertions.
+ *
+ * WHAT IT PROTECTS: the token was briefly committed as a literal into this PUBLIC
+ * repository (s55) before being moved behind a constant. The security-relevant behaviour
+ * of that fix is not merely "it throws" — it is that NO REQUEST LEAVES when the token is
+ * missing, so a misconfigured install cannot silently authenticate as nobody, and so the
+ * failure names its own cause instead of surfacing as an empty picker.
+ *
+ * @package Woodev_Framework_Tests
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Pickup;
+
+use Brain\Monkey\Functions;
+use Woodev\Framework\Shipping\Pickup\Point_Query;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/class-plugin-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/api/class-api-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-point.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-point-query.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/interface-point-source.php';
+require_once dirname( __DIR__, 4 ) . '/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php';
+
+/**
+ * @covers \Woodev_Test_Live_Yandex_Point_Source
+ */
+final class TestLiveYandexPointSourceTokenGuardTest extends TestCase {
+
+	/**
+	 * With the token constant undefined the source must throw AND must not perform the
+	 * request at all.
+	 *
+	 * `wp_safe_remote_post` is expected `->never()`: asserting only on the exception would
+	 * still pass if the guard were moved BELOW the request, which is precisely the mistake
+	 * this test exists to prevent.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_missing_token_throws_without_performing_any_request(): void {
+		$this->assertFalse(
+			defined( 'WOODEV_TEST_YANDEX_SANDBOX_TOKEN' ),
+			'Process isolation failed: the token constant leaked in from another test file.'
+		);
+
+		Functions\expect( 'wp_safe_remote_post' )->never();
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+
+		$this->expectException( \Woodev_API_Exception::class );
+		$this->expectExceptionMessageMatches( '/WOODEV_TEST_YANDEX_SANDBOX_TOKEN/' );
+
+		$source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+	}
+}


### PR DESCRIPTION
An opt-in `Point_Source` for the rig fixture, backed by Yandex.Delivery's sandbox. Closes
the research half of #185: the framework's `Point_Source` contract now has a live carrier
behind it, not only static fixture data.

**Off by default.** Neither `composer test:unit`, nor the integration suite, nor CI ever
defines the activation constant, so the class is declared but never instantiated and no
suite makes a network call.

## Payload verified by hand, not read from documentation

Four live calls against `POST /api/b2b/platform/pickup-points/list`, `geo_id: 213`:

| request | result |
|---|---|
| `{}` (no `type`) | 200 — **812** points: 808 `pickup_point` + 4 `terminal` |
| `{"type":"pickup_point"}` | 200 — 808 |
| `{"type":"terminal"}` | 200 — 4 |
| `{"type":"bogus_type"}` | **400** — `Value of 'type' (bogus_type) is not parseable into enum` |

That last row corrected a wrong assumption in the brief (that an unrecognised `type` is
ignored). The source therefore omits `type` and maps each record's own `type` client-side:
one round trip, both shapes. `pickup_point` → `PVZ`, `terminal` → `POSTAMAT`, so the
existing point icons keep working.

Two mismatches only live data exposes: `payment_methods` arrive as API codes
(`already_paid`, `bound_card`, …) but are rendered to the customer, so they are mapped to
Russian labels with unknown codes dropped (#154); `schedule` is structured while
`Pickup_Point::work_time` is a string, so it is flattened, with a pointer to #152 for the
structured redesign that is out of scope here.

## The bearer token is deliberately not in this repository

It is read at request time from `WOODEV_TEST_YANDEX_SANDBOX_TOKEN`, and the source throws
without calling out when that constant is undefined.

An earlier revision of this branch committed the token as a literal and was force-removed:
the reference plugin's directory is gitignored, so that commit was the first time a third
party's credential entered this PUBLIC repository's history. The operator has since
confirmed the token is published in Yandex's own documentation, so the exposure was not
harmful — but the constant stays, because the habit is what matters and the cost is one
line in a gitignored file. Secret scanning and push protection have been enabled on the
repository as a result.

A dedicated test in its own file pins the guard: with the constant undefined the source
throws **and** `wp_safe_remote_post` is expected `never()` — asserting only on the
exception would still pass if the guard were moved below the request. It needs process
isolation, because a PHP constant cannot be un-defined.

## Verification

1446 unit tests / 3883 assertions, phpcs clean, PHPStan clean. Cache: one transient,
`DAY_IN_SECONDS`, and only a successful fetch is cached so an outage retries rather than
being remembered as empty for a day. Failures throw `Woodev_API_Exception`, which the
existing REST layer already turns into a 502 plus retry UI.

Closes #185
