### PR TITLE
feat(pickup): framework-owned square glyphs for the sidebar list and point card

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -797,6 +797,29 @@ function woodev_test_shipping_method_plugin_init(): void {
 		3
 	);
 
+	// -----------------------------------------------------------------------
+	// Issue #171: a domain seam over `woodev_pickup_map_point_glyphs`
+	// (class-pickup-handler.php's normalized_point_glyphs()) — the framework refuses to
+	// guess a glyph from a carrier's type CODE, so a plugin whose `POSTAMAT` type reads as
+	// a parcel locker has to say so explicitly, here. `PVZ` needs no entry at all: the
+	// framework's own default is `warehouse` for every type it was never told about, which
+	// is exactly what a staffed pickup point should show. Gives the seam a real consumer on
+	// the rig (rather than shipping it speculative, s32 YAGNI) and lets the operator see two
+	// visibly different, legible glyphs in the sidebar list and the point card side by side.
+	// Same placement reasoning as the `woodev_shipping_pickup_point_selection` filter above:
+	// registering the closure does not INVOKE it, so it is safe here regardless of whether
+	// `plugin_init()`'s own deferred callback has run yet.
+	// -----------------------------------------------------------------------
+
+	add_filter(
+		'woodev_pickup_map_point_glyphs',
+		static function ( array $glyphs ): array {
+			$glyphs['POSTAMAT'] = 'package';
+
+			return $glyphs;
+		}
+	);
+
 	/**
 	 * Глобальный хелпер для доступа к тестовому плагину из тестов.
 	 *

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -1067,17 +1067,50 @@ describe( 'sectioned card body (spec V-12)', () => {
 		expect( panels.root.querySelectorAll( '.woodev-pickup-card__section' ) ).toHaveLength( 1 );
 	} );
 
-	it( 'renders the chip only when the plugin supplies an icon for this point\'s type', () => {
-		const withIcon = mount( { ...cardConfig, pointIcons: { PVZ: { default: '/pvz.svg' } } } );
-		const withoutIcon = mount( { ...cardConfig, pointIcons: {} } );
+	// Issue #171: the chip is the framework's OWN glyph now, never conditional on a
+	// plugin-supplied icon — it always renders, defaulting to the `warehouse` glyph, and a
+	// plugin reaches the two override outcomes via `config.pointGlyphs`, not `pointIcons`
+	// (that map still exists, but it now drives only the MAP's own marker pins).
+	it( 'always renders the chip, defaulting to the warehouse glyph', () => {
+		const panels = mount( cardConfig );
+		panels.openCard( { key: 'k', size: 1, points: [ point( { type: { code: 'PVZ', label: 'ПВЗ' } } ) ] } );
 
-		const p = point( { type: { code: 'PVZ', label: 'ПВЗ' } } );
+		const chip = panels.root.querySelector( '.woodev-pickup-card__chip' );
 
-		withIcon.openCard( { key: 'k', size: 1, points: [ p ] } );
-		withoutIcon.openCard( { key: 'k', size: 1, points: [ p ] } );
+		expect( chip ).not.toBeNull();
+		expect( chip.querySelector( '.woodev-pickup-card__chip-icon svg' ) ).not.toBeNull();
+	} );
 
-		expect( withIcon.root.querySelector( '.woodev-pickup-card__chip img' ) ).not.toBeNull();
-		expect( withoutIcon.root.querySelector( '.woodev-pickup-card__chip' ) ).toBeNull();
+	it( 'a plugin-supplied pointIcons map has no effect on the card chip any more', () => {
+		const panels = mount( { ...cardConfig, pointIcons: { PVZ: { default: '/pvz.svg' } } } );
+		panels.openCard( { key: 'k', size: 1, points: [ point( { type: { code: 'PVZ', label: 'ПВЗ' } } ) ] } );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__chip img' ) ).toBeNull();
+		expect( panels.root.querySelector( '.woodev-pickup-card__chip-icon svg' ) ).not.toBeNull();
+	} );
+
+	it( 'swaps in the OTHER built-in glyph via config.pointGlyphs', () => {
+		const panels = mount( { ...cardConfig, pointGlyphs: { POSTAMAT: { glyph: 'package', markup: null } } } );
+		panels.openCard( { key: 'k', size: 1, points: [ point( { type: { code: 'POSTAMAT', label: 'Постамат' } } ) ] } );
+
+		const warehouseDefault = mount( cardConfig );
+		warehouseDefault.openCard( { key: 'k', size: 1, points: [ point( { type: { code: 'PVZ', label: 'ПВЗ' } } ) ] } );
+
+		const swapped = panels.root.querySelector( '.woodev-pickup-card__chip-icon svg' ).outerHTML;
+		const defaulted = warehouseDefault.root.querySelector( '.woodev-pickup-card__chip-icon svg' ).outerHTML;
+
+		expect( swapped ).not.toBe( defaulted );
+	} );
+
+	it( 'renders a plugin-supplied raw markup override verbatim, already sanitised server-side', () => {
+		// jsdom's own innerHTML serializer re-emits a self-closing `<path/>` as `<path></path>`
+		// on read-back — this is written with an explicit closing tag from the start so the
+		// assertion below compares like with like rather than tripping over that normalisation.
+		const customSvg = '<svg viewBox="0 0 24 24"><path d="M1 1"></path></svg>';
+		const panels = mount( { ...cardConfig, pointGlyphs: { CUSTOM: { glyph: null, markup: customSvg } } } );
+		panels.openCard( { key: 'k', size: 1, points: [ point( { type: { code: 'CUSTOM', label: 'Свой' } } ) ] } );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__chip-icon' ).innerHTML ).toBe( customSvg );
 	} );
 } );
 
@@ -1149,7 +1182,7 @@ it( 'renders the close control whether or not the tab bar is present', () => {
 
 describe( 'card header layout (round 4 — chip+close row, tabs on their own row below)', () => {
 	it( 'puts the chip and the close control inside one header-row, and the tabs OUTSIDE it', () => {
-		const panels = mount( { ...cardConfig, pointIcons: { pvz: { default: '/pvz.svg' }, postamat: { default: '/postamat.svg' } } } );
+		const panels = mount( cardConfig );
 
 		panels.openCard( { key: 'k', size: 2, points: [
 			point( { id: 'a', type: { code: 'pvz', label: 'ПВЗ' } } ),
@@ -1172,7 +1205,10 @@ describe( 'card header layout (round 4 — chip+close row, tabs on their own row
 		expect( row.contains( tabs ) ).toBe( false );
 	} );
 
-	it( 'still renders the header-row (holding just the close control) when there is no chip and no tab bar', () => {
+	// Issue #171: the chip is no longer conditional (see the "always renders the chip" test
+	// above), so this now proves the header-row holds BOTH the chip and the close control even
+	// with no tab bar — the "no chip" half of the old title is gone along with the behaviour.
+	it( 'renders the header-row (chip + close, no tab bar) for a single-point group', () => {
 		const panels = mount( cardConfig );
 		panels.openCard( { key: 'k', size: 1, points: [ point() ] } );
 
@@ -1180,17 +1216,17 @@ describe( 'card header layout (round 4 — chip+close row, tabs on their own row
 
 		expect( row ).not.toBeNull();
 		expect( row.querySelector( '.woodev-pickup-card__close' ) ).not.toBeNull();
-		expect( row.querySelector( '.woodev-pickup-card__chip' ) ).toBeNull();
+		expect( row.querySelector( '.woodev-pickup-card__chip' ) ).not.toBeNull();
 		expect( panels.root.querySelector( '.woodev-pickup-card__tabs' ) ).toBeNull();
 	} );
 
-	it( 'keeps the chip inside the header-row even without a tab bar (single-point group, chip configured)', () => {
-		const panels = mount( { ...cardConfig, pointIcons: { pvz: { default: '/pvz.svg' } } } );
+	it( 'keeps the chip inside the header-row even without a tab bar (single-point group)', () => {
+		const panels = mount( cardConfig );
 		panels.openCard( { key: 'k', size: 1, points: [ point( { type: { code: 'pvz', label: 'ПВЗ' } } ) ] } );
 
 		const row = panels.root.querySelector( '.woodev-pickup-card__header-row' );
 
-		expect( row.querySelector( '.woodev-pickup-card__chip img' ) ).not.toBeNull();
+		expect( row.querySelector( '.woodev-pickup-card__chip-icon svg' ) ).not.toBeNull();
 		expect( panels.root.querySelector( '.woodev-pickup-card__tabs' ) ).toBeNull();
 	} );
 
@@ -2832,7 +2868,7 @@ describe( 'sidebar list (spec V-11)', () => {
 		expect( container.querySelector( '.woodev-pickup-list__header' ) ).toBeNull();
 	} );
 
-	it( 'renders address first in bold and the name as the subtitle', () => {
+	it( 'renders the glyph first, then address in bold, then the name as the subtitle', () => {
 		const container = document.createElement( 'div' );
 		const panels = new Panels( container, config );
 		const g = group( 'g1', 55.75, 37.61, 'ПВЗ «Магнит»' );
@@ -2842,32 +2878,102 @@ describe( 'sidebar list (spec V-11)', () => {
 		panels.setVisible( [ g ] );
 
 		const row = container.querySelector( '.woodev-pickup-list__item' );
+		const icon = row.querySelector( '.woodev-pickup-list__icon' );
 		const address = row.querySelector( '.woodev-pickup-list__address' );
 		const name = row.querySelector( '.woodev-pickup-list__name' );
 
-		expect( row.firstElementChild ).toBe( address );
+		// Issue #171: the framework's own glyph is now always the row's first element (grid
+		// places it in its own 'icon' area spanning every text row — see pickup.css); address
+		// is the first TEXT element, immediately after it.
+		expect( row.firstElementChild ).toBe( icon );
+		expect( icon.nextElementSibling ).toBe( address );
 		expect( address.textContent ).toBe( g.points[ 0 ].short_address );
 		expect( name.textContent ).toBe( g.points[ 0 ].name );
 		expect( address.getAttribute( 'title' ) ).toBe( g.points[ 0 ].address );
 	} );
 
-	it( 'renders the plugin type icon when one is configured, and none otherwise', () => {
-		const g = group( 'g1', 55.75, 37.61, 'ПВЗ' );
-		g.points[ 0 ].type = { code: 'PVZ' };
+	// Issue #171 (operator decision): a teardrop map pin is a pointer at a coordinate — shrunk
+	// into a list row there is nothing left to point at, so the framework now draws its OWN
+	// square glyph here, ALWAYS, regardless of whether the plugin configured a MAP marker via
+	// `config.pointIcons` (that map still exists, but only the map reads it now).
+	describe( 'the framework-owned type glyph (issue #171)', () => {
+		function pointOfType( code ) {
+			const g = group( 'g1', 55.75, 37.61, 'ПВЗ' );
+			g.points[ 0 ].type = { code: code };
 
-		const withIcon = new Panels( document.createElement( 'div' ), {
-			...config,
-			pointIcons: { PVZ: { default: '/pvz.svg', active: '/pvz-active.svg' } },
+			return g;
+		}
+
+		it( 'always renders a glyph, even with no plugin configuration at all', () => {
+			const panels = new Panels( document.createElement( 'div' ), config );
+			panels.render();
+			panels.setVisible( [ pointOfType( 'PVZ' ) ] );
+
+			expect( panels.root.parentNode.querySelector( '.woodev-pickup-list__icon svg' ) ).not.toBeNull();
 		} );
-		const withoutIcon = new Panels( document.createElement( 'div' ), { ...config, pointIcons: {} } );
 
-		withIcon.render();
-		withIcon.setVisible( [ g ] );
-		withoutIcon.render();
-		withoutIcon.setVisible( [ g ] );
+		it( 'a plugin-supplied pointIcons map (the MAP marker contract) has no effect here', () => {
+			const panels = new Panels( document.createElement( 'div' ), {
+				...config,
+				pointIcons: { PVZ: { default: '/pvz.svg', active: '/pvz-active.svg' } },
+			} );
+			panels.render();
+			panels.setVisible( [ pointOfType( 'PVZ' ) ] );
 
-		expect( withIcon.root.parentNode.querySelector( '.woodev-pickup-list__icon' ) ).not.toBeNull();
-		expect( withoutIcon.root.parentNode.querySelector( '.woodev-pickup-list__icon' ) ).toBeNull();
+			expect( panels.root.parentNode.querySelector( '.woodev-pickup-list__icon img' ) ).toBeNull();
+			expect( panels.root.parentNode.querySelector( '.woodev-pickup-list__icon svg' ) ).not.toBeNull();
+		} );
+
+		it( 'defaults an unrecognised type to the warehouse glyph, never a POSTAMAT/LOCKER string guess', () => {
+			const withUnknownType = new Panels( document.createElement( 'div' ), config );
+			withUnknownType.render();
+			withUnknownType.setVisible( [ pointOfType( 'SOME_CARRIER_SPECIFIC_LOCKER_CODE' ) ] );
+
+			const defaultPanels = new Panels( document.createElement( 'div' ), config );
+			defaultPanels.render();
+			defaultPanels.setVisible( [ pointOfType( 'PVZ' ) ] );
+
+			// Same markup either way — the framework never sniffs the type code's own text for
+			// carrier vocabulary, it only ever consults config.pointGlyphs (absent here).
+			expect(
+				withUnknownType.root.parentNode.querySelector( '.woodev-pickup-list__icon' ).innerHTML
+			).toBe(
+				defaultPanels.root.parentNode.querySelector( '.woodev-pickup-list__icon' ).innerHTML
+			);
+		} );
+
+		it( 'swaps in the OTHER built-in glyph via config.pointGlyphs', () => {
+			const swapped = new Panels( document.createElement( 'div' ), {
+				...config,
+				pointGlyphs: { POSTAMAT: { glyph: 'package', markup: null } },
+			} );
+			swapped.render();
+			swapped.setVisible( [ pointOfType( 'POSTAMAT' ) ] );
+
+			const defaulted = new Panels( document.createElement( 'div' ), config );
+			defaulted.render();
+			defaulted.setVisible( [ pointOfType( 'PVZ' ) ] );
+
+			expect(
+				swapped.root.parentNode.querySelector( '.woodev-pickup-list__icon' ).innerHTML
+			).not.toBe(
+				defaulted.root.parentNode.querySelector( '.woodev-pickup-list__icon' ).innerHTML
+			);
+		} );
+
+		it( 'renders a plugin-supplied raw markup override verbatim', () => {
+			// See the identical note in the card-chip version of this test, above: jsdom
+			// re-serialises a self-closing `<path/>` as `<path></path>` on innerHTML read-back.
+			const customSvg = '<svg viewBox="0 0 24 24"><path d="M1 1"></path></svg>';
+			const panels = new Panels( document.createElement( 'div' ), {
+				...config,
+				pointGlyphs: { CUSTOM: { glyph: null, markup: customSvg } },
+			} );
+			panels.render();
+			panels.setVisible( [ pointOfType( 'CUSTOM' ) ] );
+
+			expect( panels.root.parentNode.querySelector( '.woodev-pickup-list__icon' ).innerHTML ).toBe( customSvg );
+		} );
 	} );
 } );
 

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -2896,7 +2896,7 @@ describe( 'sidebar list (spec V-11)', () => {
 	// into a list row there is nothing left to point at, so the framework now draws its OWN
 	// square glyph here, ALWAYS, regardless of whether the plugin configured a MAP marker via
 	// `config.pointIcons` (that map still exists, but only the map reads it now).
-	describe( 'the framework-owned type glyph (issue #171)', () => {
+	describe( 'the framework-owned type glyph (issue #195)', () => {
 		function pointOfType( code ) {
 			const g = group( 'g1', 55.75, 37.61, 'ПВЗ' );
 			g.points[ 0 ].type = { code: code };

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1136,6 +1136,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 					'i18n',
 					'defaultLocation',
 					'pointIcons',
+					'pointGlyphs',
 					'mapConfig',
 					'replaceAddress',
 					'selection',
@@ -1462,6 +1463,119 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			Functions\when( 'wc_ship_to_billing_address_only' )->justReturn( false );
 
 			$this->assertSame( [], $this->make_handler()->get_js_config()['pointIcons'] );
+		}
+
+		// -------------------------------------------------------------------------
+		// pointGlyphs (issue #171) — sidebar list / point card glyph overrides, via the
+		// `woodev_pickup_map_point_glyphs` filter. Separate map from pointIcons above: that one
+		// drives the MAP's own marker pins, this one drives the list row and card chip.
+		// -------------------------------------------------------------------------
+
+		/**
+		 * No plugin override at all is the common case — `pointGlyphs` must be an empty
+		 * array, never missing or null; the CLIENT is what supplies the `warehouse` default
+		 * for every type this map says nothing about (see `pickup-panels.js`'s
+		 * `pointGlyphMarkup()`), never this method fabricating an entry.
+		 */
+		public function test_point_glyphs_defaults_to_an_empty_array(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			$this->stub_config_dependencies_except_filters();
+
+			$this->assertSame( [], $this->make_handler()->get_js_config()['pointGlyphs'] );
+		}
+
+		/**
+		 * A plugin naming one of the framework's two built-in glyphs for a type gets back
+		 * `{ glyph: '<name>', markup: null }` — the client picks the OTHER built-in
+		 * ({@see GLYPH_SVG} in pickup-panels.js) rather than treating the string as markup.
+		 */
+		public function test_a_builtin_glyph_key_is_passed_through(): void {
+			Filters\expectApplied( 'woodev_pickup_map_point_glyphs' )
+				->once()
+				->with( [], 'p' )
+				->andReturn( [ 'POSTAMAT' => 'package' ] );
+			$this->stub_config_dependencies_except_filters();
+
+			$this->assertSame(
+				[ 'POSTAMAT' => [ 'glyph' => 'package', 'markup' => null ] ],
+				$this->make_handler()->get_js_config()['pointGlyphs']
+			);
+		}
+
+		/**
+		 * A type the filter never mentions is simply absent — never filled in with a
+		 * `warehouse` entry the client already defaults to on its own.
+		 */
+		public function test_a_type_the_filter_does_not_mention_is_absent_not_defaulted(): void {
+			Filters\expectApplied( 'woodev_pickup_map_point_glyphs' )
+				->once()
+				->andReturn( [ 'POSTAMAT' => 'package' ] );
+			$this->stub_config_dependencies_except_filters();
+
+			$this->assertArrayNotHasKey( 'PVZ', $this->make_handler()->get_js_config()['pointGlyphs'] );
+		}
+
+		/**
+		 * Raw SVG markup (anything that is not one of the two built-in glyph keys) survives
+		 * sanitisation as `{ glyph: null, markup: '<sanitised svg>' }` — the client writes
+		 * `markup` straight into `innerHTML` when present, so this proves BOTH override
+		 * outcomes a plugin can reach are wired: swapping the built-in, and supplying its own.
+		 */
+		public function test_raw_svg_markup_is_sanitised_and_passed_through_as_markup(): void {
+			Functions\when( 'wp_kses' )->alias(
+				static function ( $html ) {
+					// Faithful-enough stand-in for this test's own needs: strip <script>…</script>
+					// like real wp_kses() would against an allowlist that excludes it — same
+					// technique the richtext-setting test in SettingUpdateValueTest.php uses.
+					return preg_replace( '#<script\b[^>]*>.*?</script>#is', '', (string) $html );
+				}
+			);
+			Filters\expectApplied( 'woodev_pickup_map_point_glyphs' )
+				->once()
+				->andReturn( [ 'CUSTOM' => '<svg viewBox="0 0 24 24"><path d="M1 1"/></svg>' ] );
+			$this->stub_config_dependencies_except_filters();
+
+			$this->assertSame(
+				[ 'CUSTOM' => [ 'glyph' => null, 'markup' => '<svg viewBox="0 0 24 24"><path d="M1 1"/></svg>' ] ],
+				$this->make_handler()->get_js_config()['pointGlyphs']
+			);
+		}
+
+		/**
+		 * Markup that sanitises down to something with no `<svg` tag left at all (a plugin
+		 * trying to smuggle a `<script>`, or simply returning plain, non-SVG text) drops the
+		 * whole type entirely — the framework never ships a broken/empty override; the
+		 * client's own `warehouse` default still applies for it.
+		 */
+		public function test_unsafe_markup_is_dropped_entirely(): void {
+			Functions\when( 'wp_kses' )->alias(
+				static function ( $html ) {
+					return preg_replace( '#<script\b[^>]*>.*?</script>#is', '', (string) $html );
+				}
+			);
+			Filters\expectApplied( 'woodev_pickup_map_point_glyphs' )
+				->once()
+				->andReturn( [
+					'MALICIOUS' => '<script>alert(1)</script>',
+					'PVZ'       => 'package',
+				] );
+			$this->stub_config_dependencies_except_filters();
+
+			$glyphs = $this->make_handler()->get_js_config()['pointGlyphs'];
+
+			$this->assertArrayNotHasKey( 'MALICIOUS', $glyphs );
+			$this->assertArrayHasKey( 'PVZ', $glyphs );
+		}
+
+		/**
+		 * A non-array return from the filter (a plugin mistake) is defensively treated as
+		 * "no overrides" rather than fataling on the `foreach` below.
+		 */
+		public function test_a_non_array_filter_return_is_treated_as_no_overrides(): void {
+			Filters\expectApplied( 'woodev_pickup_map_point_glyphs' )->once()->andReturn( 'not-an-array' );
+			$this->stub_config_dependencies_except_filters();
+
+			$this->assertSame( [], $this->make_handler()->get_js_config()['pointGlyphs'] );
 		}
 
 		// -------------------------------------------------------------------------

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1466,7 +1466,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 		}
 
 		// -------------------------------------------------------------------------
-		// pointGlyphs (issue #171) — sidebar list / point card glyph overrides, via the
+		// pointGlyphs (issue #195) — sidebar list / point card glyph overrides, via the
 		// `woodev_pickup_map_point_glyphs` filter. Separate map from pointIcons above: that one
 		// drives the MAP's own marker pins, this one drives the list row and card chip.
 		// -------------------------------------------------------------------------

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -496,12 +496,13 @@
 	color: #646970;
 }
 
-/* One row (spec V-11): the plugin's own type icon (omitted when it supplies none), address in
-   bold, name/description in muted grey underneath, separated from the next row by a bottom
-   border — icon → address → name is a CSS grid, not a flow layout, so the icon can span two text
-   rows without extra markup. Targets BOTH shapes a row can take: a single-point group's item IS
-   the row (no nested `.woodev-pickup-list__point` — see `buildListItem()` in pickup-panels.js),
-   while one point of a co-located group gets its OWN `.woodev-pickup-list__point` button instead. */
+/* One row (spec V-11): the framework's own type glyph (issue #171 — ALWAYS rendered now, never
+   omitted; see pickup-panels.js's pointGlyphMarkup()), address in bold, name/description in
+   muted grey underneath, separated from the next row by a bottom border — icon → address → name
+   is a CSS grid, not a flow layout, so the icon can span two text rows without extra markup.
+   Targets BOTH shapes a row can take: a single-point group's item IS the row (no nested
+   `.woodev-pickup-list__point` — see `buildListItem()` in pickup-panels.js), while one point of
+   a co-located group gets its OWN `.woodev-pickup-list__point` button instead. */
 .woodev-pickup-list__item:not( :has( .woodev-pickup-list__point ) ),
 .woodev-pickup-list__point {
 	display: grid;
@@ -594,11 +595,30 @@
 	justify-content: normal;
 }
 
+/* Issue #171: 20px was the OLD size for a plugin-supplied `<img>`, optional and shown only when
+   configured. The framework's own glyph is a plain `<span>` holding inline SVG now — 24px (a
+   clean 1:1 with the glyph's own 24x24 viewBox, no scaling artefact) instead, legible on its
+   own rather than relying on the customer already knowing what a 20px teardrop meant. `color`
+   is the SAME muted chrome tone `.woodev-pickup-list__name`/`__distance` already use below —
+   decoration, not the D-15 accent pairing (that stays reserved for the CTA/toggle/selected-row/
+   badge, see the file docblock). `display: flex` centres the svg child regardless of whatever
+   intrinsic size a CUSTOM plugin-supplied markup override might carry — the child rule below is
+   what actually forces the fill, this is the belt-and-braces centring for anything that slips
+   through with an odd aspect ratio. */
 .woodev-pickup-list__icon {
 	grid-area: icon;
-	width: 20px;
-	height: 20px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
 	align-self: start;
+	color: #646970;
+}
+
+.woodev-pickup-list__icon svg {
+	width: 100%;
+	height: 100%;
 }
 
 .woodev-pickup-list__address {
@@ -1291,23 +1311,25 @@
 	border-bottom: 1px solid #dcdcde;
 }
 
-/* The chip + close row (round 4) — always renders (the close control has no other way back to
-   the list, spec §6 STATE 3); the chip is conditional (spec V-12, only when the plugin supplies
-   an icon for the point's type). `align-items: center` — nothing competes for extra height in
-   this row any more (the tab bar moved to its own row below), so the old `flex-start` that used
-   to top-align the chip against a possibly-taller, wrapped tab group has nothing left to justify
-   it; centring the chip against the close button is the natural read for a plain icon-and-button
-   pair. See `.woodev-pickup-card__close`'s own `margin-left: auto` for how the close button stays
-   pinned to the right edge with or without the chip — deliberately NOT `justify-content:
-   space-between` here, which treats a single remaining child (the chip-less case) as
-   `flex-start` and would strand the close button on the LEFT instead. */
+/* The chip + close row (round 4) — the close control has no other way back to the list (spec §6
+   STATE 3), and the chip now ALSO always renders (issue #171: the framework's own type glyph,
+   never conditional on a plugin supplying one any more — see `.woodev-pickup-card__chip`'s own
+   note below). `align-items: center` — nothing competes for extra height in this row any more
+   (the tab bar moved to its own row below), so the old `flex-start` that used to top-align the
+   chip against a possibly-taller, wrapped tab group has nothing left to justify it; centring the
+   chip against the close button is the natural read for a plain icon-and-button pair. See
+   `.woodev-pickup-card__close`'s own `margin-left: auto` for how the close button stays pinned
+   to the right edge regardless. */
 .woodev-pickup-card__header-row {
 	display: flex;
 	align-items: center;
 }
 
-/* The chip (spec V-12) — only when the PLUGIN supplies an icon for the point's type; the
-   framework's own default marker pin (V-9) is map furniture and would read as decoration here. */
+/* The chip (spec V-12; issue #171 — ALWAYS renders now, the framework's own type glyph, never
+   conditional on a plugin-supplied icon any more). Background/border unchanged from the old
+   plugin-`<img>` chip: an accent-filled square, matching the D-15 accent pairing every other
+   accent-background rule in this file follows — see `.woodev-pickup-card__chip-icon`'s own
+   `color` below, which is the paired accent-CONTRAST half of that same rule. */
 .woodev-pickup-card__chip {
 	display: flex;
 	flex: 0 0 auto;
@@ -1320,9 +1342,18 @@
 	background: var( --woodev-pickup-accent, #06aedd );
 }
 
-.woodev-pickup-card__chip img {
+.woodev-pickup-card__chip-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 22px;
 	height: 22px;
+	color: var( --woodev-pickup-accent-contrast, #fff );
+}
+
+.woodev-pickup-card__chip-icon svg {
+	width: 100%;
+	height: 100%;
 }
 
 /* One tab per point of a co-located group — omitted entirely for a single-point group (D-4);

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -311,7 +311,7 @@
 		'<path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
 
 	/**
-	 * The framework's own built-in point-type glyphs (issue #171, operator decision) — the
+	 * The framework's own built-in point-type glyphs (issue #195, operator decision) — the
 	 * sidebar list row and the point card's chip now ALWAYS show one of these, replacing the
 	 * old "plugin supplies a marker URL or nothing renders" contract (see {@see pointGlyphMarkup}).
 	 * A teardrop marker pin is a POINTER AT A COORDINATE; shrunk into a list row there is
@@ -355,7 +355,7 @@
 
 	/**
 	 * The glyph key {@see pointGlyphMarkup} falls back to for every type unless a plugin says
-	 * otherwise (issue #171) — a carrier's type CODE (`PVZ`, `POSTAMAT`, whatever a carrier
+	 * otherwise (issue #195) — a carrier's type CODE (`PVZ`, `POSTAMAT`, whatever a carrier
 	 * invents) is arbitrary domain vocabulary, and sniffing it for a substring like
 	 * "POSTAMAT"/"LOCKER"/"TERMINAL" is exactly the kind of guess over someone else's naming
 	 * this framework refuses to make (mirrors the file docblock's "framework owns mechanism,
@@ -563,7 +563,7 @@
 
 	/**
 	 * The framework-owned glyph markup for a point's type, for the sidebar list row and the
-	 * point card's chip (issue #171, replacing the old `pointIconUrl()` this function used to
+	 * point card's chip (issue #195, replacing the old `pointIconUrl()` this function used to
 	 * be) — ALWAYS returns something renderable, never `''`. `config.pointIcons` (a
 	 * plugin-supplied MARKER url) is deliberately never read here any more: that map drives
 	 * the MAP's own pins (map furniture, spec V-9) and stays exactly that; this surface is a
@@ -645,7 +645,7 @@
 
 	/**
 	 * Builds one list row for a single-point group (spec V-11): the framework's own type glyph
-	 * (issue #171 — ALWAYS rendered now, see {@see pointGlyphMarkup}), address in bold,
+	 * (issue #195 — ALWAYS rendered now, see {@see pointGlyphMarkup}), address in bold,
 	 * name/description as the muted subtitle, and — when an anchor is set — the formatted
 	 * distance. Icon, then address, then name is the order the spec asks for: the address is
 	 * what the customer scans the list FOR, the name/description is secondary detail.
@@ -1028,7 +1028,7 @@
 	/**
 	 * Builds the card's header: a close control that ALWAYS renders (this is the customer's only
 	 * way back to the list without dismissing the whole modal, spec §6 STATE 3) plus the icon chip
-	 * (Task 15, spec V-12 — issue #171: now ALSO ALWAYS renders, via the SAME
+	 * (Task 15, spec V-12 — issue #195: now ALSO ALWAYS renders, via the SAME
 	 * {@see pointGlyphMarkup} lookup the sidebar row uses, so both surfaces agree on what glyph
 	 * a point's type gets) — both on a FIRST inner row, `.woodev-pickup-card__header-row` — and
 	 * the tab bar (only for a co-located group;
@@ -1061,7 +1061,7 @@
 		var headerRow = document.createElement( 'div' );
 		headerRow.className = 'woodev-pickup-card__header-row';
 
-		// The chip (spec V-12, issue #171: ALWAYS renders now). It shares {@see pointGlyphMarkup}
+		// The chip (spec V-12, issue #195: ALWAYS renders now). It shares {@see pointGlyphMarkup}
 		// with the sidebar row builder rather than a second lookup, so both surfaces agree on
 		// exactly which glyph a point's type gets.
 		var chip = document.createElement( 'div' );

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -311,6 +311,63 @@
 		'<path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
 
 	/**
+	 * The framework's own built-in point-type glyphs (issue #171, operator decision) — the
+	 * sidebar list row and the point card's chip now ALWAYS show one of these, replacing the
+	 * old "plugin supplies a marker URL or nothing renders" contract (see {@see pointGlyphMarkup}).
+	 * A teardrop marker pin is a POINTER AT A COORDINATE; shrunk into a list row there is
+	 * nothing left to point at, so the framework draws two flat, square glyphs instead —
+	 * `warehouse` (a staffed point) and `package` (a parcel locker) — geometry taken verbatim
+	 * from Lucide (ISC-licensed: https://lucide.dev/icons/warehouse,
+	 * https://lucide.dev/icons/package; https://github.com/lucide-icons/lucide, `icons/
+	 * warehouse.svg` / `icons/package.svg`), matching the "redraw/reuse a Lucide shape"
+	 * convention {@see FILTER_ICON_SVG}/{@see CLEAR_ICON_SVG} above and the map's own marker
+	 * pins already established.
+	 *
+	 * Deliberately carry NO `width`/`height` attribute of their own, unlike the two constants
+	 * above — this pair renders at TWO different sizes (the list row's icon, the card's larger
+	 * chip), so the CONSUMING element's own CSS sizes the svg (`width: 100%; height: 100%` on
+	 * `.woodev-pickup-list__icon svg` / `.woodev-pickup-card__chip-icon svg`, pickup.css) rather
+	 * than a fixed intrinsic size baked into shared markup that would be wrong for one of the two.
+	 * `stroke="currentColor"`, `fill="none"` — square, transparent background, and readable in
+	 * whatever text colour the consuming element sets, exactly like every other icon in this file.
+	 *
+	 * @since 2.0.2
+	 * @type {Object<string, string>}
+	 */
+	var GLYPH_SVG = {
+		warehouse: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ' +
+			'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">' +
+			'<path d="M18 21V10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v11"/>' +
+			'<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 1.132-1.803l7.95-3.974a2 2 0 0 1 ' +
+			'1.837 0l7.948 3.974A2 2 0 0 1 22 8z"/>' +
+			'<path d="M6 13h12"/>' +
+			'<path d="M6 17h12"/>' +
+			'</svg>',
+		'package': '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ' +
+			'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">' +
+			'<path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 ' +
+			'4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/>' +
+			'<path d="M12 22V12"/>' +
+			'<polyline points="3.29 7 12 12 20.71 7"/>' +
+			'<path d="m7.5 4.27 9 5.15"/>' +
+			'</svg>'
+	};
+
+	/**
+	 * The glyph key {@see pointGlyphMarkup} falls back to for every type unless a plugin says
+	 * otherwise (issue #171) — a carrier's type CODE (`PVZ`, `POSTAMAT`, whatever a carrier
+	 * invents) is arbitrary domain vocabulary, and sniffing it for a substring like
+	 * "POSTAMAT"/"LOCKER"/"TERMINAL" is exactly the kind of guess over someone else's naming
+	 * this framework refuses to make (mirrors the file docblock's "framework owns mechanism,
+	 * plugin owns domain" line). Every type reads as a staffed pickup point unless
+	 * `Pickup_Handler`'s `woodev_pickup_map_point_glyphs` filter names it otherwise.
+	 *
+	 * @since 2.0.2
+	 * @type {string}
+	 */
+	var DEFAULT_GLYPH = 'warehouse';
+
+	/**
 	 * @type {number} minimum number of known point types before the filter badge shows a NUMBER at
 	 * all — see the file docblock's "THE BADGE'S 3+ RULE" note (D2). Below this, `.is-filtered` on
 	 * the toggle carries the whole "something is filtered" signal by itself.
@@ -505,19 +562,40 @@
 	}
 
 	/**
-	 * The plugin's icon URL for a point's type, or `''` when the plugin supplies none.
-	 * The sidebar shows the PLUGIN's icon only — the framework's own default marker (V-9) is
-	 * map furniture and would read as decoration in a list.
+	 * The framework-owned glyph markup for a point's type, for the sidebar list row and the
+	 * point card's chip (issue #171, replacing the old `pointIconUrl()` this function used to
+	 * be) — ALWAYS returns something renderable, never `''`. `config.pointIcons` (a
+	 * plugin-supplied MARKER url) is deliberately never read here any more: that map drives
+	 * the MAP's own pins (map furniture, spec V-9) and stays exactly that; this surface is a
+	 * SEPARATE contract, `config.pointGlyphs` (`Pickup_Handler::normalized_point_glyphs()`).
 	 *
+	 * `pointGlyphs[ code ].markup`, when present, is ALREADY sanitised server-side
+	 * ({@see wp_kses()} on the PHP side) and is written via `innerHTML` verbatim by this
+	 * function's two callers — same discipline as every other server-escaped field this file
+	 * writes (see the file docblock's escaping rule). `pointGlyphs[ code ].glyph` selects the
+	 * framework's OTHER built-in ({@see GLYPH_SVG}) instead. A type with no override, or whose
+	 * override the server dropped as unsafe/unusable, falls back to {@see DEFAULT_GLYPH} —
+	 * never a guess at the carrier's own type-code vocabulary.
+	 *
+	 * @since 2.0.2
 	 * @param {Object} config
 	 * @param {Object} point
-	 * @returns {string}
+	 * @returns {string} SVG markup, safe to assign to `innerHTML` as-is.
 	 */
-	function pointIconUrl( config, point ) {
-		var icons = ( config && config.pointIcons ) || {};
+	function pointGlyphMarkup( config, point ) {
 		var code = ( point && point.type && point.type.code ) || '';
+		var glyphs = ( config && config.pointGlyphs ) || {};
+		var override = Object.prototype.hasOwnProperty.call( glyphs, code ) ? glyphs[ code ] : null;
 
-		return ( icons[ code ] && icons[ code ].default ) || '';
+		if ( override && 'string' === typeof override.markup && override.markup.length > 0 ) {
+			return override.markup;
+		}
+
+		var key = ( override && 'string' === typeof override.glyph && override.glyph.length > 0 )
+			? override.glyph
+			: DEFAULT_GLYPH;
+
+		return GLYPH_SVG[ key ] || GLYPH_SVG[ DEFAULT_GLYPH ];
 	}
 
 	/**
@@ -566,16 +644,16 @@
 	}
 
 	/**
-	 * Builds one list row for a single-point group (spec V-11): the plugin's type icon (only
-	 * when {@see pointIconUrl} finds one), address in bold, name/description as the muted
-	 * subtitle, and — when an anchor is set — the formatted distance. Icon, then address, then
-	 * name is the order the spec asks for: the address is what the customer scans the list FOR,
-	 * the name/description is secondary detail. `short_address`/`address`/`name` are
-	 * already-escaped point fields (see the file docblock) and are written via `innerHTML` here,
-	 * same as everywhere else in this file; the `title` attributes carry the DECODED text
-	 * instead (see {@see decodeForTitle}) because an HTML attribute value is never re-parsed as
-	 * markup the way `innerHTML` is, so the raw escaped string would show literal entities on
-	 * hover.
+	 * Builds one list row for a single-point group (spec V-11): the framework's own type glyph
+	 * (issue #171 — ALWAYS rendered now, see {@see pointGlyphMarkup}), address in bold,
+	 * name/description as the muted subtitle, and — when an anchor is set — the formatted
+	 * distance. Icon, then address, then name is the order the spec asks for: the address is
+	 * what the customer scans the list FOR, the name/description is secondary detail.
+	 * `short_address`/`address`/`name` are already-escaped point fields (see the file
+	 * docblock) and are written via `innerHTML` here, same as everywhere else in this file; the
+	 * `title` attributes carry the DECODED text instead (see {@see decodeForTitle}) because an
+	 * HTML attribute value is never re-parsed as markup the way `innerHTML` is, so the raw
+	 * escaped string would show literal entities on hover.
 	 *
 	 * @param {Object}        point
 	 * @param {number[]|null} anchor
@@ -586,15 +664,12 @@
 	 */
 	function buildSinglePointRow( point, anchor, group, locale, config ) {
 		var wrap = document.createDocumentFragment();
-		var iconUrl = pointIconUrl( config, point );
 
-		if ( iconUrl ) {
-			var icon = document.createElement( 'img' );
-			icon.className = 'woodev-pickup-list__icon';
-			icon.src = iconUrl;
-			icon.alt = '';
-			wrap.appendChild( icon );
-		}
+		var icon = document.createElement( 'span' );
+		icon.className = 'woodev-pickup-list__icon';
+		icon.setAttribute( 'aria-hidden', 'true' );
+		icon.innerHTML = pointGlyphMarkup( config, point ); // eslint-disable-line -- framework constant or server-sanitised markup, see pointGlyphMarkup's own docblock.
+		wrap.appendChild( icon );
 
 		var addressEl = document.createElement( 'span' );
 		addressEl.className = 'woodev-pickup-list__address';
@@ -953,9 +1028,10 @@
 	/**
 	 * Builds the card's header: a close control that ALWAYS renders (this is the customer's only
 	 * way back to the list without dismissing the whole modal, spec §6 STATE 3) plus the icon chip
-	 * (Task 15, spec V-12 — rendered only when the plugin supplies one for `point`'s type, via the
-	 * SAME {@see pointIconUrl} lookup the sidebar row uses) — both on a FIRST inner row,
-	 * `.woodev-pickup-card__header-row` — and the tab bar (only for a co-located group;
+	 * (Task 15, spec V-12 — issue #171: now ALSO ALWAYS renders, via the SAME
+	 * {@see pointGlyphMarkup} lookup the sidebar row uses, so both surfaces agree on what glyph
+	 * a point's type gets) — both on a FIRST inner row, `.woodev-pickup-card__header-row` — and
+	 * the tab bar (only for a co-located group;
 	 * {@see buildTabs} returns `null` for a single-point one) on its OWN row below that, still
 	 * inside `.woodev-pickup-card__header`.
 	 *
@@ -985,22 +1061,19 @@
 		var headerRow = document.createElement( 'div' );
 		headerRow.className = 'woodev-pickup-card__header-row';
 
-		// The chip (spec V-12) — only when the PLUGIN supplies an icon for this point's type.
-		// It shares {@see pointIconUrl} with the sidebar row builder rather than a second lookup,
-		// so both surfaces agree on what "this point has no icon" means.
-		var iconUrl = pointIconUrl( self._config, point );
+		// The chip (spec V-12, issue #171: ALWAYS renders now). It shares {@see pointGlyphMarkup}
+		// with the sidebar row builder rather than a second lookup, so both surfaces agree on
+		// exactly which glyph a point's type gets.
+		var chip = document.createElement( 'div' );
+		chip.className = 'woodev-pickup-card__chip';
+		chip.setAttribute( 'aria-hidden', 'true' );
 
-		if ( iconUrl ) {
-			var chip = document.createElement( 'div' );
-			chip.className = 'woodev-pickup-card__chip';
+		var chipIcon = document.createElement( 'span' );
+		chipIcon.className = 'woodev-pickup-card__chip-icon';
+		chipIcon.innerHTML = pointGlyphMarkup( self._config, point ); // eslint-disable-line -- framework constant or server-sanitised markup, see pointGlyphMarkup's own docblock.
+		chip.appendChild( chipIcon );
 
-			var chipIcon = document.createElement( 'img' );
-			chipIcon.src = iconUrl;
-			chipIcon.alt = '';
-			chip.appendChild( chipIcon );
-
-			headerRow.appendChild( chip );
-		}
+		headerRow.appendChild( chip );
 
 		var close = document.createElement( 'button' );
 		close.type = 'button';

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -249,7 +249,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		/**
 		 * The two glyphs the framework itself ships for the sidebar list row and the point
 		 * card's chip — never the map, which keeps drawing {@see self::$point_icons}/its own
-		 * teardrop pins unchanged (issue #171, operator decision: a teardrop is a pointer at a
+		 * teardrop pins unchanged (issue #195, operator decision: a teardrop is a pointer at a
 		 * coordinate, illegible once shrunk into a list row; the framework now owns a pair of
 		 * square, transparent-background glyphs for exactly that surface). A carrier's type
 		 * CODE (`PVZ`, `POSTAMAT`, ...) is arbitrary domain vocabulary the framework never
@@ -655,7 +655,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		private function normalized_point_glyphs(): array {
 			/**
 			 * Filters the per-type glyph overrides for the pickup point sidebar list and card
-			 * (issue #171). The framework's own default for every type is `warehouse` — it
+			 * (issue #195). The framework's own default for every type is `warehouse` — it
 			 * never guesses a glyph from a carrier's type CODE, so a plugin whose points read
 			 * as parcel lockers (a `POSTAMAT`, a `LOCKER`, ...) must say so explicitly here.
 			 *
@@ -982,7 +982,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 				'defaultLocation' => $this->default_location,
 				'pointIcons'      => $this->normalized_point_icons(),
 
-				// Sidebar list / point card glyph overrides (issue #171) — deliberately a
+				// Sidebar list / point card glyph overrides (issue #195) — deliberately a
 				// SEPARATE map from `pointIcons` above: that one drives the map's own marker
 				// pins, this one drives the list row and card chip, and the two surfaces are
 				// no longer the same picture (see {@see self::normalized_point_glyphs()}).

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -247,6 +247,21 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		private array $point_icons;
 
 		/**
+		 * The two glyphs the framework itself ships for the sidebar list row and the point
+		 * card's chip — never the map, which keeps drawing {@see self::$point_icons}/its own
+		 * teardrop pins unchanged (issue #171, operator decision: a teardrop is a pointer at a
+		 * coordinate, illegible once shrunk into a list row; the framework now owns a pair of
+		 * square, transparent-background glyphs for exactly that surface). A carrier's type
+		 * CODE (`PVZ`, `POSTAMAT`, ...) is arbitrary domain vocabulary the framework never
+		 * sniffs — see {@see self::normalized_point_glyphs()} for why every type defaults to
+		 * `warehouse` rather than a string heuristic over someone else's naming.
+		 *
+		 * @since 2.0.2
+		 * @var string[]
+		 */
+		private const BUILTIN_GLYPHS = [ 'warehouse', 'package' ];
+
+		/**
 		 * The minimum zoom level {@see self::validate_default_location()} accepts,
 		 * matching the map provider's own configured `minZoom` (spec D-7). A default
 		 * viewport the map itself refuses to render at is not a usable obligation.
@@ -611,6 +626,171 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		}
 
 		/**
+		 * Builds the sidebar-list/point-card glyph overrides, keyed by point type code (issue
+		 * #171). Applies `woodev_pickup_map_point_glyphs` ONCE, over a plugin-declared static
+		 * map — the SAME travel path {@see self::normalized_point_icons()} already established
+		 * for `pointIcons` (a plugin knows its own carrier's type-code vocabulary ahead of
+		 * time; which SPECIFIC points arrive per request is dynamic, but the vocabulary of
+		 * TYPES is not) — rather than a per-point filter re-run for every point in a list of up
+		 * to 300.
+		 *
+		 * A returned value is normalised into exactly one of two shapes the client can act on
+		 * without sniffing:
+		 * - one of {@see self::BUILTIN_GLYPHS} ('warehouse'|'package') — the OTHER built-in
+		 *   glyph, `{ glyph: <key>, markup: null }`;
+		 * - any other non-empty string — treated as raw SVG markup, sanitised through
+		 *   {@see self::sanitize_glyph_markup()} and emitted as `{ glyph: null, markup:
+		 *   <sanitised> }`. A value that sanitises down to nothing usable (no `<svg` tag
+		 *   survived) drops the whole type — the client's own `warehouse` default still
+		 *   applies, the framework never emits a broken/empty override.
+		 *
+		 * A type this filter never mentions is simply absent from the result — the client
+		 * defaults it to `warehouse` on its own (see `pickup-panels.js`'s `pointGlyphMarkup()`);
+		 * this method never fabricates an entry.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, array{glyph: string|null, markup: string|null}>
+		 */
+		private function normalized_point_glyphs(): array {
+			/**
+			 * Filters the per-type glyph overrides for the pickup point sidebar list and card
+			 * (issue #171). The framework's own default for every type is `warehouse` — it
+			 * never guesses a glyph from a carrier's type CODE, so a plugin whose points read
+			 * as parcel lockers (a `POSTAMAT`, a `LOCKER`, ...) must say so explicitly here.
+			 *
+			 * Two ways to reach the two outcomes a plugin can want:
+			 * - `'PACKAGE_TYPE_CODE' => 'package'` swaps in the framework's OTHER built-in
+			 *   glyph;
+			 * - `'CUSTOM_TYPE_CODE' => '<svg viewBox="0 0 24 24">...</svg>'` supplies raw
+			 *   markup of its own, run through {@see self::sanitize_glyph_markup()} before it
+			 *   ever reaches the browser.
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param array<string, string> $glyphs   Empty by default — the framework declares
+			 *                                         no overrides of its own. Keyed by point
+			 *                                         type code; each value is either a
+			 *                                         {@see self::BUILTIN_GLYPHS} key or raw
+			 *                                         SVG markup.
+			 * @param string                $plugin_id The plugin the map belongs to.
+			 */
+			$raw = apply_filters( 'woodev_pickup_map_point_glyphs', [], $this->plugin_id );
+
+			$normalized = [];
+
+			if ( ! is_array( $raw ) ) {
+				return $normalized;
+			}
+
+			foreach ( $raw as $type => $value ) {
+				if ( ! is_string( $type ) || '' === $type || ! is_string( $value ) || '' === $value ) {
+					continue;
+				}
+
+				if ( in_array( $value, self::BUILTIN_GLYPHS, true ) ) {
+					$normalized[ $type ] = [
+						'glyph'  => $value,
+						'markup' => null,
+					];
+
+					continue;
+				}
+
+				$markup = self::sanitize_glyph_markup( $value );
+
+				if ( '' === $markup ) {
+					continue; // Nothing safe/usable survived — the client's own `warehouse` default still applies.
+				}
+
+				$normalized[ $type ] = [
+					'glyph'  => null,
+					'markup' => $markup,
+				];
+			}
+
+			return $normalized;
+		}
+
+		/**
+		 * Sanitises a plugin-supplied raw SVG glyph override.
+		 *
+		 * `wp_kses_post()`'s own default allowlist has no `<svg>` element at all — every tag
+		 * inside a genuine icon would be stripped, leaving nothing — so this runs
+		 * {@see wp_kses()} against a small, deliberately narrow SVG-shape allowlist instead
+		 * (the handful of elements/attributes a simple icon actually uses: `svg`, `path`,
+		 * `circle`, `ellipse`, `rect`, `line`, `polyline`, `polygon`, `g`). No scripting
+		 * surface is allowed in either direction: no `<script>`, no `on*` event attributes, no
+		 * `href`/`xlink:href` (which could carry a `javascript:` URI via `<use>`) — an icon
+		 * glyph has no legitimate need for any of the three.
+		 *
+		 * Returns `''`, never the unsanitised input, whenever the result carries no `<svg` tag
+		 * at all — a plugin returning plain text, or markup `wp_kses()` stripped down to
+		 * nothing, is not a usable icon; the caller ({@see self::normalized_point_glyphs()})
+		 * drops the whole override rather than shipping a broken/empty chip to the browser.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $markup raw candidate markup from `woodev_pickup_map_point_glyphs`.
+		 *
+		 * @return string Sanitised markup, or `''` when nothing safe/usable survived.
+		 */
+		private static function sanitize_glyph_markup( string $markup ): string {
+			$core_presentation_attrs = [
+				'fill'            => true,
+				'stroke'          => true,
+				'stroke-width'    => true,
+				'stroke-linecap'  => true,
+				'stroke-linejoin' => true,
+				'class'           => true,
+			];
+
+			$allowed_svg_html = [
+				'svg'      => $core_presentation_attrs + [
+					'xmlns'       => true,
+					'viewbox'     => true,
+					'width'       => true,
+					'height'      => true,
+					'aria-hidden' => true,
+					'focusable'   => true,
+				],
+				'path'     => $core_presentation_attrs + [ 'd' => true ],
+				'circle'   => $core_presentation_attrs + [
+					'cx' => true,
+					'cy' => true,
+					'r' => true,
+				],
+				'ellipse'  => $core_presentation_attrs + [
+					'cx' => true,
+					'cy' => true,
+					'rx' => true,
+					'ry' => true,
+				],
+				'rect'     => $core_presentation_attrs + [
+					'x'      => true,
+					'y'      => true,
+					'width'  => true,
+					'height' => true,
+					'rx'     => true,
+					'ry'     => true,
+				],
+				'line'     => $core_presentation_attrs + [
+					'x1' => true,
+					'y1' => true,
+					'x2' => true,
+					'y2' => true,
+				],
+				'polyline' => $core_presentation_attrs + [ 'points' => true ],
+				'polygon'  => $core_presentation_attrs + [ 'points' => true ],
+				'g'        => $core_presentation_attrs + [ 'transform' => true ],
+			];
+
+			$sanitized = wp_kses( $markup, $allowed_svg_html );
+
+			return ( false !== stripos( $sanitized, '<svg' ) ) ? $sanitized : '';
+		}
+
+		/**
 		 * Builds the JS-safe config the browser mounts the picker from.
 		 *
 		 * Never emits a carrier credential, a callable, or the {@see Point_Source} instance
@@ -633,6 +813,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 *     i18n: array<string, string>,
 		 *     defaultLocation: array{center: array{0: float|int, 1: float|int}, zoom: int},
 		 *     pointIcons: array<string, array{default: string, active: string}>,
+		 *     pointGlyphs: array<string, array{glyph: string|null, markup: string|null}>,
 		 *     mapConfig: array<string, mixed>,
 		 *     replaceAddress: array{enabled: bool, billingOnly: bool},
 		 *     selection: array{close: bool, refreshCheckout: bool},
@@ -800,6 +981,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 
 				'defaultLocation' => $this->default_location,
 				'pointIcons'      => $this->normalized_point_icons(),
+
+				// Sidebar list / point card glyph overrides (issue #171) — deliberately a
+				// SEPARATE map from `pointIcons` above: that one drives the map's own marker
+				// pins, this one drives the list row and card chip, and the two surfaces are
+				// no longer the same picture (see {@see self::normalized_point_glyphs()}).
+				'pointGlyphs' => $this->normalized_point_glyphs(),
 
 				'mapConfig'      => $this->map_provider->get_js_config( [ 'plugin_id' => $this->plugin_id ] ),
 


### PR DESCRIPTION
The sidebar list and point card drew the same teardrop pins as the map, at 20x20. The
operator's verdict: «вообще не понятно, что там отображается».

The cause is geometric, not sizing — a teardrop is a *pointer at a coordinate*, and in a
list row there is nothing to point at. Enlarging it makes it more prominent without making
it legible, which is why the operator rejected that option himself.

Worth recording: **the reference solves this by having no list icon at all.**
Yandex.Delivery's own row is address + name + locality
(`plugins-reference/woocommerce-yandex-delivery/templates/html-modal-map.php:121-128`); its
pins live only on the map.

## What this does

The framework now owns square, transparent-background glyphs and renders them in the list
and the card **always**. The map keeps the plugin's pins, untouched —
`map-provider-yandex.js` still reads `config.pointIcons` exactly as before.

Artwork is the real ISC-licensed lucide `warehouse` and `package`, fetched from source
rather than reconstructed from memory, attributed alongside the `FILTER_ICON_SVG` /
`CLEAR_ICON_SVG` geometry this file already carries.

**The framework never guesses carrier vocabulary.** Every type defaults to `warehouse`;
there is no string heuristic sniffing for `POSTAMAT`/`LOCKER`/`TERMINAL`. A plugin whose
points are parcel lockers says so explicitly.

## The override seam

`woodev_pickup_map_point_glyphs`, applied once at config-build time, reaching both outcomes:

- `'POSTAMAT' => 'package'` — swap in the framework's other built-in
- `'CUSTOM' => '<svg viewBox="0 0 24 24">…</svg>'` — supply own markup

Raw markup is sanitised server-side through a narrow `wp_kses` SVG allowlist: no `<script>`,
no event attributes, no `href`/`xlink:href`. Markup that sanitises to nothing drops the
whole override rather than shipping a broken chip.

It is a per-*type*, config-time filter rather than a per-point one, mirroring how
`pointIcons` and `woodev_pickup_map_i18n` already travel — a plugin knows its own type
vocabulary statically, and a per-point filter would re-run for every row in a list of up
to 300.

The fixture consumes it (`POSTAMAT => 'package'`), so the seam ships exercised rather than
merely present.

## Rig-verified by measurement

- glyph box 24x24, hit-test at its centre lands on a `path` — actually painted, not merely
  present in the DOM
- `pointGlyphs` reaching the browser as `{"POSTAMAT":{"glyph":"package","markup":null}}`
- ПВЗ renders the warehouse geometry, Постамат the package geometry — confirmed by
  comparing the emitted paths, not by eye

An earlier measurement read 0x0 and looked like a defect; it was taken while the sidebar
was still collapsed. Recorded here because the same trap will catch the next person.

## Note on issue references

The implementation cited #171 in ten places, but #171 is the unrelated a11y regression
about focus and scroll position. This work came from a direct operator decision and had no
card; **#195** now records it and the references are repointed. A wrong citation is worse
than none — it sends the reader to a different defect and reads as if that one had been
fixed.

701 jest / 1436 unit, phpcs clean, PHPStan clean.

Closes #195
