### PR TITLE
fix(pickup): host the accent variables on the stage, not the panels (#212)

### DIFF
--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -191,13 +191,51 @@ describe( 'accent colours (issue #203 — brand identity split from the filled-t
 	// would be exactly the mirrored-evaluator duplication the framework avoids elsewhere (see
 	// `pickup-panels.js`'s own `applyAccentColor()` docblock).
 
+	// The accent host is the STAGE, not `panels.root` (issue #212) — reached through the DOM
+	// rather than through `panels._stage` on purpose: a private field renamed tomorrow would
+	// quietly re-point these assertions, while the element's own class name is the contract
+	// `pickup.css` is written against.
+	const accentHostOf = ( panels ) => panels.root.closest( '.woodev-pickup-stage' );
+
+	// The defect this whole block moved for: custom properties only reach DESCENDANTS, and
+	// five pickup surfaces are siblings of `panels.root`, not children of it — so hosting the
+	// triplet on `panels.root` left every one of them on `pickup.css`'s literal fallback.
+	// Invisible while the accent stayed `#06aedd`, because that literal IS what `#06aedd`
+	// derives to; a yellow accent showed a teal filter badge on a yellow map.
+	it( 'hosts the triplet where every pickup surface inherits it, not just the panels', () => {
+		const panels = new Panels( document.createElement( 'div' ), config );
+		panels.render();
+
+		const host = accentHostOf( panels );
+
+		expect( host ).not.toBeNull();
+		expect( host.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#06aedd' );
+		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '' );
+
+		// `.woodev-pickup-map` stands in for the search/filter bar: ymaps builds its controls
+		// pane inside the map element, so the bar is only ever reachable through it.
+		[
+			'.woodev-pickup-panels',
+			'.woodev-pickup-map',
+			'.woodev-pickup-list__toggle',
+			'.woodev-pickup-zoom',
+			'.woodev-pickup-overlay',
+			'.woodev-pickup-message',
+		].forEach( ( selector ) => {
+			const surface = host.querySelector( selector );
+
+			expect( surface ).not.toBeNull();
+			expect( host.contains( surface ) ).toBe( true );
+		} );
+	} );
+
 	it( 'writes the framework default triplet when the config carries none', () => {
 		const panels = new Panels( document.createElement( 'div' ), config );
 		panels.render();
 
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#06aedd' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#047a9b' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#06aedd' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#047a9b' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
 	} );
 
 	it( 'applies a server-resolved triplet verbatim, including a BLACK contrast', () => {
@@ -211,9 +249,9 @@ describe( 'accent colours (issue #203 — brand identity split from the filled-t
 		} ) );
 		panels.render();
 
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#ffeb3b' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#ffeb3b' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#000000' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#ffeb3b' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#ffeb3b' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#000000' );
 	} );
 
 	it( 'falls back to the default accent ALONE when only accentColor is unsafe', () => {
@@ -224,9 +262,9 @@ describe( 'accent colours (issue #203 — brand identity split from the filled-t
 		} ) );
 		panels.render();
 
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#06aedd' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#098534' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#06aedd' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#098534' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
 	} );
 
 	it( 'falls back to the default fill ALONE when only accentFillColor is missing', () => {
@@ -236,9 +274,9 @@ describe( 'accent colours (issue #203 — brand identity split from the filled-t
 		} ) );
 		panels.render();
 
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#0a8c37' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#047a9b' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#0a8c37' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#047a9b' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
 	} );
 
 	it( 'falls back to the default contrast ALONE when only accentContrastColor is unsafe', () => {
@@ -249,9 +287,9 @@ describe( 'accent colours (issue #203 — brand identity split from the filled-t
 		} ) );
 		panels.render();
 
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#0a8c37' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#098534' );
-		expect( panels.root.style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent' ) ).toBe( '#0a8c37' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-fill' ) ).toBe( '#098534' );
+		expect( accentHostOf( panels ).style.getPropertyValue( '--woodev-pickup-accent-contrast' ) ).toBe( '#ffffff' );
 	} );
 } );
 

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -62,8 +62,17 @@
  * fill with `--woodev-pickup-accent-fill` and its text/icon with `--woodev-pickup-accent-contrast`
  * — never `--woodev-pickup-accent` itself, and never a third, independently-invented colour.
  * Every IDENTITY rule (markers, the marker halo, the selected-row tint/bar, the native checkbox
- * tint, the `howto` summary link colour, the focus ring) uses `--woodev-pickup-accent` alone —
- * no text is drawn ON these, so no contrast partner is needed.
+ * tint, the busy spinner's arc, the focus ring) uses `--woodev-pickup-accent` alone — no text is
+ * drawn ON these, so no contrast partner is needed.
+ *
+ * That list once included the `howto` summary's link colour, and that was a MISCLASSIFICATION:
+ * the summary IS text, drawn on the panel's own white background, so the sentence above ("no
+ * text is drawn ON these") was simply untrue of it. Neither of the two accent properties can
+ * colour text against a surface the merchant does not control — the fill's derivation targets
+ * contrast against the text ON it, not against what is BEHIND it — so that rule now uses the
+ * neutral palette below and signals interactivity without colour. The general rule this leaves:
+ * the accent belongs on a surface, an outline or a mark, never on a glyph whose background the
+ * cascade never measured.
  *
  * `var( --woodev-pickup-accent, #06aedd )` / `var( --woodev-pickup-accent-fill, #047a9b )` /
  * `var( --woodev-pickup-accent-contrast, #fff )` are the ONLY THREE fallback values this file
@@ -1586,8 +1595,23 @@
 	margin-top: 6px;
 }
 
+/* NOT accent-coloured, deliberately (operator's call, rig-verified on a yellow accent). This is
+   the ONE place the file ever drew the accent as TEXT on the panel's own white background, and
+   the cascade has no colour that can carry it: `--woodev-pickup-accent` is the merchant's raw
+   brand, unconstrained against white — a yellow one rendered this line all but invisible — and
+   `--woodev-pickup-accent-fill` cannot stand in either, because its derivation targets contrast
+   against the text drawn ON it, not against the surface behind it (on a light accent the fill is
+   returned undarkened, i.e. the same unreadable value). Inventing a fourth "accent on light"
+   derivation for a single disclosure label is not worth a fourth colour to keep in agreement
+   across PHP, JS and this file.
+   So it takes the file's own primary text colour, and its interactivity is carried by
+   colour-independent affordances instead: the native `<details>` triangle, the pointer cursor,
+   the underline, and the focus ring — which stays on the accent legitimately, being an OUTLINE
+   drawn against the panel edge rather than a glyph competing with the background. */
 .woodev-pickup-card__howto > summary {
-	color: var( --woodev-pickup-accent, #06aedd );
+	color: #1e1e1e;
+	text-decoration: underline;
+	text-underline-offset: 2px;
 	cursor: pointer;
 }
 

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -299,13 +299,17 @@
 }
 
 /* Same shape as `woodev-modal.css`'s `.woodev-modal__spinner` — this file owns everything inside
-   the stage (see the file docblock), so it gets its own rule rather than reaching into that one. */
+   the stage (see the file docblock), so it gets its own rule rather than reaching into that one.
+   The moving arc is IDENTITY (`--woodev-pickup-accent`), not a filled text surface: it carries no
+   text, so the fill/contrast pair has nothing to say about it. Found alongside #212 — it had been
+   left as a bare literal, which is the same "does not follow the merchant's colour" defect by a
+   different route, and equally invisible while the accent stayed the framework default. */
 .woodev-pickup-spinner {
 	display: block;
 	width: 28px;
 	height: 28px;
 	border: 2px solid rgba( 0, 0, 0, 0.12 );
-	border-top-color: #06aedd;
+	border-top-color: var( --woodev-pickup-accent, #06aedd );
 	border-radius: 50%;
 	animation: woodev-pickup-spin 0.8s linear infinite;
 }

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -586,7 +586,20 @@
 	 * are pinned LITERALS, not a client-side fallback computation, for the same
 	 * no-mirrored-evaluator reason.
 	 *
-	 * @param {HTMLElement} root
+	 * THE HOST MUST BE THE STAGE, NOT THE PANELS ELEMENT (issue #212). Custom properties
+	 * only reach DESCENDANTS, and five pickup surfaces are SIBLINGS of
+	 * `.woodev-pickup-panels` under `.woodev-pickup-stage`, not children of it: the sidebar
+	 * toggle strip, the zoom control, the busy overlay's spinner, the message strip, and —
+	 * via ymaps' own controls pane inside `.woodev-pickup-map` — the whole search/filter bar.
+	 * Every rule in `pickup.css` is written `var( --woodev-pickup-accent-fill, #047a9b )`, so
+	 * a surface outside the host does not break: it silently falls back to the LITERAL. That
+	 * literal is `#06aedd` darkened 30%, i.e. numerically identical to what the default accent
+	 * derives to — which is why hosting on the panels element looked correct for as long as
+	 * the accent stayed `#06aedd`, and showed a teal filter badge and a teal toggle strip on a
+	 * yellow-accented map the first time a merchant colour was rig-tested. The literals stay
+	 * in the CSS on purpose: they are what paints before this function runs at all.
+	 *
+	 * @param {HTMLElement} root the accent host — `.woodev-pickup-stage`, see above.
 	 * @param {Object}      config
 	 * @returns {void}
 	 */
@@ -1851,6 +1864,12 @@
 		var stage = document.createElement( 'div' );
 		stage.className = 'woodev-pickup-stage';
 
+		// The accent host is the STAGE, not the panels element — the map (and so ymaps' own
+		// controls pane, which carries the search/filter bar), the sidebar toggle, the zoom
+		// control, the overlay and the message strip are all siblings of `panels`, and a
+		// custom property only reaches descendants. See {@see applyAccentColor} (issue #212).
+		applyAccentColor( stage, this._config );
+
 		// The map mount point — this task only builds the DOM/CSS plumbing for it; a later
 		// task rewires the caller to hand `getMapElement()` to the map provider's `init()`
 		// instead of the raw modal container. Painted first so every panel draws over it.
@@ -1859,8 +1878,6 @@
 
 		var root = document.createElement( 'div' );
 		root.className = 'woodev-pickup-panels';
-
-		applyAccentColor( root, this._config );
 
 		var list = document.createElement( 'div' );
 		list.className = 'woodev-pickup-list';


### PR DESCRIPTION
Found while rig-verifying #208 (the accent cascade on a light brand colour).

## The defect

`applyAccentColor()` wrote the three custom properties onto `.woodev-pickup-panels`. Custom
properties only reach **descendants**, and five pickup surfaces are **siblings** of that
element under `.woodev-pickup-stage`:

```
.woodev-pickup-stage
├── .woodev-pickup-map        ← ymaps builds its controls pane in here,
│                                and the search/filter bar lives in that pane
├── .woodev-pickup-panels     ← the only subtree that saw the variables
├── .woodev-pickup-list__toggle
├── .woodev-pickup-zoom
├── .woodev-pickup-overlay    ← .woodev-pickup-spinner
└── .woodev-pickup-message
```

Every rule in `pickup.css` is written `var( --woodev-pickup-accent-fill, #047a9b )`, so a
surface outside the host does not break — it silently falls back to the **literal**.

## Why nobody saw it

`#047a9b` is `#06aedd` darkened 30% — the fallback is numerically identical to what the
default accent derives to. The bug is unobservable for as long as the accent stays the
framework default, which is the only value the rig had ever run.

## Rig measurement, accent forced to `#ffeb3b`

| Surface | Inside `panels`? | Rendered |
|---|---|---|
| `.woodev-pickup-card__cta` | yes | `rgb(255,235,59)`, black text, **17.20:1** ✅ |
| `.woodev-pickup-card__chip` | yes | yellow ✅ |
| `.woodev-pickup-card__howto-summary` | yes | yellow ✅ |
| `.woodev-pickup-filter__badge` | **no** | `rgb(4,122,155)` ❌ |
| `.woodev-pickup-filter__checkbox` ×2 | **no** | `rgb(4,122,155)` ❌ |
| `.woodev-pickup-list__toggle` | **no** | `rgb(4,122,155)` ❌ |
| `.woodev-pickup-spinner` | **no** | `rgb(6,174,221)` ❌ |

3 of 3 inside went yellow; 0 of 5 outside did.

## The fix

Host the triplet on `.woodev-pickup-stage`. The CSS literals stay — they are what paints
before the script runs at all.

The new test pins the **containment**, not one more colour value: that is the half no colour
assertion could have caught. Verified by mutation — putting the call back on `root` fails it.

## Out of scope, deliberately

`.woodev-modal__close`'s focus ring also renders teal, but it sits in `.woodev-modal__header`
outside the stage, and `woodev-modal.css` knows no variables at all — four hardcoded
`#06aedd`. That is the shared modal shell, framework furniture rather than merchant brand;
whether it should follow the accent is a separate decision, not a consequence of this defect.

## Verification

- `npm run test:js -- --roots "<rootDir>/tests/js"` — 721 tests green (8 suites)
- Mutation check: reverting the host to `root` turns the new test red

Closes #212