### PR TITLE
ci: scan for secrets on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,51 @@ jobs:
         run: npm run test:js
 
   # ===========================================================================
+  # Поиск секретов в коде.
+  #
+  # Зачем, если у репозитория уже включены secret scanning и push protection:
+  # на БЕСПЛАТНОМ публичном репозитории GitHub сопоставляет только ПРОВАЙДЕРСКИЕ
+  # паттерны (AWS, Stripe, токены GitHub). Произвольные вендорские ключи ловит
+  # опция "non-provider patterns" — часть платного Secret Protection, её нет
+  # ни в UI, ни через API.
+  #
+  # Дыра не гипотетическая: в s55 в этот публичный репозиторий был закоммичен и
+  # запушен bearer-токен Яндекс.Доставки, и ничто этого не остановило.
+  # См. docs-internal/gotchas/public-repo-third-party-credentials.md.
+  #
+  # Джоба намеренно НЕ ставит зависимости: чем меньше в дереве чужого кода, тем
+  # меньше ложных срабатываний, а vendor/ и node_modules/ и так в allowlist.
+  # ===========================================================================
+  secrets:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # Бинарь напрямую, а не gitleaks-action: у официального экшена платная
+      # лицензия для организаций, и упереться в это на живом CI мы не хотим.
+      # Версия закреплена — та же, на которой конфиг проверен локально.
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o /tmp/gitleaks.tar.gz "$URL"
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          /tmp/gitleaks version
+
+      # `--no-git`: проверяем ДЕРЕВО, а не историю. Отвечает на вопрос «есть ли
+      # секрет в коде, который уедет в main», и не зависит от глубины клона.
+      # `--redact`: находка не должна печатать сам секрет в публичный лог сборки.
+      - name: Scan for secrets
+        run: /tmp/gitleaks detect --no-git --config .gitleaks.toml --redact --verbose
+
+  # ===========================================================================
   # Сборка JS-бандла и проверка паритета с закоммиченным woodev/assets/build/
   # Независимый job: node-сбой не должен маскировать PHP-матрицу
   # ===========================================================================
@@ -263,7 +308,7 @@ jobs:
     name: Publish Release v${{ needs.version.outputs.current }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [version, lint, unit-tests, test-js, assets]
+    needs: [version, lint, unit-tests, test-js, assets, secrets]
     permissions:
       contents: write
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,77 @@
+# Gitleaks configuration — secret scanning in CI.
+#
+# WHY THIS EXISTS. GitHub's own secret scanning is enabled on this repository, together with
+# push protection, but on a FREE PUBLIC repo it only matches PROVIDER patterns (AWS, Stripe,
+# GitHub tokens and the like). Matching arbitrary vendor tokens needs "non-provider patterns",
+# which is part of paid GitHub Secret Protection and is not available here — the toggle does
+# not exist in the UI and the API refuses to set it.
+#
+# That gap is not hypothetical: in s55 a Yandex.Delivery bearer token was committed and pushed
+# to this public repository, and nothing stopped it. See
+# docs-internal/gotchas/public-repo-third-party-credentials.md.
+#
+# This config is the free half of that protection — it runs on every pull request, so a leak
+# is caught before it reaches `main` rather than after.
+
+# Start from gitleaks' own maintained rule set and ADD to it, rather than replacing it: their
+# provider rules are broad, actively maintained, and we have no reason to re-litigate them.
+[extend]
+useDefault = true
+
+[[rules]]
+id = "yandex-b2b-oauth-token"
+description = "Yandex OAuth / B2B bearer token (y0_/y1_/y2_… prefix)"
+# The shape of the token that actually leaked: a `y` + digit + underscore prefix followed by a
+# long base64url body. Anchored on that prefix rather than on generic entropy, because an
+# entropy rule over this repository would fire on minified assets, class-map hashes and build
+# artefacts until someone silenced the whole job.
+regex = '''\by[0-9]_[A-Za-z0-9_-]{20,}'''
+keywords = ["y0_", "y1_", "y2_"]
+
+[[rules]]
+id = "cdek-oauth-client-secret"
+description = "CDEK API client_secret assigned inline"
+# The other carrier this framework targets authenticates with client_id/client_secret
+# (OAuth client_credentials). A secret belongs in a constant, never in a literal here.
+regex = '''(?i)client_secret['"\s]*[:=]['"\s]*[A-Za-z0-9]{20,}'''
+keywords = ["client_secret"]
+
+[allowlist]
+description = "Paths and values that are deliberately not secrets"
+
+# Every entry here is a path that is ALREADY gitignored, so nothing it hides could reach a
+# commit in the first place. They are listed because CI is not the only place this runs: a
+# local `gitleaks detect --no-git` walks the working directory, ignored paths included, and
+# without these a developer's first run returns ~18 findings — all of them phpstan.phar
+# internals and tool caches. A scanner whose first impression is noise is a scanner someone
+# switches off. Measured before writing this list, not guessed.
+paths = [
+  # Vendored reference plugins: third-party source, never shipped from this repo.
+  '''^plugins-reference/''',
+  # Build output and dependencies — nothing here is authored by us.
+  '''^woodev/assets/build/''',
+  '''^node_modules/''',
+  '''^vendor/''',
+  # Subagent git worktrees. Absent in CI; locally they carry a full copy of vendor/, whose
+  # phpstan.phar trips the generic-api-key rule on PHP function names like
+  # `sodium_crypto_aead_chacha20poly1305_decrypt`.
+  '''^\.claude/''',
+  # Serena's symbol cache. Note it genuinely DOES contain the token from the s55 incident —
+  # excluded because the cache is gitignored and rebuilt, not because it is uninteresting.
+  '''^\.serena/''',
+]
+
+# DELIBERATELY NOT EXCLUDED: `opencode.json`. A local `--no-git` run reports two findings in
+# it, and they are TRUE positives — the file holds a real Context7 API key. It is gitignored
+# and absent from CI's checkout, so it can never fail a build; silencing it here would instead
+# create a blind spot around an actual live credential, which is the opposite of the point.
+# Between that key and a `git add -A` there is exactly one line of .gitignore.
+
+regexes = [
+  # The obvious-placeholder token the fixture's own unit tests define. It authenticates with
+  # nothing; the test that uses it asserts the transport is never called.
+  '''dummy-token-for-tests''',
+  # The fixture's deliberately fake map key — it exists to prove the rig never needs a live
+  # ymaps script under PHPUnit.
+  '''FIXTURE-FAKE-YANDEX-KEY''',
+]


### PR DESCRIPTION
The free half of the protection GitHub cannot give this repository.

Secret scanning and push protection are enabled here, but on a **free public repo** they
match only **provider** patterns (AWS, Stripe, GitHub tokens). Arbitrary vendor keys need
"non-provider patterns" — part of paid GitHub Secret Protection. The toggle is absent from
the UI and the API refuses to set it.

The gap is not hypothetical: a Yandex.Delivery bearer token was committed and pushed to this
public repository earlier today, and nothing stopped it
(`docs-internal/gotchas/public-repo-third-party-credentials.md`).

## What it does

A `Secret scan` job runs gitleaks over the working tree on every PR, and is wired into
`release`'s `needs` so a leak cannot ship.

It runs the **pinned binary**, not `gitleaks-action`: the official action is licensed
per-organisation, and finding that out on live CI is not a good trade.

The config **extends** gitleaks' maintained rule set rather than replacing it, and adds two
rules for the carriers this framework actually integrates — the `y0_`/`y1_`/`y2_` Yandex
bearer shape that leaked, and an inline CDEK `client_secret`. Both anchor on their prefix
rather than on entropy: an entropy rule over this repo fires on minified assets and class-map
hashes until someone silences the whole job.

## Verified, not assumed

- A fixture carrying the real token shapes is **caught** (2 findings), while the dummy test
  token, the fixture's fake map key, and the constant-based read are **not**.
- A bare local run first returned **18** findings — all from gitignored tool caches and
  `phpstan.phar` internals (PHP function names like `sodium_crypto_aead_chacha20poly1305_decrypt`
  trip the generic rule). Those paths are now allowlisted, on the reasoning that a scanner
  whose first impression is noise is a scanner someone switches off.
- Scanning the **exact tracked-file tree CI checks out** (950 files) reports *no leaks* and
  exits 0 — so this ships green rather than red.

## One deliberate non-exclusion

`opencode.json` is **not** allowlisted. A local run flags it, and those are **true**
positives — it holds a real Context7 API key. It is gitignored and absent from CI, so it can
never fail a build; silencing it would instead create a blind spot around an actual live
credential. Between that key and a `git add -A` there is exactly one line of `.gitignore`.

Findings are `--redact`ed so a hit never prints the secret into a public build log.
