### PR TITLE
feat(pickup): disable a zoom button once the camera reaches that limit

### DIFF
--- a/tests/js/map-provider-yandex.test.js
+++ b/tests/js/map-provider-yandex.test.js
@@ -791,6 +791,98 @@ test( 'clamps zoomBy at the bottom of the range too', async () => {
 	expect( provider.map.setZoom ).toHaveBeenCalledWith( 8, { duration: 200 } );
 } );
 
+// Operator's call, 08.08.2026: the zoom buttons stayed clickable at either end of the range,
+// which reads as a bug. The RANGE lives here for the same D-3 reason `zoomBy()` does — the panels
+// emit a signed step and know nothing about map-library zoom levels — so this provider is what
+// reports a reached limit, against the SAME `MIN_ZOOM`/`MAX_ZOOM` pair `zoomBy()` clamps to.
+test( 'reports the zoom limits once for the viewport the map settled on, before any pan', async () => {
+	ymapsStub = createYmapsStub( { zoom: 18 } );
+
+	const config = makeConfig();
+
+	window[ config.ns ] = ymapsStub;
+
+	const provider = new WoodevYandexMapProvider();
+	const seen = [];
+
+	provider.on( 'zoomChange', ( limits ) => seen.push( limits ) );
+
+	await provider.init( document.createElement( 'div' ), config );
+
+	// A map that OPENS at the top of the range (what `focusGroup()` does on a restored
+	// selection) must not show a live «+» until the customer first moves the camera.
+	expect( seen ).toEqual( [ { canZoomIn: false, canZoomOut: true } ] );
+} );
+
+test( 'reports the bottom of the range the same way', async () => {
+	ymapsStub = createYmapsStub( { zoom: 8 } );
+
+	const config = makeConfig();
+
+	window[ config.ns ] = ymapsStub;
+
+	const provider = new WoodevYandexMapProvider();
+	const seen = [];
+
+	provider.on( 'zoomChange', ( limits ) => seen.push( limits ) );
+
+	await provider.init( document.createElement( 'div' ), config );
+
+	expect( seen ).toEqual( [ { canZoomIn: true, canZoomOut: false } ] );
+} );
+
+// The regression this one exists for: `boundsChange` is viewport-ONLY because it drives
+// refetching, and hanging the zoom report off it would have left the bulk strategy — which the
+// rig and every current consumer actually run — with permanently live buttons.
+test( 'reports a limit reached by a pan under the BULK strategy too', async () => {
+	const provider = await init( { strategy: 'bulk' } );
+	const seen = [];
+
+	provider.on( 'zoomChange', ( limits ) => seen.push( limits ) );
+
+	provider.map.getZoom.mockReturnValue( 18 );
+	ymapsStub.lastMap.fireBoundsChange();
+
+	expect( seen ).toEqual( [ { canZoomIn: false, canZoomOut: true } ] );
+} );
+
+test( 'reports a limit reached by a pan under the VIEWPORT strategy too', async () => {
+	const provider = await init( { strategy: 'viewport', locality: '' } );
+	const seen = [];
+
+	provider.on( 'zoomChange', ( limits ) => seen.push( limits ) );
+
+	provider.map.getZoom.mockReturnValue( 8 );
+	ymapsStub.lastMap.fireBoundsChange();
+
+	expect( seen ).toEqual( [ { canZoomIn: true, canZoomOut: false } ] );
+} );
+
+// ymaps fires `boundschange` throughout an animated move, so an undeduped report would rewrite
+// the same two booleans on every frame of every pan.
+test( 'never re-reports an unchanged pair', async () => {
+	const provider = await init( { strategy: 'bulk' } );
+	const seen = [];
+
+	provider.on( 'zoomChange', ( limits ) => seen.push( limits ) );
+
+	provider.map.getZoom.mockReturnValue( 18 );
+	ymapsStub.lastMap.fireBoundsChange();
+	ymapsStub.lastMap.fireBoundsChange();
+	ymapsStub.lastMap.fireBoundsChange();
+
+	expect( seen ).toHaveLength( 1 );
+
+	// …and reports again the moment it genuinely changes.
+	provider.map.getZoom.mockReturnValue( 12 );
+	ymapsStub.lastMap.fireBoundsChange();
+
+	expect( seen ).toEqual( [
+		{ canZoomIn: false, canZoomOut: true },
+		{ canZoomIn: true, canZoomOut: true },
+	] );
+} );
+
 test( 'zoomBy steps by exactly the signed amount inside the range', async () => {
 	const provider = await init();
 

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -240,6 +240,9 @@ function StubPanels( container, config ) {
 	this.setPointVerdict = jest.fn();
 	this.showSelectionError = jest.fn();
 
+	/** @type {Array} every `setZoomLimits()` payload, in order. */
+	this.setZoomLimitsCalls = [];
+
 	StubPanels.instances.push( this );
 }
 
@@ -445,6 +448,15 @@ StubPanels.prototype.setBusy = function( busy ) {
 
 StubPanels.prototype.isBusy = function() {
 	return !! this._busy;
+};
+
+/**
+ * Records every `setZoomLimits()` call — the return leg of the zoom wiring (the provider
+ * reports a reached limit, the panels dim that button). The real method's DOM contract is
+ * `pickup-panels.test.js`'s job; this file only proves the forwarding.
+ */
+StubPanels.prototype.setZoomLimits = function( limits ) {
+	this.setZoomLimitsCalls.push( limits );
 };
 
 /**
@@ -2287,6 +2299,28 @@ test( 'panels zoom calls provider.zoomBy with the signed step (Task 14, spec V-1
 	session.panels.emit( 'zoom', { step: -1 } );
 
 	expect( session.provider.zoomByCalls ).toEqual( [ 1, -1 ] );
+} );
+
+// The return leg of the same wiring: the provider owns the zoom RANGE (it owns the camera), so
+// it is what decides a limit has been reached; the panels only dim the button it names.
+test( 'provider zoomChange forwards to panels.setZoomLimits', async () => {
+	const session = await openSession( configWith() );
+
+	session.provider.emit( 'zoomChange', { canZoomIn: false, canZoomOut: true } );
+
+	expect( session.panels.setZoomLimitsCalls ).toEqual( [ { canZoomIn: false, canZoomOut: true } ] );
+} );
+
+// Where the fail-open actually lives. `on()` is part of the provider contract proper (`start()`
+// calls it bare for `select`/`error`), so the degradation worth pinning is not "a provider with
+// no event surface" — that one cannot mount at all — but a provider that registers and simply
+// never reports a limit. Both buttons must then stay untouched, i.e. live.
+test( 'a provider that never emits zoomChange leaves the buttons alone', async () => {
+	const session = await openSession( configWith() );
+
+	// `toHaveLength( 0 )`, not `toEqual( [] )` — see the project's own
+	// `jest-toequal-empty-array-ignores-undefined` gotcha.
+	expect( session.panels.setZoomLimitsCalls ).toHaveLength( 0 );
 } );
 
 test( 'panels searchAddressPicked resolves the address AT THAT INDEX against the provider', async () => {

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -3271,6 +3271,69 @@ describe( 'zoom control (spec V-13)', () => {
 		expect( onZoom ).toHaveBeenNthCalledWith( 2, { step: -1 } );
 	} );
 
+	// Operator's call, 08.08.2026: a button that stays clickable at the end of the zoom range
+	// while doing nothing reads as a bug. The RANGE is the provider's — this file only proves
+	// that a reported limit lands on the right button.
+	it( 'starts with both buttons enabled', () => {
+		const container = document.createElement( 'div' );
+
+		new Panels( container, config ).render();
+
+		const buttons = container.querySelectorAll( '.woodev-pickup-zoom__button' );
+
+		expect( buttons[ 0 ].disabled ).toBe( false );
+		expect( buttons[ 1 ].disabled ).toBe( false );
+	} );
+
+	it( 'disables only the button whose end of the range has been reached', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+
+		const buttons = container.querySelectorAll( '.woodev-pickup-zoom__button' );
+
+		panels.setZoomLimits( { canZoomIn: false, canZoomOut: true } );
+		expect( buttons[ 0 ].disabled ).toBe( true );
+		expect( buttons[ 1 ].disabled ).toBe( false );
+
+		panels.setZoomLimits( { canZoomIn: true, canZoomOut: false } );
+		expect( buttons[ 0 ].disabled ).toBe( false );
+		expect( buttons[ 1 ].disabled ).toBe( true );
+
+		panels.setZoomLimits( { canZoomIn: true, canZoomOut: true } );
+		expect( buttons[ 0 ].disabled ).toBe( false );
+		expect( buttons[ 1 ].disabled ).toBe( false );
+	} );
+
+	// Fail-open: a live button at a limit is a harmless no-op, a dead button that should have
+	// worked is not — so anything short of an explicit boolean leaves that button alone. This is
+	// what keeps a provider that never reports (the embedded one, or a third-party one written
+	// later against the same seam) fully usable.
+	it( 'leaves a button untouched when nothing reported its end of the range', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+
+		const buttons = container.querySelectorAll( '.woodev-pickup-zoom__button' );
+
+		panels.setZoomLimits( { canZoomIn: false, canZoomOut: false } );
+
+		panels.setZoomLimits( {} );
+		panels.setZoomLimits();
+		panels.setZoomLimits( { canZoomIn: 'yes', canZoomOut: 1 } );
+
+		expect( buttons[ 0 ].disabled ).toBe( true );
+		expect( buttons[ 1 ].disabled ).toBe( true );
+	} );
+
+	it( 'survives setZoomLimits() before render(), when the buttons do not exist yet', () => {
+		const panels = new Panels( document.createElement( 'div' ), config );
+
+		expect( () => panels.setZoomLimits( { canZoomIn: false, canZoomOut: false } ) ).not.toThrow();
+	} );
+
 	it( 'types both buttons "button" so a checkout form never submits on click', () => {
 		const container = document.createElement( 'div' );
 

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -872,6 +872,23 @@
 	background: #f6f7f7;
 }
 
+/* The camera has reached that end of the map's zoom range — `pickup-panels.js`'s
+   `setZoomLimits()`, fed by the provider's `zoomChange`. Dimmed rather than hidden: the pair must
+   keep its shape, and a button that vanishes at the edge would move the other one under the
+   cursor. `:disabled` already blocks the click and the focus; this is only what makes the state
+   READABLE, which is the whole point — a permanently-live button that does nothing reads as a
+   bug. `!important` on `display`-adjacent chrome is not needed here (nothing in the hostile-theme
+   reset touches `opacity`), but the `:hover` background IS re-neutralised below, because the
+   base `:hover` rule above would otherwise still light up a dead button. */
+.woodev-pickup-zoom__button:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+
+.woodev-pickup-zoom__button:disabled:hover {
+	background: #fff;
+}
+
 .woodev-pickup-zoom__button + .woodev-pickup-zoom__button {
 	border-top: 1px solid rgba( 0, 0, 0, 0.08 );
 }

--- a/woodev/shipping-method/assets/js/frontend/map-provider-yandex.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-yandex.js
@@ -31,7 +31,8 @@
  * `matchLoadedPoints( query )`, `suggestAddresses( query )`, `resolveAddress( displayName )`,
  * `focusAddress( latLng, label )`, `clearAddress()`, `on( event, cb )`, `destroy()`. Events out:
  * `pointClick( key )`, `clusterClick( { coords } )`, `boundsChange( bbox )`, `bboxTooWide()`,
- * `visibleChange( keys )`, `nothingNearby( { key, distanceMeters, name } )`,
+ * `visibleChange( keys )`, `zoomChange( { canZoomIn, canZoomOut } )`,
+ * `nothingNearby( { key, distanceMeters, name } )`,
  * `searchResults( { points, addresses } )`, `searchCleared()`,
  * `addressFocused( { latLng, label } )`, `addressMatchedPoint( { key } )`,
  * `error( { code, message } )`. `bbox` is the flat `[lat1,lng1,lat2,lng2]` shape
@@ -908,6 +909,7 @@
 			boundsChange: [],
 			bboxTooWide: [],
 			visibleChange: [],
+			zoomChange: [],
 			nothingNearby: [],
 			searchResults: [],
 			searchCleared: [],
@@ -915,6 +917,11 @@
 			addressMatchedPoint: [],
 			error: [],
 		};
+
+		/** @type {Object|null} the last `{ canZoomIn, canZoomOut }` pair reported through
+		 *  `zoomChange` — the dedupe baseline in {@see _emitZoomChange}. `null` means "nothing
+		 *  reported yet", which is why the first call always emits. */
+		this._zoomLimits = null;
 
 		/** @type {Object.<string, Object>} the current groups, by key — see {@see setPoints}. */
 		this._groupsByKey = {};
@@ -1051,6 +1058,13 @@
 				return;
 			}
 
+			// Strategy-independent, unlike everything below it: the zoom range is reached the
+			// same way whether or not a pan refetches. Fired once for the viewport the map
+			// settled on, so the buttons start out already correct — a map that opens AT
+			// `MAX_ZOOM` (what `focusGroup()` does on a restored selection) must not show a
+			// live «+» until the customer first moves the camera.
+			self._emitZoomChange();
+
 			if ( 'viewport' === self.config.strategy ) {
 				// Fire once for the viewport just resolved, THEN start listening — in that
 				// order, so this initial call is never immediately followed by a redundant
@@ -1058,6 +1072,7 @@
 				self._checkAndEmitBounds();
 				self.map.events.add( 'boundschange', function() {
 					self._checkAndEmitBounds();
+					self._emitZoomChange();
 				} );
 
 				return;
@@ -1068,6 +1083,7 @@
 			// camera the customer is free to move themselves. See the file docblock.
 			self.map.events.add( 'boundschange', function() {
 				self._emitVisibleChange();
+				self._emitZoomChange();
 			} );
 		} );
 	};
@@ -1597,6 +1613,50 @@
 	 *
 	 * @returns {void}
 	 */
+	/**
+	 * Reports whether the camera can still move IN and OUT, as `zoomChange`
+	 * `{ canZoomIn, canZoomOut }` — what lets the panels' own zoom buttons show a disabled
+	 * state at either end of the range instead of staying clickable no-ops (operator's call,
+	 * 08.08.2026: a permanently-clickable button that does nothing reads as a bug).
+	 *
+	 * The RANGE lives here, not in the panels, for the same D-3 reason `zoomBy()` does: the
+	 * panels emit a signed step and know nothing about map-library zoom levels. `MIN_ZOOM`/
+	 * `MAX_ZOOM` are the same two constants `_buildMap()` constrains ymaps' own drag/wheel
+	 * zoom to and `zoomBy()` clamps against, so the button's disabled state and the camera's
+	 * actual refusal to move can never disagree.
+	 *
+	 * Emitted on BOTH strategies, unlike `boundsChange` — that one is `viewport`-only because
+	 * it drives refetching, whereas a zoom limit is reached identically under `bulk`. Emitted
+	 * only when the pair CHANGES: ymaps fires `boundschange` throughout an animated move, and
+	 * a listener that re-wrote the same two booleans on every frame would be pure noise.
+	 *
+	 * @since 2.0.2
+	 * @returns {void}
+	 */
+	WoodevYandexMapProvider.prototype._emitZoomChange = function() {
+		if ( ! this.map ) {
+			return;
+		}
+
+		var zoom = this.map.getZoom();
+		var next = {
+			canZoomIn: zoom < MAX_ZOOM,
+			canZoomOut: zoom > MIN_ZOOM,
+		};
+
+		if (
+			this._zoomLimits &&
+			this._zoomLimits.canZoomIn === next.canZoomIn &&
+			this._zoomLimits.canZoomOut === next.canZoomOut
+		) {
+			return;
+		}
+
+		this._zoomLimits = next;
+
+		this.emit( 'zoomChange', next );
+	};
+
 	WoodevYandexMapProvider.prototype._checkAndEmitBounds = function() {
 		var bounds = this.map.getBounds();
 		var latSpan = Math.abs( bounds[ 1 ][ 0 ] - bounds[ 0 ][ 0 ] );
@@ -2782,12 +2842,14 @@
 		// rest of the map — this just forgets the stale accessor, matching `_marginArea`'s own
 		// treatment right above; there is no separate `.remove()` call to make here either.
 		this._topMarginArea = null;
+		this._zoomLimits = null;
 		this.handlers = {
 			pointClick: [],
 			clusterClick: [],
 			boundsChange: [],
 			bboxTooWide: [],
 			visibleChange: [],
+			zoomChange: [],
 			nothingNearby: [],
 			searchResults: [],
 			searchCleared: [],

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1943,6 +1943,12 @@
 				}
 			} );
 
+			// The RETURN leg of this pair — the provider reporting that the camera has reached
+			// either end of its zoom range — cannot be wired here: `provider` is still null at
+			// this point (only `start()` constructs one), and `start()` REPLACES it on every
+			// retry, so a subscription made once out here would be dropped by the first retry
+			// anyway. It lives beside the other `provider.on()` calls in `start()`.
+
 			// `query`, not `displayName` (live-review round 4). A suggestion now carries BOTH: the
 			// SHORT form the customer reads ("Чертановская улица, 66к1") and the FULL one the
 			// geocoder needs ("Россия, Москва, Чертановская улица, 66к1"). Resolving the short form
@@ -2183,6 +2189,19 @@
 			busyClearedThisStart = false;
 
 			provider.on( 'select', handleSelection );
+
+			// The return leg of the zoom control: the panels emit a signed step and know nothing
+			// about map-library zoom levels (D-3), so the provider — which owns the camera — is
+			// what decides a limit has been reached, and the panels only dim the button it names.
+			// Registered HERE rather than beside the `panels.on( 'zoom' )` forward leg because
+			// `start()` builds a fresh provider on every retry; a subscription made once outside
+			// would be silently dropped by the first one. The fail-open is that a provider which
+			// never emits this simply leaves both buttons live.
+			provider.on( 'zoomChange', function( limits ) {
+				if ( panels ) {
+					panels.setZoomLimits( limits );
+				}
+			} );
 
 			provider.on( 'error', function( reason ) {
 				// A provider-level error breaks the WHOLE map — the framework's own error

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -1813,6 +1813,11 @@
 		this._messageTextEl = null;
 		this._messageRetryEl = null;
 
+		// The two zoom buttons {@see Panels.prototype.setZoomLimits} disables at either end of
+		// the map's zoom range — null until `render()` builds them, exactly like the two above.
+		this._zoomInEl = null;
+		this._zoomOutEl = null;
+
 		this.root = null;
 	}
 
@@ -2033,6 +2038,8 @@
 		this._messageRetryEl = null;
 		this._overlayEl = overlay;
 		this._toggleEl = toggle;
+		this._zoomInEl = zoomIn;
+		this._zoomOutEl = zoomOut;
 
 		var self = this;
 		toggle.addEventListener( 'click', function() {
@@ -2050,6 +2057,40 @@
 		} );
 
 		renderList( this );
+	};
+
+	/**
+	 * Disables «+» and/or «−» when the camera has reached that end of the map's zoom range
+	 * (operator's call, 08.08.2026: a button that stays clickable while doing nothing reads as
+	 * a bug). `pickup.css` dims a disabled button, so the state is visible and not merely
+	 * inert; `disabled` is the real attribute, not a class, so the button also stops taking
+	 * focus and announces itself correctly to a screen reader.
+	 *
+	 * FAILS OPEN, deliberately. Both buttons are enabled at render and only ever change when
+	 * something REPORTS a limit — a missing or non-boolean field leaves that button alone
+	 * rather than guessing. A map provider that never emits `zoomChange` (the embedded one, or
+	 * a third-party one written later against this same seam) therefore keeps two working
+	 * buttons, which is the correct degradation: a live button at a limit is a harmless no-op,
+	 * a dead button that should have worked is not. The RANGE itself is never known here —
+	 * this file emits a signed step and nothing else about zoom (D-3); the provider owns both
+	 * the range and the decision, exactly as it owns the camera.
+	 *
+	 * @since 2.0.2
+	 * @param {Object}  limits
+	 * @param {boolean} limits.canZoomIn  whether «+» still has somewhere to go.
+	 * @param {boolean} limits.canZoomOut whether «−» still has somewhere to go.
+	 * @returns {void}
+	 */
+	Panels.prototype.setZoomLimits = function( limits ) {
+		var state = limits || {};
+
+		if ( this._zoomInEl && 'boolean' === typeof state.canZoomIn ) {
+			this._zoomInEl.disabled = ! state.canZoomIn;
+		}
+
+		if ( this._zoomOutEl && 'boolean' === typeof state.canZoomOut ) {
+			this._zoomOutEl.disabled = ! state.canZoomOut;
+		}
 	};
 
 	/**


### PR DESCRIPTION
Operator's call, 08.08.2026: «+» and «−» stayed clickable at either end of the zoom range while
doing nothing, which reads as a bug to a customer who cannot know the range was exhausted.

## Where the decision lives

The provider owns the range, for the same D-3 reason it owns `zoomBy()`: the panels emit a
signed step and know nothing about map-library zoom levels.

```
panels  ──── zoom { step } ────►  mount  ────►  provider.zoomBy( step )
panels  ◄─── setZoomLimits() ───  mount  ◄────  provider 'zoomChange'
```

`zoomChange( { canZoomIn, canZoomOut } )` is computed against the SAME `MIN_ZOOM`/`MAX_ZOOM`
pair `_buildMap()` constrains ymaps' own drag/wheel zoom to and `zoomBy()` clamps against, so
the button's disabled state and the camera's actual refusal to move cannot disagree.

## Three decisions worth naming

- **Emitted on BOTH strategies.** `boundsChange` is viewport-only because it drives refetching.
  Hanging the zoom report off it would have left `bulk` — what the rig and every current
  consumer actually run — with permanently live buttons. Pinned by its own test.
- **Emitted once at init**, so a map opening at `MAX_ZOOM` (what `focusGroup()` does on a
  restored selection) does not show a live «+» until the customer first moves the camera.
- **Deduped.** ymaps fires `boundschange` throughout an animated move; an undeduped report
  would rewrite the same two booleans every frame of every pan.

`setZoomLimits()` **fails open**: anything short of an explicit boolean leaves that button
alone, so a provider that never reports keeps two working buttons. A live button at a limit is
a harmless no-op; a dead button that should have worked is not.

`pickup.css` dims a disabled button to `0.4` and re-neutralises its `:hover` background (the
base hover rule would otherwise still light up a dead button). Dimmed, not hidden — a vanishing
button would slide the other one under the cursor.

## Two errors the tests caught before the rig did

1. The subscription cannot be wired beside the `panels.on( 'zoom' )` forward leg: `provider` is
   still `null` there, and `start()` **replaces** the provider on every retry, so a subscription
   made once outside would be dropped by the first one. It belongs beside the other
   `provider.on()` calls inside `start()`.
2. Feature-detecting `provider.on` was inconsistent defensive noise — `start()` already calls it
   bare for `select`/`error`; `on()` is part of the provider contract proper. The test asserting
   the guard was itself asserting a non-contract, and was replaced with the degradation that is
   real: a provider that registers and never emits.

## Verification

- `npm run test:js -- --roots "<rootDir>/tests/js"` — **732 green** (was 721; +11)
- Rig, live Yandex data, measured: initial both live → 12× out, «−» `disabled`, `opacity: 0.4`
  → 14× in, «+» `disabled`, `opacity: 0.4` → one step back, both live again.