### PR TITLE
fix(pickup): filter the sidebar on pan and indicate every background load (#222, #224)

### DIFF
--- a/tests/js/map-provider-yandex.test.js
+++ b/tests/js/map-provider-yandex.test.js
@@ -1742,6 +1742,30 @@ test( 'bulk: a boundschange listener recomputes visibleChange only — never emi
 	expect( seenTooWide ).toHaveLength( 0 );
 } );
 
+// Issue #222: under `viewport`, the `boundschange` listener used to call ONLY
+// `_checkAndEmitBounds()`/`_emitZoomChange()` — never `_emitVisibleChange()` — so the sidebar list
+// only updated once the SERVER answered the resulting `boundsChange` refetch (7-10s on the rig),
+// while the map itself (drawing whatever `setPoints()` last handed it) could show a DIFFERENT,
+// already-stale set of pins in the meantime. `_emitVisibleChange()` is a pure client-side recompute
+// over the last-drawn `_groupsByKey` — no request — so it must run on every pan/zoom exactly like
+// the `bulk` listener already does (see the test immediately above). Asserted against the listener
+// ACTUALLY REGISTERED on the map (`fireBoundsChange()`), never a direct `_emitVisibleChange()` call
+// — the whole defect was in the WIRING, not the method itself, which already had its own passing
+// tests further up this file.
+test( 'viewport: the boundschange listener ALSO recomputes visibleChange client-side, without '
+	+ 'waiting for the server-driven boundsChange refetch to answer (#222)', async () => {
+	const provider = await init( { strategy: 'viewport', locality: '' } );
+	const seenVisible = [];
+
+	provider.setPoints( [ group( 'a', 5, 5 ), group( 'b', 50, 50 ) ] );
+	provider.on( 'visibleChange', ( keys ) => seenVisible.push( keys ) );
+
+	ymapsStub.lastMap.bounds = [ [ 0, 0 ], [ 10, 10 ] ];
+	ymapsStub.lastMap.fireBoundsChange();
+
+	expect( seenVisible[ 0 ] ).toEqual( [ 'a' ] );
+} );
+
 test( 'viewport: emits boundsChange once for the initial (already-resolved) viewport, before any pan', async () => {
 	const seen = [];
 	const config = makeConfig( { strategy: 'viewport', locality: '' } );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2590,6 +2590,45 @@ describe( 'the shared background-load indicator (issues #222/#224)', () => {
 
 		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
 	} );
+
+	// Adversarial-review finding: `bumpLoading()` runs, then `realDataSource.fetchPoints()`/
+	// `fetchDetails()` is called — if THAT call throws SYNCHRONOUSLY (before ever returning a
+	// promise), neither `.then()` handler below it would run, `dropLoading()` would never fire,
+	// and the counter (and the `is-loading` class it drives) would stay pinned on forever — the
+	// exact failure mode `dropLoading()`'s own docblock rules out. Both `fetchAndSetPoints()` and
+	// `refreshPointDetails()` now wrap the dataSource call in `Promise.resolve().then( … )` so a
+	// synchronous throw lands in the SAME reject handler an async rejection already does.
+	test( 'fetchPoints() throwing SYNCHRONOUSLY still returns the indicator to false, not a leak', async () => {
+		window.WoodevPickupDataSource = fakeDataSourceFactory( () => {
+			throw new Error( 'synchronous boom' );
+		} );
+
+		const session = await openSession( configWith() );
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
+	} );
+
+	test( 'fetchDetails() throwing SYNCHRONOUSLY still returns the indicator to false, not a leak, '
+		+ 'and the memo is evicted so the next card open retries it', async () => {
+		dataSourceFactory.fetchDetails = jest.fn( () => {
+			throw new Error( 'synchronous boom' );
+		} );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
+
+		// Matches the async-rejection sibling test above ("a failed fetch is quiet and the next
+		// card open retries it") — the memo eviction in the reject branch runs identically whether
+		// the rejection arrived synchronously or asynchronously.
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
+	} );
 } );
 
 // The return leg of the same wiring: the provider owns the zoom RANGE (it owns the camera), so
@@ -3320,6 +3359,43 @@ describe( 'loading stages (spec V-4)', () => {
 		document.body.removeEventListener( 'woodev_modal_closed', onClose );
 
 		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	// Adversarial-review finding: `dropLoading()` deliberately skips `panels.setLoading( false )`
+	// once `destroyed` is true, so IF the stage element survived teardown a request settling after
+	// `destroy()` would leave it pinned `is-loading` forever. It does not survive: this session's
+	// own `destroy()` calls `panels.destroy()`, whose own docblock states it removes `this._stage`
+	// from the DOM ("Panels.prototype.destroy" in pickup-panels.js) — SYNCHRONOUSLY, before the
+	// in-flight request ever gets a chance to settle. This test pins that invariant directly
+	// (rather than re-deriving it from the two files' docblocks on faith) so a future change to
+	// either `destroy()` cannot silently re-open the leak this finding worried about.
+	test( 'destroying the session while a fetch is in flight removes the stage from the DOM — a '
+		+ 'later settle has nothing left to leave stuck is-loading', async () => {
+		const fetch = pendingDataSource();
+
+		setConfig( configWith() );
+		mountAll();
+		clickTrigger();
+		await flushAsync();
+
+		const stage = document.querySelector( '.woodev-pickup-stage' );
+
+		expect( stage ).not.toBeNull();
+		expect( document.body.contains( stage ) ).toBe( true );
+
+		getSession( FIELD_ID ).destroy();
+
+		// The stage is gone from the document IMMEDIATELY — destroy() is synchronous end to end
+		// (panels.destroy() included), never waiting on the still-pending fetch below.
+		expect( document.body.contains( stage ) ).toBe( false );
+
+		// The request settles AFTER teardown — `dropLoading()`'s `destroyed` guard skips
+		// `setLoading( false )` here, exactly as designed, and it is harmless: there is no live
+		// `.woodev-pickup-stage` left anywhere for a stale `is-loading` class to be visible on.
+		fetch.resolve( [] );
+		await flushAsync();
+
+		expect( document.querySelectorAll( '.woodev-pickup-stage' ) ).toHaveLength( 0 );
 	} );
 } );
 

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -246,6 +246,9 @@ function StubPanels( container, config ) {
 	/** @type {Array} every `updatePoint()` call, in order (issue #219). */
 	this.updatePointCalls = [];
 
+	/** @type {Array<boolean>} every `setLoading()` call, in order (issues #222/#224). */
+	this.setLoadingCalls = [];
+
 	StubPanels.instances.push( this );
 }
 
@@ -451,6 +454,16 @@ StubPanels.prototype.setBusy = function( busy ) {
 
 StubPanels.prototype.isBusy = function() {
 	return !! this._busy;
+};
+
+/**
+ * Issues #222/#224: records every `setLoading()` call, in order — the shared background-load
+ * indicator. The real method's DOM contract (the `is-loading` class, the two indicator elements)
+ * is `pickup-panels.test.js`'s job; this file only proves WHEN and how many times the mount calls
+ * it, via `panels.setLoadingCalls`.
+ */
+StubPanels.prototype.setLoading = function( loading ) {
+	this.setLoadingCalls.push( !! loading );
 };
 
 /**
@@ -2442,6 +2455,140 @@ describe( 'viewport lazy detail fetch (#219)', () => {
 		await flushAsync();
 
 		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// Issues #222/#224 — the shared background-load indicator. `fetchAndSetPoints()` (every bbox
+// refetch) and `refreshPointDetails()` (issue #219's lazy detail fetch) both drive ONE shared
+// counter, so a later task (#223, the card CTA lock) can hang off the same counter instead of
+// racing a second spinner. A COUNTER, not a boolean: a bbox refetch and a detail fetch genuinely
+// overlap, and a boolean would let whichever settles FIRST switch the indicator off while the
+// other is still running. `panels.setLoadingCalls` (a plain array — `toHaveLength( 0 )`, never
+// `toEqual( [] )`: this repo's test doubles record onto plain arrays, and `toEqual` ignores
+// `undefined` items, so an accidental `setLoading( undefined )` call would pass a `toEqual( [] )`
+// check it should have failed) records every call, in order.
+// -----------------------------------------------------------------------
+describe( 'the shared background-load indicator (issues #222/#224)', () => {
+	const openCardOn = ( session, pointId ) => {
+		const group = { key: 'g1', lat: 55.75, lng: 37.61, points: [ { id: pointId } ] };
+
+		session.panels.emit( 'cardOpened', { group: group, pointId: pointId, origin: 'list' } );
+	};
+
+	/**
+	 * Swaps in a datasource whose `fetchPoints()` AND `fetchDetails()` both stay pending until
+	 * the test explicitly settles them — the only way to observe the two requests genuinely
+	 * OVERLAPPING (a plain `fakeDataSourceFactory()` default settles `fetchPoints()` immediately,
+	 * which is fine for every OTHER describe block in this file but useless for proving the
+	 * counter's own 0→1→2→1→0 shape).
+	 */
+	function pendingFactory() {
+		let pointsSettle;
+
+		const factory = fakeDataSourceFactory( () => new Promise( ( resolve, reject ) => {
+			pointsSettle = { resolve, reject };
+		} ) );
+
+		let detailsSettle;
+
+		factory.fetchDetails = jest.fn( () => new Promise( ( resolve, reject ) => {
+			detailsSettle = { resolve, reject };
+		} ) );
+
+		window.WoodevPickupDataSource = factory;
+
+		return {
+			resolvePoints: ( points ) => pointsSettle.resolve( points || [] ),
+			rejectPoints: ( reason ) => pointsSettle.reject( reason ),
+			resolveDetails: ( point ) => detailsSettle.resolve( point ),
+			rejectDetails: ( reason ) => detailsSettle.reject( reason ),
+		};
+	}
+
+	test( 'a bbox refetch drives setLoading( true ) then setLoading( false )', async () => {
+		const ds = pendingFactory();
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true ] );
+
+		ds.resolvePoints( [] );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
+	} );
+
+	test( 'a FAILED bbox refetch still returns the indicator to false', async () => {
+		const ds = pendingFactory();
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		ds.rejectPoints( { status: 0, code: 'woodev_pickup_upstream_error', message: 'offline' } );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
+	} );
+
+	test( 'a point-detail fetch (#219) also drives setLoading( true ) then ( false )', async () => {
+		// Immediately-resolving is enough here — this test only proves BOTH calls happen, in
+		// order; the OVERLAP shape (a settle that must NOT clear the indicator) has its own test
+		// below, where genuinely holding the promise open is what the assertion needs.
+		dataSourceFactory.fetchDetails = jest.fn( () =>
+			Promise.resolve( { id: 'P1', selectable: { allowed: true, reason: null } } ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
+	} );
+
+	test( 'a FAILED point-detail fetch still returns the indicator to false', async () => {
+		dataSourceFactory.fetchDetails = jest.fn( () => Promise.reject( { status: 502 } ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
+	} );
+
+	test( 'overlap: a detail fetch settling first must NOT clear the indicator while the bbox '
+		+ 'refetch it overlapped with is still in flight', async () => {
+		const ds = pendingFactory();
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		// Request #1: the bbox refetch — left pending.
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true ] );
+
+		// Request #2: the detail fetch — overlaps #1, also left pending.
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		// Still just the ONE 0→1 transition — a second overlapping request must not re-fire it.
+		expect( session.panels.setLoadingCalls ).toEqual( [ true ] );
+
+		// #2 settles first — #1 is STILL in flight, so the indicator must stay ON.
+		ds.resolveDetails( { id: 'P1', selectable: { allowed: true, reason: null } } );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true ] );
+
+		// #1 settles — NOW the counter reaches zero and the indicator clears.
+		ds.resolvePoints( [] );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
 	} );
 } );
 

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -3601,41 +3601,75 @@ describe( 'setLoading()/isLoading() (issues #222/#224)', () => {
 	// non-`aria-hidden` text node the live region now needs to have anything to say, sourced
 	// through `text( this._config, 'loading' )` — the SAME i18n key `Pickup_Handler::get_js_config()`
 	// already emits for the dialog's own opening spinner, never a JS-side hardcoded string.
-	it( 'the sidebar role="status" region carries non-aria-hidden text from the loading i18n key', () => {
+	it( 'announces by WRITING the live region\'s text, and clears it again on the way out', () => {
 		const container = document.createElement( 'div' );
 		const loadingConfig = { ...config, i18n: { ...config.i18n, loading: 'Загрузка пунктов выдачи…' } };
 		const panels = new Panels( container, loadingConfig );
 
 		panels.render();
 
-		const region = container.querySelector( '.woodev-pickup-list__loading' );
-		const label = region.querySelector( '.woodev-pickup-visually-hidden' );
+		const status = container.querySelector( 'p.woodev-pickup-visually-hidden[role="status"]' );
 
-		expect( region.getAttribute( 'role' ) ).toBe( 'status' );
-		expect( label ).not.toBeNull();
-		expect( label.getAttribute( 'aria-hidden' ) ).toBeNull();
-		expect( label.textContent ).toBe( 'Загрузка пунктов выдачи…' );
+		expect( status ).not.toBeNull();
 
-		// The spinner stays decorative/silent — this fix adds a SECOND child, it does not touch
-		// the first.
-		const spinner = region.querySelector( '.woodev-pickup-spinner' );
+		// Idle: the region EXISTS and is in the accessibility tree, but says nothing.
+		expect( status.textContent ).toBe( '' );
 
-		expect( spinner.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+		panels.setLoading( true );
+		expect( status.textContent ).toBe( 'Загрузка пунктов выдачи…' );
+
+		// Cleared on the way out, so a SECOND load is a text CHANGE again rather than a rewrite
+		// of identical text — which some screen readers drop entirely.
+		panels.setLoading( false );
+		expect( status.textContent ).toBe( '' );
+
+		panels.setLoading( true );
+		expect( status.textContent ).toBe( 'Загрузка пунктов выдачи…' );
+	} );
+
+	// The re-critic's finding, pinned so it cannot regress: the live region must NOT be one of the
+	// two `display: none`-while-idle indicators. An element hidden that way is out of the
+	// accessibility tree, so filling it while invisible and then un-hiding it announces nothing —
+	// what a live region reports is a change to its TEXT. Hence the region is a stage sibling, and
+	// the sidebar overlay is now purely decorative.
+	it( 'the live region is a stage sibling, and the sidebar overlay is decorative only', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+
+		const status = container.querySelector( 'p.woodev-pickup-visually-hidden[role="status"]' );
+		const overlay = container.querySelector( '.woodev-pickup-list__loading' );
+
+		// The region hangs off the stage itself — not off the list panel, and not off either
+		// indicator, both of which are hidden exactly when the announcement matters most (the
+		// sidebar overlay is additionally hidden whenever a card is open or the list is collapsed).
+		expect( status.parentNode ).toBe( panels._stage );
+
+		expect( overlay.getAttribute( 'role' ) ).toBeNull();
+		expect( overlay.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+		expect( overlay.querySelector( '.woodev-pickup-spinner' ).getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+
+		// The progress bar stays decorative too — an indeterminate bar has no value to report.
+		expect( container.querySelector( '.woodev-pickup-progress' ).getAttribute( 'aria-hidden' ) ).toBe( 'true' );
 	} );
 
 	// Rule I1: a missing/blank i18n key renders blank, never a hardcoded Russian default that
 	// happens to read the same — see the file docblock. `config` (this describe block's shared
 	// fixture) carries no `loading` key at all, so this is the ordinary "PHP/JS key mismatch"
 	// case, not a deliberately-blanked override.
-	it( 'a missing loading i18n key leaves the region\'s text blank (rule I1)', () => {
+	it( 'a missing loading i18n key announces blank, never a hardcoded default (rule I1)', () => {
 		const container = document.createElement( 'div' );
 		const panels = new Panels( container, config );
 
 		panels.render();
+		panels.setLoading( true );
 
-		const label = container.querySelector( '.woodev-pickup-list__loading .woodev-pickup-visually-hidden' );
+		const status = container.querySelector( 'p.woodev-pickup-visually-hidden[role="status"]' );
 
-		expect( label.textContent ).toBe( '' );
+		// Silence, not the wrong language: a blank announcement is the correct degradation for a
+		// PHP/JS key mismatch, and it is what makes such a mismatch findable instead of masked.
+		expect( status.textContent ).toBe( '' );
 	} );
 } );
 

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -3500,6 +3500,103 @@ describe( 'setBusy()/isBusy() (spec V-4)', () => {
 } );
 
 // -----------------------------------------------------------------------
+// Issues #222/#224: setLoading()/isLoading() — the SHARED in-flight-background-load indicator,
+// separate from `setBusy()` above (the FIRST-open, stage-wide overlay) and `setSelectionBusy()`
+// (the card's own confirmation lock, live elsewhere). Drives a top-edge progress bar (any
+// in-flight load, regardless of what the sidebar is doing) and a spinner overlay on the sidebar
+// LIST specifically — both are pure CSS, keyed off `.woodev-pickup-stage`'s `is-loading` class
+// combined with the EXISTING `is-open`/`is-card` classes, so this file only has to prove the ONE
+// class this method actually owns. `pickup-mount.js`'s own wiring of WHEN to call this (a bbox
+// refetch, a lazy detail fetch, the overlap case) is that file's test's job.
+// -----------------------------------------------------------------------
+describe( 'setLoading()/isLoading() (issues #222/#224)', () => {
+	it( 'is not loading right after render() — both indicator elements exist, built once, no is-loading class', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+
+		expect( panels.isLoading() ).toBe( false );
+		expect( panels._stage.className ).not.toContain( 'is-loading' );
+		expect( container.querySelector( '.woodev-pickup-progress' ) ).not.toBeNull();
+		expect( container.querySelector( '.woodev-pickup-list__loading' ) ).not.toBeNull();
+	} );
+
+	it( 'setLoading( true ) marks the stage is-loading', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+		panels.setLoading( true );
+
+		expect( panels.isLoading() ).toBe( true );
+		expect( panels._stage.className ).toContain( 'is-loading' );
+	} );
+
+	it( 'setLoading( false ) clears is-loading again — the same two nodes, not new ones', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+		panels.setLoading( true );
+		const progress = container.querySelector( '.woodev-pickup-progress' );
+		const listLoading = container.querySelector( '.woodev-pickup-list__loading' );
+		panels.setLoading( false );
+
+		expect( panels.isLoading() ).toBe( false );
+		expect( panels._stage.className ).not.toContain( 'is-loading' );
+		expect( container.querySelector( '.woodev-pickup-progress' ) ).toBe( progress );
+		expect( container.querySelector( '.woodev-pickup-list__loading' ) ).toBe( listLoading );
+	} );
+
+	it( 'does not throw when called before render(), and the flag is still tracked (matches setBusy()\'s own shape)', () => {
+		const panels = new Panels( document.createElement( 'div' ), config );
+
+		expect( () => panels.setLoading( true ) ).not.toThrow();
+		expect( panels.isLoading() ).toBe( true );
+	} );
+
+	// #224: an open CARD must stay live and uncovered during a refetch — the sidebar overlay is
+	// CSS-gated on `.is-loading.is-open:not(.is-card)`, so this pins the CLASS COMBINATION that
+	// selector depends on rather than a computed style (jsdom does not execute this project's
+	// stylesheet). With `is-card` present, that selector cannot match, so the overlay cannot show —
+	// which is the whole point: a bbox refetch must never cover the point details/select button the
+	// customer is reading.
+	it( 'opening a card while loading leaves is-card set alongside is-loading/is-open — the CSS '
+		+ 'combination the sidebar overlay selector requires is-open AND is-loading AND NOT is-card', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+		panels.setLoading( true );
+		panels.openCard( group( 'g1', 55.75, 37.61, 'Точка' ) );
+
+		const stage = panels._stage;
+
+		expect( stage.classList.contains( 'is-loading' ) ).toBe( true );
+		expect( stage.classList.contains( 'is-open' ) ).toBe( true );
+		expect( stage.classList.contains( 'is-card' ) ).toBe( true );
+	} );
+
+	// The list-open, no-card case — the sidebar overlay's selector CAN match here.
+	it( 'opening the list (no card) while loading leaves is-card OFF — the combination the '
+		+ 'sidebar overlay selector requires', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+		panels.setLoading( true );
+		panels.openList();
+
+		const stage = panels._stage;
+
+		expect( stage.classList.contains( 'is-loading' ) ).toBe( true );
+		expect( stage.classList.contains( 'is-open' ) ).toBe( true );
+		expect( stage.classList.contains( 'is-card' ) ).toBe( false );
+	} );
+} );
+
+// -----------------------------------------------------------------------
 // Task 17 (spec V-5): showMessage()/hideMessage() — the plugin's own empty/error text as a
 // centred card over the map. NEVER a replacement for the whole interface (s48 decision, kept
 // here): unlike setBusy()'s stage-wide overlay above, this must not toggle `is-busy` — the list,

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -3594,6 +3594,49 @@ describe( 'setLoading()/isLoading() (issues #222/#224)', () => {
 		expect( stage.classList.contains( 'is-open' ) ).toBe( true );
 		expect( stage.classList.contains( 'is-card' ) ).toBe( false );
 	} );
+
+	// The adversarial-review fix: `.woodev-pickup-list__loading` carries `role="status"` but its
+	// only OTHER child is a decorative spinner marked `aria-hidden="true"` — toggling this
+	// element's CSS `display` announced nothing at all to a screen-reader user. This pins the
+	// non-`aria-hidden` text node the live region now needs to have anything to say, sourced
+	// through `text( this._config, 'loading' )` — the SAME i18n key `Pickup_Handler::get_js_config()`
+	// already emits for the dialog's own opening spinner, never a JS-side hardcoded string.
+	it( 'the sidebar role="status" region carries non-aria-hidden text from the loading i18n key', () => {
+		const container = document.createElement( 'div' );
+		const loadingConfig = { ...config, i18n: { ...config.i18n, loading: 'Загрузка пунктов выдачи…' } };
+		const panels = new Panels( container, loadingConfig );
+
+		panels.render();
+
+		const region = container.querySelector( '.woodev-pickup-list__loading' );
+		const label = region.querySelector( '.woodev-pickup-visually-hidden' );
+
+		expect( region.getAttribute( 'role' ) ).toBe( 'status' );
+		expect( label ).not.toBeNull();
+		expect( label.getAttribute( 'aria-hidden' ) ).toBeNull();
+		expect( label.textContent ).toBe( 'Загрузка пунктов выдачи…' );
+
+		// The spinner stays decorative/silent — this fix adds a SECOND child, it does not touch
+		// the first.
+		const spinner = region.querySelector( '.woodev-pickup-spinner' );
+
+		expect( spinner.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+	} );
+
+	// Rule I1: a missing/blank i18n key renders blank, never a hardcoded Russian default that
+	// happens to read the same — see the file docblock. `config` (this describe block's shared
+	// fixture) carries no `loading` key at all, so this is the ordinary "PHP/JS key mismatch"
+	// case, not a deliberately-blanked override.
+	it( 'a missing loading i18n key leaves the region\'s text blank (rule I1)', () => {
+		const container = document.createElement( 'div' );
+		const panels = new Panels( container, config );
+
+		panels.render();
+
+		const label = container.querySelector( '.woodev-pickup-list__loading .woodev-pickup-visually-hidden' );
+
+		expect( label.textContent ).toBe( '' );
+	} );
 } );
 
 // -----------------------------------------------------------------------

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -383,6 +383,19 @@
  *   CARD must stay live and uncovered (spec: it is about one specific point, and a bbox refetch
  *   does not change its contents; covering it would hide the address/hours the customer is
  *   reading and block the select button for the duration of the refetch).
+ *
+ * `display: none !important` / `display: block|flex !important` ON BOTH THE RESTING AND THE
+ * ACTIVE RULE FOR BOTH ELEMENTS — see `docs-internal/gotchas/hostile-theme-button-display-none-
+ * needs-important.md`'s s54 addendum: three separate defects in this same file already came from
+ * a plain (non-`!important`) `display` losing to a theme's own `!important` on that property, and
+ * the addendum promotes "treat `display` on any element inside `.woodev-pickup-stage` as an
+ * `!important`-only property" from anecdote to rule after the third hit. A theme that forces
+ * `display` on generic elements (some resets/page builders do exactly this, unconditionally, not
+ * only on interactive controls) would otherwise beat whichever one of the pair here has no
+ * `!important` of its own — the ACTIVE rule without it lets the indicator silently never appear
+ * (the defect this fix exists for); the RESTING rule without it would let the SAME theme force the
+ * indicator permanently visible instead. Both directions are the identical bug, so both rules for
+ * both elements carry the flag, not just the one the original report happened to notice.
  * ---------------------------------------------------------------------- */
 
 .woodev-pickup-progress {
@@ -400,11 +413,11 @@
 	overflow: hidden;
 	background: rgba( 0, 0, 0, 0.06 );
 	pointer-events: none;
-	display: none;
+	display: none !important;
 }
 
 .woodev-pickup-stage.is-loading .woodev-pickup-progress {
-	display: block;
+	display: block !important;
 }
 
 /* The moving sliver — INDETERMINATE (no known percentage, so no width/position ever settles):
@@ -457,14 +470,35 @@
 	position: absolute;
 	inset: 0;
 	z-index: 1;
-	display: none;
+	display: none !important;
 	align-items: center;
 	justify-content: center;
 	background: rgba( 255, 255, 255, 0.75 );
 }
 
 .woodev-pickup-stage.is-loading.is-open:not( .is-card ) .woodev-pickup-list__loading {
-	display: flex;
+	display: flex !important;
+}
+
+/* Visually-hidden but still screen-reader-readable — the standard clip-rect technique, scoped to
+   this component's own naming convention rather than relying on a host theme's `.screen-reader-text`
+   (WordPress core ships one, but nothing guarantees a given theme keeps it, or keeps it correct).
+   `.woodev-pickup-list__loading`'s `role="status"` region needs SOME non-`aria-hidden` content to
+   have anything to announce — its only other child is a decorative spinner marked `aria-hidden`
+   (`pickup-panels.js`'s `render()`) — so this class exists to give that region readable text without
+   drawing a visible label over the spinner. `position: absolute` (not `display: none`/`visibility:
+   hidden`, both of which would remove the text from the accessibility tree the same way they remove
+   it from layout) and a 0×0 clip box are what keep it announced but never painted. */
+.woodev-pickup-visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect( 0, 0, 0, 0 );
+	white-space: nowrap;
+	border: 0;
 }
 
 /* -------------------------------------------------------------------------

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -415,17 +415,28 @@
 .woodev-pickup-progress__bar {
 	position: absolute;
 	top: 0;
-	left: -40%;
+	left: 0;
 	width: 40%;
 	height: 100%;
 	background: var( --woodev-pickup-accent, #06aedd );
 	animation: woodev-pickup-progress-slide 1.2s ease-in-out infinite;
 }
 
+/* TRANSFORM, NOT `left` — the two look identical and cost differently. This indicator exists
+   precisely for the slow case (a 10-13s fetch, measured on the rig), running over a live map
+   canvas the customer is also panning; animating `left` puts a layout pass on the main thread
+   every frame for the whole duration, which is main-thread time taken from the very map the
+   spinner is apologising for. A `translateX` animation is compositor-only. Percentages here are
+   of the BAR's own width (40% of the track), not the track's — hence -100%/250%, which place its
+   trailing edge at the track's left edge and its leading edge past the right one. */
 @keyframes woodev-pickup-progress-slide {
 
+	from {
+		transform: translateX( -100% );
+	}
+
 	to {
-		left: 100%;
+		transform: translateX( 250% );
 	}
 }
 

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -355,6 +355,108 @@
 }
 
 /* -------------------------------------------------------------------------
+ * The shared background-load indicator (issues #222/#224) — `pickup-panels.js`'s `setLoading()`,
+ * shown for every load AFTER the first one settles (a viewport pan/zoom refetch, a type-filter
+ * refetch, the lazy point-detail fetch from issue #219). The FIRST fetch of a session keeps its
+ * own, separately-measured-correct `.is-busy` overlay above, UNCHANGED; this is a DIFFERENT signal
+ * for every load after it, where that overlay never re-shows (`pickup-mount.js`'s
+ * `busyClearedThisStart` is one-shot per session).
+ *
+ * TWO ELEMENTS, ONE `is-loading` CLASS, DIFFERENT GATES — deliberately class-driven, NOT a
+ * `hidden` attribute toggled from JS. `.woodev-pickup-overlay`/`.woodev-pickup-message` above use
+ * `hidden` because a SINGLE JS call is the whole story for whether they show; these two are
+ * different — whether the SIDEBAR overlay specifically should show also depends on whether the
+ * LIST is the panel currently on screen, and the customer is free to open/close the list or a card
+ * at any moment during a load. A `hidden` attribute would need `pickup-panels.js` to re-evaluate
+ * that on every `listToggle`/`openCard()`/`closeCard()`, in addition to every `setLoading()` call;
+ * keying both off `.woodev-pickup-stage`'s classes lets the cascade do that math for free — `is-open`/
+ * `is-card` already exist and are already kept correct by every one of those calls, see the "ONE
+ * OPEN STATE, ON THE STAGE" note in this file's own docblock.
+ *
+ * - `.woodev-pickup-progress` (the top-edge bar): gated on `is-loading` ALONE — spans the whole
+ *   map regardless of what the sidebar is doing, because under `viewport` the customer usually
+ *   pans with the panel collapsed, and a sidebar-only indicator would be invisible exactly when it
+ *   matters most (a bbox refetch with no on-screen signal at all reads as a silently stuck map).
+ * - `.woodev-pickup-list__loading` (the sidebar spinner, a CHILD of `.woodev-pickup-list` — see
+ *   that element's own build in `pickup-panels.js`'s `render()`): gated on `is-loading` AND
+ *   `is-open` AND `NOT is-card` — the list must actually be the panel showing, and an open point
+ *   CARD must stay live and uncovered (spec: it is about one specific point, and a bbox refetch
+ *   does not change its contents; covering it would hide the address/hours the customer is
+ *   reading and block the select button for the duration of the refetch).
+ * ---------------------------------------------------------------------- */
+
+.woodev-pickup-progress {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 3px;
+
+	/* Above EVERYTHING else this file stacks, including the busy overlay's own z-index: 6 — the
+	   two are allowed to show together (see `pickup-panels.js`'s `setLoading()` docblock on why
+	   the FIRST fetch is not special-cased), and this bar must still read as "something is
+	   happening" rather than sit invisibly behind the overlay's translucent white. */
+	z-index: 7;
+	overflow: hidden;
+	background: rgba( 0, 0, 0, 0.06 );
+	pointer-events: none;
+	display: none;
+}
+
+.woodev-pickup-stage.is-loading .woodev-pickup-progress {
+	display: block;
+}
+
+/* The moving sliver — INDETERMINATE (no known percentage, so no width/position ever settles):
+   a fixed-width bar sweeps left to right and loops, the same "something is happening, no ETA"
+   language `.woodev-pickup-spinner` already speaks for the busy overlay. `--woodev-pickup-accent`
+   (identity, not the fill/contrast pair — this is a moving mark, not a surface with text on it),
+   matching `.woodev-pickup-spinner`'s own identical choice immediately below in this file. */
+.woodev-pickup-progress__bar {
+	position: absolute;
+	top: 0;
+	left: -40%;
+	width: 40%;
+	height: 100%;
+	background: var( --woodev-pickup-accent, #06aedd );
+	animation: woodev-pickup-progress-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes woodev-pickup-progress-slide {
+
+	to {
+		left: 100%;
+	}
+}
+
+/* Slowed rather than stopped, matching `.woodev-pickup-spinner`'s own note immediately below in
+   this file — a frozen bar reads as a hang, the opposite of what it exists to communicate. */
+@media ( prefers-reduced-motion: reduce ) {
+
+	.woodev-pickup-progress__bar {
+		animation-duration: 3.6s;
+	}
+}
+
+/* The sidebar spinner overlay — a CHILD of `.woodev-pickup-list` (not a stage sibling), so it
+   inherits the list's own `position: absolute` box/rounded corners and covers exactly the list
+   panel, never the map or the card. `z-index: 1` is relative to the LIST's own stacking context
+   (its siblings inside `.woodev-pickup-list`, e.g. `.woodev-pickup-list__body`), not the stage's. */
+.woodev-pickup-list__loading {
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	display: none;
+	align-items: center;
+	justify-content: center;
+	background: rgba( 255, 255, 255, 0.75 );
+}
+
+.woodev-pickup-stage.is-loading.is-open:not( .is-card ) .woodev-pickup-list__loading {
+	display: flex;
+}
+
+/* -------------------------------------------------------------------------
  * Message card (Task 17, spec V-5) — the plugin's own empty/error text (`pickup-panels.js`'s
  * `showMessage()`) as a small centred card over the map, DELIBERATELY NOT the busy overlay
  * above: it carries no `is-busy`-equivalent companion class, so the search/filter controls and

--- a/woodev/shipping-method/assets/js/frontend/map-provider-yandex.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-yandex.js
@@ -1072,6 +1072,16 @@
 				self._checkAndEmitBounds();
 				self.map.events.add( 'boundschange', function() {
 					self._checkAndEmitBounds();
+
+					// Issue #222: without this, the sidebar list only updated once the SERVER
+					// answered the `boundsChange` refetch above (7-10s on the rig) — the map could
+					// already be showing a different, freshly-drawn set of pins while the list still
+					// listed the PREVIOUS viewport's points. `_emitVisibleChange()` is a pure
+					// client-side recompute over `_groupsByKey` (the last set `setPoints()` drew) —
+					// no request — so there is no reason to wait for the refetch before the sidebar
+					// catches up with what the camera already shows. Matches the `bulk` listener
+					// below, which has called this unconditionally from day one.
+					self._emitVisibleChange();
 					self._emitZoomChange();
 				} );
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1148,6 +1148,69 @@
 		 *  re-shows or re-hides the overlay a customer has already moved past. */
 		var busyClearedThisStart = false;
 
+		/** @type {number} Issues #222/#224: count of in-flight background requests — a bbox
+		 *  refetch ({@see fetchAndSetPoints}) and a lazy point-detail fetch ({@see refreshPointDetails},
+		 *  issue #219) both bump/drop it, and they genuinely overlap (the customer can open a card
+		 *  while a pan's refetch is still in flight), so this is a COUNTER, not a boolean — the
+		 *  first of two overlapping requests to settle must not switch
+		 *  {@see window.WoodevPickupPanels}'s shared indicator ({@see Panels#setLoading}) off while
+		 *  the other is still running. UNLIKE `busyClearedThisStart` above, this is never reset
+		 *  per {@see start} cycle — it is a plain in-flight tally, and a request that outlives a
+		 *  retry's fresh `start()` call (it cannot: every request this counts is scoped to ONE
+		 *  `provider`/`panels` pair that a retry destroys and rebuilds) would need to keep counting
+		 *  down regardless. See {@see bumpLoading}/{@see dropLoading}. */
+		var loadingCount = 0;
+
+		/**
+		 * Marks one more background request as in-flight (issues #222/#224) — the 0→1 transition is
+		 * what actually turns the shared indicator on; a second, third, … overlapping request only
+		 * bumps the count, and does NOT touch `panels.setLoading()` again (it is already on).
+		 *
+		 * `panels` is null under `ownsChrome` (an embedded provider owns its own chrome, see the
+		 * file docblock) and `destroyed` once the session has been torn down — both guarded exactly
+		 * like {@see clearInitialBusy} does, so this never touches a `panels` instance that may not
+		 * exist or whose DOM may already be gone. The counter itself still increments regardless of
+		 * either guard, so {@see dropLoading} always sees the matching decrement for every
+		 * {@see bumpLoading} call, however this session ends.
+		 *
+		 * @returns {void}
+		 */
+		function bumpLoading() {
+			loadingCount += 1;
+
+			if ( 1 === loadingCount && panels && ! destroyed ) {
+				panels.setLoading( true );
+			}
+		}
+
+		/**
+		 * The counterpart to {@see bumpLoading} — called on EVERY settle path of every request
+		 * that called it (both branches of {@see fetchAndSetPoints}'s `dataSource.fetchPoints()`
+		 * chain, both branches of {@see refreshPointDetails}'s `dataSource.fetchDetails()` chain,
+		 * success AND failure alike), so the counter always returns to zero, including when a
+		 * request fails — a counter that never reaches zero would pin the indicator on forever
+		 * (the exact shape a staleness guard elsewhere in this file was once burned by). Only the
+		 * 1→0 transition actually turns the indicator off, which is the whole reason this is a
+		 * counter and not a boolean: a request that settles while ANOTHER is still in flight (the
+		 * overlap case #222/#224 exists for) must leave the indicator showing.
+		 *
+		 * Never lets the counter go negative — defensive only; every call site pairs exactly one
+		 * {@see bumpLoading} with exactly one {@see dropLoading} per request (a settled Promise
+		 * invokes exactly one of its two callbacks exactly once, so within a single request there
+		 * is no way to double-drop).
+		 *
+		 * @returns {void}
+		 */
+		function dropLoading() {
+			if ( loadingCount > 0 ) {
+				loadingCount -= 1;
+			}
+
+			if ( 0 === loadingCount && panels && ! destroyed ) {
+				panels.setLoading( false );
+			}
+		}
+
 		/**
 		 * Clears the stage-wide busy overlay {@see start} opened once the map was drawn — the
 		 * stage 2 → stage 3 transition (spec V-4). Idempotent per {@see start} cycle via
@@ -1403,9 +1466,12 @@
 			}
 
 			detailedPoints[ id ] = true;
+			bumpLoading();
 
 			realDataSource.fetchDetails( id ).then(
 				function( point ) {
+					dropLoading();
+
 					// The card can move to another point while this is in flight — a marker click
 					// and a sidebar row both swap it without waiting for anything. Applying then
 					// would write one point's record over whatever the customer is now reading.
@@ -1416,6 +1482,8 @@
 					panels.updatePoint( id, point );
 				},
 				function() {
+					dropLoading();
+
 					// Retryable: the memo is what makes the next card open ask again, and the
 					// point keeps its permissive listing verdict until something says otherwise.
 					delete detailedPoints[ id ];
@@ -1424,8 +1492,12 @@
 		}
 
 		function fetchAndSetPoints( query ) {
+			bumpLoading();
+
 			return realDataSource.fetchPoints( query ).then(
 				function( points ) {
+					dropLoading();
+
 					// Task 16 (spec V-4): THIS fetch is the one stage 2's overlay was waiting on —
 					// win, lose, or empty, the customer gets an answer and the map becomes usable.
 					// A no-op past the first settle of this start() cycle (see the flag's own docblock).
@@ -1529,6 +1601,7 @@
 					// successful one does; the customer gets the error card, not a map stuck
 					// non-interactive forever over a request that will never come back.
 					clearInitialBusy();
+					dropLoading();
 
 					if ( ! destroyed ) {
 						showFetchMessage( errorMessageKey( config, reason ) );

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1468,7 +1468,25 @@
 			detailedPoints[ id ] = true;
 			bumpLoading();
 
-			realDataSource.fetchDetails( id ).then(
+			// `realDataSource.fetchDetails( id )` is still called SYNCHRONOUSLY, right here, exactly
+			// as before this fix — several call sites (this file's own tests among them) rely on the
+			// dataSource being asked THIS TICK, before anything awaits. What changed is the `try`:
+			// a dataSource that throws SYNCHRONOUSLY (before ever returning a promise) used to skip
+			// the `.then( resolve, reject )` pair below entirely — `bumpLoading()` already ran,
+			// `dropLoading()` never would, and the shared indicator would stay `is-loading` forever
+			// (the exact failure mode {@see dropLoading}'s own docblock rules out). Catching the
+			// throw and converting it to an already-rejected promise routes it through the SAME
+			// reject handler an async rejection already gets — `dropLoading()` plus the memo
+			// eviction below — rather than duplicating that cleanup a second time here.
+			var detailsPromise;
+
+			try {
+				detailsPromise = realDataSource.fetchDetails( id );
+			} catch ( error ) {
+				detailsPromise = Promise.reject( error );
+			}
+
+			detailsPromise.then(
 				function( point ) {
 					dropLoading();
 
@@ -1494,7 +1512,30 @@
 		function fetchAndSetPoints( query ) {
 			bumpLoading();
 
-			return realDataSource.fetchPoints( query ).then(
+			// `realDataSource.fetchPoints( query )` is still called SYNCHRONOUSLY, right here — see
+			// {@see refreshPointDetails}'s identical `try` immediately above for why: several
+			// callers (the provider's own `boundsChange`, this file's tests) expect the dataSource
+			// to be asked THIS TICK, and deferring the call itself (e.g. via a bare
+			// `Promise.resolve().then( function() { return realDataSource.fetchPoints( query ); } )`
+			// wrapper) would push it a microtask later than every one of them observes today.
+			// What the `try` adds is a safety net for a dataSource that throws SYNCHRONOUSLY (before
+			// ever returning a promise) — without it, `bumpLoading()`'s increment above is never
+			// balanced by a `dropLoading()`, because the exception unwinds the call stack straight
+			// past the `.then( resolve, reject )` pair below. Catching it and converting it to an
+			// already-rejected promise routes it through that SAME reject branch instead — the exact
+			// cleanup (`dropLoading()`, `clearInitialBusy()`, the degrade UI, the `Promise.reject()`
+			// re-throw) an async rejection already gets, not a second copy of it. Every existing
+			// caller of this function chains `.catch( function() {} )` onto its return value, so the
+			// settled-promise contract they observe is unchanged either way.
+			var pointsPromise;
+
+			try {
+				pointsPromise = realDataSource.fetchPoints( query );
+			} catch ( error ) {
+				pointsPromise = Promise.reject( error );
+			}
+
+			return pointsPromise.then(
 				function( points ) {
 					dropLoading();
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -1813,6 +1813,7 @@
 		this._loading = false;
 		this._progressEl = null;
 		this._listLoadingEl = null;
+		this._loadingStatusEl = null;
 
 		// Task 17 (spec V-5): the message card {@see Panels.prototype.showMessage} shows/hides —
 		// null until `render()` builds it, exactly like `_overlayEl` above.
@@ -1933,31 +1934,25 @@
 		// own `position: absolute` box and covers exactly the list panel, never the card that can sit
 		// above it (spec: an open card must stay live and uncovered during a refetch — see
 		// `pickup.css`'s own note on why this element's own visibility rule additionally requires
-		// `:not( .is-card )`). `role="status"` here, not on the top-edge progress bar built in
-		// {@see setLoading}'s own docblock — one live-region announcement per loading state is
-		// enough; the progress bar is purely decorative chrome for the SAME state.
+		// `:not( .is-card )`).
+		//
+		// PURELY VISUAL — `aria-hidden`, deliberately NOT a `role="status"` live region. It carries
+		// only a decorative spinner, and it is `display: none` whenever idle; an element hidden that
+		// way is out of the accessibility tree entirely, so a live region here would be created
+		// empty, populated while invisible, and then merely UN-HIDDEN. That is not a reliable
+		// announcement trigger in any screen reader: what a live region announces is a change to the
+		// TEXT INSIDE IT, and no text here would ever change. The announcement is carried instead by
+		// the always-present region {@see Panels.prototype.render} builds on the stage below, whose
+		// text {@see Panels.prototype.setLoading} writes and clears. Found by the Codex re-critic
+		// pass on this branch, after a first attempt did exactly the unreliable thing.
 		var listLoading = document.createElement( 'div' );
 		listLoading.className = 'woodev-pickup-list__loading';
-		listLoading.setAttribute( 'role', 'status' );
+		listLoading.setAttribute( 'aria-hidden', 'true' );
 
 		var listSpinner = document.createElement( 'span' );
 		listSpinner.className = 'woodev-pickup-spinner';
 		listSpinner.setAttribute( 'aria-hidden', 'true' );
 		listLoading.appendChild( listSpinner );
-
-		// The `role="status"` region above has no accessible text without this: the spinner is its
-		// only OTHER child and is itself `aria-hidden`, so toggling the region's CSS `display`
-		// announced nothing at all to a screen-reader user — visually the loading state was
-		// obvious, non-visually it did not exist. `text( this._config, 'loading' )` is the SAME
-		// i18n key `modal.showLoading()` already uses for the dialog's own opening spinner
-		// (`Pickup_Handler::get_js_config()`'s `loading` string); a missing key still renders blank
-		// per rule I1, never a hardcoded Russian default. `.woodev-pickup-visually-hidden`
-		// (pickup.css) keeps the text out of the visual layout — the spinner alone still carries the
-		// visible affordance — while leaving it in the accessibility tree for the region to announce.
-		var listLoadingText = document.createElement( 'span' );
-		listLoadingText.className = 'woodev-pickup-visually-hidden';
-		listLoadingText.textContent = text( this._config, 'loading' );
-		listLoading.appendChild( listLoadingText );
 
 		list.appendChild( listLoading );
 
@@ -2038,6 +2033,22 @@
 
 		stage.appendChild( progress );
 
+		// The ONE live region for the loading state (issues #222/#224). Permanently in the DOM and
+		// permanently in the ACCESSIBILITY TREE — visually hidden by clipping, never by `display`/
+		// `visibility`, both of which would take it back out of that tree and defeat the point.
+		//
+		// A live region announces a CHANGE TO ITS TEXT, not its own appearance, which is why this
+		// is a stage sibling rather than something inside either indicator: both of those are
+		// `display: none` while idle, and the sidebar one is additionally hidden whenever a card is
+		// open or the sidebar is collapsed — i.e. exactly when the customer most needs telling that
+		// the map is still working. This node is subject to none of that. {@see setLoading} writes
+		// the text on the way in and clears it on the way out, so a repeated load announces again.
+		var status = document.createElement( 'p' );
+		status.className = 'woodev-pickup-visually-hidden';
+		status.setAttribute( 'role', 'status' );
+
+		stage.appendChild( status );
+
 		// Task 16 (spec V-4 stage 2): built once here, always present, HIDDEN by default — never
 		// created/destroyed by `setBusy()` itself, matching `WoodevModal#showLoading()`'s own
 		// "idempotent, additive" node-reuse discipline (see that file's docblock). A stage sibling,
@@ -2108,6 +2119,7 @@
 		this._overlayEl = overlay;
 		this._progressEl = progress;
 		this._listLoadingEl = listLoading;
+		this._loadingStatusEl = status;
 		this._toggleEl = toggle;
 		this._zoomInEl = zoomIn;
 		this._zoomOutEl = zoomOut;
@@ -2251,6 +2263,18 @@
 
 		if ( this._stage ) {
 			this._stage.classList.toggle( 'is-loading', this._loading );
+		}
+
+		// The non-visual half. Writing the text is what actually ANNOUNCES — a live region reports
+		// a change to its contents, so un-hiding a pre-filled one says nothing (see the region's own
+		// build note in {@see render}). Cleared on the way out so the NEXT load is a change again
+		// rather than a rewrite of identical text, which some screen readers drop.
+		//
+		// Rule I1: the label comes from the plugin's own i18n bag and renders BLANK on a missing
+		// key — never a hardcoded Russian default that would mask a PHP/JS key mismatch. A blank
+		// announcement is the correct degradation here: silence, not a wrong language.
+		if ( this._loadingStatusEl ) {
+			this._loadingStatusEl.textContent = this._loading ? text( this._config, 'loading' ) : '';
 		}
 	};
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -1945,6 +1945,20 @@
 		listSpinner.setAttribute( 'aria-hidden', 'true' );
 		listLoading.appendChild( listSpinner );
 
+		// The `role="status"` region above has no accessible text without this: the spinner is its
+		// only OTHER child and is itself `aria-hidden`, so toggling the region's CSS `display`
+		// announced nothing at all to a screen-reader user — visually the loading state was
+		// obvious, non-visually it did not exist. `text( this._config, 'loading' )` is the SAME
+		// i18n key `modal.showLoading()` already uses for the dialog's own opening spinner
+		// (`Pickup_Handler::get_js_config()`'s `loading` string); a missing key still renders blank
+		// per rule I1, never a hardcoded Russian default. `.woodev-pickup-visually-hidden`
+		// (pickup.css) keeps the text out of the visual layout — the spinner alone still carries the
+		// visible affordance — while leaving it in the accessibility tree for the region to announce.
+		var listLoadingText = document.createElement( 'span' );
+		listLoadingText.className = 'woodev-pickup-visually-hidden';
+		listLoadingText.textContent = text( this._config, 'loading' );
+		listLoading.appendChild( listLoadingText );
+
 		list.appendChild( listLoading );
 
 		var card = document.createElement( 'div' );

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -1806,6 +1806,14 @@
 		this._busy = false;
 		this._overlayEl = null;
 
+		// Issues #222/#224: whether ANY background load (a bbox refetch, a lazy detail fetch) is
+		// currently in flight — see {@see Panels.prototype.setLoading}. Same "false until render(),
+		// but always tracked" shape as `_busy` above; `_progressEl`/`_listLoadingEl` are the two
+		// elements {@see Panels.prototype.render} builds for it.
+		this._loading = false;
+		this._progressEl = null;
+		this._listLoadingEl = null;
+
 		// Task 17 (spec V-5): the message card {@see Panels.prototype.showMessage} shows/hides —
 		// null until `render()` builds it, exactly like `_overlayEl` above.
 		this._messageEl = null;
@@ -1919,6 +1927,26 @@
 
 		list.appendChild( body );
 
+		// Issues #222/#224: built once here, always present, HIDDEN BY DEFAULT — same "build
+		// once, never create/destroy" discipline as `.woodev-pickup-overlay`/`.woodev-pickup-message`
+		// above. A CHILD of `.woodev-pickup-list` (not a stage sibling), so it inherits the list's
+		// own `position: absolute` box and covers exactly the list panel, never the card that can sit
+		// above it (spec: an open card must stay live and uncovered during a refetch — see
+		// `pickup.css`'s own note on why this element's own visibility rule additionally requires
+		// `:not( .is-card )`). `role="status"` here, not on the top-edge progress bar built in
+		// {@see setLoading}'s own docblock — one live-region announcement per loading state is
+		// enough; the progress bar is purely decorative chrome for the SAME state.
+		var listLoading = document.createElement( 'div' );
+		listLoading.className = 'woodev-pickup-list__loading';
+		listLoading.setAttribute( 'role', 'status' );
+
+		var listSpinner = document.createElement( 'span' );
+		listSpinner.className = 'woodev-pickup-spinner';
+		listSpinner.setAttribute( 'aria-hidden', 'true' );
+		listLoading.appendChild( listSpinner );
+
+		list.appendChild( listLoading );
+
 		var card = document.createElement( 'div' );
 		card.className = 'woodev-pickup-card';
 
@@ -1968,6 +1996,33 @@
 		zoom.appendChild( zoomOut );
 
 		stage.appendChild( zoom );
+
+		// Issues #222/#224: the top-edge progress bar — built once here, always present, HIDDEN by
+		// default, same node-reuse discipline as the overlay/message below. Spans the MAP's full
+		// width regardless of what the sidebar is doing (spec: under `viewport` the customer usually
+		// pans with the panel collapsed, so a sidebar-only indicator would be invisible exactly when
+		// it matters most). `y = 0`: the map already reserves a 64px top strip for the search bar
+		// (`map.margin`, see `map-provider-yandex.js`'s own docblock) and the bar itself sits at
+		// `top: 16px`, so this element's own few pixels at the very top lie clear above it — see
+		// `pickup.css`'s own placement note.
+		//
+		// `aria-hidden="true"`: DECORATIVE, not `role="progressbar"`. An indeterminate progress bar
+		// has no `aria-valuenow` to report (that is the whole meaning of "indeterminate" — there is
+		// no known percentage), so `role="progressbar"` here would be an accessible control with
+		// nothing correct to say about its own state. `.woodev-pickup-list__loading` above already
+		// carries `role="status"` for the SAME loading state whenever the sidebar is the panel
+		// showing; this element exists for the case that one does not cover (a collapsed sidebar
+		// under `viewport`), where the customer has no assistive-tech-relevant control to lose either
+		// way — the animation is a purely visual affordance here.
+		var progress = document.createElement( 'div' );
+		progress.className = 'woodev-pickup-progress';
+		progress.setAttribute( 'aria-hidden', 'true' );
+
+		var progressBar = document.createElement( 'span' );
+		progressBar.className = 'woodev-pickup-progress__bar';
+		progress.appendChild( progressBar );
+
+		stage.appendChild( progress );
 
 		// Task 16 (spec V-4 stage 2): built once here, always present, HIDDEN by default — never
 		// created/destroyed by `setBusy()` itself, matching `WoodevModal#showLoading()`'s own
@@ -2037,6 +2092,8 @@
 		this._messageTextEl = messageText;
 		this._messageRetryEl = null;
 		this._overlayEl = overlay;
+		this._progressEl = progress;
+		this._listLoadingEl = listLoading;
 		this._toggleEl = toggle;
 		this._zoomInEl = zoomIn;
 		this._zoomOutEl = zoomOut;
@@ -2139,6 +2196,56 @@
 	 */
 	Panels.prototype.isBusy = function() {
 		return this._busy;
+	};
+
+	/**
+	 * Toggles the SHARED in-flight-background-load indicator (issues #222/#224): a top-edge
+	 * progress bar spanning the whole map, shown for ANY background fetch regardless of what the
+	 * sidebar is doing, plus a spinner overlay on the sidebar's own LIST body — but the list overlay
+	 * only while the LIST is actually the panel showing, never while a card is open (an open card
+	 * stays live and uncovered during a refetch: it is about one specific point, and a bbox refetch
+	 * does not change its contents — covering it would hide the address/hours the customer is
+	 * reading and block the select button for the duration).
+	 *
+	 * BOTH are pure CSS, keyed off `.woodev-pickup-stage`'s `is-loading` class here COMBINED with
+	 * the EXISTING `is-open`/`is-card` classes {@see setStageOpen}/{@see Panels#openCard} already
+	 * manage — this method only ever owns `is-loading`, never `is-open`/`is-card` themselves. That
+	 * split is deliberate: the customer is free to open/close the sidebar or a card mid-load, and a
+	 * CSS combinator re-evaluates which indicator shows for that on every such toggle for free —
+	 * this method (and `pickup-mount.js`'s own caller) would otherwise have to re-run this same
+	 * decision on every `listToggle`/`openCard()`/`closeCard()` too, just to keep it in sync.
+	 *
+	 * DELIBERATELY SEPARATE FROM `setBusy()` above (the FIRST-open, stage-wide overlay — measurement
+	 * confirmed that one already works correctly and is left untouched) and `setSelectionBusy()`
+	 * (the card's own confirmation lock, unrelated to a background LOAD): this state is the
+	 * indicator for every background load AFTER the first one — a viewport pan/zoom refetch, a
+	 * type-filter refetch, a lazy point-detail fetch (issue #219) — none of which either of the
+	 * other two states cover. Showing this ALONGSIDE `setBusy()`'s own overlay during the very
+	 * first fetch is acceptable and not specially suppressed here — see `pickup-mount.js`'s own
+	 * `bumpLoading()`/`dropLoading()` docblock for why the caller does not special-case that fetch.
+	 *
+	 * Same "no-op on the class when called before `render()`, but the flag is still tracked" shape
+	 * as {@see setBusy}'s own docblock — a caller asking {@see isLoading} before `render()` still
+	 * gets the correct answer.
+	 *
+	 * @since 2.0.2
+	 * @param {boolean} loading
+	 * @returns {void}
+	 */
+	Panels.prototype.setLoading = function( loading ) {
+		this._loading = !! loading;
+
+		if ( this._stage ) {
+			this._stage.classList.toggle( 'is-loading', this._loading );
+		}
+	};
+
+	/**
+	 * @since 2.0.2
+	 * @returns {boolean}
+	 */
+	Panels.prototype.isLoading = function() {
+		return this._loading;
 	};
 
 	/**


### PR DESCRIPTION
Closes #222
Closes #224

## #222 — the sidebar did not filter while panning (viewport only)

The `boundschange` listener forked by strategy: the `viewport` branch called
`_checkAndEmitBounds()` + `_emitZoomChange()` and returned, never
`_emitVisibleChange()`. `bulk` had called it from day one. So under `viewport`
the sidebar only re-filtered once the SERVER answered the refetch — 7–10s on the
rig — while the map already showed a different set of pins.

`_emitVisibleChange()` is a pure client-side recompute over `_groupsByKey` (the
last set `setPoints()` drew), so this costs nothing. The receiving side was
already wired: the mount listens to `visibleChange` unconditionally.

**Rig-measured on the fix:** one zoom step re-filtered the list 2 → 1 rows at
**t=305 ms**; the server did not answer until **t=12375 ms**.

## #224 — no indicator on any load after the first

Measured: one zoom step, request at 87746 ms, response at 97564 ms — **9.8 s**
with no on-screen signal at all. The first open's stage-wide overlay is
one-shot per `start()` cycle by design, and measurement confirmed it works
correctly there, so it is untouched. This adds a second, narrower signal.

### Operator's design (08.08.2026), implemented as specified

| | |
|---|---|
| Progress bar | 3px indeterminate, along the top edge of the **map**, full width, for **any** in-flight load |
| Sidebar overlay | spinner, **only while the LIST is showing** |
| Open point card | **stays live and uncovered** |
| Stage-wide overlay | unchanged — **first open only** |

Not in the sidebar: under `viewport` the customer usually pans with the panel
collapsed, so a sidebar-only indicator is invisible exactly when it matters
most. The card stays live because it is about one specific point — a bbox
refetch does not change its contents, and covering it would hide the address and
hours being read, block the CTA for ~10s, and collide with the second lock
coming from #223.

Both indicators are pure CSS off the stage's `is-loading` class combined with the
existing `is-open`/`is-card`, so opening or closing the sidebar mid-load
re-evaluates for free rather than needing JS to re-decide on every toggle.

### One shared counter, not a boolean

A bbox refetch and the #219 lazy detail fetch genuinely overlap. A boolean would
let whichever settled first switch the indicator off while the other was still
running. Every settle path decrements, failures included — a counter that never
returns to zero pins the indicator on forever (the shape s53 was burned by).
#223 will hang the card CTA lock off this same counter rather than racing a
second spinner.

## Verification

**Tests:** 743 → **755** (12 new), 8 suites, via
`npm run test:js -- --roots "<rootDir>/tests/js"`. The #222 test asserts against
the listener **actually registered on the map**, not a direct method call — the
defect was in the wiring, and the method already had its own passing tests.

**Rig** (viewport, `:8973`, chrome-devtools MCP), all measured not eyeballed:

| Case | Result |
|---|---|
| First open | bar visible 7322 → 20966 ms |
| One zoom step | bar visible 210 → 12377 ms; stage overlay correctly did **not** re-show |
| List open + loading | sidebar overlay `flex`, bar `block` |
| Card open + loading | sidebar overlay `none`, card visible, CTA reachable |
| Bar geometry | track at map top edge, 1024×3, sliver animating, `#06aedd` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mux4YLJ1CrbjsBMR42VT4R