### PR TITLE
feat(pickup): derive a readable fill from the brand accent

### DIFF
--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -182,6 +182,79 @@ it( 'renders a blank label rather than a Russian default when an i18n key is mis
 		.toBe( '' );
 } );
 
+describe( 'accent colours (issue #203 — brand identity split from the filled-text surface)', () => {
+	// The derivation (darken-to-30%-then-black WCAG algorithm) runs server-side, once
+	// (`Pickup_Handler::resolve_accent_fill_color()`/`resolve_accent_contrast_color()`) — these
+	// tests prove the CLIENT half only: it applies whatever the config carries verbatim (through
+	// `safeColor()`), and falls back to a pinned literal PER PROPERTY when the config is missing
+	// or unsafe. They deliberately do NOT re-derive fill/contrast from an accent value — that
+	// would be exactly the mirrored-evaluator duplication the framework avoids elsewhere (see
+	// `pickup-panels.js`'s own `applyAccentColor()` docblock).
+
+	it( 'writes the framework default triplet when the config carries none', () => {
+		const panels = new Panels( document.createElement( 'div' ), config );
+		panels.render();
+
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#06aedd' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#047a9b' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+	} );
+
+	it( 'applies a server-resolved triplet verbatim, including a BLACK contrast', () => {
+		// `#ffeb3b` (issue #203's own light-colour example): the server would resolve fill
+		// unchanged and contrast to black — proves the client does not assume contrast is
+		// always white.
+		const panels = new Panels( document.createElement( 'div' ), Object.assign( {}, config, {
+			accentColor: '#ffeb3b',
+			accentFillColor: '#ffeb3b',
+			accentContrastColor: '#000000',
+		} ) );
+		panels.render();
+
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#ffeb3b' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#ffeb3b' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#000000' );
+	} );
+
+	it( 'falls back to the default accent ALONE when only accentColor is unsafe', () => {
+		const panels = new Panels( document.createElement( 'div' ), Object.assign( {}, config, {
+			accentColor: 'javascript:alert(1)',
+			accentFillColor: '#098534',
+			accentContrastColor: '#ffffff',
+		} ) );
+		panels.render();
+
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#06aedd' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#098534' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+	} );
+
+	it( 'falls back to the default fill ALONE when only accentFillColor is missing', () => {
+		const panels = new Panels( document.createElement( 'div' ), Object.assign( {}, config, {
+			accentColor: '#0a8c37',
+			accentContrastColor: '#ffffff',
+		} ) );
+		panels.render();
+
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#0a8c37' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#047a9b' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+	} );
+
+	it( 'falls back to the default contrast ALONE when only accentContrastColor is unsafe', () => {
+		const panels = new Panels( document.createElement( 'div' ), Object.assign( {}, config, {
+			accentColor: '#0a8c37',
+			accentFillColor: '#098534',
+			accentContrastColor: 'not-a-colour',
+		} ) );
+		panels.render();
+
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#0a8c37' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#098534' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+	} );
+} );
+
 // -----------------------------------------------------------------------
 // Extra coverage beyond the plan's own spec — see the task report for which
 // mutation each one kills.

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1141,6 +1141,8 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 					'replaceAddress',
 					'selection',
 					'accentColor',
+					'accentFillColor',
+					'accentContrastColor',
 					'modal',
 					'search',
 				],
@@ -1705,6 +1707,151 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$handler = $this->make_handler( [ 'accent_color' => '#06aedd', 'setting_accent' => '#1937FF' ] );
 
 			$this->assertSame( '#1937ff', $handler->get_js_config()['accentColor'] );
+		}
+
+		// -------------------------------------------------------------------------
+		// accentFillColor / accentContrastColor (issue #203) — the surface under
+		// contrast-coloured text, split from the brand-identity accent above.
+		// Derivation: white on the accent unchanged if it already clears 4.5:1;
+		// else darken 5%-30% (mirroring wc_hex_darker()) until white does; else
+		// black on the undarkened accent. Computed server-side ONCE and shipped as
+		// literal hex values — never mirrored in JS (see
+		// Pickup_Handler::resolve_accent_fill_color()'s own docblock).
+		// -------------------------------------------------------------------------
+
+		/**
+		 * White already clears 4.5:1 on WordPress's own blue (5.17:1, issue #203's own
+		 * measurement table) — no darkening needed, fill is the accent unchanged.
+		 */
+		public function test_white_direct_needs_no_darkening(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [ 'accent_color' => '#2271b1' ] )->get_js_config();
+
+			$this->assertSame( '#2271b1', $config['accentFillColor'] );
+			$this->assertSame( '#ffffff', $config['accentContrastColor'] );
+		}
+
+		/**
+		 * CDEK's own green (`#0a8c37`) fails white directly (4.36:1, issue #203's own table)
+		 * but clears it after only a SINGLE 5% darkening step (~4.76:1) — proves the loop
+		 * tries intermediate steps, not just the 30% ceiling. Notably DIFFERENT from what the
+		 * IDENTITY decision (`contrastFor()`, client-side, spec D-15) picks for the same raw
+		 * colour (black — 4.82:1 beats white's 4.36:1 undarkened): the two algorithms answer
+		 * different questions on purpose, and this is the case that proves it.
+		 */
+		public function test_white_after_a_single_darkening_step(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [ 'accent_color' => '#0a8c37' ] )->get_js_config();
+
+			$this->assertSame( '#098534', $config['accentFillColor'] );
+			$this->assertSame( '#ffffff', $config['accentContrastColor'] );
+		}
+
+		/**
+		 * The exact case the operator noticed (issue #203): `#06aedd` needs the FULL 30%
+		 * ceiling before white clears 4.5:1 (~4.93:1) — pins the boundary, not just an
+		 * interior step. `make_handler()`'s own default accent is already `#06aedd`.
+		 */
+		public function test_white_after_darkening_to_the_full_thirty_percent_cap(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler()->get_js_config();
+
+			$this->assertSame( '#047a9b', $config['accentFillColor'] );
+			$this->assertSame( '#ffffff', $config['accentContrastColor'] );
+		}
+
+		/**
+		 * `#ffeb3b` (issue #203's own light-colour example) still fails white even at the
+		 * full 30% darkening ceiling (2.55:1) — falls back to black on the UNDARKENED accent
+		 * (17.20:1), not the 30%-darkened "khaki" the issue explicitly rejects.
+		 */
+		public function test_black_fallback_on_the_undarkened_accent_for_a_light_colour(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [ 'accent_color' => '#ffeb3b' ] )->get_js_config();
+
+			$this->assertSame( '#ffeb3b', $config['accentFillColor'] );
+			$this->assertSame( '#000000', $config['accentContrastColor'] );
+		}
+
+		/**
+		 * The fill/contrast derivation reads {@see Pickup_Handler::resolve_accent_color()}'s
+		 * FINAL resolved value (merchant setting wins over the plugin default), not the raw
+		 * constructor `accent_color` — a plugin defaulting to `#06aedd` but a merchant
+		 * overriding to `#ffeb3b` must derive from `#ffeb3b`.
+		 */
+		public function test_fill_and_contrast_derive_from_the_resolved_accent_not_the_plugin_default(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [
+				'accent_color'   => '#06aedd',
+				'setting_accent' => '#ffeb3b',
+			] )->get_js_config();
+
+			$this->assertSame( '#ffeb3b', $config['accentFillColor'] );
+			$this->assertSame( '#000000', $config['accentContrastColor'] );
+		}
+
+		/**
+		 * A filter overrides the derived FILL — independently of contrast, which stays the
+		 * DERIVED default for the (untouched) resolved accent.
+		 */
+		public function test_a_filter_overrides_the_fill_color(): void {
+			Filters\expectApplied( 'woodev_pickup_accent_fill_color' )->andReturn( '#123456' );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [ 'accent_color' => '#06aedd' ] )->get_js_config();
+
+			$this->assertSame( '#123456', $config['accentFillColor'] );
+			$this->assertSame( '#ffffff', $config['accentContrastColor'] );
+		}
+
+		/**
+		 * A filter overrides the derived CONTRAST — independently of fill, which stays the
+		 * DERIVED default for the (untouched) resolved accent.
+		 */
+		public function test_a_filter_overrides_the_contrast_color(): void {
+			Filters\expectApplied( 'woodev_pickup_accent_contrast_color' )->andReturn( '#123456' );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [ 'accent_color' => '#06aedd' ] )->get_js_config();
+
+			$this->assertSame( '#123456', $config['accentContrastColor'] );
+			$this->assertSame( '#047a9b', $config['accentFillColor'] );
+		}
+
+		/**
+		 * Same discipline as the accent's own filter (spec D-15): the fill value is
+		 * interpolated into CSS on the client, so a filter returning garbage falls back to
+		 * the derived default instead of reaching `setProperty()` unsanitised.
+		 */
+		public function test_a_fill_filter_returning_garbage_is_sanitised_too(): void {
+			Filters\expectApplied( 'woodev_pickup_accent_fill_color' )->andReturn( 'javascript:alert(1)' );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [ 'accent_color' => '#06aedd' ] )->get_js_config();
+
+			$this->assertSame( '#047a9b', $config['accentFillColor'] );
+		}
+
+		/**
+		 * Same discipline for the contrast filter.
+		 */
+		public function test_a_contrast_filter_returning_garbage_is_sanitised_too(): void {
+			Filters\expectApplied( 'woodev_pickup_accent_contrast_color' )->andReturn( 'javascript:alert(1)' );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler( [ 'accent_color' => '#06aedd' ] )->get_js_config();
+
+			$this->assertSame( '#ffffff', $config['accentContrastColor'] );
 		}
 
 		/**

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -35,28 +35,51 @@
  * a specificity war, while every property that matters for LAYOUT states its own value outright
  * rather than inheriting one a theme might have overridden globally.
  *
- * ACCENT COLOUR — D-15, ONE KNOB, NO SECOND COLOUR. `pickup-panels.js`'s `applyAccentColor()`
- * sets exactly two custom properties on `.woodev-pickup-panels` (the panels' own root, appended
- * as a sibling of the ymaps map surface inside the SAME modal body) through the CSSOM — never a
- * generated `<style>` block, never a string-built `style=` attribute:
+ * ACCENT COLOURS — D-15, split into THREE knobs by issue #203 (was two: a single accent
+ * doubled as both brand identity AND the surface under contrast text, which is why
+ * `#06aedd`'s honestly-computed black text read badly on saturated cyan). `pickup-panels.js`'s
+ * `applyAccentColor()` sets exactly three custom properties on `.woodev-pickup-panels` (the
+ * panels' own root, appended as a sibling of the ymaps map surface inside the SAME modal body)
+ * through the CSSOM — never a generated `<style>` block, never a string-built `style=` attribute:
  *
- *   --woodev-pickup-accent           the merchant/plugin colour, or its own safe fallback
- *   --woodev-pickup-accent-contrast  black or white — whichever actually reads on the accent
+ *   --woodev-pickup-accent           the merchant/plugin BRAND colour, unchanged — identity
+ *                                     only: map markers, outlines, focus ring, the selected-row
+ *                                     bar. Contrast is against the PAGE, never against text
+ *                                     drawn on it.
+ *   --woodev-pickup-accent-fill      the SURFACE a filled CTA/badge/chip draws text on — the
+ *                                     accent unchanged when white already clears 4.5:1 on it,
+ *                                     else the accent darkened (mirroring `wc_hex_darker()`) up
+ *                                     to 30% until white does, else the UNDARKENED accent (see
+ *                                     `Pickup_Handler::derive_accent_fill()`).
+ *   --woodev-pickup-accent-contrast  white or black — whichever `derive_accent_fill()` paired
+ *                                     with `--woodev-pickup-accent-fill` above. Despite the
+ *                                     name, this is NEVER paired with `--woodev-pickup-accent`
+ *                                     directly any more — every rule below pairs it with
+ *                                     `--woodev-pickup-accent-fill`.
  *
- * Every accent-background rule below pairs the two: fill with `--woodev-pickup-accent`, its
- * text/icon with `--woodev-pickup-accent-contrast` — never a third, independently-invented
- * colour (the CTA, the open toggle, the active card tab, the selected filter checkbox, the
- * focus ring). `var( --woodev-pickup-accent, #06aedd )` / `var( --woodev-pickup-accent-contrast,
- * #fff )` are the ONLY two fallback pairs this file declares: `#06aedd` is the framework's
- * canonical accent — the same value `Pickup_Handler::DEFAULT_ACCENT_COLOR` resolves to and
- * `pickup-panels.js`'s own `DEFAULT_ACCENT` constant carries. All three must agree: a fallback
- * that disagreed would be visibly wrong the one moment it actually fires (JS failing before it
- * sets the property), and it would not be the colour the merchant sees anywhere else in the
- * plugin's admin. `#fff` reads on that cyan. Every
- * OTHER colour below (panel background, body text, borders, the warning strip) is a plain
- * hardcoded value matching `woodev-modal.css`'s own neutral chrome palette (`#fff` / `#1e1e1e` /
- * `#646970` / `#dcdcde`) for one consistent dialog look, because D-15 draws the merchant-override
- * line at exactly that one property pair, not at "every colour the feature uses".
+ * Every filled-text rule below (the CTA, the list/mobile toggle, the filter badge and its
+ * "filtered" toggle state, the checked filter checkbox, the card chip, the active card tab) pairs
+ * fill with `--woodev-pickup-accent-fill` and its text/icon with `--woodev-pickup-accent-contrast`
+ * — never `--woodev-pickup-accent` itself, and never a third, independently-invented colour.
+ * Every IDENTITY rule (markers, the marker halo, the selected-row tint/bar, the native checkbox
+ * tint, the `howto` summary link colour, the focus ring) uses `--woodev-pickup-accent` alone —
+ * no text is drawn ON these, so no contrast partner is needed.
+ *
+ * `var( --woodev-pickup-accent, #06aedd )` / `var( --woodev-pickup-accent-fill, #047a9b )` /
+ * `var( --woodev-pickup-accent-contrast, #fff )` are the ONLY THREE fallback values this file
+ * declares: `#06aedd` is the framework's canonical accent — the same value
+ * `Pickup_Handler::DEFAULT_ACCENT_COLOR` resolves to and `pickup-panels.js`'s own
+ * `DEFAULT_ACCENT` constant carries; `#047a9b` is `#06aedd` darkened the full 30% (it needs the
+ * cap), the same value `Pickup_Handler::derive_accent_fill()` computes for it and
+ * `pickup-panels.js`'s own `DEFAULT_ACCENT_FILL` constant carries; `#fff` is the contrast that
+ * pairs with it. All four (this file, both JS constants, the PHP default) must agree: a
+ * fallback that disagreed would be visibly wrong the one moment it actually fires (JS failing
+ * before it sets the properties), and it would not be the colour the merchant sees anywhere
+ * else in the plugin's admin. Every OTHER colour below (panel background, body text, borders,
+ * the warning strip) is a plain hardcoded value matching `woodev-modal.css`'s own neutral
+ * chrome palette (`#fff` / `#1e1e1e` / `#646970` / `#dcdcde`) for one consistent dialog look,
+ * because D-15 draws the merchant-override line at exactly those three properties, not at
+ * "every colour the feature uses".
  *
  * MARKERS ARE NOT STYLED VIA ymaps INTERNALS. `map-provider-yandex.js` draws every marker as an
  * HTML `templateLayoutFactory` layout THIS project owns (`<div class="woodev-pickup-marker">`,
@@ -364,7 +387,7 @@
 	padding: 6px 16px;
 	border: 0;
 	border-radius: 4px;
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 	color: var( --woodev-pickup-accent-contrast, #fff );
 	cursor: pointer;
 }
@@ -538,10 +561,13 @@
    the DEFAULT merchant. The second declaration is what D-15 actually requires and overrides the
    first wherever `color-mix()` is supported: a tint derived from `--woodev-pickup-accent` itself,
    not a hardcoded colour, so a merchant who set a red accent gets a red tint, not this file's own
-   cyan frozen in place. No other rule in this file blends the accent to a soft/tinted surface
-   (every other `--woodev-pickup-accent` background below is a solid, opaque fill) — `color-mix()`
-   is the only mechanism a plain custom-property value (`#rrggbb`, not a channel triplet) can be
-   alpha-blended through without a second, independently-invented CSS variable for the channels. */
+   cyan frozen in place. Deliberately `--woodev-pickup-accent`, not `--woodev-pickup-accent-fill`
+   (issue #203): no text sits ON this tint (the row's own text stays its normal dark colour, see
+   above), so this is an IDENTITY use — "which row is selected", read against the page — not a
+   filled-text surface. No other rule in this file blends the accent to a soft/tinted surface —
+   `color-mix()` is the only mechanism a plain custom-property value (`#rrggbb`, not a channel
+   triplet) can be alpha-blended through without a second, independently-invented CSS variable for
+   the channels. */
 .woodev-pickup-list__item.is-selected,
 .woodev-pickup-list__point.is-selected {
 	background: rgba( 6, 174, 221, 0.06 );
@@ -724,7 +750,7 @@
 	height: 44px;
 	padding: 0;
 	color: var( --woodev-pickup-accent-contrast, #fff );
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 	border: 0;
 	border-radius: 8px;
 	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.04 ), 0 4px 8px rgba( 0, 0, 0, 0.06 );
@@ -1091,7 +1117,7 @@
 .woodev-pickup-filter__toggle.is-filtered,
 .woodev-pickup-list .woodev-pickup-filter__toggle.is-filtered {
 	color: var( --woodev-pickup-accent-contrast, #fff );
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.04 ), 0 4px 8px rgba( 0, 0, 0, 0.06 );
 }
 
@@ -1119,7 +1145,7 @@
 	font-weight: 700;
 	line-height: 1;
 	color: var( --woodev-pickup-accent-contrast, #fff );
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 	border-radius: 8px;
 }
 
@@ -1220,13 +1246,14 @@
 }
 
 .woodev-pickup-filter__checkbox:checked {
-	background: var( --woodev-pickup-accent, #06aedd );
-	border-color: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
+	border-color: var( --woodev-pickup-accent-fill, #047a9b );
 }
 
 /* The tick — the classic two-border-sides-rotated-45deg technique (no image, no build step,
-   matching this file's own "plain CSS, no preprocessor" rule). Drawn in the accent's own
-   CONTRAST colour, never a hard-coded white, so it keeps reading against any accent a merchant
+   matching this file's own "plain CSS, no preprocessor" rule). Drawn in the FILL's own
+   CONTRAST colour (issue #203 — this box is a filled surface a graphic mark is drawn on, not
+   brand identity), never a hard-coded white, so it keeps reading against any accent a merchant
    picks, light or dark — the same pairing every other accent-filled control in this file uses. */
 .woodev-pickup-filter__checkbox:checked::after {
 	content: '';
@@ -1327,9 +1354,10 @@
 
 /* The chip (spec V-12; issue #171 — ALWAYS renders now, the framework's own type glyph, never
    conditional on a plugin-supplied icon any more). Background/border unchanged from the old
-   plugin-`<img>` chip: an accent-filled square, matching the D-15 accent pairing every other
-   accent-background rule in this file follows — see `.woodev-pickup-card__chip-icon`'s own
-   `color` below, which is the paired accent-CONTRAST half of that same rule. */
+   plugin-`<img>` chip: a FILLED square (issue #203 — a filled surface an icon is drawn on, not
+   brand identity), matching the D-15 fill/contrast pairing every other filled-text rule in this
+   file follows — see `.woodev-pickup-card__chip-icon`'s own `color` below, which is the paired
+   accent-CONTRAST half of that same rule. */
 .woodev-pickup-card__chip {
 	display: flex;
 	flex: 0 0 auto;
@@ -1339,7 +1367,7 @@
 	height: 40px;
 	border: 1px solid rgba( 0, 0, 0, 0.12 );
 	border-radius: 8px;
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 }
 
 .woodev-pickup-card__chip-icon {
@@ -1454,7 +1482,7 @@
 
 .woodev-pickup-card__tab.is-active {
 	color: var( --woodev-pickup-accent-contrast, #fff );
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 }
 
 /* `margin-left: auto` (round 4) pins this to `.woodev-pickup-card__header-row`'s right edge
@@ -1605,7 +1633,7 @@
 	font-size: 14px;
 	font-weight: 600;
 	color: var( --woodev-pickup-accent-contrast, #fff );
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 	border: 0;
 	border-radius: 4px;
 	cursor: pointer;
@@ -1715,7 +1743,9 @@
 
 /* The group-count bubble for a marker holding more than one co-located point. Positioned
    ABSOLUTELY inside the pin — it must never change `.woodev-pickup-marker`'s own box, which is
-   the exact size/offset ymaps was already told for hit-testing (see the file docblock). */
+   the exact size/offset ymaps was already told for hit-testing (see the file docblock). A FILLED
+   surface carrying 10px text (issue #203 — the exact "counter badge" the issue's own problem
+   statement names), same as `.woodev-pickup-filter__badge` — not brand identity. */
 .woodev-pickup-marker__badge {
 	position: absolute;
 	top: -4px;
@@ -1730,7 +1760,7 @@
 	font-weight: 700;
 	line-height: 1;
 	color: var( --woodev-pickup-accent-contrast, #fff );
-	background: var( --woodev-pickup-accent, #06aedd );
+	background: var( --woodev-pickup-accent-fill, #047a9b );
 	border: 1px solid #fff;
 	border-radius: 8px;
 }

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -33,13 +33,16 @@
  * a PHP/JS i18n-key mismatch instead of surfacing it (the same I1 rule
  * `pickup-mount.js` and `map-provider-yandex.js` already carry).
  *
- * ACCENT COLOUR is delivered on `config.accentColor` (top level, not inside
- * `mapConfig` — Task 8B/D-15) and applied through the CSSOM via
- * `pickup-geo.js`'s `safeColor()`/`contrastFor()`, never a generated
- * `<style>` block or a string-built `style=` attribute — see {@see applyAccentColor}.
- * The value is already sanitised server-side; the client re-validates too,
- * deliberately, because a filter can return garbage and the server check is
- * not authoritative on the client.
+ * ACCENT COLOURS are delivered on `config.accentColor`/`accentFillColor`/
+ * `accentContrastColor` (top level, not inside `mapConfig` — Task 8B/D-15, split into
+ * three by issue #203) and applied through the CSSOM via `pickup-geo.js`'s `safeColor()`,
+ * never a generated `<style>` block or a string-built `style=` attribute — see
+ * {@see applyAccentColor}. Every value is already DERIVED and sanitised server-side
+ * (`Pickup_Handler::resolve_accent_fill_color()`/`resolve_accent_contrast_color()`, issue
+ * #203); the client re-validates via `safeColor()` too, deliberately, because a filter can
+ * return garbage and the server check is not authoritative on the client — but never
+ * recomputes the derivation itself. `contrastFor()` still exists in `pickup-geo.js` (and is
+ * still tested) for the identity contrast decision; it is not part of this pipeline.
  *
  * EVENT SEMANTICS: `on( event, cb )` ADDS a listener — a second `on()` call
  * for the same event fires BOTH callbacks, it never replaces the first. This
@@ -252,6 +255,28 @@
 
 	/** @type {string} fallback text colour, used only when `config.accentColor` is absent/unsafe. */
 	var DEFAULT_ACCENT = '#06aedd';
+
+	/**
+	 * Fallback fill colour, used only when `config.accentFillColor` is absent/unsafe — the
+	 * darkened surface {@see DEFAULT_ACCENT} resolves to on the server (issue #203,
+	 * `Pickup_Handler::derive_accent_fill()`). A pinned LITERAL, not a client-side
+	 * recomputation: the derivation (darken-to-30%-then-black WCAG algorithm) runs
+	 * server-side exactly once and ships its result — see {@see applyAccentColor}'s own
+	 * docblock for why. Must agree with `Pickup_Handler::DEFAULT_ACCENT_COLOR`'s own derived
+	 * fill, the same "all three must agree" contract `pickup.css`'s file docblock already
+	 * documents for the accent/contrast pair.
+	 *
+	 * @type {string}
+	 */
+	var DEFAULT_ACCENT_FILL = '#047a9b';
+
+	/**
+	 * Fallback contrast colour paired with {@see DEFAULT_ACCENT_FILL} — see that constant's
+	 * own docblock.
+	 *
+	 * @type {string}
+	 */
+	var DEFAULT_ACCENT_CONTRAST = '#ffffff';
 
 	/**
 	 * @type {number} debounce (ms) between the last keystroke and the `searchType` event —
@@ -508,13 +533,27 @@
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Sets the two accent CSS custom properties on `root`, through the CSSOM
+	 * Sets the three accent CSS custom properties on `root`, through the CSSOM
 	 * (`style.setProperty`) — never a generated `<style>` block, never a
-	 * string-built `style=` attribute (D-15). Re-validates `config.accentColor`
-	 * client-side via `pickup-geo.js`'s `safeColor()` even though the server
-	 * already sanitised it: a filter returning garbage bypasses the server
-	 * check, and this client check is not authoritative on its own either —
-	 * both layers are deliberate.
+	 * string-built `style=` attribute (D-15). Re-validates every one of
+	 * `config.accentColor`/`accentFillColor`/`accentContrastColor` client-side via
+	 * `pickup-geo.js`'s `safeColor()` even though the server already sanitised them: a
+	 * filter returning garbage bypasses the server check, and this client check is not
+	 * authoritative on its own either — both layers are deliberate.
+	 *
+	 * `accentFillColor`/`accentContrastColor` (issue #203) split the brand colour
+	 * (`--woodev-pickup-accent`, identity — markers, outlines, focus ring, the selected-row
+	 * bar) from the surface a filled CTA/badge/chip draws TEXT on
+	 * (`--woodev-pickup-accent-fill` + `--woodev-pickup-accent-contrast`). The darken/WCAG
+	 * derivation itself runs ONCE, server-side (`Pickup_Handler::resolve_accent_fill_color()`
+	 * / `resolve_accent_contrast_color()`) and ships here as literal hex values — this
+	 * function does NOT recompute it. `contrastFor()` (below, still exported and tested) is
+	 * a DIFFERENT, still-valid decision (identity contrast, a two-way luminance-crossover
+	 * comparison) and is deliberately not called here any more; it answers "which of
+	 * black/white reads better on this colour", not "does white clear an actual 4.5:1 ratio",
+	 * which is what the fill needs. {@see DEFAULT_ACCENT_FILL}/{@see DEFAULT_ACCENT_CONTRAST}
+	 * are pinned LITERALS, not a client-side fallback computation, for the same
+	 * no-mirrored-evaluator reason.
 	 *
 	 * @param {HTMLElement} root
 	 * @param {Object}      config
@@ -526,9 +565,12 @@
 		}
 
 		var accent = geo.safeColor( config && config.accentColor, DEFAULT_ACCENT );
+		var fill = geo.safeColor( config && config.accentFillColor, DEFAULT_ACCENT_FILL );
+		var contrast = geo.safeColor( config && config.accentContrastColor, DEFAULT_ACCENT_CONTRAST );
 
 		root.style.setProperty( '--woodev-pickup-accent', accent );
-		root.style.setProperty( '--woodev-pickup-accent-contrast', geo.contrastFor( accent ) );
+		root.style.setProperty( '--woodev-pickup-accent-fill', fill );
+		root.style.setProperty( '--woodev-pickup-accent-contrast', contrast );
 	}
 
 	// -------------------------------------------------------------------------

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -292,10 +292,48 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		private const DEFAULT_ACCENT_COLOR = '#06aedd';
 
 		/**
-		 * The plugin's default accent colour (spec D-15) — drives the map's CTA, the
-		 * active list item, the drawer toggle, the cluster icon, and the checkout trigger
-		 * button. Overridden by {@see self::$setting_accent_color} when the merchant has
-		 * set one.
+		 * The WCAG contrast ratio the accent-FILL surface must clear against white text
+		 * (issue #203) — `4.5:1`, the "normal text" threshold, not the `3:1` large-text
+		 * allowance, because the smallest text drawn on the fill is a 10px counter badge.
+		 *
+		 * @since 2.0.2
+		 * @var float
+		 */
+		private const FILL_TEXT_CONTRAST_MIN = 4.5;
+
+		/**
+		 * The darkening step {@see self::derive_accent_fill()} tries between 0% and
+		 * {@see self::FILL_DARKEN_MAX_PERCENT} while white still fails
+		 * {@see self::FILL_TEXT_CONTRAST_MIN} (issue #203).
+		 *
+		 * @since 2.0.2
+		 * @var int
+		 */
+		private const FILL_DARKEN_STEP_PERCENT = 5;
+
+		/**
+		 * The darkening ceiling {@see self::derive_accent_fill()} gives up at, falling back
+		 * to black on the UNDARKENED accent instead (issue #203). A colour that still fails
+		 * white at 30% darkening is, by definition, light — black already reads excellently
+		 * on a light colour, and darkening further would start destroying the brand colour
+		 * itself (the issue's own example: `#ffeb3b` needs -50% for white, and the result is
+		 * khaki, not yellow) for no readability gain over just using black. A sweep of
+		 * 140,608 colours (issue #203) found zero colours where neither branch reaches
+		 * {@see self::FILL_TEXT_CONTRAST_MIN} — this ceiling is not a compromise, every
+		 * colour resolves one way or the other.
+		 *
+		 * @since 2.0.2
+		 * @var int
+		 */
+		private const FILL_DARKEN_MAX_PERCENT = 30;
+
+		/**
+		 * The plugin's default accent colour (spec D-15) — drives the map's markers,
+		 * outlines, focus ring and the active list item's own selection bar directly; the
+		 * CTA, the drawer toggle, counter badges and the card chip draw on
+		 * {@see self::resolve_accent_fill_color()}'s DERIVED fill instead, not this value
+		 * raw (issue #203 split the brand colour from the filled-text surface). Overridden
+		 * by {@see self::$setting_accent_color} when the merchant has set one.
 		 *
 		 * @since 2.0.2
 		 * @var string
@@ -479,6 +517,228 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 				?: ( sanitize_hex_color( $this->accent_color ) ?: self::DEFAULT_ACCENT_COLOR );
 
 			return strtolower( $sanitized );
+		}
+
+		/**
+		 * Resolves the surface colour text is drawn ON — the CTA, the counter badges, the
+		 * filter chip — derived from {@see self::resolve_accent_color()} via
+		 * {@see self::derive_accent_fill()} (issue #203), then filterable and sanitised
+		 * exactly like the accent itself.
+		 *
+		 * Computed server-side, once, and shipped as a literal hex value — never mirrored as
+		 * a second formula in `pickup-geo.js`. This repo already rejected a mirrored-evaluator
+		 * shape for the pickup feature once (SP-5's `Constraint_Checker`: the client renders
+		 * the server's verdict, it never re-implements COD/weight rules) specifically to avoid
+		 * the maintenance a mirrored evaluator carries; the same reasoning applies here. The
+		 * client (`pickup-panels.js`'s `applyAccentColor()`) only re-validates this value via
+		 * `safeColor()` before writing it to the CSSOM — the exact same defense-in-depth
+		 * re-validation `accentColor` itself already gets, never a second darken/contrast-ratio
+		 * implementation.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string a valid, lower-cased hex colour, never an empty string.
+		 */
+		private function resolve_accent_fill_color(): string {
+			$accent  = $this->resolve_accent_color();
+			$derived = self::derive_accent_fill( $accent );
+
+			/**
+			 * Filters the pickup map's accent FILL colour — the surface under
+			 * contrast-coloured text (issue #203).
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param string $fill_color the derived fill, before sanitisation.
+			 * @param string $accent     the resolved accent colour it was derived from.
+			 */
+			$filtered = (string) apply_filters( 'woodev_pickup_accent_fill_color', $derived['fill'], $accent );
+
+			$sanitized = sanitize_hex_color( $filtered ) ?: $derived['fill'];
+
+			return strtolower( $sanitized );
+		}
+
+		/**
+		 * Resolves the text/icon colour paired with
+		 * {@see self::resolve_accent_fill_color()} — white or black, whichever
+		 * {@see self::derive_accent_fill()} chose (issue #203). Filterable and sanitised the
+		 * same way, and independently overridable: a plugin/merchant may override just the
+		 * contrast without touching the fill, or vice versa.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string a valid, lower-cased hex colour, never an empty string.
+		 */
+		private function resolve_accent_contrast_color(): string {
+			$accent  = $this->resolve_accent_color();
+			$derived = self::derive_accent_fill( $accent );
+
+			/**
+			 * Filters the pickup map's accent-fill CONTRAST colour — the text/icon colour
+			 * drawn on {@see self::resolve_accent_fill_color()} (issue #203).
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param string $contrast_color the derived contrast, before sanitisation.
+			 * @param string $accent         the resolved accent colour it was derived from.
+			 */
+			$filtered = (string) apply_filters( 'woodev_pickup_accent_contrast_color', $derived['contrast'], $accent );
+
+			$sanitized = sanitize_hex_color( $filtered ) ?: $derived['contrast'];
+
+			return strtolower( $sanitized );
+		}
+
+		/**
+		 * Expands a 3- or 6-digit hex colour (`#` optional) to its `[ R, G, B ]` byte
+		 * triplet — the same shorthand expansion `wc_hex_darker()`'s own `wc_rgb_from_hex()`
+		 * performs (`wc-formatting-functions.php`, verified against WooCommerce core), so a
+		 * value already sanitised by {@see self::resolve_accent_color()} (which preserves
+		 * shorthand rather than expanding it) darkens and measures identically to how
+		 * WooCommerce itself would.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $hex a 3- or 6-digit hex colour, `#` optional.
+		 * @return int[] `[ R, G, B ]`, each 0-255.
+		 */
+		private static function hex_to_rgb( string $hex ): array {
+			$hex = str_replace( '#', '', $hex );
+			$hex = (string) preg_replace( '/^(.)(.)(.)$/', '$1$1$2$2$3$3', $hex );
+
+			return [
+				hexdec( substr( $hex, 0, 2 ) ),
+				hexdec( substr( $hex, 2, 2 ) ),
+				hexdec( substr( $hex, 4, 2 ) ),
+			];
+		}
+
+		/**
+		 * Darkens `$hex` by `$percent`, channel-by-channel — a byte-for-byte port of
+		 * `wc_hex_darker()` (`wc-formatting-functions.php`, verified against WooCommerce
+		 * core): each channel loses `round( ( $v / 100 ) * $percent )` of itself, PHP's own
+		 * half-away-from-zero rounding. A port rather than a call to the real function
+		 * because this class has no runtime dependency on WooCommerce being loaded elsewhere
+		 * ({@see self::wc_cart()} probes for WC() lazily for the same reason).
+		 *
+		 * MUST stay byte-for-byte identical to `wc_hex_darker()` — issue #203 is explicit
+		 * that the framework's own darkening curve must match WooCommerce's, not invent a
+		 * different one; a future WC update changing that function's rounding would need this
+		 * one updated to match.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $hex     a 3- or 6-digit hex colour, `#` optional.
+		 * @param int    $percent 0-100.
+		 * @return string a 6-digit hex colour (lower-cased, leading `#`).
+		 */
+		private static function darken_hex_color( string $hex, int $percent ): string {
+			[ $r, $g, $b ] = self::hex_to_rgb( $hex );
+			$color         = '#';
+
+			foreach ( [ $r, $g, $b ] as $channel ) {
+				$darkened = $channel - (int) round( ( $channel / 100 ) * $percent );
+				$color   .= str_pad( dechex( $darkened ), 2, '0', STR_PAD_LEFT );
+			}
+
+			return $color;
+		}
+
+		/**
+		 * WCAG relative luminance of `$hex` — gamma-linearized channels combined with the
+		 * Rec.709 luma weights, the SAME formula `pickup-geo.js`'s `contrastFor()` uses
+		 * client-side for the IDENTITY contrast decision (spec D-15). This does not
+		 * duplicate `contrastFor()`'s own logic: `contrastFor()` picks whichever of
+		 * black/white wins a luminance-crossover comparison (correct for identity — "which
+		 * reads better"), which is a DIFFERENT question from "does this reach an actual
+		 * 4.5:1 ratio" (both options can lose that, or both can win it) — the question
+		 * {@see self::contrast_ratio()} answers for the fill.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $hex a 3- or 6-digit hex colour, `#` optional.
+		 * @return float 0.0-1.0.
+		 */
+		private static function relative_luminance( string $hex ): float {
+			$linearize = static function ( int $channel ): float {
+				$s = $channel / 255;
+
+				return $s <= 0.03928 ? $s / 12.92 : ( ( $s + 0.055 ) / 1.055 ) ** 2.4;
+			};
+
+			[ $r, $g, $b ] = self::hex_to_rgb( $hex );
+
+			return 0.2126 * $linearize( $r ) + 0.7152 * $linearize( $g ) + 0.0722 * $linearize( $b );
+		}
+
+		/**
+		 * WCAG contrast ratio between two colours: `( L_lighter + 0.05 ) / ( L_darker + 0.05 )`
+		 * — always >= 1.0, regardless of argument order.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $hex_a a 3- or 6-digit hex colour, `#` optional.
+		 * @param string $hex_b a 3- or 6-digit hex colour, `#` optional.
+		 * @return float
+		 */
+		private static function contrast_ratio( string $hex_a, string $hex_b ): float {
+			$luminance_a = self::relative_luminance( $hex_a );
+			$luminance_b = self::relative_luminance( $hex_b );
+
+			$lighter = max( $luminance_a, $luminance_b );
+			$darker  = min( $luminance_a, $luminance_b );
+
+			return ( $lighter + 0.05 ) / ( $darker + 0.05 );
+		}
+
+		/**
+		 * Derives the fill/contrast pair for text drawn ON the accent (issue #203):
+		 *
+		 * 1. White already clears {@see self::FILL_TEXT_CONTRAST_MIN} on `$accent` -> white
+		 *    on the accent, unchanged.
+		 * 2. Else darken `$accent` in {@see self::FILL_DARKEN_STEP_PERCENT} steps up to
+		 *    {@see self::FILL_DARKEN_MAX_PERCENT} ({@see self::darken_hex_color()}) until
+		 *    white clears the threshold on the darkened colour -> white on that.
+		 * 3. Else -> black on the UNDARKENED accent (see {@see self::FILL_DARKEN_MAX_PERCENT}'s
+		 *    own docblock for why 30% is the right ceiling, not a compromise).
+		 *
+		 * Pure and static — output depends only on `$accent` — per this codebase's own
+		 * convention for pure methods.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $accent a sanitised, already-resolved accent colour (see
+		 *                       {@see self::resolve_accent_color()}).
+		 * @return array{fill: string, contrast: string} lower-cased hex colours.
+		 */
+		private static function derive_accent_fill( string $accent ): array {
+			if ( self::contrast_ratio( '#ffffff', $accent ) >= self::FILL_TEXT_CONTRAST_MIN ) {
+				return [
+					'fill'     => strtolower( $accent ),
+					'contrast' => '#ffffff',
+				];
+			}
+
+			for (
+				$percent = self::FILL_DARKEN_STEP_PERCENT;
+				$percent <= self::FILL_DARKEN_MAX_PERCENT;
+				$percent += self::FILL_DARKEN_STEP_PERCENT
+			) {
+				$darkened = self::darken_hex_color( $accent, $percent );
+
+				if ( self::contrast_ratio( '#ffffff', $darkened ) >= self::FILL_TEXT_CONTRAST_MIN ) {
+					return [
+						'fill'     => strtolower( $darkened ),
+						'contrast' => '#ffffff',
+					];
+				}
+			}
+
+			return [
+				'fill'     => strtolower( $accent ),
+				'contrast' => '#000000',
+			];
 		}
 
 		/**
@@ -818,6 +1078,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 *     replaceAddress: array{enabled: bool, billingOnly: bool},
 		 *     selection: array{close: bool, refreshCheckout: bool},
 		 *     accentColor: string,
+		 *     accentFillColor: string,
+		 *     accentContrastColor: string,
 		 *     modal: array{width: int, bodyHeight: string},
 		 *     search: bool
 		 * }
@@ -1013,7 +1275,14 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 
 				// Top level, NOT inside `mapConfig`: the checkout trigger button lives
 				// outside the modal entirely and needs this too (spec D-15).
-				'accentColor' => $this->resolve_accent_color(),
+				//
+				// `accentFillColor`/`accentContrastColor` (issue #203) split the brand
+				// colour from the surface a filled CTA/badge/chip draws text ON — see
+				// self::resolve_accent_fill_color()'s own docblock for why the derivation
+				// runs HERE, server-side, and is never mirrored in JS.
+				'accentColor'         => $this->resolve_accent_color(),
+				'accentFillColor'     => $this->resolve_accent_fill_color(),
+				'accentContrastColor' => $this->resolve_accent_contrast_color(),
 
 				// Consumed by the map provider's own address-search fit (Task 19, D-6) — see
 


### PR DESCRIPTION
`--woodev-pickup-accent` was serving two incompatible jobs: brand identity (markers,
outlines, focus ring — contrast against the PAGE) and a filled surface carrying text (the
CTA, a 10px counter badge, the card chip — contrast against THAT TEXT). `#06aedd` cannot be
both, which is why the computed contrast colour looked wrong: black is correct (8.11:1 vs
white's 2.59:1) but reads badly on saturated cyan.

They are now separate: the accent stays the brand colour, and the fill is derived.

## The rule

1. white already clears **4.5:1** on the accent → white, fill = accent unchanged
2. else darken the accent (mirroring `wc_hex_darker()`) in 5% steps up to **30%** until white
   clears → white on the darkened fill
3. else → **black** on the *undarkened* accent

4.5:1 because the smallest text on the fill is a 10px badge, so the large-text 3:1 allowance
does not apply.

**Why 30%:** a colour needing more than that is by definition light, and black on it is
already excellent. Yellow needs −50% and comes out khaki — destroying the brand colour to
force white is wrong when black gives 17.20:1 on it.

**Verified against a sweep of 140,608 colours** (step 5 per channel): there is **no** colour
where neither white-within-30% nor black reaches 4.5:1. The rule has no hole. Tests pin a
representative sample rather than the sweep.

`#06aedd` → fill `#047a9b`, white ≈4.93:1, at the cap.

## Where it runs, and why not both sides

Server-side only, in `Pickup_Handler`; the browser receives literal hex and merely validates
it. Mirroring the algorithm into `pickup-geo.js` would create two formulas that can drift —
this repo already chose the same way for `Constraint_Checker`'s verdict, explicitly "avoiding
the mirrored-evaluator maintenance `show_if` needed". Drift is bounded to one pinned fallback
pair, the same shape the file already used for `#06aedd`.

`contrastFor()` is untouched and still tested — it answers a different question (identity
contrast) and its WCAG boundary cases, including the documented CDEK-green one, remain valid.

`wc_hex_darker()`/`wc_rgb_from_hex()` were checked against WooCommerce core source, including
`NumberUtil::round()`, so the port is faithful rather than approximate.

## Why not `wc_light_or_dark()` wholesale

`wc_hex_is_light()` is the legacy YIQ brightness heuristic — it answers "is this colour light",
not "what is readable on it". It would give white at 2.59:1 here and flip CDEK green from
4.82:1 to 4.36:1, degrading exactly the cases where the WCAG computation is more accurate.
`wc_hex_darker()` from the same file **is** used, so the borrowing stands — just a different
function.

## Audit, not a blanket replace

18 CSS sites became fill; 7 stayed accent (selected-row tint and bar, hover tint, native
`accent-color`, the how-to summary's accent-as-text, the marker pin, its active halo, the
focus ring). One site beyond the brief was caught and fixed: the map marker's group-count
badge — the same 10px shape the issue names, just in a second place.

All three colours are filterable (`woodev_pickup_accent_fill_color`,
`woodev_pickup_accent_contrast_color`), sanitised like the existing accent hook.

1461 unit / 706 jest, phpcs clean, PHPStan clean.

Closes #203
