### PR TITLE
feat(pickup): per-point icons as the third tier of the marker cascade

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
@@ -5,6 +5,13 @@
  * proving the framework's `Point_Source` contract against a live carrier response instead
  * of a static array (issue #185).
  *
+ * PER-POINT ICONS BY OPERATOR (issue #193): {@see self::icons_for_operator()} gives every
+ * `5post` point its own icon, keyed off the raw record's `operator_id` — the field the
+ * type-level tier cannot read at all, and the only one that separates a 5post point from a
+ * Yandex.Market one when both report the SAME `type: "pickup_point"` (see PAYLOAD below).
+ * This is `Pickup_Point`'s new per-point `icons` override (cascade tier 1) wired to a real
+ * consumer on real data.
+ *
  * ACTIVATION: never on by default. `woodev-test-shipping-method.php` only constructs this
  * class when `WOODEV_TEST_PICKUP_LIVE_YANDEX` is truthy (defined near
  * `WOODEV_TEST_PICKUP_STRATEGY` at the top of that file, default `false`). Neither
@@ -150,6 +157,12 @@ if ( ! class_exists( 'Woodev_Test_Live_Yandex_Point_Source' ) ) {
 
 		/** Yandex `geo_id` for Moscow — see the file docblock's SCOPE section. */
 		private const MOSCOW_GEO_ID = 213;
+
+		/**
+		 * The `operator_id` this fixture singles out for its own per-point icon (issue
+		 * #193) — see {@see self::icons_for_operator()}.
+		 */
+		private const FIVE_POST_OPERATOR_ID = '5post';
 
 		/**
 		 * The fixture's one static "city" — mirrors
@@ -402,8 +415,47 @@ if ( ! class_exists( 'Woodev_Test_Live_Yandex_Point_Source' ) ) {
 					),
 					'services'        => $this->map_services( $services ),
 					'photos'          => [],
+					'icons'           => $this->icons_for_operator( $raw_point['operator_id'] ?? null ),
 				]
 			);
+		}
+
+		/**
+		 * This fixture's consumer of {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point}'s
+		 * new per-point icon override (issue #193, cascade tier 1). Only a `5post` point
+		 * gets one — every other operator (`market_l4g`, or the field absent entirely) falls
+		 * through to the existing `PVZ`/`POSTAMAT` TYPE-level tier, unchanged.
+		 *
+		 * Live measurement, `geo_id: 213` (Moscow), 812 points: `5post`/`pickup_point`: 679,
+		 * `market_l4g`/`pickup_point`: 129, `market_l4g`/`terminal`: 4. The type code alone
+		 * cannot separate the 679 5post points from the 129 Yandex.Market ones — both report
+		 * `type: "pickup_point"` — so this is the real-data case the whole cascade tier
+		 * exists for, wired to the fixture's own live consumer.
+		 *
+		 * Reuses the fixture's EXISTING terminal SVGs — `yandex-delivery-map-pin-terminal
+		 * [-active].svg`, already shipped for the `POSTAMAT` type-level icon just below in
+		 * `woodev-test-shipping-method.php` — rather than adding new artwork: the office pin
+		 * already draws every OTHER `pickup_point` (the type tier), so the terminal pin
+		 * reused here is immediately visually distinguishable on the rig without a new file.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param mixed $operator_id Raw `operator_id` value from the API, or null when the
+		 *                            record carries none.
+		 *
+		 * @return array{default: string, active: string}|null
+		 */
+		private function icons_for_operator( $operator_id ): ?array {
+			if ( self::FIVE_POST_OPERATOR_ID !== $operator_id ) {
+				return null;
+			}
+
+			$icons_url = plugins_url( 'assets/images', __FILE__ );
+
+			return [
+				'default' => $icons_url . '/yandex-delivery-map-pin-terminal.svg',
+				'active'  => $icons_url . '/yandex-delivery-map-pin-terminal-active.svg',
+			];
 		}
 
 		/**

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -487,6 +487,13 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// icons for its Yandex.Delivery integration, not hotlinked — see each file's own
 				// attribution comment) — "office" is this fixture's `PVZ`, "terminal" its
 				// `POSTAMAT`.
+				//
+				// This is cascade tier 2 only (domain icons BY TYPE CODE — issue #193). Under
+				// WOODEV_TEST_PICKUP_LIVE_YANDEX, tier 1 (a POINT's own icon) is wired
+				// separately, in `Woodev_Test_Live_Yandex_Point_Source::icons_for_operator()`:
+				// a `5post` point gets its own icon by `operator_id`, reusing these SAME
+				// terminal SVGs, because 5post and Yandex.Market points otherwise share this
+				// fixture's `PVZ` type code (`pickup_point`) and would draw identically.
 				$icons_url = plugins_url( 'assets/images', __FILE__ );
 
 				$point_icons = [

--- a/tests/js/map-provider-yandex.test.js
+++ b/tests/js/map-provider-yandex.test.js
@@ -887,6 +887,115 @@ test( 'a known type resolves its icon URLs onto the feature properties; an unkno
 	expect( unknown.properties.iconHrefActive ).toBe( '' );
 } );
 
+// -------------------------------------------------------------------------
+// Cascade tier 1 (issue #193): a POINT's own icon beats the domain's type-keyed icon,
+// which beats the framework's default pin. Yandex.Delivery mixes 5post and Yandex.Market
+// points under the identical type code `pickup_point` (812-point live sample: 679 5post +
+// 129 market_l4g, both `pickup_point`) — the type-code tier alone cannot tell them apart;
+// only a per-point field can.
+// -------------------------------------------------------------------------
+
+test( 'a point\'s own icon overrides the domain\'s type-keyed icon', async () => {
+	const provider = await init( { pointIcons: { pvz: { default: '/pvz.svg', active: '/pvz-a.svg' } } } );
+
+	provider.setPoints( [ {
+		key: 'a', lat: 55.75, lng: 37.61, typeCode: 'pvz', size: 1,
+		points: [ { type: { code: 'pvz' }, icons: { default: '/5post.svg', active: '/5post-a.svg' } } ],
+	} ] );
+
+	const feature = ymapsStub.lastObjectManager.added[ 0 ];
+
+	expect( feature.properties.iconHref ).toBe( '/5post.svg' );
+	expect( feature.properties.iconHrefActive ).toBe( '/5post-a.svg' );
+} );
+
+test( 'a point\'s own icon is used even when the domain has no icon at all for that type', async () => {
+	const provider = await init(); // no pointIcons configured
+
+	provider.setPoints( [ {
+		key: 'a', lat: 55.75, lng: 37.61, typeCode: 'other', size: 1,
+		points: [ { type: { code: 'other' }, icons: { default: '/5post.svg', active: '/5post-a.svg' } } ],
+	} ] );
+
+	const feature = ymapsStub.lastObjectManager.added[ 0 ];
+
+	expect( feature.properties.iconHref ).toBe( '/5post.svg' );
+	expect( feature.properties.iconHrefActive ).toBe( '/5post-a.svg' );
+} );
+
+test( 'a point with no icon of its own falls back to the domain\'s type-keyed icon', async () => {
+	const provider = await init( { pointIcons: { pvz: { default: '/pvz.svg', active: '/pvz-a.svg' } } } );
+
+	provider.setPoints( [ {
+		key: 'a', lat: 55.75, lng: 37.61, typeCode: 'pvz', size: 1,
+		points: [ { type: { code: 'pvz' } } ], // no `icons` key at all
+	} ] );
+
+	const feature = ymapsStub.lastObjectManager.added[ 0 ];
+
+	expect( feature.properties.iconHref ).toBe( '/pvz.svg' );
+	expect( feature.properties.iconHrefActive ).toBe( '/pvz-a.svg' );
+} );
+
+test( 'a point whose own icon has only a default gets active mirrored from it (D-5, per-point tier)', async () => {
+	const provider = await init();
+
+	provider.setPoints( [ {
+		key: 'a', lat: 55.75, lng: 37.61, typeCode: 'pvz', size: 1,
+		points: [ { type: { code: 'pvz' }, icons: { default: '/5post.svg' } } ], // no `active`
+	} ] );
+
+	const feature = ymapsStub.lastObjectManager.added[ 0 ];
+
+	expect( feature.properties.iconHref ).toBe( '/5post.svg' );
+	expect( feature.properties.iconHrefActive ).toBe( '/5post.svg' );
+} );
+
+/**
+ * `??`, never `||` (same discipline as `resolveFlag()`'s `close` flag, PR #192) — but the
+ * DECISION here is the opposite of that flag's: an empty icon URL carries no meaningful
+ * information distinct from "absent" (a blank string can never be an image), so it falls
+ * through to the next cascade tier exactly like an absent `icons` key would, rather than
+ * being honoured as an explicit "no icon" that stops the cascade. A server-sanitized point
+ * (`Pickup_Point::sanitize_icons()`) never actually emits this shape — this guards a point
+ * object built directly, bypassing that sanitisation (a test, or a future caller).
+ */
+test( 'an empty-string default on a point\'s own icon is treated as absent, not honoured', async () => {
+	const provider = await init( { pointIcons: { pvz: { default: '/pvz.svg', active: '/pvz-a.svg' } } } );
+
+	provider.setPoints( [ {
+		key: 'a', lat: 55.75, lng: 37.61, typeCode: 'pvz', size: 1,
+		points: [ { type: { code: 'pvz' }, icons: { default: '', active: '' } } ],
+	} ] );
+
+	const feature = ymapsStub.lastObjectManager.added[ 0 ];
+
+	expect( feature.properties.iconHref ).toBe( '/pvz.svg' );
+	expect( feature.properties.iconHrefActive ).toBe( '/pvz-a.svg' );
+} );
+
+/**
+ * Documents a consequence of the EXISTING grouping behaviour (`_buildProperties()` always
+ * reads `displayPoints[0]`), not a new defect introduced by this tier: a co-located group
+ * mixing a 5post point (own icon) with a plain point (no icon) shows only the
+ * REPRESENTATIVE's own resolution. Order matters — the representative is whichever point
+ * survived filtering and sorts first, exactly as it already does for `typeCode`.
+ */
+test( 'a co-located group shows only the REPRESENTATIVE point\'s own icon, never a blend', async () => {
+	const provider = await init( { pointIcons: { pvz: { default: '/pvz.svg', active: '/pvz-a.svg' } } } );
+
+	provider.setPoints( [ mixedGroup( 'a', 55.75, 37.61, [
+		{ typeCode: 'pvz' }, // no icon of its own — the representative (first)
+		{ typeCode: 'pvz', icons: { default: '/5post.svg', active: '/5post-a.svg' } },
+	] ) ] );
+
+	const feature = ymapsStub.lastObjectManager.added[ 0 ];
+
+	// The representative (points[0]) has no own icon, so the group falls to the domain's
+	// type-keyed icon — the second point's own icon is never consulted.
+	expect( feature.properties.iconHref ).toBe( '/pvz.svg' );
+} );
+
 test( 'marks a group of more than one point so the badge renders', async () => {
 	const provider = await init();
 

--- a/tests/unit/Shipping/Pickup/PickupPointTest.php
+++ b/tests/unit/Shipping/Pickup/PickupPointTest.php
@@ -301,4 +301,153 @@ final class PickupPointTest extends TestCase {
 
 		$this->assertSame( [ 'https://example.test/a.jpg' ], $point->to_array()['photos'] );
 	}
+
+	// -----------------------------------------------------------------------------
+	// icons (issue #193) — cascade tier 1: the point's OWN icon, ahead of the domain's
+	// type-keyed icons and the framework's default pin.
+	// -----------------------------------------------------------------------------
+
+	public function test_icons_default_to_null_when_the_key_is_absent(): void {
+		$point = $this->make_point( [] );
+
+		$this->assertNull( $point->to_array()['icons'] );
+	}
+
+	/**
+	 * An explicit `null` and an absent key must resolve identically — both mean "this
+	 * point carries no icon of its own", not two different states worth telling apart.
+	 */
+	public function test_icons_default_to_null_when_explicitly_null(): void {
+		$point = $this->make_point( [ 'icons' => null ] );
+
+		$this->assertNull( $point->to_array()['icons'] );
+	}
+
+	public function test_icons_are_kept_when_both_states_are_supplied(): void {
+		$point = $this->make_point(
+			[
+				'icons' => [
+					'default' => 'https://example.test/5post.svg',
+					'active'  => 'https://example.test/5post-active.svg',
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'default' => 'https://example.test/5post.svg',
+				'active'  => 'https://example.test/5post-active.svg',
+			],
+			$point->to_array()['icons']
+		);
+	}
+
+	/**
+	 * D-5's rule, applied to the per-point tier too (mirrors
+	 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::normalized_point_icons()}):
+	 * a domain that supplies only one image gets it mirrored into `active`, never a blank.
+	 */
+	public function test_icons_active_falls_back_to_default_when_only_default_is_supplied(): void {
+		$point = $this->make_point( [ 'icons' => [ 'default' => 'https://example.test/5post.svg' ] ] );
+
+		$this->assertSame(
+			[ 'default' => 'https://example.test/5post.svg', 'active' => 'https://example.test/5post.svg' ],
+			$point->to_array()['icons']
+		);
+	}
+
+	/**
+	 * An empty `default` carries no more information than an absent one — a blank string
+	 * can never be rendered as an image, so it is treated the SAME as "no icon" rather than
+	 * a distinct third state. This is deliberately not the `close`-flag trap (PR #192): that
+	 * flag is a boolean, where an explicit `false` is itself a meaningful decision distinct
+	 * from "unspoken". A URL has no equivalent meaningful-but-empty state.
+	 */
+	public function test_icons_with_an_empty_default_are_dropped_to_null(): void {
+		$point = $this->make_point( [ 'icons' => [ 'default' => '', 'active' => 'https://example.test/a.svg' ] ] );
+
+		$this->assertNull( $point->to_array()['icons'] );
+	}
+
+	public function test_icons_with_a_non_array_value_are_dropped_to_null(): void {
+		$point = $this->make_point( [ 'icons' => 'https://example.test/5post.svg' ] );
+
+		$this->assertNull( $point->to_array()['icons'] );
+	}
+
+	public function test_icons_with_a_non_string_default_are_dropped_to_null(): void {
+		$point = $this->make_point( [ 'icons' => [ 'default' => [ 'x' ] ] ] );
+
+		$this->assertNull( $point->to_array()['icons'] );
+	}
+
+	public function test_icons_with_a_non_string_active_fall_back_to_default(): void {
+		$point = $this->make_point(
+			[ 'icons' => [ 'default' => 'https://example.test/5post.svg', 'active' => [ 'x' ] ] ]
+		);
+
+		$this->assertSame(
+			[ 'default' => 'https://example.test/5post.svg', 'active' => 'https://example.test/5post.svg' ],
+			$point->to_array()['icons']
+		);
+	}
+
+	public function test_to_array_does_not_escape_icons(): void {
+		$point = $this->make_point( [ 'icons' => [ 'default' => 'https://example.test/a.svg?x=1&y=2' ] ] );
+
+		$this->assertStringNotContainsString( '&amp;', $point->to_array()['icons']['default'] );
+	}
+
+	public function test_to_browser_array_escapes_icons_via_esc_url_raw_not_esc_url(): void {
+		// The stubbed esc_url_raw() from stubEscapeFunctions() is a pass-through, which is
+		// enough to prove the VALUE is untouched (no HTML-entity-encoding of the querystring
+		// '&') — the same JSON-payload rule `photos` already documents.
+		$point = $this->make_point( [ 'icons' => [ 'default' => 'https://example.test/a.svg?x=1&y=2' ] ] );
+
+		$this->assertSame(
+			'https://example.test/a.svg?x=1&y=2',
+			$point->to_browser_array()['icons']['default']
+		);
+	}
+
+	public function test_to_browser_array_escapes_the_active_icon_url_too(): void {
+		$point = $this->make_point(
+			[
+				'icons' => [
+					'default' => 'https://example.test/a.svg',
+					'active'  => 'https://example.test/a-active.svg?x=1&y=2',
+				],
+			]
+		);
+
+		$this->assertSame(
+			'https://example.test/a-active.svg?x=1&y=2',
+			$point->to_browser_array()['icons']['active']
+		);
+	}
+
+	public function test_to_browser_array_icons_are_null_when_absent(): void {
+		$point = $this->make_point( [] );
+
+		$this->assertNull( $point->to_browser_array()['icons'] );
+	}
+
+	/**
+	 * A `default` that survives `esc_url_raw()` as an empty string (a `javascript:` URL,
+	 * which WordPress's own bad-protocol stripping collapses to `''`) drops the whole icon
+	 * override at the browser boundary — mirrors
+	 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::normalized_point_icons()}'s
+	 * own rule for the type-level tier.
+	 */
+	public function test_to_browser_array_drops_icons_whose_default_becomes_empty_after_escaping(): void {
+		\Brain\Monkey\Functions\when( 'esc_url_raw' )->alias(
+			static function ( $url ) {
+				return 0 === stripos( ltrim( (string) $url ), 'javascript:' ) ? '' : $url;
+			}
+		);
+
+		$point = $this->make_point( [ 'icons' => [ 'default' => 'javascript:alert(1)' ] ] );
+
+		$this->assertNull( $point->to_browser_array()['icons'] );
+	}
 }

--- a/tests/unit/Shipping/Pickup/SelectionResultTest.php
+++ b/tests/unit/Shipping/Pickup/SelectionResultTest.php
@@ -226,6 +226,41 @@ final class SelectionResultTest extends TestCase {
 		$this->assertArrayNotHasKey( 'carrier_raw', $point );
 	}
 
+	/**
+	 * Issue #193's own regression target: `Pickup_Point::from_array()` is load-bearing on
+	 * THIS path — a domain filter's corrected point is rebuilt through it before it ever
+	 * reaches the browser (see {@see \Woodev\Framework\Shipping\Pickup\Selection_Result::sanitize_point()}'s
+	 * own docblock). A field `from_array()` does not know is silently dropped, which for
+	 * `icons` would mean a point's own icon override vanishing at EXACTLY the moment the
+	 * customer confirms a selection — the one place a domain most plausibly wants to say
+	 * "actually, THIS point gets its own pin" (e.g. after resolving which operator a
+	 * co-located group's representative actually belongs to).
+	 */
+	public function test_a_corrected_points_own_icon_survives_the_confirmation_path(): void {
+		$this->stub_real_esc_html();
+
+		$computed          = Selection_Result::from_verdict( [ 'allowed' => true, 'reason' => null ] );
+		$filtered          = $computed;
+		$filtered['point'] = $this->corrected_point(
+			[
+				'icons' => [
+					'default' => 'https://example.test/5post.svg',
+					'active'  => 'https://example.test/5post-active.svg?x=1&y=2',
+				],
+			]
+		);
+
+		$point = Selection_Result::sanitize( $filtered, $computed )['point'];
+
+		$this->assertSame(
+			[
+				'default' => 'https://example.test/5post.svg',
+				'active'  => 'https://example.test/5post-active.svg?x=1&y=2',
+			],
+			$point['icons']
+		);
+	}
+
 	public function test_the_corrected_points_verdict_mirrors_the_results_own(): void {
 		// A point whose `selectable` disagreed with the result carrying it would let a
 		// domain hand the browser a refusal and a point that says it is fine, so the entry

--- a/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
+++ b/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
@@ -310,6 +310,79 @@ final class TestLiveYandexPointSourceTest extends TestCase {
 		$this->assertSame( 'Постамат Яндекс.Маркет', $point->to_array()['name'] );
 	}
 
+	// -----------------------------------------------------------------------------
+	// Per-point icons by operator_id (issue #193): 5post and Yandex-branded/market
+	// points share the SAME type code (`pickup_point`) in a live response — a live
+	// 812-point Moscow sample measured 679 `5post` + 129 `market_l4g` points, both
+	// reporting `type: "pickup_point"` — so only a per-point field, `operator_id`,
+	// can tell them apart. This wires the fixture's own consumer for the framework's
+	// new cascade tier 1 (`Pickup_Point`'s `icons` field).
+	// -----------------------------------------------------------------------------
+
+	/**
+	 * A `5post` point gets its own icon override, reusing the fixture's EXISTING terminal
+	 * SVGs (already shipped for the `POSTAMAT` type-level icon) rather than new artwork —
+	 * visually distinguishable from the office pin the `PVZ` type tier already draws for
+	 * every OTHER `pickup_point`, which is exactly what a 5post point needs: it is a
+	 * DIFFERENT branded network sharing the same type code.
+	 */
+	public function test_5post_points_get_their_own_icon_by_operator_id(): void {
+		Functions\when( 'plugins_url' )->alias(
+			static fn( $path, $file ) => 'https://example.test/wp-content/plugins/woodev-test-shipping-method/' . $path
+		);
+
+		$record                 = $this->real_pickup_point_record();
+		$record['operator_id']  = '5post';
+
+		$this->stub_successful_transport( [ $record ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertSame(
+			[
+				'default' => 'https://example.test/wp-content/plugins/woodev-test-shipping-method/'
+					. 'assets/images/yandex-delivery-map-pin-terminal.svg',
+				'active'  => 'https://example.test/wp-content/plugins/woodev-test-shipping-method/'
+					. 'assets/images/yandex-delivery-map-pin-terminal-active.svg',
+			],
+			$points[0]->to_array()['icons']
+		);
+	}
+
+	/**
+	 * A `market_l4g` (or any other) operator gets no icon override of its own — it falls
+	 * through to the domain's existing type-keyed tier (`PVZ`'s office icon), unchanged.
+	 */
+	public function test_non_5post_operators_get_no_icon_of_their_own(): void {
+		$record                = $this->real_pickup_point_record();
+		$record['operator_id'] = 'market_l4g';
+
+		$this->stub_successful_transport( [ $record ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertNull( $points[0]->to_array()['icons'] );
+	}
+
+	/**
+	 * The captured live records above carry no `operator_id` at all — a record with the
+	 * field simply absent must not fatal, and must resolve to "no icon of its own" exactly
+	 * like an explicit non-5post value.
+	 */
+	public function test_a_record_with_no_operator_id_at_all_gets_no_icon_of_its_own(): void {
+		$this->stub_successful_transport( [ $this->real_terminal_record() ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertNull( $points[0]->to_array()['icons'] );
+	}
+
 	public function test_fetch_details_returns_null_for_an_unknown_id(): void {
 		Functions\when( 'get_transient' )->justReturn( [ $this->real_pickup_point_record() ] );
 

--- a/woodev/shipping-method/assets/js/frontend/map-provider-yandex.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-yandex.js
@@ -41,7 +41,9 @@
  * `mapConfig` (`scriptUrl`, `ns`, `hasApiKey`, `lang`, `layers`, `copyrights`) plus
  * `strategy`/`locality`/`i18n`, and (Task 20) the plugin-level `defaultLocation`
  * (`{ center: [lat,lng], zoom }`, ALWAYS present — a required plugin argument),
- * `pointIcons` (`{ typeCode: { default, active } }`, `active` always filled),
+ * `pointIcons` (`{ typeCode: { default, active } }`, `active` always filled — cascade
+ * tier 2, see the "ICONS ARE AN HTML LAYOUT" section below for tier 1, a POINT's own
+ * `icons`),
  * `accentColor`, and
  * `searchLayoutEl` (Task 12, spec V-6 — a DETACHED `HTMLElement` built by
  * `pickup-panels.js`'s `buildSearchLayout()`, or `null` when the plugin disabled search; see
@@ -110,6 +112,28 @@
  * only `default` (CDEK's own approach — `active` mirrors `default` server-side, see
  * `Pickup_Handler::normalized_point_icons()`) gets the SAME image drawn larger, both driven by
  * the one `data-state` attribute Task 21's CSS keys off.
+ *
+ * ICON RESOLUTION IS A THREE-TIER CASCADE (issue #193): a POINT's own icon
+ * ({@see pointOwnIcons}, `group.points[n].icons`) beats `config.pointIcons[ typeCode ]`
+ * (the tier described above), which beats the framework's default pin. This exists because
+ * a type CODE is not always enough to tell branded networks apart — Yandex.Delivery mixes
+ * points from different operators in one response under the SAME type code (a live,
+ * 812-point Moscow sample measured 679 `5post` + 129 `market_l4g` points, both reporting
+ * `type: "pickup_point"`), so resolving by type code alone draws them identically even
+ * though they are visually distinct networks. {@see WoodevYandexMapProvider#_buildProperties}
+ * resolves both tiers with `??`, never `||` — see {@see pointOwnIcons}'s own docblock for
+ * why an empty icon URL at either tier means "keep falling through", the opposite decision
+ * from the `close` flag's `??` (PR #192), and why that is still the correct, deliberate
+ * choice for a URL rather than an oversight. The per-point tier is resolved from the
+ * group's REPRESENTATIVE point (`displayPoints[0]`, the SAME point that decides
+ * `typeCode`) — a co-located group (`pickup-geo.js`'s `groupByPosition()`) therefore shows
+ * only the representative's own icon, never a blend of its members'; a marker sitting at
+ * one coordinate that folds a 5post point together with a Yandex-branded one draws
+ * whichever sorts first. This is a consequence of the existing grouping, not a defect this
+ * tier introduces. SCOPE: this cascade is the MAP marker's own icon resolution only — the
+ * sidebar list row and the point card keep the framework's own glyphs regardless (issue
+ * #195/PR #196, `woodev_pickup_map_point_glyphs`); a point's own `icons` never reaches
+ * those surfaces.
  *
  * MAP MARGINS ARE TWO SEPARATE, NEVER-CONFUSED RESERVATIONS, both via ymaps' native
  * `map.margin.addArea()` — whose RETURNED ACCESSOR is what removes it again, there is no
@@ -675,6 +699,37 @@
 	 */
 	function pointTypeCode( point ) {
 		return ( point && point.type && point.type.code ) || '';
+	}
+
+	/**
+	 * A single point's own icon override (issue #193 — cascade tier 1: the point's own icon
+	 * beats the domain's type-keyed icon, which beats the framework's default pin).
+	 * `{ default, active }`, or `null` when the point carries no usable icon of its own.
+	 *
+	 * `??`, never `||` — the SAME discipline `pickup-mount.js`'s `resolveFlag()` established
+	 * for the `close` flag (PR #192), but the DECISION here is the opposite of that flag's:
+	 * `resolveFlag()` must preserve an explicit `false` as distinct from "unspoken", because a
+	 * boolean's `false` is itself a meaningful state. A URL has no such state — a blank string
+	 * can never be rendered as an image, so an explicitly empty `default` carries no more
+	 * information than an absent `icons` key, and both fall through to the next cascade tier
+	 * identically. `Pickup_Point::sanitize_icons()` already guarantees the server never emits
+	 * an `icons` object with an empty `default`; the truthy check below is defensive, for a
+	 * point object built directly (a test, or a future caller bypassing that sanitisation).
+	 *
+	 * @since 2.0.2
+	 * @param {Object} point
+	 * @returns {{default: string, active: string}|null}
+	 */
+	function pointOwnIcons( point ) {
+		var icons = ( point && point.icons ) ?? null;
+
+		if ( ! icons || 'string' !== typeof icons.default || '' === icons.default ) {
+			return null;
+		}
+
+		var active = 'string' === typeof icons.active && icons.active ? icons.active : icons.default;
+
+		return { default: icons.default, active: active };
 	}
 
 	/**
@@ -1753,12 +1808,23 @@
 	 * to decide whether the feature is drawn AT ALL, so it must never shrink to only the
 	 * currently-surviving subset the way `typeCode`/`iconHref` do.
 	 *
-	 * `iconHref`/`iconHrefActive` are resolved from `config.pointIcons[ <the surviving subset's
-	 * representative type> ]` — empty for an unrecognised type, in which case {@see _renderMarker}
-	 * still draws the framework's own default pin, never an invisible/broken one. `active` is
-	 * guaranteed filled server-side whenever the type is known at all (mirroring `default` when
-	 * the plugin supplied only one image — D-5, `Pickup_Handler::normalized_point_icons()`), so
-	 * `iconHrefActive` is never a broken/empty URL for a KNOWN type.
+	 * `iconHref`/`iconHrefActive` are resolved through the FULL three-tier cascade (issue
+	 * #193): the representative point's own icon ({@see pointOwnIcons}), else
+	 * `config.pointIcons[ <the surviving subset's representative type> ]`, else empty — in
+	 * which case {@see _renderMarker} still draws the framework's own default pin, never an
+	 * invisible/broken one. Both tiers are resolved with `??`, never `||` — see
+	 * {@see pointOwnIcons}'s own docblock for why an empty value at either tier means "keep
+	 * falling through", not "stop here with nothing". `active` is guaranteed filled whenever
+	 * `default` is (mirroring it when only one image was supplied — D-5, applied identically
+	 * at both tiers: {@see pointOwnIcons} for the point, `Pickup_Handler::normalized_point_icons()`
+	 * for the type), so `iconHrefActive` is never a broken/empty URL whenever `iconHref` isn't.
+	 *
+	 * The representative point is the SAME one that decides `typeCode` — `displayPoints[0]`.
+	 * A co-located group (`pickup-geo.js`'s `groupByPosition()`) therefore shows only the
+	 * REPRESENTATIVE's own icon resolution, never a blend of its members': a group folding a
+	 * 5post point and a Yandex-branded point onto one coordinate draws whichever one sorts
+	 * first, exactly as it already does for the type-code badge. This is a consequence of the
+	 * existing grouping, not a defect introduced here.
 	 *
 	 * @param {Object} group
 	 * @returns {Object}
@@ -1768,7 +1834,8 @@
 		var survivors = this._survivingPoints( group );
 		var displayPoints = survivors.length > 0 ? survivors : ( group.points || [] );
 		var displayType = pointTypeCode( displayPoints[ 0 ] ) || group.typeCode;
-		var icons = ( this.config.pointIcons && this.config.pointIcons[ displayType ] ) || null;
+		var typeIcons = ( this.config.pointIcons && this.config.pointIcons[ displayType ] ) || null;
+		var icons = pointOwnIcons( displayPoints[ 0 ] ) ?? typeIcons ?? null;
 
 		return {
 			// Unfiltered, `groupSize` mirrors `group.size` DIRECTLY, exactly as before this fix —

--- a/woodev/shipping-method/pickup/class-pickup-point.php
+++ b/woodev/shipping-method/pickup/class-pickup-point.php
@@ -114,8 +114,57 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Point' ) ) :
 					'services'        => $services,
 					'accepts_cod'     => isset( $payload['accepts_cod'] ) ? (bool) $payload['accepts_cod'] : null,
 					'max_weight'      => isset( $payload['max_weight'] ) ? (int) $payload['max_weight'] : null,
+					'icons'           => self::sanitize_icons( $payload['icons'] ?? null ),
 				]
 			);
+		}
+
+		/**
+		 * Sanitizes the point's own icon override — cascade tier 1 (issue #193): the
+		 * point's own icon beats the domain's type-keyed icons, which beat the framework's
+		 * default pin. Resolution itself happens client-side, in `map-provider-yandex.js`'s
+		 * `_buildProperties()`; this method only decides what SURVIVES onto `to_array()`.
+		 *
+		 * An ABSENT `icons` key and an explicit `null` both mean "this point carries no icon
+		 * of its own" — fall through to the next cascade tier. So does a `default` that is
+		 * missing, non-string, or empty. This is DELIBERATELY not the trap `close` fell into
+		 * before PR #192 (`Pickup_Handler`/`pickup-mount.js`'s `resolveFlag()`), which treats
+		 * an explicit `false` as a decision distinct from "the domain said nothing" and must
+		 * beat a truthy default: there the value is a BOOLEAN, and `false` is itself a
+		 * meaningful, distinct state worth preserving. An icon is a URL — a blank string can
+		 * never be rendered as an image, so it has no equivalent meaningful-but-empty state
+		 * to protect. Treating "empty" the same as "absent" here loses no information the
+		 * cascade could otherwise have honoured; it IS the correct, and only sensible,
+		 * reading.
+		 *
+		 * `active` mirrors `default` when the domain supplies only one image — the same D-5
+		 * rule {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::normalized_point_icons()}
+		 * already applies to the type-level tier, so a point supplying its own icon never
+		 * reaches the browser with a broken/empty `active` URL.
+		 *
+		 * Values are kept RAW here, matching `to_array()`'s unescaped, canonical contract
+		 * (the same split `photos` already establishes) — escaping via `esc_url_raw()`, and
+		 * the post-escape "did this collapse to an unusable empty string" recheck, happen
+		 * once, in {@see self::to_browser_array()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param mixed $icons Raw `icons` payload value.
+		 *
+		 * @return array{default: string, active: string}|null
+		 */
+		private static function sanitize_icons( $icons ): ?array {
+			if ( ! is_array( $icons ) || empty( $icons['default'] ) || ! is_string( $icons['default'] ) ) {
+				return null;
+			}
+
+			$default = $icons['default'];
+			$active  = ( ! empty( $icons['active'] ) && is_string( $icons['active'] ) ) ? $icons['active'] : $default;
+
+			return [
+				'default' => $default,
+				'active'  => $active,
+			];
 		}
 
 		/**
@@ -313,6 +362,26 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Point' ) ) :
 			// HTML-entity-encodes '&' to '&#038;', which is correct for an HTML attribute
 			// and wrong for a JSON string a client will use as a URL.
 			$out['photos'] = array_map( 'esc_url_raw', $out['photos'] );
+
+			// Same esc_url_raw rule as `photos`, plus the post-escape recheck
+			// `Pickup_Handler::normalized_point_icons()` already applies to the type-level
+			// tier: a `default` that survives escaping as an empty string (a `javascript:`
+			// URL, which WordPress's bad-protocol stripping collapses to `''`) drops the
+			// whole override rather than reaching the browser as an icon pointing at `""`.
+			if ( null !== $out['icons'] ) {
+				$default = esc_url_raw( $out['icons']['default'] );
+
+				if ( '' === $default ) {
+					$out['icons'] = null;
+				} else {
+					$active = esc_url_raw( $out['icons']['active'] );
+
+					$out['icons'] = [
+						'default' => $default,
+						'active'  => '' !== $active ? $active : $default,
+					];
+				}
+			}
 
 			return $out;
 		}


### PR DESCRIPTION
Map marker icons resolved by **type code only**. The cascade is now three tiers:

    point's own icons  >  domain icons by type code  >  framework default pin

## Why this is not speculative

Measured against the live Yandex.Delivery sandbox (`geo_id: 213`, 812 points):

| operator_id | type | count |
|---|---|---|
| `5post` | `pickup_point` | **679** |
| `market_l4g` | `pickup_point` | 129 |
| `market_l4g` | `terminal` | 4 |

679 5post points and 129 Yandex ones arrive with the **same** `type: "pickup_point"`, so a
type-keyed lookup cannot tell two different branded networks apart. Only a per-point field
separates them.

## `??` here reaches the OPPOSITE conclusion from the close flag, on purpose

PR #192 established that an explicit `false` from the domain is a decision distinct from
"unspoken", so `??` must preserve it. **That reasoning does not transfer here.** An icon is
a URL: a blank string can never be rendered, so there is no meaningful "explicitly nothing,
distinct from absent" state. An empty `default` at any tier therefore falls through exactly
like an absent one.

`??` is still used rather than `||` so each tier resolves to a real object or `null` and
never to some other falsy value — and both docblocks say this explicitly, so the next reader
does not take it for a copy-paste of the close-flag reasoning.

## The confirmation path was the trap

`Pickup_Point::from_array()` is load-bearing: the domain selection filter's returned `point`
is rebuilt through it (fixed in s53, not accepted as-is). A field `from_array()` does not
know is silently dropped *exactly when the customer clicks select*. Covered by a test that
runs a domain payload through `Selection_Result::sanitize()` and asserts the escaped `icons`
survive.

Sanitisation mirrors `Pickup_Handler::normalized_point_icons()`: drop when `default` is
missing/empty/non-string, `active` falls back to `default` (D-5), raw in `to_array()` and
`esc_url_raw()` in `to_browser_array()` — with a post-escape recheck so a `javascript:` URL
that collapses to empty drops the whole override.

## Known consequence, documented not hidden

Co-located points are grouped and `_buildProperties()` draws the representative
(`displayPoints[0]`), so a group mixing a 5post and a Yandex point at one coordinate shows
the representative's icon. That follows from existing grouping rather than from this change.

## Consumer

The fixture's live Yandex source keys icons off `operator_id`, reusing the terminal pin
already shipped for the `POSTAMAT` tier rather than inventing artwork. Behind
`WOODEV_TEST_PICKUP_LIVE_YANDEX`, so the default rig path is untouched.

1469 unit / 707 jest, phpcs clean, PHPStan clean.

Closes #193
