### PR TITLE
fix(pickup): per-type short tab name + strip an upstream stringified boolean (#207, #210)

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
@@ -129,6 +129,16 @@
  * `'Оплата картой при получении'` -> `'Картой при получении'`. `bound_card`/`postpay` were
  * already short nouns in the same register as the other two — left unchanged.
  *
+ * SHORT NAME (issue #207): Yandex's payload carries no short/abbreviated name — the observed
+ * record shape below has `name` (the branch's own name, e.g. "Пятёрочка") and nothing else in
+ * that register — so the tab label for co-located points fell through to `type.label` and read
+ * "Пункт выдачи заказов 1" / "Пункт выдачи заказов 2", which does not fit a tab. `TYPE_MAP`
+ * therefore carries a `short` string per type, fed into `point_short_name`: the framework
+ * numbers co-located tabs, the domain names them (`buildTabs()` in `pickup-panels.js`).
+ * `type.label` itself deliberately stays LONG — it is rendered only in the type-filter chips,
+ * which have a full row to themselves and where "ПВЗ" would be needlessly terse. The two are
+ * different surfaces, not two names for the same slot.
+ *
  * Declared inside the plugin's init callback (`require_once`d from
  * `woodev-test-shipping-method.php`, same arrangement as `class-test-bulk-point-source.php`
  * — see that file's own docblock and
@@ -194,15 +204,23 @@ if ( ! class_exists( 'Woodev_Test_Live_Yandex_Point_Source' ) ) {
 		 * existing point icons (registered in `woodev-test-shipping-method.php` under
 		 * exactly these `PVZ`/`POSTAMAT` keys) keep working — the framework compares type
 		 * codes case-sensitively.
+		 *
+		 * `short` is this fixture's own tab wording (issue #207), NOT part of the framework's
+		 * type shape: `Pickup_Point::from_array()` whitelists `code`/`label` out of the `type`
+		 * array, so the extra key never reaches the point. It is fed separately into
+		 * `point_short_name` by {@see self::map_point()} — see the file docblock's SHORT NAME
+		 * section for why the label itself stays long.
 		 */
 		private const TYPE_MAP = [
 			'pickup_point' => [
 				'code'  => 'PVZ',
 				'label' => 'Пункт выдачи заказов',
+				'short' => 'ПВЗ',
 			],
 			'terminal'     => [
 				'code'  => 'POSTAMAT',
 				'label' => 'Постамат',
+				'short' => 'Постамат',
 			],
 		];
 
@@ -412,23 +430,27 @@ if ( ! class_exists( 'Woodev_Test_Live_Yandex_Point_Source' ) ) {
 
 			return \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array(
 				[
-					'id'              => $raw_point['id'] ?? '',
-					'name'            => $raw_point['name'] ?? '',
-					'lat'             => $position['latitude'] ?? null,
-					'lng'             => $position['longitude'] ?? null,
-					'address'         => $address['full_address'] ?? '',
-					'type'            => $type,
-					'locality'        => $address['locality'] ?? '',
-					'postal_code'     => $address['postal_code'] ?? '',
-					'phone'           => $contact['phone'] ?? '',
-					'instruction'     => $raw_point['instruction'] ?? '',
-					'work_time'       => $this->flatten_schedule( $schedule ),
-					'payment_methods' => $this->map_payment_methods(
+					'id'               => $raw_point['id'] ?? '',
+					'name'             => $raw_point['name'] ?? '',
+					'lat'              => $position['latitude'] ?? null,
+					'lng'              => $position['longitude'] ?? null,
+					'address'          => $address['full_address'] ?? '',
+					'type'             => $type,
+					// Issue #207 — the domain names the tab, the framework numbers it. Yandex's
+					// payload carries no short name of its own (see the file docblock's SHORT
+					// NAME section), so the fixture supplies one per type.
+					'point_short_name' => $type['short'],
+					'locality'         => $address['locality'] ?? '',
+					'postal_code'      => $address['postal_code'] ?? '',
+					'phone'            => $contact['phone'] ?? '',
+					'instruction'      => $raw_point['instruction'] ?? '',
+					'work_time'        => $this->flatten_schedule( $schedule ),
+					'payment_methods'  => $this->map_payment_methods(
 						is_array( $raw_point['payment_methods'] ?? null ) ? $raw_point['payment_methods'] : []
 					),
-					'services'        => $this->map_services( $services ),
-					'photos'          => [],
-					'icons'           => $this->icons_for_operator( $raw_point['operator_id'] ?? null ),
+					'services'         => $this->map_services( $services ),
+					'photos'           => [],
+					'icons'            => $this->icons_for_operator( $raw_point['operator_id'] ?? null ),
 				]
 			);
 		}

--- a/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-live-yandex-point-source.php
@@ -70,7 +70,8 @@
  * `available_for_c2c_dropoff`, `pickup_services{is_fitting_allowed,is_partial_refuse_allowed,
  * is_paperless_pickup_allowed,is_unboxing_allowed}`. No `max_weight`/weight-limit field
  * anywhere in the payload, so `Pickup_Point::get_max_weight()` stays null for every live
- * point — this is an honest "the carrier did not say", not a mapping gap.
+ * point — this is an honest "the carrier did not say", not a mapping gap. The `address.house`
+ * string is DIRTY for one operator — see {@see self::strip_stringified_boolean()} (issue #210).
  *
  * SCOPE: like `Woodev_Test_Bulk_Point_Source`, this fixture serves exactly one city
  * (Moscow, Yandex `geo_id` 213) — `MOSCOW_GEO_ID` is hardcoded rather than resolved from
@@ -434,7 +435,7 @@ if ( ! class_exists( 'Woodev_Test_Live_Yandex_Point_Source' ) ) {
 					'name'             => $raw_point['name'] ?? '',
 					'lat'              => $position['latitude'] ?? null,
 					'lng'              => $position['longitude'] ?? null,
-					'address'          => $address['full_address'] ?? '',
+					'address'          => self::strip_stringified_boolean( $address['full_address'] ?? '' ),
 					'type'             => $type,
 					// Issue #207 — the domain names the tab, the framework numbers it. Yandex's
 					// payload carries no short name of its own (see the file docblock's SHORT
@@ -453,6 +454,39 @@ if ( ! class_exists( 'Woodev_Test_Live_Yandex_Point_Source' ) ) {
 					'icons'            => $this->icons_for_operator( $raw_point['operator_id'] ?? null ),
 				]
 			);
+		}
+
+		/**
+		 * Removes an upstream stringified boolean from the address (issue #210).
+		 *
+		 * The `5post` operator composes its `house` field upstream as
+		 * `{house} к{housing} стр{building}` and renders a MISSING value as the literal
+		 * `false`, so the customer is shown "Островитянова ул 19/22 кfalse". Yandex passes the
+		 * string through untouched — its own structured `housing`/`building` keys arrive EMPTY,
+		 * which is how we know the composition happened before Yandex, not here.
+		 *
+		 * Measured on the live sandbox, `geo_id: 213`, 812 points (08.08.2026): 679 affected,
+		 * every one of them `operator_id: 5post`; the artefact is always the exact substring
+		 * " кfalse" (space + Cyrillic `к` U+043A + `false`), always inside `house`; zero
+		 * occurrences of `true`, `стрfalse`, or any other form. The `стр` slot is covered here
+		 * anyway because the SAME composition can put the same literal there — that is the
+		 * shape of the upstream bug, not speculation about a future one.
+		 *
+		 * Deliberately narrow: only a boolean literal directly behind one of those two
+		 * prefixes is removed, so a real housing value ("17 к6") and any word that merely
+		 * contains the letters ("Falsettoвая") survive. This lives in the FIXTURE, not the
+		 * framework: the framework must never guess at the meaning of an address string, and a
+		 * real carrier plugin owns the hygiene of the data it hands over — the same division
+		 * of labour as `point_short_name` in issue #207.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param mixed $address Raw `address.full_address` from the API.
+		 *
+		 * @return string
+		 */
+		private static function strip_stringified_boolean( $address ): string {
+			return (string) preg_replace( '/\s(?:к|стр)(?:false|true)\b/iu', '', (string) $address );
 		}
 
 		/**

--- a/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
+++ b/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
@@ -224,6 +224,31 @@ final class TestLiveYandexPointSourceTest extends TestCase {
 		$this->assertSame( [ 'code' => 'POSTAMAT', 'label' => 'Постамат' ], $postamat->to_array()['type'] );
 	}
 
+	/**
+	 * Issue #207: Yandex's payload carries no short name, so co-located tabs fell back to
+	 * `type.label` and read "Пункт выдачи заказов 1/2" — too long for a tab. The fixture now
+	 * supplies a per-type short name; the framework still does the numbering.
+	 *
+	 * The assertion on `type` above is what pins the other half of this: `TYPE_MAP`'s extra
+	 * `short` key must NOT leak into the point's `type` array (`from_array()` whitelists
+	 * `code`/`label`), or the browser would receive a shape the contract never declared.
+	 */
+	public function test_each_type_carries_its_own_short_name_for_the_tab_label(): void {
+		$this->stub_successful_transport( [ $this->real_pickup_point_record(), $this->real_terminal_record() ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$short_by_code = [];
+		foreach ( $points as $point ) {
+			$short_by_code[ $point->to_array()['type']['code'] ] = $point->to_array()['point_short_name'];
+		}
+
+		$this->assertSame( 'ПВЗ', $short_by_code['PVZ'] );
+		$this->assertSame( 'Постамат', $short_by_code['POSTAMAT'] );
+	}
+
 	public function test_unrecognised_type_is_skipped_not_fatal(): void {
 		$foreign_type_record         = $this->real_pickup_point_record();
 		$foreign_type_record['type'] = 'a_future_yandex_type_this_fixture_does_not_know';

--- a/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
+++ b/tests/unit/Shipping/Pickup/TestLiveYandexPointSourceTest.php
@@ -249,6 +249,66 @@ final class TestLiveYandexPointSourceTest extends TestCase {
 		$this->assertSame( 'Постамат', $short_by_code['POSTAMAT'] );
 	}
 
+	/**
+	 * Issue #210 — the `5post` operator composes `house` upstream as
+	 * `{house} к{housing} стр{building}` and stringifies a MISSING value as the boolean
+	 * `false`, so 679 of the 812 live Moscow points carry a literal " кfalse" in the address
+	 * shown to the customer. The addresses below are byte-preserved from the live payload.
+	 *
+	 * @dataProvider provide_addresses_with_the_stringified_boolean
+	 */
+	public function test_a_stringified_boolean_is_stripped_from_the_address( string $raw, string $expected ): void {
+		$record                            = $this->real_pickup_point_record();
+		$record['address']['full_address'] = $raw;
+
+		$this->stub_successful_transport( [ $record ] );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Yandex_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'locality' => 'Москва' ] ) );
+
+		$this->assertSame( $expected, $points[0]->get_address() );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public function provide_addresses_with_the_stringified_boolean(): array {
+		return [
+			// The plain majority — the artefact sits at the very end.
+			'trailing housing'        => [
+				'г.Москва Островитянова ул 19/22 кfalse',
+				'г.Москва Островитянова ул 19/22',
+			],
+			// A real building value follows it, so the strip must not eat the tail.
+			'housing before building' => [
+				'г.Москва Привольная ул 3 кfalse стрк.1',
+				'г.Москва Привольная ул 3 стрк.1',
+			],
+			// The operator's own screenshot.
+			'operator screenshot'     => [
+				'г.Москва, п.Вороновское п.ЛМС 7 кfalse стробъект №1',
+				'г.Москва, п.Вороновское п.ЛМС 7 стробъект №1',
+			],
+			// The building slot can carry the same stringified boolean by construction, even
+			// though the live Moscow payload happens to show zero of them.
+			'building slot'           => [
+				'г.Москва Тестовая ул 5 к2 стрfalse',
+				'г.Москва Тестовая ул 5 к2',
+			],
+			// A REAL housing value must survive untouched — this is the over-strip guard.
+			'real housing kept'       => [
+				'Москва Новокосинская 17 к6',
+				'Москва Новокосинская 17 к6',
+			],
+			// "false" as part of a longer word is not the artefact.
+			'word containing false'   => [
+				'Москва Falsettoвая ул 1',
+				'Москва Falsettoвая ул 1',
+			],
+		];
+	}
+
 	public function test_unrecognised_type_is_skipped_not_fatal(): void {
 		$foreign_type_record         = $this->real_pickup_point_record();
 		$foreign_type_record['type'] = 'a_future_yandex_type_this_fixture_does_not_know';


### PR DESCRIPTION
Two data-hygiene fixes in the live Yandex fixture, both the same division of labour: the
framework provides the mechanism, the domain provides (and cleans) the data.

## #207 — «Пункт выдачи заказов N» in the tabs

Yandex's payload carries no short/abbreviated name, so the tab label for co-located points
fell through to `type.label` and did not fit. `TYPE_MAP` now carries a `short` per type
(`ПВЗ` / `Постамат`), fed into `point_short_name`; the framework still does the numbering.

`type.label` stays long on purpose — it renders only in the type-filter chips, which have a
full row and where "ПВЗ" would be needlessly terse. `Pickup_Point::from_array()` whitelists
`code`/`label` out of the `type` array, so the extra key never reaches the point; the
existing exact-shape assertion on `type` pins that.

## #210 — «кfalse» in the address (operator found it on the rig)

The customer was shown `Островитянова ул 19/22 кfalse`. **Not our bug** — the `5post`
operator composes `house` upstream as `{house} к{housing} стр{building}` and renders a
missing value as the literal `false`. Yandex passes it through untouched; its own structured
`housing`/`building` keys arrive **empty**, which is how we know the composition happened
before Yandex.

Measured on the live sandbox (`geo_id: 213`, 812 points):

| Fact | Value |
|---|---|
| Affected | 679 of 812 |
| Operator | all 679 are `5post` |
| Form | exactly ` кfalse` — space + Cyrillic `к` U+043A + `false` |
| `true` / `стрfalse` / other forms | 0 |

Cleaned in the **fixture**, not the framework — the framework must never guess at the
meaning of an address string. Data-provider tests pin all four live shapes plus two
over-strip guards (a real housing value `17 к6`, and a word merely containing the letters).

## Verification

- `composer test:unit` — 1490 tests green (was 1484; +6)
- `composer phpcs` — clean
- Rig verification of both on live Yandex data: see the PR conversation.

Closes #207
Closes #210