### PR TITLE
fix(pickup): wire the viewport strategy's lazy detail fetch (#219)

### DIFF
--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -243,6 +243,9 @@ function StubPanels( container, config ) {
 	/** @type {Array} every `setZoomLimits()` payload, in order. */
 	this.setZoomLimitsCalls = [];
 
+	/** @type {Array} every `updatePoint()` call, in order (issue #219). */
+	this.updatePointCalls = [];
+
 	StubPanels.instances.push( this );
 }
 
@@ -460,6 +463,15 @@ StubPanels.prototype.setZoomLimits = function( limits ) {
 };
 
 /**
+ * Issue #219: records the landing half of the viewport lazy-detail fetch. The real method's
+ * merge semantics are `pickup-panels.test.js`'s job; this file proves only WHEN the mount
+ * calls it.
+ */
+StubPanels.prototype.updatePoint = function( pointId, fields ) {
+	this.updatePointCalls.push( { pointId: pointId, fields: fields } );
+};
+
+/**
  * Task 17 (spec V-5): records every `showMessage( key )`/`hideMessage()` call — this file's own
  * tests assert on `panels.showMessageCalls`/`panels.hideMessageCalls` rather than any modal-level
  * DOM, since the real `Panels.prototype.showMessage()`'s own DOM contract is `pickup-panels.test.js`'s
@@ -505,12 +517,20 @@ function fakeDataSourceFactory( impl ) {
 
 		return {
 			fetchPoints: impl,
-			fetchDetails: function() {
-				return Promise.resolve( {} );
-			},
+			fetchDetails: factory.fetchDetails,
 			selectPoint: factory.selectPoint,
 		};
 	}
+
+	// Issue #219: resolves with the full record `Pickup_Controller::get_point_data()` returns —
+	// the same shape a listing point has, plus a freshly computed `selectable`. Overridable per
+	// test (`factory.fetchDetails = …`) for the staleness/failure paths.
+	factory.fetchDetails = jest.fn( function( pointId ) {
+		return Promise.resolve( {
+			id: pointId,
+			selectable: { allowed: false, reason: 'Только предоплата.' },
+		} );
+	} );
 
 	factory.selectPoint = jest.fn( function() {
 		return Promise.resolve( { allowed: true, reason: null, close: null, refresh_checkout: null } );
@@ -944,13 +964,23 @@ function openPicker( overrides ) {
 	};
 }
 
+/**
+ * The factory `beforeEach()` installs on `window` — held here so a test can read its
+ * `fetchDetails` spy or swap it for a controllable one (issue #219). `openPicker()` installs its
+ * OWN factory and is deliberately not covered by this handle.
+ *
+ * @type {Function}
+ */
+let dataSourceFactory;
+
 beforeEach( () => {
 	StubProvider.instances = [];
 	StubPanels.instances = [];
 	callOrder = [];
 	buildCheckoutDom();
 	window.WoodevPickupMapProviders = { testProvider: StubProvider };
-	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [] ) );
+	dataSourceFactory = fakeDataSourceFactory( () => Promise.resolve( [] ) );
+	window.WoodevPickupDataSource = dataSourceFactory;
 	window.WoodevPickupPanels = StubPanels;
 } );
 
@@ -2299,6 +2329,120 @@ test( 'panels zoom calls provider.zoomBy with the signed step (Task 14, spec V-1
 	session.panels.emit( 'zoom', { step: -1 } );
 
 	expect( session.provider.zoomByCalls ).toEqual( [ 1, -1 ] );
+} );
+
+// -----------------------------------------------------------------------
+// Issue #219 — the viewport strategy's lazy detail fetch. Every piece of it existed (the REST
+// route, `Point_Source::fetch_details()`, the server-side verdict recomputation, the datasource
+// method and its own tests) except a production caller: `fetchPoints` was rewired onto the mount
+// during the Task 20 migration and `fetchDetails` was left behind. A `STRATEGY_VIEWPORT` carrier
+// may omit `accepts_cod`/`max_weight` from its bbox listing, so without this every point stayed
+// selectable and the refusal only arrived at confirmation.
+// -----------------------------------------------------------------------
+describe( 'viewport lazy detail fetch (#219)', () => {
+	const openCardOn = ( session, pointId ) => {
+		const group = { key: 'g1', lat: 55.75, lng: 37.61, points: [ { id: pointId } ] };
+
+		session.panels.emit( 'cardOpened', { group: group, pointId: pointId, origin: 'list' } );
+	};
+
+	test( 'opening a card pulls that point\'s full record and merges it in', async () => {
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'FIX-VIEW-2' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledWith( 'FIX-VIEW-2' );
+		expect( session.panels.updatePointCalls ).toEqual( [ {
+			pointId: 'FIX-VIEW-2',
+			fields: { id: 'FIX-VIEW-2', selectable: { allowed: false, reason: 'Только предоплата.' } },
+		} ] );
+	} );
+
+	// The bulk listing already carried the full record; a request per card open would be pure
+	// waste against the merchant's carrier quota.
+	test( 'bulk never asks — its listing already carried the full record', async () => {
+		const session = await openSession( configWith( { strategy: 'bulk' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).not.toHaveBeenCalled();
+		expect( session.panels.updatePointCalls ).toHaveLength( 0 );
+	} );
+
+	// Re-opening a card, switching tabs inside a co-located group and re-entering from the map
+	// all funnel through `cardOpened`, and none of them learn anything new.
+	test( 'asks once per point per listing, however many times the card reopens', async () => {
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+		openCardOn( session, 'P1' );
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	// …but a fresh listing carries freshly computed verdicts, because the cart weight or the
+	// payment method may be exactly what changed.
+	test( 'asks again after a new listing lands', async () => {
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		// A pan — the ordinary way a new listing lands under this strategy.
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	// A marker click and a sidebar row both swap the card without waiting for anything, so an
+	// answer can land about a point the customer is no longer reading.
+	test( 'a late answer is dropped when the card has moved to another point', async () => {
+		let settle;
+
+		dataSourceFactory.fetchDetails = jest.fn( () => new Promise( ( resolve ) => {
+			settle = resolve;
+		} ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		openCardOn( session, 'P2' );
+
+		settle( { id: 'P1', selectable: { allowed: false, reason: 'нет' } } );
+		await flushAsync();
+
+		const forP1 = session.panels.updatePointCalls.filter( ( c ) => 'P1' === c.pointId );
+
+		expect( forP1 ).toHaveLength( 0 );
+	} );
+
+	// Degrades to exactly the pre-#219 behaviour: the SELECT route runs `fetch_details()` +
+	// `Constraint_Checker` itself, so a refused point is still refused — just later. The memo
+	// must not swallow the retry, though.
+	test( 'a failed fetch is quiet and the next card open retries it', async () => {
+		dataSourceFactory.fetchDetails = jest.fn( () => Promise.reject( { status: 502 } ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.updatePointCalls ).toHaveLength( 0 );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
+	} );
 } );
 
 // The return leg of the same wiring: the provider owns the zoom RANGE (it owns the camera), so

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -1064,6 +1064,74 @@ describe( 'setPointVerdict', () => {
 	} );
 } );
 
+// Issue #219: the landing half of the viewport strategy's lazy detail fetch. A
+// `STRATEGY_VIEWPORT` source may answer `fetch_points()` sparsely; `get_point_data()` returns the
+// SAME shape as a listing entry plus a freshly computed `selectable`, so this merges rather than
+// parses.
+describe( 'updatePoint', () => {
+	it( 'merges the fuller record over the held point and redraws the open card', () => {
+		const panels = mount( cardConfig );
+		const g = { key: 'k', size: 1, points: [ point() ] };
+		panels.setVisible( [ g ] );
+		panels.openCard( g, 'p1', 'list' );
+
+		panels.updatePoint( 'p1', { selectable: { allowed: false, reason: 'Только предоплата.' } } );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__warning' ).textContent )
+			.toBe( 'Только предоплата.' );
+		expect( panels.root.querySelector( '.woodev-pickup-card__cta' ).disabled ).toBe( true );
+	} );
+
+	// Load-bearing: the point objects inside `_groups` are the very objects the map provider also
+	// holds (`setVisible()`'s own note — panels keeps no private copy). Swapping one would leave
+	// every other holder pointing at the old sparse record.
+	it( 'mutates in place rather than replacing the object', () => {
+		const panels = mount( cardConfig );
+		const held = point();
+		const g = { key: 'k', size: 1, points: [ held ] };
+		panels.setVisible( [ g ] );
+
+		panels.updatePoint( 'p1', { phone: '+7 495 000-00-00' } );
+
+		expect( g.points[ 0 ] ).toBe( held );
+		expect( held.phone ).toBe( '+7 495 000-00-00' );
+	} );
+
+	// A details response carrying a different id is a server/domain bug; letting it through would
+	// silently re-key a point inside a group, which nothing downstream would detect.
+	it( 'never lets the payload overwrite the id', () => {
+		const panels = mount( cardConfig );
+		const held = point();
+		panels.setVisible( [ { key: 'k', size: 1, points: [ held ] } ] );
+
+		panels.updatePoint( 'p1', { id: 'SOMETHING-ELSE', phone: '+7 000' } );
+
+		expect( held.id ).toBe( 'p1' );
+		expect( held.phone ).toBe( '+7 000' );
+	} );
+
+	it( 'leaves other points in the same group alone', () => {
+		const panels = mount( cardConfig );
+		const a = point( { id: 'a' } );
+		const b = point( { id: 'b' } );
+		panels.setVisible( [ { key: 'k', size: 2, points: [ a, b ] } ] );
+
+		panels.updatePoint( 'a', { phone: '+7 111' } );
+
+		expect( a.phone ).toBe( '+7 111' );
+		expect( b.phone ).not.toBe( '+7 111' );
+	} );
+
+	it( 'is a no-op for an unknown point, a non-object payload, or before any points arrived', () => {
+		const panels = mount( cardConfig );
+		panels.setVisible( [ { key: 'k', size: 1, points: [ point() ] } ] );
+
+		expect( () => panels.updatePoint( 'nope', { phone: '+7' } ) ).not.toThrow();
+		expect( () => panels.updatePoint( 'p1', null ) ).not.toThrow();
+		expect( () => mount( cardConfig ).updatePoint( 'p1', { phone: '+7' } ) ).not.toThrow();
+	} );
+} );
+
 describe( 'showSelectionError', () => {
 	it( 'shows a transient message without disabling the CTA', () => {
 		const panels = mount( cardConfig );

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1080,6 +1080,17 @@
 		 *  'viewport'` only) — what a type-filter change or {@see refresh} re-fetches against. */
 		var lastBbox = null;
 
+		/** @type {string|null} the point the card currently shows, as the `cardOpened` funnel last
+		 *  reported it — the staleness guard for {@see refreshPointDetails}. A plain id, not a
+		 *  generation, because unlike a confirmation a detail fetch is idempotent and re-opening
+		 *  the SAME point is a legitimate reason to accept a late answer. */
+		var cardPointId = null;
+
+		/** @type {Object.<string, boolean>} point ids whose details have already landed this
+		 *  listing — see {@see refreshPointDetails}. Emptied on every successful listing fetch,
+		 *  because that is the moment the cart (and so the verdict) may have changed under us. */
+		var detailedPoints = {};
+
 		/** @type {number} mints one unique, monotonic token per confirmation this session sends.
 		 *  Never reset, never reused — that is the whole point (see `pendingSelectionToken`). */
 		var selectionTokens = 0;
@@ -1356,6 +1367,62 @@
 			return { locality: resolveLocality( config ), types: currentTypeFilter };
 		}
 
+		/**
+		 * Pulls one point's FULL record and merges it over the sparse one the card is showing —
+		 * the missing half of the viewport strategy (issue #219).
+		 *
+		 * A `STRATEGY_VIEWPORT` source may answer `fetch_points()` without the constraint inputs
+		 * (`accepts_cod`, `max_weight`); `Pickup_Controller::get_point_data()` re-runs
+		 * `Constraint_Checker` over the full record, so the response carries a REAL verdict where
+		 * the listing carried a permissive-by-omission one. Without this call the customer is
+		 * offered every point as selectable and only learns otherwise at confirmation.
+		 *
+		 * `bulk` never calls this: its listing already carried the full record, so a request per
+		 * card open would be pure waste against the merchant's carrier quota.
+		 *
+		 * ONCE PER POINT PER LISTING. Re-opening a card, switching tabs inside a co-located group
+		 * and re-entering from the map all funnel through `cardOpened`, and none of them learn
+		 * anything new. The memo is emptied whenever a listing fetch succeeds, because that is the
+		 * moment the cart — and therefore the verdict — may have moved underneath us.
+		 *
+		 * DEGRADES TO EXACTLY TODAY'S BEHAVIOUR ON FAILURE, which is why it stays quiet: the
+		 * SELECT route runs `fetch_details()` + `Constraint_Checker` itself
+		 * ({@see handle_select_request}), so a refused point is still refused — the refusal simply
+		 * arrives when the customer clicks rather than when the card opens. Blocking the card on a
+		 * request that only ever IMPROVES what it already shows would trade a working picker for a
+		 * spinner.
+		 *
+		 * @param {string} pointId
+		 * @returns {void}
+		 */
+		function refreshPointDetails( pointId ) {
+			var id = String( pointId );
+
+			if ( 'viewport' !== config.strategy || ! id || detailedPoints[ id ] ) {
+				return;
+			}
+
+			detailedPoints[ id ] = true;
+
+			realDataSource.fetchDetails( id ).then(
+				function( point ) {
+					// The card can move to another point while this is in flight — a marker click
+					// and a sidebar row both swap it without waiting for anything. Applying then
+					// would write one point's record over whatever the customer is now reading.
+					if ( destroyed || ! panels || id !== cardPointId ) {
+						return;
+					}
+
+					panels.updatePoint( id, point );
+				},
+				function() {
+					// Retryable: the memo is what makes the next card open ask again, and the
+					// point keeps its permissive listing verdict until something says otherwise.
+					delete detailedPoints[ id ];
+				}
+			);
+		}
+
 		function fetchAndSetPoints( query ) {
 			return realDataSource.fetchPoints( query ).then(
 				function( points ) {
@@ -1367,6 +1434,12 @@
 					if ( destroyed ) {
 						return points;
 					}
+
+					// A fresh listing carries a freshly computed verdict for every point, so
+					// whatever a detail fetch learned about the PREVIOUS listing is now history —
+					// the cart weight or the payment method may be what changed. See
+					// {@see refreshPointDetails}.
+					detailedPoints = {};
 
 					var groups = geo.groupByPosition( points );
 					var byKey = {};
@@ -1886,6 +1959,13 @@
 				if ( 0 !== pendingSelectionToken && String( payload.pointId ) !== pendingSelectionPointId ) {
 					invalidateSelection();
 				}
+
+				// Recorded BEFORE the early `'restore'` return below — a restored card shows a
+				// point like any other, and its details are just as worth having. It is also what
+				// {@see refreshPointDetails} checks its own late answer against.
+				cardPointId = String( payload.pointId );
+
+				refreshPointDetails( payload.pointId );
 
 				// `'restore'` is the ONE origin that moves no camera at all (operator decision,
 				// 06.08.2026 — the reopened picker shows the chosen point's CARD now, not the

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -3069,6 +3069,61 @@
 	};
 
 	/**
+	 * Merges a fuller record over a point this instance already holds — the landing half of the
+	 * viewport strategy's lazy detail fetch (issue #219).
+	 *
+	 * A `STRATEGY_VIEWPORT` source is explicitly allowed to answer `fetch_points()` SPARSELY:
+	 * the constraint inputs (`accepts_cod`, `max_weight`) and any display field a bbox listing
+	 * omits arrive only from `fetch_details()`. `Pickup_Controller::get_point_data()` returns the
+	 * SAME shape as a listing entry — `to_browser_array()` plus a freshly computed `selectable`
+	 * — so this merges rather than parses: whatever the server sent wins, field by field.
+	 *
+	 * MUTATES IN PLACE rather than swapping the object, which is load-bearing: the point objects
+	 * inside `this._groups` are the very objects the map provider also holds (see
+	 * {@see Panels.prototype.setVisible}'s note — `panels` keeps no private copy). Replacing one
+	 * would leave every other holder pointing at the old sparse record.
+	 *
+	 * `id` is never overwritten, whatever the payload says. A details response carrying a
+	 * different id is a server/domain bug, and letting it through would silently re-key a point
+	 * inside a group — the one corruption this method could cause that nothing downstream would
+	 * detect.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @param {string|number} pointId
+	 * @param {Object}        fields the fuller record, in the same shape a listing point has.
+	 * @returns {void}
+	 */
+	Panels.prototype.updatePoint = function( pointId, fields ) {
+		if ( ! fields || 'object' !== typeof fields ) {
+			return;
+		}
+
+		var id = String( pointId );
+		var found = false;
+
+		this._groups.forEach( function( group ) {
+			group.points.forEach( function( point ) {
+				if ( String( point.id ) !== id ) {
+					return;
+				}
+
+				found = true;
+
+				Object.keys( fields ).forEach( function( key ) {
+					if ( 'id' !== key ) {
+						point[ key ] = fields[ key ];
+					}
+				} );
+			} );
+		} );
+
+		if ( found && this._activeGroup ) {
+			renderCard( this );
+		}
+	};
+
+	/**
 	 * Shows a TRANSIENT selection failure — a dropped request, a timeout, a stale page — in the
 	 * card's existing `.woodev-pickup-card__warning` slot (spec D-6/D-7). Deliberately NOT
 	 * stored anywhere, unlike {@see Panels.prototype.setPointVerdict}: nothing about the point


### PR DESCRIPTION
## The defect

The lazy-detail half of `STRATEGY_VIEWPORT` was built on both sides and never connected:

| Link | Before |
|---|---|
| REST `/points/(?P<id>…)` | ✅ existed |
| `Point_Source::fetch_details()` | ✅ existed, implemented in both fixtures |
| Server-side verdict recomputation over the full record | ✅ existed |
| `dataSource.fetchDetails()` | ✅ existed, tested (nonce, 404, no debounce) |
| **A production caller** | ❌ **none anywhere** |

The mount's own test file recorded it in a docblock: *"`fetchDetails()` is unused by this file
and stubbed trivially."*

**A migration regression.** `map-provider-yandex.js` still carries the fossil: the provider used
to pull points through an injected dataSource (`fetchPoints`/`fetchDetails`) and Task 20 moved
that to the mount — `fetchPoints` was rewired, `fetchDetails` was not. Nothing could catch it:
`bulk` has no use for lazy details, and viewport had not been rig-run since s46.

**What it cost.** A viewport carrier may omit `accepts_cod`/`max_weight` from its bbox listing —
the OZON/Pochta shape the strategy exists for — so every point stayed selectable and the refusal
only arrived at confirmation.

## The fix

`Panels.prototype.updatePoint()` merges the fuller record over the held point.
`Pickup_Controller::get_point_data()` already returns the SAME shape as a listing entry plus a
freshly computed `selectable`, so this merges rather than parses.

Two things it is careful about:

- **Mutates in place.** Those point objects are the very objects the map provider also holds
  (`setVisible()`'s own note — panels keeps no private copy). Swapping one would leave every
  other holder pointing at the old sparse record.
- **Never overwrites `id`.** A details response for a different id is a server/domain bug, and
  letting it through would silently re-key a point inside a group — the one corruption nothing
  downstream would detect.

The mount asks **once per point per listing** (a reopen, a tab switch inside a co-located group
and a re-entry from the map all funnel through `cardOpened` and learn nothing new), and empties
that memo whenever a listing lands, because that is the moment the cart — and so the verdict —
may have moved. A late answer is dropped when the card has already moved to another point.

**`bulk` never asks**: its listing already carried the full record, so a request per card open
would be pure waste against the merchant's carrier quota.

## Quiet on failure — and why that is not a silent failure

The SELECT route runs `fetch_details()` + `Constraint_Checker` itself, so a refused point is
still refused; the refusal simply arrives at the click instead of at the card — i.e. exactly the
pre-#219 behaviour. Blocking the card on a request that only ever IMPROVES what it already shows
would trade a working picker for a spinner. The memo is released so the next card open retries.

## Verification

Rig-measured on `FIX-VIEW-2` — the fixture point built for precisely this case and never once
observed working:

```
calls   : ["/points/FIX-VIEW-2", "/points?bbox=…"]
cta     : { disabled: true }
warning : «В этом пункте выдачи недоступна оплата при получении…»
```

`npm run test:js -- --roots "<rootDir>/tests/js"` — **743 green** (was 732; +11), covering: the
viewport fetch and merge, `bulk` never asking, the per-listing memo, the memo released by a new
listing, the stale-answer drop, and the quiet retryable failure.

Closes #219