### PR TITLE
fix(pickup): keep the open card's verdict fresh and lock its CTA while it is unknown (#223, #225)

### DIFF
--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -240,6 +240,12 @@ function StubPanels( container, config ) {
 	this.setPointVerdict = jest.fn();
 	this.showSelectionError = jest.fn();
 
+	// Issue #223: the verdict-pending card lock, as a per-instance `jest.fn()` for the same
+	// reason `setSelectionBusy` above is one — tests assert on `toHaveBeenLastCalledWith()`
+	// across the whole in-flight window (start, success, failure, the card moving on), which a
+	// hand-rolled array would only say less precisely.
+	this.setVerdictPending = jest.fn();
+
 	/** @type {Array} every `setZoomLimits()` payload, in order. */
 	this.setZoomLimitsCalls = [];
 
@@ -2456,6 +2462,228 @@ describe( 'viewport lazy detail fetch (#219)', () => {
 
 		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
 	} );
+
+	// Issue #225's own gap (Part 3, "the gap Part 1 exposes"): before this fix, NOTHING re-asked
+	// for a card that stayed OPEN across a listing refetch — `detailedPoints` was correctly wiped
+	// (the cart may have changed), but only a FRESH `cardOpened` (an explicit reopen, as the test
+	// above drives) ever re-triggered `refreshPointDetails()`. This test drives the refetch with
+	// NO further `cardOpened` in between — the card stays open on P1 throughout — proving the
+	// mount itself re-asks automatically.
+	test( 'a successful listing re-asks for the still-open card automatically, exactly once, '
+		+ 'with no reopen', async () => {
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+
+		// A pan — the ordinary way a new listing lands — with no `cardOpened` of its own.
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenLastCalledWith( 'P1' );
+	} );
+
+	// The restore pass (spec D-15) is one of the two callers of `openCard()`/`cardOpened` that can
+	// make a card "already open" the MOMENT a listing lands — the Part 3 re-ask must not fire a
+	// SECOND time on top of what the restore's own `cardOpened` already triggered.
+	test( 'the restore pass\'s own cardOpened already covers the re-ask — no double fetch', async () => {
+		document.getElementById( FIELD_ID ).value = 'P1';
+
+		// The restore only finds a group once the listing actually carries the stored point id —
+		// the default `beforeEach()` factory resolves `[]`, which would leave nothing to restore.
+		dataSourceFactory = fakeDataSourceFactory( () => Promise.resolve( [ point( { id: 'P1' } ) ] ) );
+		window.WoodevPickupDataSource = dataSourceFactory;
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledWith( 'P1' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// Issue #223 — the card's CTA locks while `refreshPointDetails()`'s own detail fetch is in
+// flight for the point the card currently shows: the sparse listing verdict on screen right now
+// is exactly what the fetch may be about to overturn. `panels.setVerdictPending()` (a jest.fn()
+// on `StubPanels`, mirroring `setSelectionBusy`) is the SEPARATE lock this drives — never folded
+// into the confirmation lock, since a `refreshCheckout()` confirmation-lock and a fresh detail
+// fetch can genuinely overlap on one card (see `pickup-panels.js`'s own `setVerdictPending()`
+// docblock for the scenario).
+// -----------------------------------------------------------------------
+describe( 'the card lock during a lazy detail fetch (issue #223)', () => {
+	const openCardOn = ( session, pointId ) => {
+		const group = { key: 'g1', lat: 55.75, lng: 37.61, points: [ { id: pointId } ] };
+
+		session.panels.emit( 'cardOpened', { group: group, pointId: pointId, origin: 'list' } );
+	};
+
+	test( 'locks on fetch start and unlocks on success', async () => {
+		let settle;
+
+		dataSourceFactory.fetchDetails = jest.fn( () => new Promise( ( resolve ) => {
+			settle = resolve;
+		} ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( true );
+
+		settle( { id: 'P1', selectable: { allowed: true, reason: null } } );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
+	} );
+
+	// Non-negotiable per the brief: a FAILED fetch must not leave the card locked forever either.
+	test( 'unlocks on failure too', async () => {
+		let settle;
+
+		dataSourceFactory.fetchDetails = jest.fn( () => new Promise( ( resolve, reject ) => {
+			settle = reject;
+		} ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( true );
+
+		settle( { status: 502 } );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
+	} );
+
+	// The card moving to another point mid-flight releases the OLD lock immediately (matching
+	// `invalidateSelection()`'s own "release on the move, not on the settle" discipline) — and the
+	// abandoned fetch, once it finally answers, must not stomp the NEW point's own, still-live
+	// lock. This is the s53 shape the brief calls out by name: a naive staleness guard that skips
+	// the RELEASE too, rather than transferring ownership at the move, leaves the wrong card
+	// locked.
+	test( 'releases on the move, not on the settle — an abandoned fetch does not stomp the new '
+		+ 'point\'s lock', async () => {
+		let settleP1;
+		let settleP2;
+
+		dataSourceFactory.fetchDetails = jest.fn( ( pointId ) => new Promise( ( resolve ) => {
+			if ( 'P1' === pointId ) {
+				settleP1 = resolve;
+			} else {
+				settleP2 = resolve;
+			}
+		} ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( true );
+
+		session.panels.setVerdictPending.mockClear();
+
+		// The card moves to P2 before P1's fetch ever answers.
+		openCardOn( session, 'P2' );
+		await flushAsync();
+
+		// Released for the move (P1's lock), THEN re-acquired for P2's own fresh fetch — in that
+		// order, both inside this one flush.
+		expect( session.panels.setVerdictPending.mock.calls.map( ( c ) => c[ 0 ] ) ).toEqual( [ false, true ] );
+
+		session.panels.setVerdictPending.mockClear();
+
+		// P1's abandoned fetch finally answers — it must NOT touch P2's still-live lock.
+		settleP1( { id: 'P1', selectable: { allowed: true, reason: null } } );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).not.toHaveBeenCalled();
+
+		// P2's own fetch settling DOES release its own, still-owned lock.
+		settleP2( { id: 'P2', selectable: { allowed: true, reason: null } } );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
+	} );
+
+	// The real overlap case `pickup-panels.js`'s own `setVerdictPending()` docblock documents:
+	// `refreshCheckout()` holds `setSelectionBusy( true )` on the still-open card while a
+	// post-confirmation totals refresh is in flight; if the customer opens a DIFFERENT point's
+	// card during that same window, a fresh detail fetch locks `_verdictPending` too — two
+	// independent locks on one `panels` instance, live at once. Neither release may stomp the
+	// other.
+	test( 'a confirmation lock (refreshCheckout) and a detail fetch overlapping do not stomp '
+		+ 'each other\'s release', async () => {
+		// A jQuery double, same minimal shape `openPicker()`'s own `jq` fixture uses — `refreshCheckout()`
+		// needs `.one()`/`.trigger()`, `dropRefreshWaiter()` needs `.off()`. `.one()` is RECORDED
+		// rather than wired to `.trigger()` (jQuery's real `.one()` self-unbinds; this double does
+		// not need to reproduce that to prove the point), so firing it is `jq.one[ 0 ].handler()`,
+		// matching every other `updated_checkout` test in this file.
+		const jq = { triggered: [], one: [], off: [] };
+
+		window.jQuery = () => ( {
+			one: ( type, handler ) => jq.one.push( { type: type, handler: handler } ),
+			off: ( type, handler ) => jq.off.push( { type: type, handler: handler } ),
+			trigger: ( type ) => jq.triggered.push( type ),
+		} );
+
+		let settleDetails;
+
+		dataSourceFactory.fetchDetails = jest.fn( () => new Promise( ( resolve ) => {
+			settleDetails = resolve;
+		} ) );
+		dataSourceFactory.selectPoint = jest.fn( () => Promise.resolve( {
+			allowed: true, reason: null, close: false, refresh_checkout: true,
+		} ) );
+
+		const session = await openSession( configWith( {
+			strategy: 'viewport',
+			selection: { close: false, refreshCheckout: true },
+			// Address replacement is not this test's subject — every field it would write that no
+			// §8 store owns logs a `console.warn` the WP jest preset turns into a failure (see
+			// `openPicker()`'s own identical override, above).
+			replaceAddress: { enabled: false, billingOnly: true },
+		} ) );
+
+		// P1 is confirmed and accepted; `refresh_checkout: true` + `close: false` leaves the
+		// card open and locked via `setSelectionBusy( true )` while WooCommerce's totals refresh
+		// is pending.
+		session.panels.emit( 'select', { id: 'P1' } );
+		await flushAsync();
+
+		expect( session.panels.setSelectionBusy ).toHaveBeenLastCalledWith( true );
+
+		// A DIFFERENT point's card opens during that same window — its own detail fetch locks
+		// `_verdictPending` independently.
+		openCardOn( session, 'P2' );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( true );
+		// The confirmation lock is untouched by the detail fetch starting.
+		expect( session.panels.setSelectionBusy ).toHaveBeenLastCalledWith( true );
+
+		// The detail fetch settles first — the confirmation lock must survive it.
+		settleDetails( { id: 'P2', selectable: { allowed: true, reason: null } } );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
+		expect( session.panels.setSelectionBusy ).toHaveBeenLastCalledWith( true );
+
+		// WooCommerce answers the totals refresh — the confirmation lock finally releases, and
+		// the (already-released) verdict-pending lock is untouched by it.
+		jq.one[ 0 ].handler();
+
+		expect( session.panels.setSelectionBusy ).toHaveBeenLastCalledWith( false );
+	} );
 } );
 
 // -----------------------------------------------------------------------
@@ -2584,11 +2812,21 @@ describe( 'the shared background-load indicator (issues #222/#224)', () => {
 
 		expect( session.panels.setLoadingCalls ).toEqual( [ true ] );
 
-		// #1 settles — NOW the counter reaches zero and the indicator clears.
+		// #1 settles — the counter WOULD reach zero here, except issue #225's own fix
+		// (`fetchAndSetPoints()`'s Part 3 re-ask) fires the instant a listing succeeds while a
+		// card is open: request #3, a fresh detail fetch for the still-open card, starts before
+		// the indicator ever gets a chance to rest at zero. Both transitions — #1's own 1→0 and
+		// #3's immediate 0→1 — land inside this one flush, back to back.
 		ds.resolvePoints( [] );
 		await flushAsync();
 
-		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false, true ] );
+
+		// #3 settles — NOW the counter finally reaches zero and the indicator clears for good.
+		ds.resolveDetails( { id: 'P1', selectable: { allowed: true, reason: null } } );
+		await flushAsync();
+
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false, true, false ] );
 	} );
 
 	// Adversarial-review finding: `bumpLoading()` runs, then `realDataSource.fetchPoints()`/

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2543,15 +2543,13 @@ describe( 'the card lock during a lazy detail fetch (issue #223)', () => {
 		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
 	} );
 
-	// THE ABA CASE, and the reason this lock is keyed on a monotonic TOKEN rather than the point
-	// id it started as — the identical correction `pendingSelectionToken` already had to make.
+	// THE STORM GUARD, and the reason `detailsInFlight` exists alongside the per-listing memo.
 	//
-	// Two fetches for the SAME point overlap in an ordinary flow: one starts when the card opens,
-	// and the camera move that open causes triggers a listing whose success clears
-	// `detailedPoints` and re-asks for that same point. Keyed on the id, the FIRST fetch settling
-	// matched the stored id and released a lock the SECOND still needed — silently reopening the
-	// very window #223 exists to close — and its OLDER answer could also land over the newer one.
-	test( 'a superseded fetch for the SAME point releases nothing and applies nothing', async () => {
+	// A successful listing wipes `detailedPoints` (correct — a new listing may mean a new cart) and
+	// then re-asks for the still-open card. Under a rapidly panning customer that is a listing, a
+	// wipe and another request PER PAN, all for the same point, all in flight at once. The landed-
+	// memo cannot stop it, because the wipe is what clears it. Found by the Codex critic pass.
+	test( 'a listing re-ask does NOT start a second request for a point already being fetched', async () => {
 		const settlers = [];
 
 		dataSourceFactory.fetchDetails = jest.fn( () => new Promise( ( resolve ) => {
@@ -2560,37 +2558,60 @@ describe( 'the card lock during a lazy detail fetch (issue #223)', () => {
 
 		const session = await openSession( configWith( { strategy: 'viewport' } ) );
 
-		// Fetch #1 — the card opening.
 		openCardOn( session, 'P1' );
 		await flushAsync();
 
+		expect( settlers ).toHaveLength( 1 );
 		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( true );
 
-		// A listing lands: it clears the memo and re-asks for the SAME still-open point, so
-		// fetch #2 starts while #1 is still travelling.
+		// Three listings land back to back, each wiping the landed-memo and re-asking.
 		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
 		await flushAsync();
-
-		expect( settlers ).toHaveLength( 2 );
-
-		session.panels.setVerdictPending.mockClear();
-		session.panels.updatePointCalls.length = 0;
-
-		// #1 — now SUPERSEDED — settles first, with a stale permissive verdict.
-		settlers[ 0 ]( { id: 'P1', selectable: { allowed: true, reason: null } } );
+		session.provider.emit( 'boundsChange', [ 2, 3, 4, 5 ] );
+		await flushAsync();
+		session.provider.emit( 'boundsChange', [ 3, 4, 5, 6 ] );
 		await flushAsync();
 
-		// It must neither release the lock #2 still holds…
-		expect( session.panels.setVerdictPending ).not.toHaveBeenCalled();
+		// Still exactly ONE detail request in flight for P1 — not four.
+		expect( settlers ).toHaveLength( 1 );
 
-		// …nor write its older answer over what #2 is about to bring.
-		expect( session.panels.updatePointCalls ).toHaveLength( 0 );
-
-		// #2, the live one, settles with the authoritative refusal — and THAT one applies.
-		settlers[ 1 ]( { id: 'P1', selectable: { allowed: false, reason: 'too heavy' } } );
+		// And when it lands it still applies, and still releases the lock it owns.
+		settlers[ 0 ]( { id: 'P1', selectable: { allowed: false, reason: 'too heavy' } } );
 		await flushAsync();
 
 		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
+		expect( session.panels.updatePointCalls ).toHaveLength( 1 );
+		expect( session.panels.updatePointCalls[ 0 ].fields.selectable.allowed ).toBe( false );
+	} );
+
+	// The other half of the same guard: leaving the point and coming BACK while its request is
+	// still travelling must not discard the answer. The lock was released on the way out and
+	// `detailsInFlight` starts no new request on the way back, so this answer is the ONLY verdict
+	// anyone will fetch — ownership decides who may release the lock, `cardPointId` decides whose
+	// answer may land.
+	test( 'an answer still applies after the card left the point and came back', async () => {
+		const settlers = [];
+
+		dataSourceFactory.fetchDetails = jest.fn( () => new Promise( ( resolve ) => {
+			settlers.push( resolve );
+		} ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		openCardOn( session, 'P2' );
+		await flushAsync();
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		session.panels.updatePointCalls.length = 0;
+
+		settlers[ 0 ]( { id: 'P1', selectable: { allowed: false, reason: 'too heavy' } } );
+		await flushAsync();
+
 		expect( session.panels.updatePointCalls ).toHaveLength( 1 );
 		expect( session.panels.updatePointCalls[ 0 ].fields.selectable.allowed ).toBe( false );
 	} );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2543,6 +2543,58 @@ describe( 'the card lock during a lazy detail fetch (issue #223)', () => {
 		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
 	} );
 
+	// THE ABA CASE, and the reason this lock is keyed on a monotonic TOKEN rather than the point
+	// id it started as — the identical correction `pendingSelectionToken` already had to make.
+	//
+	// Two fetches for the SAME point overlap in an ordinary flow: one starts when the card opens,
+	// and the camera move that open causes triggers a listing whose success clears
+	// `detailedPoints` and re-asks for that same point. Keyed on the id, the FIRST fetch settling
+	// matched the stored id and released a lock the SECOND still needed — silently reopening the
+	// very window #223 exists to close — and its OLDER answer could also land over the newer one.
+	test( 'a superseded fetch for the SAME point releases nothing and applies nothing', async () => {
+		const settlers = [];
+
+		dataSourceFactory.fetchDetails = jest.fn( () => new Promise( ( resolve ) => {
+			settlers.push( resolve );
+		} ) );
+
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		// Fetch #1 — the card opening.
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( true );
+
+		// A listing lands: it clears the memo and re-asks for the SAME still-open point, so
+		// fetch #2 starts while #1 is still travelling.
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		expect( settlers ).toHaveLength( 2 );
+
+		session.panels.setVerdictPending.mockClear();
+		session.panels.updatePointCalls.length = 0;
+
+		// #1 — now SUPERSEDED — settles first, with a stale permissive verdict.
+		settlers[ 0 ]( { id: 'P1', selectable: { allowed: true, reason: null } } );
+		await flushAsync();
+
+		// It must neither release the lock #2 still holds…
+		expect( session.panels.setVerdictPending ).not.toHaveBeenCalled();
+
+		// …nor write its older answer over what #2 is about to bring.
+		expect( session.panels.updatePointCalls ).toHaveLength( 0 );
+
+		// #2, the live one, settles with the authoritative refusal — and THAT one applies.
+		settlers[ 1 ]( { id: 'P1', selectable: { allowed: false, reason: 'too heavy' } } );
+		await flushAsync();
+
+		expect( session.panels.setVerdictPending ).toHaveBeenLastCalledWith( false );
+		expect( session.panels.updatePointCalls ).toHaveLength( 1 );
+		expect( session.panels.updatePointCalls[ 0 ].fields.selectable.allowed ).toBe( false );
+	} );
+
 	// Non-negotiable per the brief: a FAILED fetch must not leave the card locked forever either.
 	test( 'unlocks on failure too', async () => {
 		let settle;

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -1032,6 +1032,94 @@ describe( 'setSelectionBusy', () => {
 	} );
 } );
 
+// Issue #223: the CTA locks while the viewport strategy's own lazy detail fetch (#219) is in
+// flight for the point the card currently shows — a SEPARATE state from `setSelectionBusy` above
+// (see that method's own docblock, and `setVerdictPending()`'s, for why the two are never merged
+// into one flag).
+describe( 'setVerdictPending', () => {
+	const pendingConfig = {
+		...cardConfig,
+		i18n: { ...cardConfig.i18n, confirming: 'Проверяем…', checkingAvailability: 'Проверяем доступность…' },
+	};
+
+	it( 'locks the CTA and shows the checking-availability label, distinct from confirming', () => {
+		const panels = mount( pendingConfig );
+		panels.openCard( { key: 'k', size: 1, points: [ point() ] } );
+
+		panels.setVerdictPending( true );
+
+		const cta = panels.root.querySelector( '.woodev-pickup-card__cta' );
+
+		expect( cta.disabled ).toBe( true );
+		expect( cta.textContent ).toBe( 'Проверяем доступность…' );
+	} );
+
+	it( 'restores the CTA when the fetch settles', () => {
+		const panels = mount( pendingConfig );
+		panels.openCard( { key: 'k', size: 1, points: [ point() ] } );
+
+		panels.setVerdictPending( true );
+		panels.setVerdictPending( false );
+
+		const cta = panels.root.querySelector( '.woodev-pickup-card__cta' );
+
+		expect( cta.disabled ).toBe( false );
+		expect( cta.textContent ).toBe( 'Забрать здесь' );
+	} );
+
+	it( 'does not emit select while pending, even if something bypasses the disabled attribute', () => {
+		const onSelect = jest.fn();
+		const panels = mount( pendingConfig );
+		panels.on( 'select', onSelect );
+		panels.openCard( { key: 'k', size: 1, points: [ point() ] } );
+
+		panels.setVerdictPending( true );
+
+		const cta = panels.root.querySelector( '.woodev-pickup-card__cta' );
+		cta.disabled = false;
+		cta.click();
+
+		expect( onSelect ).not.toHaveBeenCalled();
+	} );
+
+	// A confirmation and a detail fetch can genuinely overlap on one card (see
+	// `setVerdictPending()`'s own docblock for the real `refreshCheckout()` scenario) — a single
+	// shared boolean would let whichever releases first wrongly unlock a CTA the other still
+	// needs held. `confirming` wins the label when both are true (the more advanced, more
+	// customer-relevant state), but the CTA stays locked either way.
+	it( 'a confirmation and a detail fetch overlapping do not stomp each other\'s lock', () => {
+		const panels = mount( pendingConfig );
+		panels.openCard( { key: 'k', size: 1, points: [ point() ] } );
+
+		panels.setSelectionBusy( true );
+		panels.setVerdictPending( true );
+
+		let cta = panels.root.querySelector( '.woodev-pickup-card__cta' );
+		expect( cta.disabled ).toBe( true );
+		expect( cta.textContent ).toBe( 'Проверяем…' ); // confirming wins the label.
+
+		// The detail fetch settles first — the confirmation is still live, so the CTA must stay
+		// locked (not fall back to `checkingAvailability`'s own release unlocking it).
+		panels.setVerdictPending( false );
+
+		cta = panels.root.querySelector( '.woodev-pickup-card__cta' );
+		expect( cta.disabled ).toBe( true );
+		expect( cta.textContent ).toBe( 'Проверяем…' );
+
+		// The confirmation settles too — NOW the CTA unlocks.
+		panels.setSelectionBusy( false );
+
+		cta = panels.root.querySelector( '.woodev-pickup-card__cta' );
+		expect( cta.disabled ).toBe( false );
+	} );
+
+	it( 'does not throw when called before render()', () => {
+		const panels = new Panels( document.createElement( 'div' ), pendingConfig );
+
+		expect( () => panels.setVerdictPending( true ) ).not.toThrow();
+	} );
+} );
+
 // -----------------------------------------------------------------------
 // Task 9 (spec D-6/D-7): a domain refusal is remembered on the held point (so a re-render or a
 // later tab switch still shows it); a transport failure is shown once and forgotten on the next
@@ -1129,6 +1217,92 @@ describe( 'updatePoint', () => {
 		expect( () => panels.updatePoint( 'nope', { phone: '+7' } ) ).not.toThrow();
 		expect( () => panels.updatePoint( 'p1', null ) ).not.toThrow();
 		expect( () => mount( cardConfig ).updatePoint( 'p1', { phone: '+7' } ) ).not.toThrow();
+	} );
+} );
+
+// Issue #225 (measured on the rig, see the file docblock's `setVisible()` note): a listing
+// refetch rebuilds `_groups` with BRAND NEW group/point objects via `geo.groupByPosition()` —
+// same `key`, different object — even while a card is open on one of them. Before this fix,
+// `_activeGroup` kept pointing at the OLD, orphaned object: `setPointVerdict()`/`updatePoint()`
+// walked `_groups` and mutated the NEW object (`found` true), while `renderCard()` read
+// `_activeGroup` (the OLD one) — the write landed somewhere the card never looked again.
+describe( 'identity healing across a listing refetch (#225)', () => {
+	it( 'setVisible() repoints _activeGroup at the fresh object by key and re-renders the card live', () => {
+		const panels = mount( cardConfig );
+		const g1 = { key: 'k', size: 1, points: [ point() ] };
+		panels.setVisible( [ g1 ] );
+		panels.openCard( g1, 'p1', 'list' );
+
+		// The refetch: same `key`, brand new objects — exactly what `fetchAndSetPoints()`'s
+		// `geo.groupByPosition()` call produces.
+		const g2 = { key: 'k', size: 1, points: [ point( { name: 'Свежее имя' } ) ] };
+		panels.setVisible( [ g2 ] );
+
+		expect( panels._activeGroup ).toBe( g2 );
+		expect( panels.root.querySelector( '.woodev-pickup-card__title' ).textContent ).toBe( 'Свежее имя' );
+	} );
+
+	// The regression test for the measured bug: without the Part 1/Part 2 fix, this verdict
+	// mutates the ORPHANED `g1` object (still referenced only by the pre-refetch `_activeGroup`
+	// this test never touches directly) while the card keeps rendering from whatever `_activeGroup`
+	// held — the CTA would stay enabled. Confirmed FAILING before the fix (reverting
+	// `setVisible()`'s healing pass and `setPointVerdict()`'s belt-and-braces write reproduces
+	// exactly that: `cta.disabled` reads `false`).
+	it( 'a verdict arriving after a listing refetch still reaches the open card (setPointVerdict)', () => {
+		const panels = mount( cardConfig );
+		const g1 = { key: 'k', size: 1, points: [ point() ] };
+		panels.setVisible( [ g1 ] );
+		panels.openCard( g1, 'p1', 'list' );
+
+		// A listing refetch lands while the card is still open — new objects, same key.
+		const g2 = { key: 'k', size: 1, points: [ point() ] };
+		panels.setVisible( [ g2 ] );
+
+		panels.setPointVerdict( 'p1', { allowed: false, reason: 'Слишком тяжело' } );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__warning' ).textContent ).toBe( 'Слишком тяжело' );
+		expect( panels.root.querySelector( '.woodev-pickup-card__cta' ).disabled ).toBe( true );
+	} );
+
+	// The #219/updatePoint half of the same measured bug — issue #223's own refusal path
+	// (`finishSelection()` → `setPointVerdict()`) is covered above; the lazy-detail-fetch landing
+	// half goes through `updatePoint()` instead, and shares the identical `_groups`-scan /
+	// `_activeGroup`-render split this whole fix exists to close.
+	it( 'a detail-fetch merge arriving after a listing refetch still reaches the open card (updatePoint)', () => {
+		const panels = mount( cardConfig );
+		const g1 = { key: 'k', size: 1, points: [ point() ] };
+		panels.setVisible( [ g1 ] );
+		panels.openCard( g1, 'p1', 'list' );
+
+		const g2 = { key: 'k', size: 1, points: [ point() ] };
+		panels.setVisible( [ g2 ] );
+
+		panels.updatePoint( 'p1', { selectable: { allowed: false, reason: 'Только предоплата.' } } );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__warning' ).textContent )
+			.toBe( 'Только предоплата.' );
+		expect( panels.root.querySelector( '.woodev-pickup-card__cta' ).disabled ).toBe( true );
+	} );
+
+	// The panned-out case (Part 1's deliberate "case B", Part 2's belt-and-braces): the new
+	// viewport set no longer contains the open card's group AT ALL (no `key` match) — the card
+	// must keep its point rather than blank out or close, and a write must still land on it.
+	it( 'a panned-out point (no key match in the new set) keeps the card open and still takes a write', () => {
+		const panels = mount( cardConfig );
+		const g1 = { key: 'k', size: 1, points: [ point() ] };
+		panels.setVisible( [ g1 ] );
+		panels.openCard( g1, 'p1', 'list' );
+
+		// A DIFFERENT group's viewport — the card's own group is nowhere in the new set.
+		panels.setVisible( [ { key: 'elsewhere', size: 1, points: [ point( { id: 'other' } ) ] } ] );
+
+		// Kept, not cleared, not blanked.
+		expect( panels._activeGroup ).toBe( g1 );
+		expect( panels.root.querySelector( '.woodev-pickup-card__cta' ) ).not.toBeNull();
+
+		panels.setPointVerdict( 'p1', { allowed: false, reason: 'Нет' } );
+
+		expect( panels.root.querySelector( '.woodev-pickup-card__cta' ).disabled ).toBe( true );
 	} );
 } );
 

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -2061,6 +2061,12 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 				// `selectFailed` is deliberately not `error`: that one describes a failed
 				// points FETCH, not a refused confirmation.
 				'confirming'       => 'Проверяем…',
+				// Issue #223: a SEPARATE CTA state from `confirming` above. That one is shown
+				// while a confirmation is already travelling to the server; this one while the
+				// viewport strategy's lazy detail fetch (#219) is still deciding whether the
+				// sparse listing's permissive-by-omission verdict even holds. Two different
+				// questions, two independently released locks -- see `setVerdictPending()`.
+				'checkingAvailability' => 'Проверяем доступность…',
 				'selectFailed'     => 'Не удалось подтвердить выбор. Попробуйте ещё раз.',
 				'stalePage'        => 'Страница устарела. Обновите её и выберите пункт выдачи заново.',
 			];

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1123,17 +1123,32 @@
 		 *  "the card re-rendered on the same one". Never the guard's identity; see above. */
 		var pendingSelectionPointId = null;
 
-		/** @type {string|null} issue #223: the point id whose {@see refreshPointDetails} fetch
-		 *  currently owns the card's `panels.setVerdictPending( true )` lock — `null` when none
-		 *  does. A SEPARATE lock owner from `pendingSelectionToken` above (see
+		/** @type {number} mints one unique, monotonic token per detail fetch this session sends —
+		 *  the same device `selectionTokens` above provides for confirmations, for the same
+		 *  reason. See `verdictPendingToken`. */
+		var verdictTokens = 0;
+
+		/** @type {number} issue #223: the token of the {@see refreshPointDetails} fetch that
+		 *  currently owns the card's `panels.setVerdictPending( true )` lock — `0` when none does.
+		 *  A SEPARATE lock owner from `pendingSelectionToken` above (see
 		 *  {@see Panels.prototype.setVerdictPending}'s own docblock for why the two locks must
 		 *  never be merged into one flag): released ONLY by whoever ends ITS OWN ownership — the
 		 *  fetch itself settling ({@see refreshPointDetails}), the card moving to a different
 		 *  point before it does (the `cardOpened` listener, below), or the session being torn
-		 *  down ({@see releaseVerdictPending}'s call in `destroy()`). A plain point id, not a
-		 *  generation/token: unlike a confirmation, a detail fetch is idempotent, and this lock
-		 *  only ever needs to answer "is the fetch I started still the one the card is showing",
-		 *  which an id already answers exactly. */
+		 *  down ({@see releaseVerdictPending}'s call in `destroy()`).
+		 *
+		 *  A TOKEN, NOT A POINT ID — this started as an id and was corrected, exactly as
+		 *  `pendingSelectionToken` had to be. Two fetches for the SAME point overlap in an
+		 *  ordinary flow: one starts when the card opens, and the camera move that open causes
+		 *  triggers a listing whose success clears `detailedPoints` and re-asks for the same
+		 *  point. Keyed on the id, the FIRST settling would match and release a lock the SECOND
+		 *  still needs, and its older answer could overwrite the newer one. */
+		var verdictPendingToken = 0;
+
+		/** @type {string|null} the point id `verdictPendingToken`'s fetch is about — read ONLY by
+		 *  the `cardOpened` listener, to tell "the card moved onto another point" from "the card
+		 *  re-rendered on the same one". Never the guard's identity; see above. Mirrors
+		 *  `pendingSelectionPointId`'s relationship to `pendingSelectionToken` exactly. */
 		var verdictPendingPointId = null;
 
 		/** @type {Function|null} the pending `updated_checkout` handler {@see refreshCheckout}
@@ -1484,12 +1499,26 @@
 			// Issue #223: locks the card's CTA for the window this fetch is in flight — the card
 			// is still showing the sparse listing's permissive-by-omission verdict, which is
 			// exactly what this request may be about to overturn. A SEPARATE lock from the
-			// confirmation one (`pendingSelectionToken`) — see `verdictPendingPointId`'s own
+			// confirmation one (`pendingSelectionToken`) — see `verdictPendingToken`'s own
 			// docblock and `Panels.prototype.setVerdictPending`'s for why the two must never be
 			// merged. Both call sites of this function (the `cardOpened` listener below, and the
 			// re-ask a successful listing triggers — see `fetchAndSetPoints()`) only ever pass the
-			// CURRENT `cardPointId`, so acquiring the lock under `id` here is always acquiring it
-			// for the point the card is showing right now.
+			// CURRENT `cardPointId`, so acquiring the lock here is always acquiring it for the
+			// point the card is showing right now.
+			//
+			// A TOKEN, NOT THE POINT ID — the same correction `pendingSelectionToken` above already
+			// had to make, for the same reason. TWO fetches for the SAME point genuinely overlap:
+			// this one starts when the card opens, then the camera move that card open causes
+			// triggers a listing, and that listing's success clears `detailedPoints` and re-asks
+			// for the very same point (see `fetchAndSetPoints()`). Keyed on the id, the FIRST
+			// fetch settling would match `verdictPendingPointId` and release a lock the SECOND one
+			// still needs held — reopening the exact window #223 exists to close — and its older
+			// answer could also be applied over the newer one. A token is unique per request, so
+			// "is the answer that just arrived still the one the card is waiting on?" has exactly
+			// one true answer no matter how many fetches name the same point.
+			var myVerdictToken = ++verdictTokens;
+
+			verdictPendingToken = myVerdictToken;
 			verdictPendingPointId = id;
 
 			if ( panels && ! destroyed ) {
@@ -1519,20 +1548,27 @@
 					dropLoading();
 
 					// Non-negotiable per issue #223: release on EVERY outcome, success included —
-					// but ONLY when this fetch still OWNS the lock. The card can have moved to
-					// ANOTHER point while this was in flight, whose own `refreshPointDetails()`
-					// call would then have re-acquired the lock under a DIFFERENT id — releasing
-					// unconditionally here would stomp that still-live lock the instant this
-					// abandoned fetch happens to settle (the exact s53 staleness-guard shape this
-					// fix is deliberately not repeating). See `releaseVerdictPending()`.
-					if ( id === verdictPendingPointId ) {
+					// but ONLY when THIS fetch still owns the lock. Two things can have taken it
+					// since: the card moving to another point (whose own `refreshPointDetails()`
+					// re-acquired it), or a listing re-asking for this SAME point. Releasing
+					// unconditionally would stomp a still-live lock the moment this abandoned
+					// fetch happens to settle — the s53 staleness-guard shape this deliberately
+					// does not repeat. See `releaseVerdictPending()`.
+					var ownsLock = myVerdictToken === verdictPendingToken;
+
+					if ( ownsLock ) {
 						releaseVerdictPending();
 					}
 
 					// The card can move to another point while this is in flight — a marker click
 					// and a sidebar row both swap it without waiting for anything. Applying then
 					// would write one point's record over whatever the customer is now reading.
-					if ( destroyed || ! panels || id !== cardPointId ) {
+					//
+					// `ownsLock` is checked too, not just the point id: a SUPERSEDED fetch for the
+					// same point (a listing re-asked while this one was still travelling) is an
+					// OLDER answer, and letting it land would overwrite the newer one whenever it
+					// happens to arrive second.
+					if ( destroyed || ! panels || id !== cardPointId || ! ownsLock ) {
 						return;
 					}
 
@@ -1543,9 +1579,15 @@
 
 					// Same non-negotiable release, same ownership guard — see the resolve branch
 					// above. A failed fetch must not leave the card locked forever either.
-					if ( id === verdictPendingPointId ) {
-						releaseVerdictPending();
+					if ( myVerdictToken !== verdictPendingToken ) {
+						// SUPERSEDED. Release nothing (a live fetch holds the lock) and, just as
+						// importantly, evict nothing: `detailedPoints[ id ]` now belongs to that
+						// LIVE request, and clearing it here would let a third fetch start for a
+						// point already being fetched.
+						return;
 					}
+
+					releaseVerdictPending();
 
 					// Retryable: the memo is what makes the next card open ask again, and the
 					// point keeps its permissive listing verdict until something says otherwise.
@@ -1771,10 +1813,11 @@
 		 * @returns {void}
 		 */
 		function releaseVerdictPending() {
-			if ( null === verdictPendingPointId ) {
+			if ( 0 === verdictPendingToken ) {
 				return;
 			}
 
+			verdictPendingToken = 0;
 			verdictPendingPointId = null;
 
 			if ( panels && ! destroyed ) {
@@ -2171,7 +2214,7 @@
 				// "release on the move" discipline `invalidateSelection()` just applied above.
 				// `refreshPointDetails()` below re-acquires the lock fresh if THIS point still
 				// needs a fetch this listing.
-				if ( null !== verdictPendingPointId && verdictPendingPointId !== String( payload.pointId ) ) {
+				if ( 0 !== verdictPendingToken && verdictPendingPointId !== String( payload.pointId ) ) {
 					releaseVerdictPending();
 				}
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1123,6 +1123,19 @@
 		 *  "the card re-rendered on the same one". Never the guard's identity; see above. */
 		var pendingSelectionPointId = null;
 
+		/** @type {string|null} issue #223: the point id whose {@see refreshPointDetails} fetch
+		 *  currently owns the card's `panels.setVerdictPending( true )` lock — `null` when none
+		 *  does. A SEPARATE lock owner from `pendingSelectionToken` above (see
+		 *  {@see Panels.prototype.setVerdictPending}'s own docblock for why the two locks must
+		 *  never be merged into one flag): released ONLY by whoever ends ITS OWN ownership — the
+		 *  fetch itself settling ({@see refreshPointDetails}), the card moving to a different
+		 *  point before it does (the `cardOpened` listener, below), or the session being torn
+		 *  down ({@see releaseVerdictPending}'s call in `destroy()`). A plain point id, not a
+		 *  generation/token: unlike a confirmation, a detail fetch is idempotent, and this lock
+		 *  only ever needs to answer "is the fetch I started still the one the card is showing",
+		 *  which an id already answers exactly. */
+		var verdictPendingPointId = null;
+
 		/** @type {Function|null} the pending `updated_checkout` handler {@see refreshCheckout}
 		 *  bound through jQuery, held only so {@see dropRefreshWaiter} can take it off again —
 		 *  the second (and last) long-lived binding a session makes; see the file docblock. */
@@ -1468,6 +1481,21 @@
 			detailedPoints[ id ] = true;
 			bumpLoading();
 
+			// Issue #223: locks the card's CTA for the window this fetch is in flight — the card
+			// is still showing the sparse listing's permissive-by-omission verdict, which is
+			// exactly what this request may be about to overturn. A SEPARATE lock from the
+			// confirmation one (`pendingSelectionToken`) — see `verdictPendingPointId`'s own
+			// docblock and `Panels.prototype.setVerdictPending`'s for why the two must never be
+			// merged. Both call sites of this function (the `cardOpened` listener below, and the
+			// re-ask a successful listing triggers — see `fetchAndSetPoints()`) only ever pass the
+			// CURRENT `cardPointId`, so acquiring the lock under `id` here is always acquiring it
+			// for the point the card is showing right now.
+			verdictPendingPointId = id;
+
+			if ( panels && ! destroyed ) {
+				panels.setVerdictPending( true );
+			}
+
 			// `realDataSource.fetchDetails( id )` is still called SYNCHRONOUSLY, right here, exactly
 			// as before this fix — several call sites (this file's own tests among them) rely on the
 			// dataSource being asked THIS TICK, before anything awaits. What changed is the `try`:
@@ -1490,6 +1518,17 @@
 				function( point ) {
 					dropLoading();
 
+					// Non-negotiable per issue #223: release on EVERY outcome, success included —
+					// but ONLY when this fetch still OWNS the lock. The card can have moved to
+					// ANOTHER point while this was in flight, whose own `refreshPointDetails()`
+					// call would then have re-acquired the lock under a DIFFERENT id — releasing
+					// unconditionally here would stomp that still-live lock the instant this
+					// abandoned fetch happens to settle (the exact s53 staleness-guard shape this
+					// fix is deliberately not repeating). See `releaseVerdictPending()`.
+					if ( id === verdictPendingPointId ) {
+						releaseVerdictPending();
+					}
+
 					// The card can move to another point while this is in flight — a marker click
 					// and a sidebar row both swap it without waiting for anything. Applying then
 					// would write one point's record over whatever the customer is now reading.
@@ -1501,6 +1540,12 @@
 				},
 				function() {
 					dropLoading();
+
+					// Same non-negotiable release, same ownership guard — see the resolve branch
+					// above. A failed fetch must not leave the card locked forever either.
+					if ( id === verdictPendingPointId ) {
+						releaseVerdictPending();
+					}
 
 					// Retryable: the memo is what makes the next card open ask again, and the
 					// point keeps its permissive listing verdict until something says otherwise.
@@ -1635,6 +1680,23 @@
 						showFetchMessage( 'bulk' === config.strategy ? 'emptyLocality' : 'emptyInView' );
 					}
 
+					// Issue #225's own gap: `detailedPoints = {}` above is correct — the cart may
+					// have changed under us — but nothing ELSE re-asks for a card that is ALREADY
+					// open when this listing lands. Before this, an open card fell back to the
+					// sparse, permissive listing verdict (Part 1/2's fix keeps that card SHOWING,
+					// but showing stale data is still the bug this line closes) until the customer
+					// happened to close and reopen it. Runs LAST, after any restore pass above:
+					// `restoreSelection()`'s own `openCard()` call (when it ran) already drove
+					// `refreshPointDetails()` through the `cardOpened` listener while the memo was
+					// still fresh, so `detailedPoints[ cardPointId ]` is already `true` and this
+					// call is a harmless, guard-caught no-op for that pass — never a double fetch.
+					// Unconditional on `points.length` — an open card's point can legitimately have
+					// panned OUT of this exact listing (Part 1's "keep the stale object" case) and
+					// still deserves a fresh verdict for whatever cart change just happened.
+					if ( panels && cardPointId ) {
+						refreshPointDetails( cardPointId );
+					}
+
 					return points;
 				},
 				function( reason ) {
@@ -1689,6 +1751,34 @@
 		function releaseSelectionBusy() {
 			if ( panels && ! destroyed ) {
 				panels.setSelectionBusy( false );
+			}
+		}
+
+		/**
+		 * Releases the card's verdict-pending lock (issue #223), if this session currently holds
+		 * one — a no-op otherwise. The single entry point for every path that makes an in-flight
+		 * detail fetch stop being about the point the card currently shows: the fetch itself
+		 * settling ({@see refreshPointDetails}, both outcomes), the card moving to a different
+		 * point before it does (the `cardOpened` listener, below), and the session being torn
+		 * down.
+		 *
+		 * Mirrors {@see invalidateSelection}'s own "release on the move, not on the settle"
+		 * discipline: waiting for a stale fetch to settle before releasing would leave the card —
+		 * now showing a DIFFERENT point that may not need a fetch of its own at all — locked for
+		 * however long the abandoned request takes to come back, over a state that no longer
+		 * describes what is on screen.
+		 *
+		 * @returns {void}
+		 */
+		function releaseVerdictPending() {
+			if ( null === verdictPendingPointId ) {
+				return;
+			}
+
+			verdictPendingPointId = null;
+
+			if ( panels && ! destroyed ) {
+				panels.setVerdictPending( false );
 			}
 		}
 
@@ -2072,6 +2162,17 @@
 				// rather than leaving it frozen until an answer nobody wants finally lands.
 				if ( 0 !== pendingSelectionToken && String( payload.pointId ) !== pendingSelectionPointId ) {
 					invalidateSelection();
+				}
+
+				// Issue #223's own half of the same idea, one paragraph up: the PREVIOUS point's
+				// in-flight detail fetch, if any, is no longer about what the card shows — release
+				// its lock NOW rather than waiting for that fetch to settle (which could be
+				// seconds away — the rig measured 5-10s — or never), matching the exact
+				// "release on the move" discipline `invalidateSelection()` just applied above.
+				// `refreshPointDetails()` below re-acquires the lock fresh if THIS point still
+				// needs a fetch this listing.
+				if ( null !== verdictPendingPointId && verdictPendingPointId !== String( payload.pointId ) ) {
+					releaseVerdictPending();
 				}
 
 				// Recorded BEFORE the early `'restore'` return below — a restored card shows a
@@ -2601,15 +2702,17 @@
 			modal: modal,
 			refresh: refresh,
 			destroy: function() {
-				// BOTH card locks a session can be holding — an in-flight confirmation's and an
-				// in-flight checkout refresh's — are released HERE, while `destroyed` is still
-				// false and the panels are still alive to hear it. `setSelectionBusy()` does not
-				// track why it was called and never self-balances (see its own docblock in
-				// `pickup-panels.js`); a `true` left unpaired locks every card the instance opens
-				// afterwards, and nothing else in this file would ever pair it. Cheap insurance
-				// against a panels object that outlives its session — a plugin holding its own
-				// reference, or a future reuse of the instance.
+				// EVERY card lock a session can be holding — an in-flight confirmation's, an
+				// in-flight checkout refresh's, and (issue #223) an in-flight detail fetch's — is
+				// released HERE, while `destroyed` is still false and the panels are still alive to
+				// hear it. Neither `setSelectionBusy()` nor `setVerdictPending()` tracks why it was
+				// called and neither self-balances (see their own docblocks in `pickup-panels.js`);
+				// a `true` left unpaired locks every card the instance opens afterwards, and
+				// nothing else in this file would ever pair it. Cheap insurance against a panels
+				// object that outlives its session — a plugin holding its own reference, or a
+				// future reuse of the instance.
 				invalidateSelection();
+				releaseVerdictPending();
 				dropRefreshWaiter();
 
 				destroyed = true;

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1126,6 +1126,19 @@
 		/** @type {number} mints one unique, monotonic token per detail fetch this session sends —
 		 *  the same device `selectionTokens` above provides for confirmations, for the same
 		 *  reason. See `verdictPendingToken`. */
+		/** @type {Object.<string, boolean>} point ids whose detail fetch is IN FLIGHT right now —
+		 *  a different question from `detailedPoints` above, which records what has already
+		 *  LANDED for the current listing and is wiped on every successful one.
+		 *
+		 *  Both are needed. Wiping `detailedPoints` is correct (a new listing means a possibly
+		 *  new cart, so a landed verdict is history), but it was also the only thing stopping a
+		 *  second request for a point already being fetched — and since a successful listing now
+		 *  re-asks for the open card, a customer panning quickly produced a listing, a wipe, and
+		 *  another request, per pan, all for the same point, all in flight together. This map
+		 *  survives the wipe, so "already asking" stays true until the answer actually arrives.
+		 *  Found by the Codex critic pass on this branch. */
+		var detailsInFlight = {};
+
 		var verdictTokens = 0;
 
 		/** @type {number} issue #223: the token of the {@see refreshPointDetails} fetch that
@@ -1489,11 +1502,23 @@
 		function refreshPointDetails( pointId ) {
 			var id = String( pointId );
 
-			if ( 'viewport' !== config.strategy || ! id || detailedPoints[ id ] ) {
+			// `detailsInFlight` is checked alongside the landed-memo, and `destroyed` alongside
+			// both: the first stops a second request for a point already being asked about (see
+			// that map's own docblock — the per-listing memo cannot, because a successful listing
+			// wipes it), the second stops a listing that settles DURING teardown from acquiring a
+			// lock the session has already released on its way out.
+			if (
+				'viewport' !== config.strategy ||
+				! id ||
+				destroyed ||
+				detailedPoints[ id ] ||
+				detailsInFlight[ id ]
+			) {
 				return;
 			}
 
 			detailedPoints[ id ] = true;
+			detailsInFlight[ id ] = true;
 			bumpLoading();
 
 			// Issue #223: locks the card's CTA for the window this fetch is in flight — the card
@@ -1546,6 +1571,7 @@
 			detailsPromise.then(
 				function( point ) {
 					dropLoading();
+					delete detailsInFlight[ id ];
 
 					// Non-negotiable per issue #223: release on EVERY outcome, success included —
 					// but ONLY when THIS fetch still owns the lock. Two things can have taken it
@@ -1564,11 +1590,15 @@
 					// and a sidebar row both swap it without waiting for anything. Applying then
 					// would write one point's record over whatever the customer is now reading.
 					//
-					// `ownsLock` is checked too, not just the point id: a SUPERSEDED fetch for the
-					// same point (a listing re-asked while this one was still travelling) is an
-					// OLDER answer, and letting it land would overwrite the newer one whenever it
-					// happens to arrive second.
-					if ( destroyed || ! panels || id !== cardPointId || ! ownsLock ) {
+					// Deliberately NOT also gated on `ownsLock`. That would look symmetrical and
+					// would be wrong: a customer who leaves this point and comes BACK while the
+					// request is still travelling has released the lock on the way out and, thanks
+					// to `detailsInFlight`, starts no new request on the way back — so this answer
+					// arrives owning no lock, about the point the card is showing, with nothing
+					// else on its way. Discarding it would throw away the only verdict anyone is
+					// going to fetch. Ownership decides who may RELEASE THE LOCK; `cardPointId`
+					// decides whose answer may LAND. Two questions, two guards.
+					if ( destroyed || ! panels || id !== cardPointId ) {
 						return;
 					}
 
@@ -1576,6 +1606,7 @@
 				},
 				function() {
 					dropLoading();
+					delete detailsInFlight[ id ];
 
 					// Same non-negotiable release, same ownership guard — see the resolve branch
 					// above. A failed fetch must not leave the card locked forever either.

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -2468,7 +2468,7 @@
 				// the same order as the stale one it replaces.
 				var currentPoint = this._activeGroup.points[ this._activeIndex ];
 				var currentPointId = currentPoint ? String( currentPoint.id ) : null;
-				var freshIndex = 0;
+				var freshIndex = -1;
 
 				if ( null !== currentPointId ) {
 					for ( var j = 0; j < freshActive.points.length; j++ ) {
@@ -2479,9 +2479,22 @@
 					}
 				}
 
-				this._activeGroup = freshActive;
-				this._activeIndex = freshIndex;
-				renderCard( this );
+				// BOTH identities must resolve, not just the group's. A group `key` is a
+				// COORDINATE (co-located points share one), so a fresh group under the same key
+				// can legitimately contain a DIFFERENT set of points — one filtered out by a type
+				// change, one the carrier dropped, one whose tab index no longer exists. Falling
+				// back to index 0 there, as this first did, silently swapped the card onto ANOTHER
+				// PVZ under the customer while they were reading it: same card, same position on
+				// screen, different address and different verdict. Found by the Codex critic pass.
+				//
+				// So an unresolvable point is treated exactly like the panned-out case below —
+				// keep the stale object, keep showing the point the customer actually opened, and
+				// let the direct-write path in `updatePoint()`/`setPointVerdict()` reach it.
+				if ( -1 !== freshIndex ) {
+					this._activeGroup = freshActive;
+					this._activeIndex = freshIndex;
+					renderCard( this );
+				}
 			}
 
 			// Case B (`freshActive` stays null): the customer panned the point out of the new

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -1328,6 +1328,15 @@
 	 * {@see Panels.prototype.showSelectionError} writes into this same slot directly, for a
 	 * transient transport failure, without going through a full render.
 	 *
+	 * ISSUE #223: `self._verdictPending` locks the CTA the same way `self._selectionBusy` does —
+	 * see {@see Panels.prototype.setVerdictPending}'s own docblock for why the two are tracked
+	 * (and released) independently rather than merged into one flag. `_selectionBusy` wins the
+	 * LABEL when both happen to be true at once (see that method's docblock for the one real case
+	 * where they overlap): a confirmation already on its way to the server is the more advanced,
+	 * more customer-relevant state to report than "still checking availability", and CTA text
+	 * choices elsewhere in this function already follow the same "most specific state wins"
+	 * pattern (`confirming` over `continueCheckout`/`select`).
+	 *
 	 * @param {Panels} self
 	 * @param {Object} point
 	 * @returns {HTMLElement}
@@ -1346,21 +1355,27 @@
 		}
 
 		var isSelected = null !== self._selectedId && String( point.id ) === self._selectedId;
+		var locked = self._selectionBusy || self._verdictPending;
 
 		var cta = document.createElement( 'button' );
 		cta.type = 'button';
-		cta.className = 'woodev-pickup-card__cta' + ( self._selectionBusy ? ' is-busy' : '' );
+		cta.className = 'woodev-pickup-card__cta' + ( locked ? ' is-busy' : '' );
 		cta.textContent = self._selectionBusy
 			? text( self._config, 'confirming' )
-			: ( isSelected ? text( self._config, 'continueCheckout' ) : text( self._config, 'select' ) );
-		cta.disabled = ! selectable.allowed || self._selectionBusy;
+			: ( self._verdictPending
+				? text( self._config, 'checkingAvailability' )
+				: ( isSelected ? text( self._config, 'continueCheckout' ) : text( self._config, 'select' ) ) );
+		cta.disabled = ! selectable.allowed || locked;
 		cta.addEventListener( 'click', function() {
 			/*
 			 * Two guards, not one, exactly as the pre-existing `selectable.allowed` guard is
 			 * doubled by the `disabled` attribute: `disabled` is presentation, the refusal
-			 * here is behaviour, and a programmatic `.click()` respects only the second.
+			 * here is behaviour, and a programmatic `.click()` respects only the second. Reads
+			 * `self._selectionBusy`/`self._verdictPending` directly rather than the closed-over
+			 * `locked` above, matching this handler's own pre-existing style of reading
+			 * `self._selectionBusy` fresh rather than a captured local.
 			 */
-			if ( ! selectable.allowed || self._selectionBusy ) {
+			if ( ! selectable.allowed || self._selectionBusy || self._verdictPending ) {
 				return;
 			}
 
@@ -1759,6 +1774,16 @@
 		 * {@see Panels.prototype.setSelectionBusy}.
 		 */
 		this._selectionBusy = false;
+
+		/**
+		 * @type {boolean} true while the viewport strategy's lazy detail fetch (issue #219) is
+		 * in flight FOR THE POINT THE CARD CURRENTLY SHOWS — see
+		 * {@see Panels.prototype.setVerdictPending}. A SEPARATE flag from `_selectionBusy` above
+		 * — see that method's own docblock for why the two must never be merged into one.
+		 *
+		 * @since 2.0.2
+		 */
+		this._verdictPending = false;
 		this._activeGroup = null;
 		this._activeIndex = 0;
 		this._listeners = {};
@@ -2407,11 +2432,65 @@
 	 * mutating a point in place is visible to every other holder of that same object, not just
 	 * this instance.
 	 *
+	 * HEALS `_activeGroup`'S IDENTITY AGAINST THE FRESH SET (measured #225 root cause). The
+	 * mount's `fetchAndSetPoints()` rebuilds groups via `geo.groupByPosition()` on EVERY refetch
+	 * — a listing landing while a card is open hands this method brand-new group/point objects
+	 * even when a group's `key` (its IDENTITY, not its object identity) is unchanged. Left
+	 * unrepointed, `_activeGroup` keeps referencing the OLD, now-orphaned object while `_groups`
+	 * holds the new one: {@see Panels.prototype.updatePoint}/{@see Panels.prototype.setPointVerdict}
+	 * walk `_groups` (mutating the NEW object, `found` true) while {@see renderCard} reads
+	 * `_activeGroup` (the OLD one) — a verdict that LOOKS applied is actually landing somewhere
+	 * the card never looks again. Rig-measured: `afterRefusal_CTA: { disabled: false }` with the
+	 * write landing in `_groups` while the card kept showing the pre-refusal, permissive verdict.
+	 *
 	 * @param {Array} groups
 	 * @returns {void}
 	 */
 	Panels.prototype.setVisible = function( groups ) {
 		this._groups = groups || [];
+
+		if ( this._activeGroup ) {
+			var freshActive = null;
+
+			for ( var i = 0; i < this._groups.length; i++ ) {
+				if ( this._groups[ i ].key === this._activeGroup.key ) {
+					freshActive = this._groups[ i ];
+					break;
+				}
+			}
+
+			if ( freshActive ) {
+				// Case A: the open card's group is still present in the new set (by `key`) —
+				// repoint at the fresh object so every later read (this render, the next
+				// `updatePoint()`/`setPointVerdict()`) sees LIVE data, not the orphaned one.
+				// `_activeIndex` is re-resolved by point id rather than reused as a bare number:
+				// it indexes into `points`, and nothing guarantees the fresh group's array keeps
+				// the same order as the stale one it replaces.
+				var currentPoint = this._activeGroup.points[ this._activeIndex ];
+				var currentPointId = currentPoint ? String( currentPoint.id ) : null;
+				var freshIndex = 0;
+
+				if ( null !== currentPointId ) {
+					for ( var j = 0; j < freshActive.points.length; j++ ) {
+						if ( String( freshActive.points[ j ].id ) === currentPointId ) {
+							freshIndex = j;
+							break;
+						}
+					}
+				}
+
+				this._activeGroup = freshActive;
+				this._activeIndex = freshIndex;
+				renderCard( this );
+			}
+
+			// Case B (`freshActive` stays null): the customer panned the point out of the new
+			// viewport set. Deliberately KEEP the stale object rather than clearing
+			// `_activeGroup` — an open card must not blank out or close just because its point
+			// left the viewport. `updatePoint()`/`setPointVerdict()` cover this orphaned object
+			// directly (see `activeGroupInGroups()`, below), since it is no longer reachable by
+			// walking `_groups`.
+		}
 
 		renderList( this );
 	};
@@ -3173,6 +3252,96 @@
 	};
 
 	/**
+	 * Marks the viewport strategy's lazy detail fetch (issue #219) as in flight — or settled —
+	 * FOR THE POINT THE CARD CURRENTLY SHOWS (issue #223). While that fetch is running, the card
+	 * is still displaying the sparse listing's permissive-by-omission verdict, which is exactly
+	 * what the fetch is on its way to maybe overturn; the CTA locks for that window so the
+	 * customer cannot confirm a point on a verdict already known to be provisional.
+	 *
+	 * A SEPARATE flag from {@see Panels.prototype.setSelectionBusy}, DELIBERATELY not folded into
+	 * it, even though both end up disabling the same CTA: the two states answer different
+	 * questions ("is the server confirming this point right now" vs "are we still finding out
+	 * whether this point is even offerable"), and — unlike the ONE confirmation this file ever
+	 * has in flight at a time — they CAN be true together on the SAME card. `pickup-mount.js`'s
+	 * own `refreshCheckout()` holds `setSelectionBusy( true )` on the still-open card while a
+	 * POST-confirmation checkout totals refresh is in flight (accepted-but-not-closed, spec
+	 * §5.2); if the customer opens a DIFFERENT point's card during that same window, a fresh
+	 * viewport detail fetch starts for it and this flag goes true too — two independent locks on
+	 * one `panels` instance, live at once, for two unrelated reasons. A single shared boolean
+	 * cannot represent "both reasons are live" without one release wrongly unlocking the CTA the
+	 * other still needs held — the exact defect class the whole #225 investigation this fix
+	 * belongs to is about. `pickup-mount.js` mirrors this split with two independent lock owners
+	 * (`pendingSelectionToken` / `verdictPendingPointId`), each released only by whoever ends ITS
+	 * OWN ownership.
+	 *
+	 * The card's `is-verdict-pending` class is a state marker for CSS/tests, kept separate from
+	 * `is-locked` (the confirmation lock's own overlay-bearing class, see `setSelectionBusy()`
+	 * above) — this state does not cover the card with a click-blocking sheet the way `is-locked`
+	 * does. The CTA itself reuses the EXISTING `.woodev-pickup-card__cta.is-busy` spinner/disabled
+	 * treatment {@see buildCardFooter} already applies for a confirmation — a card-local signal,
+	 * not a new spinner competing with the shared background-load indicator ({@see
+	 * Panels.prototype.setLoading}, issues #222/#224) that already counts this same fetch globally.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @param {boolean} pending
+	 * @returns {void}
+	 */
+	Panels.prototype.setVerdictPending = function( pending ) {
+		this._verdictPending = !! pending;
+
+		if ( this._cardEl ) {
+			this._cardEl.classList.toggle( 'is-verdict-pending', this._verdictPending );
+		}
+
+		if ( this._activeGroup ) {
+			renderCard( this );
+		}
+	};
+
+	/**
+	 * Whether `self._activeGroup` is one of the objects in `self._groups` right now — by
+	 * REFERENCE, not by `key`. Reference equality is the correct test given
+	 * {@see Panels.prototype.setVisible}'s own healing pass: a `key` match there repoints
+	 * `_activeGroup` at the FRESH object from the new `_groups`, so after that call "same key" and
+	 * "same object" always agree; the only way they can legitimately disagree afterwards is the
+	 * panned-out case `setVisible()` deliberately leaves unrepointed — exactly the case this
+	 * helper exists to detect for {@see Panels.prototype.updatePoint}/
+	 * {@see Panels.prototype.setPointVerdict}, so a write meant for the card's held point does not
+	 * silently land nowhere once that point's group has left `_groups` entirely.
+	 *
+	 * @since 2.0.2
+	 * @param {Panels} self
+	 * @returns {boolean}
+	 */
+	function activeGroupInGroups( self ) {
+		for ( var i = 0; i < self._groups.length; i++ ) {
+			if ( self._groups[ i ] === self._activeGroup ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Writes one verdict onto one point object — the mutation {@see Panels.prototype.setPointVerdict}
+	 * applies, factored out so it can run against BOTH `_groups` and a panned-out `_activeGroup`
+	 * without duplicating the shape it writes.
+	 *
+	 * @since 2.0.2
+	 * @param {Object}                                     point
+	 * @param {{allowed: boolean, reason: (string|null)}} verdict
+	 * @returns {void}
+	 */
+	function applyVerdict( point, verdict ) {
+		point.selectable = {
+			allowed: !! verdict.allowed,
+			reason: 'string' === typeof verdict.reason ? verdict.reason : null,
+		};
+	}
+
+	/**
 	 * Records a domain verdict against one point, so a refusal SURVIVES a card re-render (spec
 	 * D-6/D-7). The framework's own fetch-time `selectable` verdict ({@see Constraint_Checker})
 	 * is deliberately permissive about data a carrier's list response omits — a selection
@@ -3188,6 +3357,15 @@
 	 * shown — the write still lands on the held point, and the next `openCard()`/tab switch to
 	 * it will read it correctly.
 	 *
+	 * ALSO WRITES `_activeGroup` DIRECTLY WHEN IT HAS PANNED OUT OF `_groups` (measured #225/#223
+	 * belt-and-braces): {@see Panels.prototype.setVisible}'s own identity-healing pass
+	 * deliberately leaves a panned-out `_activeGroup` unrepointed, so the loop over `_groups`
+	 * below never reaches its point at all in that case — a refusal that lands while the card is
+	 * showing a point outside the current viewport would otherwise be silently discarded, exactly
+	 * the defect this whole fix exists for. {@see activeGroupInGroups} tells the two cases apart;
+	 * when `_activeGroup` IS one of `_groups`, the loop below already covers it and this does not
+	 * run a second time.
+	 *
 	 * @since 2.0.2
 	 *
 	 * @param {string|number}                             pointId
@@ -3200,13 +3378,18 @@
 		this._groups.forEach( function( group ) {
 			group.points.forEach( function( point ) {
 				if ( String( point.id ) === id ) {
-					point.selectable = {
-						allowed: !! verdict.allowed,
-						reason: 'string' === typeof verdict.reason ? verdict.reason : null,
-					};
+					applyVerdict( point, verdict );
 				}
 			} );
 		} );
+
+		if ( this._activeGroup && ! activeGroupInGroups( this ) ) {
+			this._activeGroup.points.forEach( function( point ) {
+				if ( String( point.id ) === id ) {
+					applyVerdict( point, verdict );
+				}
+			} );
+		}
 
 		if ( this._activeGroup ) {
 			renderCard( this );
@@ -3232,6 +3415,15 @@
 	 * different id is a server/domain bug, and letting it through would silently re-key a point
 	 * inside a group — the one corruption this method could cause that nothing downstream would
 	 * detect.
+	 *
+	 * ALSO WRITES `_activeGroup` DIRECTLY WHEN IT HAS PANNED OUT OF `_groups` — same
+	 * belt-and-braces reasoning as {@see Panels.prototype.setPointVerdict}'s own note (measured
+	 * #225): {@see Panels.prototype.setVisible}'s identity-healing pass deliberately leaves a
+	 * panned-out `_activeGroup` unrepointed, so the loop over `_groups` below never reaches its
+	 * point. `found` is shared across both loops on purpose — a hit in EITHER one means the
+	 * merge landed somewhere real and the card is worth re-rendering; {@see activeGroupInGroups}
+	 * guards the second loop so an `_activeGroup` that IS already covered by `_groups` is never
+	 * walked (and therefore never merged) twice.
 	 *
 	 * @since 2.0.2
 	 *
@@ -3262,6 +3454,22 @@
 				} );
 			} );
 		} );
+
+		if ( this._activeGroup && ! activeGroupInGroups( this ) ) {
+			this._activeGroup.points.forEach( function( point ) {
+				if ( String( point.id ) !== id ) {
+					return;
+				}
+
+				found = true;
+
+				Object.keys( fields ).forEach( function( key ) {
+					if ( 'id' !== key ) {
+						point[ key ] = fields[ key ];
+					}
+				} );
+			} );
+		}
 
 		if ( found && this._activeGroup ) {
 			renderCard( this );

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -1184,6 +1184,13 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 				// пункты") and, shown under a button the customer has just pressed to CONFIRM
 				// a point, would describe the wrong operation entirely.
 				'confirming'       => __( 'Проверяем…', 'woodev-plugin-framework' ),
+				// Issue #223: a SEPARATE CTA state from `confirming` above — the card reads this
+				// while the viewport strategy's own lazy detail fetch (issue #219) is in flight for
+				// the point currently shown, checking whether the sparse listing's
+				// permissive-by-omission verdict still holds, NOT while a confirmation is already
+				// on its way to the server. See `pickup-panels.js`'s own `setVerdictPending()`
+				// docblock for why the two states are tracked, and released, independently.
+				'checkingAvailability' => __( 'Проверяем доступность…', 'woodev-plugin-framework' ),
 				'selectFailed'     => __(
 					'Не удалось подтвердить выбор. Попробуйте ещё раз.',
 					'woodev-plugin-framework'


### PR DESCRIPTION
Closes #223
Closes #225

Both cards are **one root cause**, found by measurement. Full diagnosis:
https://github.com/kalbac/woodev-plugin-framework/issues/225#issuecomment-5224200512

## The bug

`updatePoint()` and `setPointVerdict()` locate a point by walking `_groups`.
`renderCard()` renders from `_activeGroup`, captured at `openCard()` time. While
no listing arrives those are the same objects.

When a listing refetch lands between a card opening and its answer,
`fetchAndSetPoints()` rebuilds the groups via `geo.groupByPosition()` — **new
objects** — and `setVisible()` replaces `_groups`, orphaning `_activeGroup`. Both
writers then find the point (`found === true`, so `renderCard()` even runs),
mutate the **new** object, and the card re-renders from the **old** one. The
verdict is applied and silently discarded.

### Measured, before the fix

```
start:                { cta.disabled: false, activeGroupStillInGroups: true  }
afterListingRefetch:  { cta.disabled: false, activeGroupStillInGroups: false }
afterRefusal_CTA:     { disabled: false }                    <- CTA STILL CLICKABLE
verdictInGroups:      { allowed: false, reason: "refused" }  <- the write landed here
verdictInActiveGroup: { allowed: true,  reason: null }       <- the card renders from here
```

The control run with no intervening listing disabled the CTA correctly, so what
breaks is precisely the object divergence — not the verdict path.

This explains all six of the operator's observations on #225, including the
otherwise-puzzling sixth: the same listing also clears the `detailedPoints` memo,
so the next card open re-requests, and that time nothing intervenes. It is also
the "требует разбора" half of #223 — `finishSelection()` refusing through
`setPointVerdict()` hits the identical split, hence «ушёл `/select`, ответ
вернулся, и ничего не произошло».

## The fix — four parts

1. **`setVisible()` heals the identity** — re-points `_activeGroup` at the fresh
   group of the same `key` and re-renders, re-resolving `_activeIndex` by point id
   (nothing guarantees the rebuilt group keeps its point order). A point panned
   **out** of the new set keeps the stale object on purpose: an open card must not
   blank out because its point left the viewport.
2. **Belt and braces** — `updatePoint()`/`setPointVerdict()` also cover
   `_activeGroup` when it is not reachable through `_groups` (the panned-out case
   part 1 leaves unhealed), guarded against double-applying.
3. **The gap part 1 exposes** — a successful listing clears the memo, but nothing
   re-asked for a card **already** open, so it fell back to the sparse permissive
   verdict and never asked again. It now re-requests for the open point; the memo
   makes that exactly one request per listing, and the restore pass is a
   guard-caught no-op.
4. **#223 — the CTA lock.** A new `is-verdict-pending` card state locks the CTA
   («Проверяем доступность…») for the detail fetch's window, where the card is
   still showing the permissive-by-omission verdict that fetch may be about to
   overturn.

### Why #223 is a separate state, not `setSelectionBusy()`

They can be true **at once** on one panels instance: a post-confirmation checkout
refresh holds the confirmation lock on the still-open card while the customer
opens a different point, whose fresh detail fetch takes this one. A single boolean
cannot represent "both reasons are live" without one release wrongly unlocking a
CTA the other still needs held — the same defect class this whole investigation is
about. The mount mirrors the split with two independent lock owners
(`pendingSelectionToken` / `verdictPendingPointId`), each released only by whoever
ends **its own** ownership.

Released on **every** outcome — success, failure, the card moving on, teardown —
mirroring `invalidateSelection()`'s "release on the move, not on the settle". A
failed detail fetch leaving the card locked forever is the exact s53 shape #223
calls out.

No third spinner: the shared `is-loading` progress bar from #222/#224 already
counts this same fetch globally; this is the card-local signal, and the card is
never covered by the sidebar overlay.

## Verification

**Tests:** 761 → **776** (15 new). The four #225 regression tests were confirmed
**RED before the fix** (verified by stashing the production changes — all four
failed with the exact symptom: the card showing the pre-refusal permissive
verdict). phpcs + phpstan clean.

**Rig** (viewport, `:8973`, chrome-devtools MCP) — the identical test that failed
above:

```
afterListing:         { activeGroupStillInGroups: true }   <- identity healed
afterRefusal_CTA:     { disabled: true }                   <- FIXED
verdictInActiveGroup: { allowed: false, reason: "…" }      <- card's own object took the write
verdictInGroups:      { allowed: false, reason: "…" }
```

And the request sequence for opening a card, checked for a storm — it terminates:

| | |
|---|---|
| `points?bbox=…` | req 101902 → res 108936 (camera move on card open) |
| `points/FIX-VIEW-1` | req 108939 → res 115544 (part 3's re-ask) |
| further requests | **none** |

with `ctaDisabled: true, «Проверяем доступность…»` during the detail window and
released after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mux4YLJ1CrbjsBMR42VT4R