### PR TITLE
feat(fixture): live Russian Post viewport point source (#226)

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/class-test-live-pochta-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-live-pochta-point-source.php
@@ -1,0 +1,991 @@
+<?php
+/**
+ * Woodev_Test_Live_Pochta_Point_Source — OPT-IN STRATEGY_VIEWPORT fixture Point_Source that
+ * calls the REAL Russian Post (Почта РФ) pickup-point widget API on `widget.pochta.ru`,
+ * proving the framework's viewport strategy — bbox listing, pagination, and lazy per-point
+ * detail fetch (#219/#223) — against a genuinely sparse live carrier response instead of the
+ * three static points in `Woodev_Test_Viewport_Point_Source` (issue #226).
+ *
+ * ACTIVATION: never on by default. `woodev-test-shipping-method.php` only constructs this
+ * class when `WOODEV_TEST_PICKUP_LIVE_POCHTA` is truthy (defined near
+ * `WOODEV_TEST_PICKUP_STRATEGY`/`WOODEV_TEST_PICKUP_LIVE_YANDEX` at the top of that file,
+ * default `false`). Neither `composer test:unit` nor `composer test:integration` nor CI ever
+ * sets that constant, so this class is declared (cheap — no I/O happens merely by
+ * `require_once`ing it) but never INSTANTIATED, and therefore never makes a network call, in
+ * either suite. PRECEDENCE: `WOODEV_TEST_PICKUP_LIVE_YANDEX` still wins when both live
+ * switches are truthy at once (an operator misconfiguration this fixture does not try to
+ * prevent, only to resolve deterministically) — see the wiring file's own comment. When only
+ * this source's switch is on, it wins over `WOODEV_TEST_PICKUP_STRATEGY`, the same way Yandex
+ * wins over it: Pochta's real API is viewport-only, so "live Pochta + bulk strategy" is not a
+ * combination that exists to choose between.
+ *
+ * ACCOUNT IDENTITY — NOT IN THIS FILE, AND NOT IN THIS REPOSITORY. `accountId` and
+ * `settings_id` identify the operator's OWN Pochta widget account/site, and this repository is
+ * PUBLIC. They are read at request time from `self::ACCOUNT_ID_CONSTANT`
+ * (`WOODEV_TEST_POCHTA_ACCOUNT_ID`) and `self::SETTINGS_ID_CONSTANT`
+ * (`WOODEV_TEST_POCHTA_SETTINGS_ID`); when neither resolves, {@see self::resolve_settings_id()}
+ * throws instead of calling out, so the failure names its own cause and NO REQUEST reaches the
+ * network (pinned by a `never()` transport test in this class's own test suite — see the
+ * `public-repo-third-party-credentials` gotcha this rule exists because of).
+ *
+ * Define them in `wp-config.php`, or in the GITIGNORED `.wp-env.override.json` rather than the
+ * tracked `.wp-env.json`:
+ *
+ *     define( 'WOODEV_TEST_POCHTA_ACCOUNT_ID', '…' );
+ *     // OR, skipping the settings lookup entirely:
+ *     define( 'WOODEV_TEST_POCHTA_SETTINGS_ID', … );
+ *
+ * SETTINGS_ID RESOLUTION — a deliberate two-path design. `WOODEV_TEST_POCHTA_SETTINGS_ID`,
+ * when defined, is used directly and `POST /api/sites/public_show` is never called — the fast
+ * path. Otherwise `WOODEV_TEST_POCHTA_ACCOUNT_ID` is required, and the settings id is resolved
+ * from it via that endpoint and cached (own transient, `SETTINGS_CACHE_TTL`, successful
+ * responses only). Both paths are real: a fresh install only has an account id and exercises
+ * the resolution call at least once; a rig that already knows its settings id can skip it
+ * entirely. See {@see self::resolve_settings_id()}. `fetch_details()` needs NEITHER constant —
+ * see that method's own docblock for why gating it the same way would guard a dependency the
+ * measured `GET /api/pvz/{id}` contract does not have.
+ *
+ * PAYLOAD, contract given by the operator and measured live 08.08.2026 (issue #226's own body
+ * carries the full write-up) — NOT taken from documentation, matching this project's
+ * "reference is not enough" lesson. Three endpoints on `https://widget.pochta.ru`:
+ *
+ *  1. `POST /api/sites/public_show` `{accountId, accountType:"wordpress"}` -> HTTP 200,
+ *     carries `id` (or `pickupId`) = the `settings_id` the listing call needs.
+ *  2. `POST /api/pvz` `{settings_id, pageSize, page, currentTopRightPoint,
+ *     currentBottomLeftPoint, pvzType}` -> `{ boundingBox, data[], pageNumber, totalEntries,
+ *     totalPages }`. Measured over central Moscow: 113 points, `totalPages: 1` (79
+ *     `russian_post` + 34 `postamat`). The listing record is genuinely SPARSE — only `id`,
+ *     `type`, `geo`, `address`, `deliveryPointIndex`. No name, no payment methods, no hours:
+ *     this is the whole reason this fixture exists, proving #219's lazy-detail fetch against a
+ *     real carrier instead of three fixture points that already carried everything up front.
+ *  3. `GET /api/pvz/{id}` -> the full record, adding `cashPayment` (bool — this IS
+ *     `accepts_cod`), `cardPayment`, `acceptEcom`, `workTime` (list of strings), `holidays`,
+ *     `closed`, `temporaryClosed`, `brandName`, `deliveryPointType`, `withFitting`,
+ *     `partialRedemption`, `returnAvailable`, `contentsChecking`, `boxSize`, `typesizeVal`.
+ *
+ * ⚠️ TRAP 1 — COORDINATES. Both the listing request's bbox corners and each record's
+ * `geo.coordinates` are `[lng, lat]`, NOT `[lat, lng]`. Measured control: the SAME rectangle
+ * sent as `[lat, lng]` returned 0 points instead of 113, at HTTP 200, with no error — "this
+ * city has no pickup points", silently. `Point_Query::get_bounds()` gives
+ * `[min_lat, min_lng, max_lat, max_lng]`; `currentTopRightPoint` takes the maxima,
+ * `currentBottomLeftPoint` the minima — see {@see self::request_points_page()}. The
+ * `geo.coordinates` half was first derived from the vendored widget bundle
+ * (`plugins-reference/pochta-widget/main.a7d147fb5267ec1f0932.js` builds its ymaps marker as
+ * `geometry.coordinates: t.geo.coordinates.reverse()`, and ymaps wants `[lat, lng]`) and has
+ * since been CONFIRMED BY LIVE CAPTURE — see the RAW CAPTURE section below.
+ * See {@see self::extract_coordinates()}.
+ *
+ * ⚠️ TRAP 2 — DETAILS KEY. `fetch_details()` must be called with the numeric `id` from the
+ * listing, NEVER `deliveryPointIndex` (the postal index) — measured: `/api/pvz/26600` -> full
+ * record (2191 bytes); `/api/pvz/111033` (the postal index of the SAME point) -> HTTP 200 with
+ * a 4-byte body. A wrong key is an EMPTY SUCCESS, not a 404 and not an error. The 4-byte body
+ * is almost certainly the literal JSON `null` (4 characters); `json_decode()` turns that into
+ * PHP `null`, which fails the `is_array($body) && isset($body['id'])` guard in
+ * {@see self::request_point_details()} the same way any other unshaped body would — mapped to
+ * a `null` RETURN, not a thrown exception. See that method's own docblock for why that is the
+ * contractually correct read of the interface's `@return` clause, not its `@throws` one.
+ *
+ * RAW CAPTURE, 08.08.2026 — the field-level shape below is MEASURED, not inferred. It was
+ * captured after this class was first written (the card recorded only the top-level key NAMES
+ * of `geo`/`address`, never their contents), and it CONFIRMED the widget-bundle reading that
+ * the first draft rested on. Kept verbatim here because a fixture poorer than production is
+ * how s49 hid two of its four map defects, and because the next person to touch this file
+ * should not have to re-derive the shape from a minified bundle.
+ *
+ * One sparse LISTING record, exactly as returned:
+ *
+ *     {"address":{"addressType":"DEFAULT","area":null,"building":null,"corpus":"2",
+ *       "hotel":null,"house":"3","id":62170,"index":"111543",
+ *       "insertedAt":"2024-01-25T03:02:48","letter":null,"location":null,
+ *       "manualInput":false,"numAddressType":null,"office":null,"place":"г. Москва",
+ *       "region":"г. Москва","room":null,"slash":null,"street":"ш. Энтузиастов",
+ *       "updatedAt":"2026-06-20T03:02:01","vladenie":null},
+ *      "addressString":null,"deletedAt":null,"deliveryPointIndex":"111543",
+ *      "geo":{"coordinates":[37.692995,55.748245],
+ *        "crs":{"properties":{"name":"EPSG:4326"},"type":"name"},"type":"Point"},
+ *      "id":62257,"type":"russian_post"}
+ *
+ * ⚠️ `address.id` (62170) IS NOT THE POINT ID (62257). They coincide on some records and not on
+ * others, so a mapper reading `address.id` would look correct on the first record it was tested
+ * against and silently mis-key the rest — always take the TOP-LEVEL `id`. Also note the address
+ * object carries more slots than the widget composes (`vladenie`, `office`, `room`, `hotel`,
+ * `index`), all null on this record.
+ *
+ * `geo.coordinates: [37.692995, 55.748245]` is Moscow — longitude first. TRAP 1 confirmed.
+ *
+ * The matching DETAILS record (`GET /api/pvz/62257`, HTTP 200, 1987 bytes) adds, verbatim:
+ * `acceptEcom:true`, `boxSize:null`, `brandId:null`, `brandName:"Почта России"`,
+ * `cardPayment:false`, `cashPayment:false`, `closed:false`, `contentsChecking:false`,
+ * `deliveryPointType:"ГОПС"`, `functionalityChecking:false`, `getto:null`, `holidays:[…]`,
+ * `legalName:null`, `legalShortName:null`, `partialRedemption:false`, `pochtaId:null`,
+ * `returnAvailable:false`, `temporaryClosed:false`, `typesizeId:null`, `typesizeVal:null`,
+ * `withFitting:false`, and
+ * `workTime:["пн, выходной","вт, открыто: 10:00 - 19:00","ср, выходной",…]`.
+ *
+ * NOTE ON `workTime`: unlike Yandex's structured `schedule.restrictions` (which the sibling
+ * live source has to flatten), Pochta returns ALREADY HUMAN-READABLE Russian strings, one per
+ * weekday. There is nothing to reconstruct — joining them is the whole job, and inventing a
+ * parser for them would be a way to introduce bugs, not remove them.
+ *
+ * `cashPayment: false` on this real record is the live proof the lazy-detail path (#219/#223)
+ * was built for: the sparse listing says nothing about cash on delivery, the detail call says
+ * "no", and the verdict flips only after that second request lands.
+ *
+ * TRAP 2 re-confirmed in the same capture: `GET /api/pvz/111543` (this point's own postal
+ * index) returned HTTP 200 with the 4-byte body `null`.
+ *
+ * ADDRESS COMPOSITION — {@see self::compose_address()}'s `place`/`location`/street algorithm
+ * follows the vendored widget bundle's own `C()`/`N()` helpers (what fills its
+ * `#balloon-address` for a selected point), so our composition matches what a customer sees in
+ * Pochta's own widget rather than being a second, divergent idea of the same address.
+ * `addressString` is always `null` in both responses (per the brief), which is why the address
+ * is built from these structural fields instead.
+ *
+ * "STRINGIFIED BOOLEAN"-STYLE WORKAROUND (issue #210) — checked, not assumed. Yandex's 5post
+ * bug came from a THIRD PARTY pre-composing one finished address STRING upstream of Yandex and
+ * stringifying an absent boolean field inside it. Here, {@see self::compose_address()} builds
+ * the string itself from typed sub-fields, and {@see self::address_field()} treats a JSON
+ * `null` (via `isset()`) or a non-scalar value the same as "absent" — so a boolean `false`
+ * sub-field would decode to PHP `''` (an actual empty string, via `(string) false === ''`),
+ * never to the four characters "false". No guard is added here because there is no matching
+ * failure mode to guard against, not because the check was skipped.
+ *
+ * TYPE MAP — reuses this fixture's EXISTING `PVZ`/`POSTAMAT` type codes (see
+ * `Woodev_Test_Live_Yandex_Point_Source::TYPE_MAP` and the icon registration in
+ * `woodev-test-shipping-method.php`), so the already-registered marker icons keep working
+ * without any new icon files. `russian_post` -> `PVZ`, `postamat` -> `POSTAMAT`; labels are the
+ * exact Russian strings the real widget bundle itself displays for these two types (its own
+ * `m()` helper: "Почтовое отделение" / "Почтомат"). The widget bundle exposes a THIRD type,
+ * `additional_pvz` ("Партнерский ПВЗ", partner pickup points) — outside this fixture's scope:
+ * the operator's own measured `pvzType` filter and point count (79+34=113) never included it,
+ * so an `additional_pvz` record here is simply an unrecognised type and is SKIPPED, not fatal,
+ * the same as any other unknown type (interface contract).
+ *
+ * TYPE FILTER (D-10, mandatory for a viewport source) — {@see self::pvz_types_for_query()} maps
+ * `Point_Query::get_types()` (our own `PVZ`/`POSTAMAT` codes) back to Pochta's `pvzType`
+ * values. An EMPTY `get_types()` means "all types" per that method's own contract; this fixture
+ * sends every known `pvzType` value EXPLICITLY rather than omitting the parameter, because
+ * omitting it was never part of the operator's measurement — there is no verified evidence an
+ * omitted `pvzType` behaves as "no filter" server-side, so this class does not guess that it
+ * does. A NON-empty `get_types()` whose codes match NOTHING in `TYPE_MAP` (a filter UI
+ * regression, or a future type this fixture does not know) short-circuits to an empty result
+ * WITHOUT a network call — no carrier type can match a filter this source cannot even
+ * translate, so making the request would only spend a round trip to learn nothing.
+ *
+ * PAGINATION — real (`page`/`pageSize`/`totalPages`), and followed by
+ * {@see self::request_points_paginated()} until `totalPages` is reached, bounded by
+ * `MAX_PAGES` (10) so a misbehaving upstream cannot loop forever. `MAX_PAGES * PAGE_SIZE` =
+ * 2000 points per viewport request — far beyond the 113-point measured control for central
+ * Moscow, the densest single-bbox result this fixture is ever likely to see in practice, while
+ * still bounded rather than open-ended. A response whose `totalPages` is missing or
+ * non-numeric defaults to `1` (this page is the only page) rather than looping.
+ *
+ * CACHING — unlike Yandex's ONE global transient (a single bulk/locality-addressed call covers
+ * a whole city), a viewport source is queried once PER BBOX, so a naive locality-shaped cache
+ * key would create an unbounded number of transients as the customer pans the map across a
+ * long rig session. {@see self::cache_key_for_query()} rounds each bbox coordinate to 3 decimal
+ * places (~111m at the equator — coarse enough that re-opening roughly the same viewport still
+ * hits the cache, fine enough that two genuinely different viewports do not collide) and folds
+ * in the sorted `pvzType` filter, so the type-filter chips do not share a cache entry with an
+ * unfiltered view. TTL is `15 * MINUTE_IN_SECONDS`, much shorter than Yandex's day-long TTL:
+ * that TTL was safe for exactly ONE cache key; this source's key SPACE grows with every
+ * distinct viewport the operator explores, and a shorter TTL bounds both how many stale entries
+ * accumulate in `wp_options` and how long any one of them can go stale, while still absorbing
+ * the rapid repeated re-fetches a panning/zooming map naturally produces within one browsing
+ * session. Only a SUCCESSFUL response is cached (both the points cache and the separate
+ * settings-id cache skip `set_transient()` on a thrown exception), so a sandbox outage is
+ * retried on the very next request rather than remembered.
+ *
+ * FAIL SOFT — same contract as the Yandex live source: every transport/HTTP/shape failure
+ * throws `\Woodev_API_Exception` (never a silently empty/short result for THOSE failure modes),
+ * which the REST layer already turns into a `502` + retry UI. The ONE exception is TRAP 2's
+ * empty-success body, which is deliberately NOT thrown — see that trap's own paragraph above
+ * and {@see self::request_point_details()}'s docblock for why `null` is the contractually
+ * correct read there. `wp_safe_remote_post()`/`wp_safe_remote_get()` are used (never the unsafe
+ * variants) with an explicit `REQUEST_TIMEOUT` (8s, matching the Yandex source). `widget.pochta.ru`
+ * is a public host on the standard port 443, so `http_request_host_is_external` never blocks
+ * it — the local-rig gotcha (`docs-internal/gotchas/wp-safe-remote-request-local-rig.md`) only
+ * bites a private/loopback host or a non-standard port, neither of which applies here.
+ *
+ * NAME SYNTHESIS (issue #226 point 1) — neither the sparse listing nor most full records carry
+ * a name for `russian_post`/`postamat` (only `additional_pvz`-style partner points get
+ * `brandName`, per the widget bundle's own eligibility rules). {@see self::synthesize_name()}
+ * uses `brandName` when present, else builds "{type label} №{index}, {city}" — THIS IS OUR OWN
+ * CONSTRUCTION, not a carrier field, and it deliberately mirrors the exact template the real
+ * widget itself uses for its own point-list subtitle (verified in the vendored bundle), so an
+ * operator comparing this fixture's list against Pochta's own would recognise the format.
+ *
+ * FIELDS WITH NO HOME IN `Pickup_Point` — `boxSize`/`typesizeVal` (dimensions) and
+ * `closed`/`temporaryClosed` (availability) are in the measured full-record table but have no
+ * matching key in `Pickup_Point::from_array()`'s contract, the same category as Yandex's
+ * dropped `dayoffs`/`deactivation_date`. They are NOT mapped here. Surfacing "this point is
+ * temporarily closed" to the customer is a real gap, but it needs a NEW mechanism (most
+ * plausibly the existing `woodev_shipping_pickup_point_selection` domain filter this very
+ * fixture already demonstrates for `DEMO-PVZ-REFUSE`), not a silent field this class invents on
+ * its own — explicitly out of scope for #226.
+ *
+ * `region`/`area` (from the `address` object) are read by `compose_address()`'s underlying
+ * sub-fields but deliberately EXCLUDED from the composed string, matching the real widget's own
+ * `N()` function, which only joins `place`, `location`, and the street/house line — the
+ * region/area are shown by the widget elsewhere (its own shipping-cost panel), not as part of a
+ * point's address line, and this fixture follows the same choice.
+ *
+ * Declared inside the plugin's init callback (`require_once`d from
+ * `woodev-test-shipping-method.php`, same arrangement as `class-test-live-yandex-point-source.php`
+ * — see that file's own docblock and
+ * `docs-internal/gotchas/fixture-classes-must-live-inside-plugin-init.md`): a class naming a
+ * `Woodev\Framework\*` interface in `implements` fatals if declared before the bootstrap has
+ * selected a framework copy and registered its autoloader.
+ *
+ * @package Woodev_Test_Shipping_Method
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Woodev_Test_Live_Pochta_Point_Source' ) ) {
+
+	/**
+	 * Class Woodev_Test_Live_Pochta_Point_Source
+	 *
+	 * Live Russian Post (Почта РФ) widget-API viewport Point_Source — see the file-level
+	 * docblock for the full rationale (activation gate, verified payload shape, pagination,
+	 * caching, both traps, and fail-soft behaviour).
+	 */
+	class Woodev_Test_Live_Pochta_Point_Source implements \Woodev\Framework\Shipping\Pickup\Point_Source {
+
+		/**
+		 * Name of the constant supplying the operator's Pochta widget account id — see the
+		 * file docblock's ACCOUNT IDENTITY section. The value itself is deliberately NOT in
+		 * this file: this repository is PUBLIC, and the value identifies the operator's own
+		 * site, not ours to publish.
+		 */
+		private const ACCOUNT_ID_CONSTANT = 'WOODEV_TEST_POCHTA_ACCOUNT_ID';
+
+		/**
+		 * Name of the constant supplying an already-known `settings_id`, skipping the
+		 * `public_show` resolution call entirely when defined — see the file docblock's
+		 * SETTINGS_ID RESOLUTION section.
+		 */
+		private const SETTINGS_ID_CONSTANT = 'WOODEV_TEST_POCHTA_SETTINGS_ID';
+
+		/** Pochta's widget-API host — verified live 08.08.2026, see file docblock. */
+		private const HOST = 'https://widget.pochta.ru';
+
+		/** Verified live 08.08.2026 — settings/`accountId` resolution endpoint. */
+		private const SETTINGS_PATH = '/api/sites/public_show';
+
+		/** Verified live 08.08.2026 — sparse, paginated, bbox-addressed point listing. */
+		private const LIST_PATH = '/api/pvz';
+
+		/** Verified live 08.08.2026 — full per-point record, keyed by numeric `id` (TRAP 2). */
+		private const DETAILS_PATH = '/api/pvz/';
+
+		/** `accountType` value the settings call expects for a WordPress integration. */
+		private const ACCOUNT_TYPE = 'wordpress';
+
+		/** Matches the operator's own measured request — see file docblock PAYLOAD section. */
+		private const PAGE_SIZE = 200;
+
+		/** Bounded so a misbehaving upstream cannot loop forever — see file docblock PAGINATION. */
+		private const MAX_PAGES = 10;
+
+		/** Bounded so a hung sandbox degrades to an error, not an indefinite wait. */
+		private const REQUEST_TIMEOUT = 8;
+
+		/** Own transient for the resolved `settings_id` — see file docblock SETTINGS_ID RESOLUTION. */
+		private const SETTINGS_CACHE_KEY = 'woodev_test_live_pochta_settings_id';
+
+		/** A day — site/account configuration barely changes; matches Yandex's own convention. */
+		private const SETTINGS_CACHE_TTL = DAY_IN_SECONDS;
+
+		/** Prefix for the bbox+type-addressed points cache — see file docblock CACHING section. */
+		private const POINTS_CACHE_PREFIX = 'woodev_test_live_pochta_pts_';
+
+		/** See file docblock CACHING section for why this is far shorter than Yandex's day-long TTL. */
+		private const POINTS_CACHE_TTL = 15 * MINUTE_IN_SECONDS;
+
+		/** Decimal places a bbox coordinate is rounded to before hashing into a cache key (~111m). */
+		private const CACHE_BBOX_PRECISION = 3;
+
+		/**
+		 * Maps Pochta's raw `type` values onto the fixture's EXISTING `PVZ`/`POSTAMAT` type
+		 * codes so the already-registered marker icons keep working — see the file docblock's
+		 * TYPE MAP section. `short` is this fixture's own tab wording (issue #207); like
+		 * Yandex's `TYPE_MAP`, it is fed separately into `point_short_name` and never reaches
+		 * `Pickup_Point`'s whitelisted `type` array.
+		 *
+		 * @var array<string, array{code: string, label: string, short: string}>
+		 */
+		private const TYPE_MAP = [
+			'russian_post' => [
+				'code'  => 'PVZ',
+				'label' => 'Почтовое отделение',
+				'short' => 'Почта',
+			],
+			'postamat'     => [
+				'code'  => 'POSTAMAT',
+				'label' => 'Почтомат',
+				'short' => 'Почтомат',
+			],
+		];
+
+		/**
+		 * @inheritDoc
+		 */
+		public function get_strategy(): string {
+			return self::STRATEGY_VIEWPORT;
+		}
+
+		/**
+		 * Returns the sparse points inside the requested bbox, honouring the type filter
+		 * (D-10, mandatory for a viewport source) — see the file docblock's TYPE FILTER
+		 * section.
+		 *
+		 * @inheritDoc
+		 *
+		 * @throws \Woodev_API_Exception On a sandbox transport, HTTP, settings-resolution, or
+		 *                                 payload-shape failure — see the file docblock's
+		 *                                 FAIL SOFT section.
+		 */
+		public function fetch_points( \Woodev\Framework\Shipping\Pickup\Point_Query $query ): array {
+			// Guaranteed non-null for a STRATEGY_VIEWPORT source — see the Point_Source
+			// interface docblock.
+			[ $min_lat, $min_lng, $max_lat, $max_lng ] = $query->get_bounds();
+
+			$pvz_types = $this->pvz_types_for_query( $query->get_types() );
+
+			if ( [] === $pvz_types ) {
+				// Every requested type code is foreign to this source — nothing can match, and
+				// there is no verified evidence an empty `pvzType` array means "all types" on
+				// the wire (see file docblock TYPE FILTER section), so this refuses the guess
+				// rather than risk it being read as "no filter" server-side.
+				return [];
+			}
+
+			$raw_points = $this->fetch_points_cached( $min_lat, $min_lng, $max_lat, $max_lng, $pvz_types );
+
+			return array_values( array_filter( array_map( [ $this, 'map_sparse_point' ], $raw_points ) ) );
+		}
+
+		/**
+		 * Fetches one point's full record by its numeric listing `id` (TRAP 2 — see file
+		 * docblock). Deliberately requires NEITHER `ACCOUNT_ID_CONSTANT` nor
+		 * `SETTINGS_ID_CONSTANT`: the measured `GET /api/pvz/{id}` contract carries no
+		 * account-identifying parameter at all, so gating this call behind those constants
+		 * would guard a dependency that does not exist — the fixture's activation gate
+		 * (`WOODEV_TEST_PICKUP_LIVE_POCHTA`, checked only in the wiring file, mirroring how
+		 * Yandex's own live-switch is never referenced inside its class either) is what keeps
+		 * this call from ever firing on an unconfigured install.
+		 *
+		 * @inheritDoc
+		 *
+		 * @throws \Woodev_API_Exception On a sandbox transport, HTTP, or unshaped-but-not-empty
+		 *                                 payload failure — see the file docblock's FAIL SOFT
+		 *                                 section. TRAP 2's specific empty-success shape is
+		 *                                 NOT one of these — see {@see self::request_point_details()}.
+		 */
+		public function fetch_details( string $point_id ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
+			$raw_point = $this->request_point_details( $point_id );
+
+			if ( null === $raw_point ) {
+				return null;
+			}
+
+			return $this->map_full_point( $raw_point );
+		}
+
+		/**
+		 * Maps `Point_Query::get_types()` (this fixture's own `PVZ`/`POSTAMAT` codes) back onto
+		 * Pochta's `pvzType` values — see the file docblock's TYPE FILTER section.
+		 *
+		 * @param string[] $type_codes Requested type codes, or an empty array meaning "all types".
+		 *
+		 * @return string[] Pochta `pvzType` values to send, or an empty array when the request
+		 *                   cannot match anything this source knows how to translate.
+		 */
+		private function pvz_types_for_query( array $type_codes ): array {
+			if ( [] === $type_codes ) {
+				return array_keys( self::TYPE_MAP );
+			}
+
+			$pvz_types = [];
+
+			foreach ( self::TYPE_MAP as $pvz_type => $mapping ) {
+				if ( in_array( $mapping['code'], $type_codes, true ) ) {
+					$pvz_types[] = $pvz_type;
+				}
+			}
+
+			return $pvz_types;
+		}
+
+		/**
+		 * Returns the raw sparse point records for one bbox+type-filter combination, from
+		 * cache when fresh — see the file docblock's CACHING section.
+		 *
+		 * @param float    $min_lat   Minimum latitude.
+		 * @param float    $min_lng   Minimum longitude.
+		 * @param float    $max_lat   Maximum latitude.
+		 * @param float    $max_lng   Maximum longitude.
+		 * @param string[] $pvz_types Pochta `pvzType` values to request.
+		 *
+		 * @return array<int, mixed> Raw records from the API's `data` array, across all pages.
+		 *
+		 * @throws \Woodev_API_Exception On a sandbox transport, HTTP, settings-resolution, or
+		 *                                 payload-shape failure.
+		 */
+		private function fetch_points_cached( float $min_lat, float $min_lng, float $max_lat, float $max_lng, array $pvz_types ): array {
+			$cache_key = $this->cache_key_for_query( $min_lat, $min_lng, $max_lat, $max_lng, $pvz_types );
+			$cached    = get_transient( $cache_key );
+
+			if ( is_array( $cached ) ) {
+				return $cached;
+			}
+
+			$points = $this->request_points_paginated( $min_lat, $min_lng, $max_lat, $max_lng, $pvz_types );
+
+			set_transient( $cache_key, $points, self::POINTS_CACHE_TTL );
+
+			return $points;
+		}
+
+		/**
+		 * Builds the bbox+type-addressed cache key — see the file docblock's CACHING section
+		 * for why a viewport source cannot reuse Yandex's single global transient.
+		 *
+		 * @param float    $min_lat   Minimum latitude.
+		 * @param float    $min_lng   Minimum longitude.
+		 * @param float    $max_lat   Maximum latitude.
+		 * @param float    $max_lng   Maximum longitude.
+		 * @param string[] $pvz_types Pochta `pvzType` values narrowing this request.
+		 *
+		 * @return string
+		 */
+		private function cache_key_for_query( float $min_lat, float $min_lng, float $max_lat, float $max_lng, array $pvz_types ): string {
+			$rounded = array_map(
+				static fn( float $v ): float => round( $v, self::CACHE_BBOX_PRECISION ),
+				[ $min_lat, $min_lng, $max_lat, $max_lng ]
+			);
+
+			$sorted_types = $pvz_types;
+			sort( $sorted_types );
+
+			return self::POINTS_CACHE_PREFIX . md5( implode( ',', $rounded ) . '|' . implode( ',', $sorted_types ) );
+		}
+
+		/**
+		 * Performs the live paginated call to Pochta's listing endpoint and returns every
+		 * page's `data` merged, bounded by `MAX_PAGES` — see the file docblock's PAGINATION
+		 * section.
+		 *
+		 * @param float    $min_lat   Minimum latitude.
+		 * @param float    $min_lng   Minimum longitude.
+		 * @param float    $max_lat   Maximum latitude.
+		 * @param float    $max_lng   Maximum longitude.
+		 * @param string[] $pvz_types Pochta `pvzType` values to request.
+		 *
+		 * @return array<int, mixed>
+		 *
+		 * @throws \Woodev_API_Exception On a sandbox transport, HTTP, settings-resolution, or
+		 *                                 payload-shape failure.
+		 */
+		private function request_points_paginated( float $min_lat, float $min_lng, float $max_lat, float $max_lng, array $pvz_types ): array {
+			$settings_id = $this->resolve_settings_id();
+
+			$all_points  = [];
+			$page        = 1;
+			$total_pages = 1;
+
+			do {
+				$body = $this->request_points_page( $settings_id, $min_lat, $min_lng, $max_lat, $max_lng, $pvz_types, $page );
+
+				$all_points = array_merge( $all_points, $body['data'] );
+
+				// A missing/non-numeric totalPages defaults to 1 (this page is the only page)
+				// rather than looping — an upstream shape change must not spin this forever.
+				$total_pages = isset( $body['totalPages'] ) && is_numeric( $body['totalPages'] )
+					? max( 1, (int) $body['totalPages'] )
+					: 1;
+
+				++$page;
+			} while ( $page <= $total_pages && $page <= self::MAX_PAGES );
+
+			return $all_points;
+		}
+
+		/**
+		 * Performs one page of the live listing call.
+		 *
+		 * TRAP 1: `currentTopRightPoint`/`currentBottomLeftPoint` are `[lng, lat]`, NOT
+		 * `[lat, lng]` — see the file docblock's own TRAP 1 section. `Point_Query::get_bounds()`
+		 * gives `[min_lat, min_lng, max_lat, max_lng]`; TopRight takes the maxima, BottomLeft
+		 * the minima.
+		 *
+		 * @param int      $settings_id Resolved settings id.
+		 * @param float    $min_lat     Minimum latitude.
+		 * @param float    $min_lng     Minimum longitude.
+		 * @param float    $max_lat     Maximum latitude.
+		 * @param float    $max_lng     Maximum longitude.
+		 * @param string[] $pvz_types   Pochta `pvzType` values to request.
+		 * @param int      $page        1-based page number.
+		 *
+		 * @return array<string, mixed> Decoded response body.
+		 *
+		 * @throws \Woodev_API_Exception On a transport failure, a non-200 HTTP response, or a
+		 *                                 body that does not decode to `{ "data": [...] }`.
+		 */
+		private function request_points_page( int $settings_id, float $min_lat, float $min_lng, float $max_lat, float $max_lng, array $pvz_types, int $page ): array {
+			$response = wp_safe_remote_post(
+				self::HOST . self::LIST_PATH,
+				[
+					'timeout' => self::REQUEST_TIMEOUT,
+					'headers' => [ 'Content-Type' => 'application/json' ],
+					'body'    => wp_json_encode(
+						[
+							'settings_id'            => $settings_id,
+							'pageSize'               => self::PAGE_SIZE,
+							'page'                   => $page,
+							'currentTopRightPoint'   => [ $max_lng, $max_lat ],
+							'currentBottomLeftPoint' => [ $min_lng, $min_lat ],
+							'pvzType'                => $pvz_types,
+						]
+					),
+				]
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new \Woodev_API_Exception(
+					sprintf( 'Pochta sandbox transport failure: %s', $response->get_error_message() )
+				);
+			}
+
+			$code = (int) wp_remote_retrieve_response_code( $response );
+
+			if ( 200 !== $code ) {
+				throw new \Woodev_API_Exception( sprintf( 'Pochta sandbox returned HTTP %d.', $code ), $code );
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( ! is_array( $body ) || ! isset( $body['data'] ) || ! is_array( $body['data'] ) ) {
+				throw new \Woodev_API_Exception( 'Pochta sandbox returned an unexpected payload shape.' );
+			}
+
+			return $body;
+		}
+
+		/**
+		 * Resolves the `settings_id` — the constant when defined, else via
+		 * `WOODEV_TEST_POCHTA_ACCOUNT_ID` and a cached call to `public_show` — see the file
+		 * docblock's SETTINGS_ID RESOLUTION section.
+		 *
+		 * @return int
+		 *
+		 * @throws \Woodev_API_Exception When neither constant is defined (no request is made —
+		 *                                 this is the security-relevant guard, pinned by a
+		 *                                 `never()` transport test), or on a transport, HTTP, or
+		 *                                 payload-shape failure resolving via `ACCOUNT_ID_CONSTANT`.
+		 */
+		private function resolve_settings_id(): int {
+			if ( defined( self::SETTINGS_ID_CONSTANT ) ) {
+				return (int) constant( self::SETTINGS_ID_CONSTANT );
+			}
+
+			if ( ! defined( self::ACCOUNT_ID_CONSTANT ) ) {
+				throw new \Woodev_API_Exception(
+					sprintf(
+						'Pochta sandbox account not configured: define %s directly, or %s to resolve it via %s.',
+						self::SETTINGS_ID_CONSTANT,
+						self::ACCOUNT_ID_CONSTANT,
+						self::SETTINGS_PATH
+					)
+				);
+			}
+
+			$cached = get_transient( self::SETTINGS_CACHE_KEY );
+
+			// A transient round-trips through the options table as a string in real WordPress
+			// (scalars are not re-typed on the way back out), so this checks is_numeric() and
+			// casts, rather than is_int() — an is_int() check would never match a REAL cached
+			// value and would silently defeat the cache on every request past the first.
+			if ( is_numeric( $cached ) ) {
+				return (int) $cached;
+			}
+
+			$settings_id = $this->request_settings_id();
+
+			set_transient( self::SETTINGS_CACHE_KEY, $settings_id, self::SETTINGS_CACHE_TTL );
+
+			return $settings_id;
+		}
+
+		/**
+		 * Performs the live call to `public_show` and returns the resolved `settings_id`.
+		 *
+		 * @return int
+		 *
+		 * @throws \Woodev_API_Exception On a transport failure, a non-200 HTTP response, or a
+		 *                                 body carrying neither `id` nor `pickupId`.
+		 */
+		private function request_settings_id(): int {
+			$response = wp_safe_remote_post(
+				self::HOST . self::SETTINGS_PATH,
+				[
+					'timeout' => self::REQUEST_TIMEOUT,
+					'headers' => [ 'Content-Type' => 'application/json' ],
+					'body'    => wp_json_encode(
+						[
+							'accountId'   => (string) constant( self::ACCOUNT_ID_CONSTANT ),
+							'accountType' => self::ACCOUNT_TYPE,
+						]
+					),
+				]
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new \Woodev_API_Exception(
+					sprintf( 'Pochta sandbox transport failure resolving settings_id: %s', $response->get_error_message() )
+				);
+			}
+
+			$code = (int) wp_remote_retrieve_response_code( $response );
+
+			if ( 200 !== $code ) {
+				throw new \Woodev_API_Exception( sprintf( 'Pochta sandbox settings lookup returned HTTP %d.', $code ), $code );
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( ! is_array( $body ) ) {
+				throw new \Woodev_API_Exception( 'Pochta sandbox settings lookup returned an unexpected payload shape.' );
+			}
+
+			// The measured response carries the settings id as either `id` or `pickupId` — the
+			// real widget bundle (vendored at plugins-reference/pochta-widget/) reads `.id`, so
+			// that is tried first; `pickupId` is the brief's own alternate name for the same value.
+			$settings_id = $body['id'] ?? $body['pickupId'] ?? null;
+
+			if ( ! is_numeric( $settings_id ) ) {
+				throw new \Woodev_API_Exception( 'Pochta sandbox settings lookup returned an unexpected payload shape.' );
+			}
+
+			return (int) $settings_id;
+		}
+
+		/**
+		 * Performs the live details call and returns the decoded body, or null for TRAP 2's
+		 * empty-success shape — see the file docblock's own TRAP 2 section for why null (not a
+		 * thrown exception) is the correct read of the interface's `@return` contract here:
+		 * nothing failed upstream, this specific id simply does not resolve to a shaped record.
+		 *
+		 * @param string $point_id Numeric listing `id` (NOT `deliveryPointIndex` — TRAP 2).
+		 *
+		 * @return array<string, mixed>|null
+		 *
+		 * @throws \Woodev_API_Exception On a transport failure or a non-200 HTTP response —
+		 *                                 real carrier failures, unlike TRAP 2's empty success.
+		 */
+		private function request_point_details( string $point_id ): ?array {
+			$response = wp_safe_remote_get(
+				self::HOST . self::DETAILS_PATH . rawurlencode( $point_id ),
+				[ 'timeout' => self::REQUEST_TIMEOUT ]
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new \Woodev_API_Exception(
+					sprintf( 'Pochta sandbox transport failure: %s', $response->get_error_message() )
+				);
+			}
+
+			$code = (int) wp_remote_retrieve_response_code( $response );
+
+			if ( 200 !== $code ) {
+				throw new \Woodev_API_Exception( sprintf( 'Pochta sandbox returned HTTP %d.', $code ), $code );
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( ! is_array( $body ) || ! isset( $body['id'] ) ) {
+				return null;
+			}
+
+			return $body;
+		}
+
+		/**
+		 * Reads one `address` sub-field as a trimmed string, treating an absent key, a JSON
+		 * `null` (via `isset()`), or any non-scalar value (an un-flattened nested object) as
+		 * "no value" rather than coercing it — the same "drop, do not coerce" rule
+		 * `Pickup_Point::sanitize_string_list()` already applies elsewhere (issue #154).
+		 *
+		 * @param array<string, mixed> $address Raw `address` object.
+		 * @param string                $key     Field name to read.
+		 *
+		 * @return string
+		 */
+		private static function address_field( array $address, string $key ): string {
+			return isset( $address[ $key ] ) && is_scalar( $address[ $key ] ) ? trim( (string) $address[ $key ] ) : '';
+		}
+
+		/**
+		 * Composes the display address from the structural `address` object — see the file
+		 * docblock's ADDRESS COMPOSITION section for where this algorithm comes from.
+		 *
+		 * @param array<string, mixed> $address Raw `address` object.
+		 *
+		 * @return string
+		 */
+		private function compose_address( array $address ): string {
+			$house_number = self::address_field( $address, 'house' ) . self::address_field( $address, 'letter' );
+			$slash        = self::address_field( $address, 'slash' );
+			$corpus       = self::address_field( $address, 'corpus' );
+			$building     = self::address_field( $address, 'building' );
+
+			$house_part = implode(
+				' ',
+				array_filter(
+					[
+						$house_number,
+						'' !== $slash ? '/' . $slash : '',
+						'' !== $corpus ? 'к. ' . $corpus : '',
+						'' !== $building ? 'стр. ' . $building : '',
+					],
+					static fn( string $part ): bool => '' !== $part
+				)
+			);
+
+			$street_part = implode(
+				' ',
+				array_filter(
+					[ self::address_field( $address, 'street' ), $house_part ],
+					static fn( string $part ): bool => '' !== $part
+				)
+			);
+
+			return implode(
+				', ',
+				array_filter(
+					[ self::address_field( $address, 'place' ), self::address_field( $address, 'location' ), $street_part ],
+					static fn( string $part ): bool => '' !== $part
+				)
+			);
+		}
+
+		/**
+		 * Extracts `[lat, lng]` from a raw record's `geo.coordinates`, or null when the field
+		 * is missing, the wrong shape, or non-numeric — see the file docblock's own TRAP 1
+		 * section for the `[lng, lat]` -> `[lat, lng]` reorder this performs.
+		 *
+		 * @param array<string, mixed> $raw_point One raw record from the listing or details call.
+		 *
+		 * @return array{0: float, 1: float}|null `[lat, lng]`, or null.
+		 */
+		private function extract_coordinates( array $raw_point ): ?array {
+			$geo         = is_array( $raw_point['geo'] ?? null ) ? $raw_point['geo'] : [];
+			$coordinates = is_array( $geo['coordinates'] ?? null ) ? array_values( $geo['coordinates'] ) : null;
+
+			if ( null === $coordinates || 2 !== count( $coordinates ) ) {
+				return null;
+			}
+
+			if ( ! is_numeric( $coordinates[0] ) || ! is_numeric( $coordinates[1] ) ) {
+				return null;
+			}
+
+			// geo.coordinates is [lng, lat] — see file docblock TRAP 1 section.
+			return [ (float) $coordinates[1], (float) $coordinates[0] ];
+		}
+
+		/**
+		 * Synthesizes a display name for a point — see the file docblock's NAME SYNTHESIS
+		 * section for why neither carrier response reliably supplies one, and why this
+		 * fallback mirrors the real widget's own subtitle template.
+		 *
+		 * @param array<string, mixed>                  $raw_point One raw record.
+		 * @param array{code: string, label: string, short: string} $type Resolved TYPE_MAP entry.
+		 *
+		 * @return string
+		 */
+		private function synthesize_name( array $raw_point, array $type ): string {
+			if ( isset( $raw_point['brandName'] ) && is_string( $raw_point['brandName'] ) && '' !== trim( $raw_point['brandName'] ) ) {
+				return trim( $raw_point['brandName'] );
+			}
+
+			$address = is_array( $raw_point['address'] ?? null ) ? $raw_point['address'] : [];
+			$place   = self::address_field( $address, 'place' );
+			$index   = $raw_point['deliveryPointIndex'] ?? '';
+
+			return trim( sprintf( '%s №%s, %s', $type['label'], (string) $index, $place ), ' ,' );
+		}
+
+		/**
+		 * Maps one raw SPARSE listing record onto the framework's normalized payload — no
+		 * payment methods, work_time, services, accepts_cod, or max_weight until
+		 * `fetch_details()` runs. Returns null (skips the point) for a non-array record, an
+		 * unrecognised `type`, or unusable coordinates — one bad record must not empty the
+		 * whole map (interface contract).
+		 *
+		 * @param mixed $raw_point One element of the listing's `data` array.
+		 *
+		 * @return \Woodev\Framework\Shipping\Pickup\Pickup_Point|null
+		 */
+		private function map_sparse_point( $raw_point ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
+			if ( ! is_array( $raw_point ) ) {
+				return null;
+			}
+
+			$type = self::TYPE_MAP[ (string) ( $raw_point['type'] ?? '' ) ] ?? null;
+
+			if ( null === $type ) {
+				return null;
+			}
+
+			$coordinates = $this->extract_coordinates( $raw_point );
+
+			if ( null === $coordinates ) {
+				return null;
+			}
+
+			[ $lat, $lng ] = $coordinates;
+			$address = is_array( $raw_point['address'] ?? null ) ? $raw_point['address'] : [];
+
+			return \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array(
+				[
+					'id'               => $raw_point['id'] ?? '',
+					'name'             => $this->synthesize_name( $raw_point, $type ),
+					'lat'              => $lat,
+					'lng'              => $lng,
+					'address'          => $this->compose_address( $address ),
+					'type'             => [ 'code' => $type['code'], 'label' => $type['label'] ],
+					'point_short_name' => $type['short'],
+					'locality'         => self::address_field( $address, 'place' ),
+				]
+			);
+		}
+
+		/**
+		 * Maps one raw FULL detail record onto the framework's normalized payload, adding
+		 * everything the sparse listing omits. Returns null for an unrecognised `type` or
+		 * unusable coordinates, same rule as the sparse mapper.
+		 *
+		 * @param array<string, mixed> $raw_point Decoded body from `GET /api/pvz/{id}`.
+		 *
+		 * @return \Woodev\Framework\Shipping\Pickup\Pickup_Point|null
+		 */
+		private function map_full_point( array $raw_point ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
+			$type = self::TYPE_MAP[ (string) ( $raw_point['type'] ?? '' ) ] ?? null;
+
+			if ( null === $type ) {
+				return null;
+			}
+
+			$coordinates = $this->extract_coordinates( $raw_point );
+
+			if ( null === $coordinates ) {
+				return null;
+			}
+
+			[ $lat, $lng ] = $coordinates;
+			$address = is_array( $raw_point['address'] ?? null ) ? $raw_point['address'] : [];
+
+			return \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array(
+				[
+					'id'               => $raw_point['id'] ?? '',
+					'name'             => $this->synthesize_name( $raw_point, $type ),
+					'lat'              => $lat,
+					'lng'              => $lng,
+					'address'          => $this->compose_address( $address ),
+					'type'             => [ 'code' => $type['code'], 'label' => $type['label'] ],
+					'point_short_name' => $type['short'],
+					'locality'         => self::address_field( $address, 'place' ),
+					'work_time'        => $this->format_work_time( $raw_point ),
+					'payment_methods'  => $this->map_payment_methods( $raw_point ),
+					'services'         => $this->map_services( $raw_point ),
+					// cashPayment (bool) IS accepts_cod — see file docblock PAYLOAD section.
+					// Absent entirely means "the carrier did not say", matching
+					// Pickup_Point::from_array()'s own null default.
+					'accepts_cod'      => isset( $raw_point['cashPayment'] ) ? (bool) $raw_point['cashPayment'] : null,
+					'photos'           => [],
+				]
+			);
+		}
+
+		/**
+		 * Flattens `workTime` (a list of already-formatted strings) and `holidays` into one
+		 * display string — unlike Yandex's structured `schedule`, there is nothing here to
+		 * parse or group, only to join.
+		 *
+		 * @param array<string, mixed> $raw_point Full detail record.
+		 *
+		 * @return string
+		 */
+		private function format_work_time( array $raw_point ): string {
+			$lines = [];
+
+			if ( is_array( $raw_point['workTime'] ?? null ) ) {
+				foreach ( $raw_point['workTime'] as $line ) {
+					if ( is_string( $line ) && '' !== trim( $line ) ) {
+						$lines[] = trim( $line );
+					}
+				}
+			}
+
+			if ( isset( $raw_point['holidays'] ) && is_string( $raw_point['holidays'] ) && '' !== trim( $raw_point['holidays'] ) ) {
+				$lines[] = 'Выходные: ' . trim( $raw_point['holidays'] );
+			}
+
+			return implode( '; ', $lines );
+		}
+
+		/**
+		 * Maps the full record's payment-method booleans to Russian display labels.
+		 *
+		 * @param array<string, mixed> $raw_point Full detail record.
+		 *
+		 * @return string[]
+		 */
+		private function map_payment_methods( array $raw_point ): array {
+			$labels = [];
+
+			if ( ! empty( $raw_point['cardPayment'] ) ) {
+				$labels[] = 'Оплата картой';
+			}
+
+			if ( ! empty( $raw_point['cashPayment'] ) ) {
+				$labels[] = 'Оплата наличными';
+			}
+
+			return $labels;
+		}
+
+		/**
+		 * Maps the full record's service booleans to Russian display labels — see the file
+		 * docblock's PAYLOAD table for which four of the measured flags have a home here.
+		 *
+		 * @param array<string, mixed> $raw_point Full detail record.
+		 *
+		 * @return string[]
+		 */
+		private function map_services( array $raw_point ): array {
+			$labels = [];
+
+			if ( ! empty( $raw_point['withFitting'] ) ) {
+				$labels[] = 'Примерка';
+			}
+
+			if ( ! empty( $raw_point['contentsChecking'] ) ) {
+				$labels[] = 'Проверка вложений';
+			}
+
+			if ( ! empty( $raw_point['partialRedemption'] ) ) {
+				$labels[] = 'Частичный выкуп';
+			}
+
+			if ( ! empty( $raw_point['returnAvailable'] ) ) {
+				$labels[] = 'Возможен возврат';
+			}
+
+			return $labels;
+		}
+	}
+}

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -42,6 +42,28 @@ if ( ! defined( 'WOODEV_TEST_PICKUP_LIVE_YANDEX' ) ) {
 }
 
 /**
+ * Issue #226: opt-in switch to the LIVE Russian Post (Почта РФ) widget-API viewport
+ * Point_Source (`Woodev_Test_Live_Pochta_Point_Source`, calling `widget.pochta.ru`) instead of
+ * the static fixture data. Defaults to `false` — neither the unit suite, the integration
+ * suite, nor CI ever defines this, so no test makes a network call. Flip via
+ * `define( 'WOODEV_TEST_PICKUP_LIVE_POCHTA', true );` in wp-config.php or the `.wp-env.json`
+ * `config` block, same idiom as the two constants above.
+ *
+ * PRECEDENCE (documented, not merely arbitrary — see the source-selection block below):
+ * `WOODEV_TEST_PICKUP_LIVE_YANDEX` still wins when BOTH live switches are truthy at once. That
+ * combination is a misconfiguration this fixture does not try to prevent (there is only one
+ * map on the rig at a time regardless), only to resolve deterministically without ever
+ * constructing two live sources — Yandex keeps its existing precedence for backward
+ * compatibility, since it was the first live switch and nothing before now depended on Pochta
+ * outranking it. When only THIS switch is truthy, it wins over `WOODEV_TEST_PICKUP_STRATEGY`
+ * the same way Yandex does: Pochta's real API is viewport-only, so "live Pochta + bulk
+ * strategy" is not a combination that exists to choose between.
+ */
+if ( ! defined( 'WOODEV_TEST_PICKUP_LIVE_POCHTA' ) ) {
+	define( 'WOODEV_TEST_PICKUP_LIVE_POCHTA', false );
+}
+
+/**
  * Определяем корневую директорию фреймворка.
  *
  * В wp-env контейнере: WOODEV_FRAMEWORK_DIR задаётся через config в .wp-env.json
@@ -214,6 +236,10 @@ function woodev_test_shipping_method_plugin_init(): void {
 	// just below — declaring a class is free (no I/O), only INSTANTIATING it below does
 	// anything, and that only happens when WOODEV_TEST_PICKUP_LIVE_YANDEX is truthy.
 	require_once __DIR__ . '/class-test-live-yandex-point-source.php';
+
+	// Issue #226: same reasoning as the live Yandex require just above — only INSTANTIATING it
+	// below does anything, and that only happens when WOODEV_TEST_PICKUP_LIVE_POCHTA is truthy.
+	require_once __DIR__ . '/class-test-live-pochta-point-source.php';
 
 	if ( ! class_exists( 'Woodev_Test_Viewport_Point_Source' ) ) {
 
@@ -403,13 +429,20 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// switch loading strategy without a code edit.
 				//
 				// Issue #185: WOODEV_TEST_PICKUP_LIVE_YANDEX (also defined near the top of
-				// this file, default false) wins over WOODEV_TEST_PICKUP_STRATEGY when
-				// truthy — Yandex only offers a bulk/geo_id-addressed endpoint, so "live"
-				// and "viewport" are not a combination that exists to choose between.
+				// this file, default false) wins over everything below when truthy — Yandex
+				// only offers a bulk/geo_id-addressed endpoint, so "live Yandex" and
+				// "viewport" are not a combination that exists to choose between, and it
+				// keeps its precedence over Pochta too (see that constant's own docblock).
+				//
+				// Issue #226: WOODEV_TEST_PICKUP_LIVE_POCHTA wins over WOODEV_TEST_PICKUP_STRATEGY
+				// when truthy, same reasoning as Yandex above but for the opposite strategy —
+				// Pochta's real API is viewport-only.
 				$viewport_strategy = \Woodev\Framework\Shipping\Pickup\Point_Source::STRATEGY_VIEWPORT;
 
 				if ( WOODEV_TEST_PICKUP_LIVE_YANDEX ) {
 					$point_source = new \Woodev_Test_Live_Yandex_Point_Source();
+				} elseif ( WOODEV_TEST_PICKUP_LIVE_POCHTA ) {
+					$point_source = new \Woodev_Test_Live_Pochta_Point_Source();
 				} else {
 					$point_source = ( $viewport_strategy === WOODEV_TEST_PICKUP_STRATEGY )
 						? new \Woodev_Test_Viewport_Point_Source()

--- a/tests/unit/Shipping/Pickup/TestLivePochtaPointSourceAccountGuardTest.php
+++ b/tests/unit/Shipping/Pickup/TestLivePochtaPointSourceAccountGuardTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Guards `Woodev_Test_Live_Pochta_Point_Source`'s refusal to call the LISTING endpoint
+ * without an account/settings id, and separately proves `fetch_details()` needs neither
+ * constant at all — see that method's own docblock for why.
+ *
+ * WHY THIS IS ITS OWN FILE, AND WHY EACH METHOD IS ITS OWN PROCESS: the behaviour under test
+ * hinges on which of `WOODEV_TEST_POCHTA_ACCOUNT_ID` / `WOODEV_TEST_POCHTA_SETTINGS_ID` is
+ * defined, and a PHP constant cannot be un-defined once set. The sibling
+ * `TestLivePochtaPointSourceTest` defines `WOODEV_TEST_POCHTA_SETTINGS_ID` for its whole
+ * class, so asserting "only ACCOUNT_ID is defined" or "neither is defined" from inside that
+ * class — or even from a different class in the SAME PHP process — is impossible/order
+ * dependent. Hence `@runInSeparateProcess` / `@preserveGlobalState disabled` on every method
+ * here, the same isolation idiom `TestLiveYandexPointSourceTokenGuardTest` uses.
+ *
+ * WHAT THE FIRST TWO TESTS PROTECT: the fixture reads `accountId`/`settings_id` from
+ * constants, never a literal (see `docs-internal/gotchas/public-repo-third-party-credentials.md`).
+ * The security-relevant behaviour is not merely "it throws" — it is that NO REQUEST LEAVES
+ * when neither constant resolves, so a misconfigured install cannot silently call out with an
+ * empty identity, and the failure names its own cause instead of surfacing as an empty map.
+ *
+ * WHAT THE THIRD TEST PROTECTS: `fetch_details()` deliberately does NOT require either
+ * constant, because the measured `GET /api/pvz/{id}` contract carries no account-identifying
+ * parameter — gating it the same way would guard a dependency that does not exist. This test
+ * pins that as a deliberate design choice, not an oversight: with BOTH constants absent, a
+ * stubbed `fetch_details()` call must still reach the (stubbed) transport, not throw.
+ *
+ * @package Woodev_Framework_Tests
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Pickup;
+
+use Brain\Monkey\Functions;
+use Woodev\Framework\Shipping\Pickup\Point_Query;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/class-plugin-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/api/class-api-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-point.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-point-query.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/interface-point-source.php';
+require_once dirname( __DIR__, 4 ) . '/tests/_fixtures/woodev-test-shipping-method/class-test-live-pochta-point-source.php';
+
+/**
+ * @covers \Woodev_Test_Live_Pochta_Point_Source
+ */
+final class TestLivePochtaPointSourceAccountGuardTest extends TestCase {
+
+	/**
+	 * With NEITHER constant defined, `fetch_points()` must throw AND must not perform any
+	 * request at all — `wp_safe_remote_post` is expected `->never()`, not merely asserted via
+	 * the exception, which would still pass if the guard were moved BELOW the request.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_missing_both_constants_throws_without_performing_any_request(): void {
+		$this->assertFalse(
+			defined( 'WOODEV_TEST_POCHTA_SETTINGS_ID' ),
+			'Process isolation failed: the settings-id constant leaked in from another test file.'
+		);
+		$this->assertFalse(
+			defined( 'WOODEV_TEST_POCHTA_ACCOUNT_ID' ),
+			'Process isolation failed: the account-id constant leaked in from another test file.'
+		);
+
+		Functions\expect( 'wp_safe_remote_post' )->never();
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+
+		$this->expectException( \Woodev_API_Exception::class );
+		$this->expectExceptionMessageMatches( '/WOODEV_TEST_POCHTA_SETTINGS_ID.*WOODEV_TEST_POCHTA_ACCOUNT_ID/' );
+
+		$source->fetch_points( Point_Query::from_request( [ 'bbox' => '55.72,37.55,55.80,37.70' ] ) );
+	}
+
+	/**
+	 * With only `WOODEV_TEST_POCHTA_ACCOUNT_ID` defined, `fetch_points()` resolves the
+	 * `settings_id` via `POST /api/sites/public_show`, caches it, and proceeds to the listing
+	 * call — the slow/resolution path this file's sibling never exercises (it always defines
+	 * `SETTINGS_ID` directly).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_account_id_resolves_settings_id_via_public_show_and_caches_it(): void {
+		$this->assertFalse(
+			defined( 'WOODEV_TEST_POCHTA_SETTINGS_ID' ),
+			'Process isolation failed: the settings-id constant leaked in from another test file.'
+		);
+
+		define( 'WOODEV_TEST_POCHTA_ACCOUNT_ID', 'dummy-account-for-tests' );
+
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		// The settings cache starts empty; the points cache also starts empty.
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\expect( 'set_transient' )->atLeast()->once();
+
+		Functions\expect( 'wp_safe_remote_post' )->once()->with(
+			'https://widget.pochta.ru/api/sites/public_show',
+			\Mockery::on(
+				static function ( array $args ): bool {
+					$body = json_decode( $args['body'], true );
+
+					return 'dummy-account-for-tests' === $body['accountId'] && 'wordpress' === $body['accountType'];
+				}
+			)
+		)->andReturn( [ 'call' => 'settings' ] );
+
+		Functions\expect( 'wp_safe_remote_post' )->once()->with(
+			'https://widget.pochta.ru/api/pvz',
+			\Mockery::on(
+				static function ( array $args ): bool {
+					$body = json_decode( $args['body'], true );
+
+					return 41353 === $body['settings_id'];
+				}
+			)
+		)->andReturn( [ 'call' => 'listing' ] );
+
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			static function ( $response ) {
+				if ( 'settings' === ( $response['call'] ?? null ) ) {
+					return json_encode( [ 'id' => 41353, 'showPostamat' => true ] );
+				}
+
+				return json_encode( [ 'data' => [], 'totalPages' => 1 ] );
+			}
+		);
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => '55.72,37.55,55.80,37.70' ] ) );
+
+		$this->assertSame( [], $points );
+	}
+
+	/**
+	 * `fetch_details()` needs neither constant — see the file docblock's own explanation.
+	 * With BOTH constants absent, a stubbed successful details call must still succeed.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_fetch_details_needs_no_account_constants(): void {
+		$this->assertFalse( defined( 'WOODEV_TEST_POCHTA_SETTINGS_ID' ) );
+		$this->assertFalse( defined( 'WOODEV_TEST_POCHTA_ACCOUNT_ID' ) );
+
+		Functions\when( 'wp_safe_remote_get' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn(
+			json_encode(
+				[
+					'id'      => 26600,
+					'type'    => 'russian_post',
+					'geo'     => [ 'coordinates' => [ 37.855554, 55.740522 ] ],
+					'address' => [ 'place' => 'Москва', 'street' => 'Новокосинская', 'house' => '17' ],
+					'deliveryPointIndex' => 111673,
+					'cashPayment'        => true,
+				]
+			)
+		);
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$point  = $source->fetch_details( '26600' );
+
+		$this->assertNotNull( $point );
+		$this->assertTrue( $point->get_accepts_cod() );
+	}
+}

--- a/tests/unit/Shipping/Pickup/TestLivePochtaPointSourceTest.php
+++ b/tests/unit/Shipping/Pickup/TestLivePochtaPointSourceTest.php
@@ -1,0 +1,606 @@
+<?php
+/**
+ * Unit tests for issue #226: `Woodev_Test_Live_Pochta_Point_Source`, the rig's OPT-IN
+ * STRATEGY_VIEWPORT Point_Source that calls the real Russian Post (Почта РФ) widget API
+ * instead of the three static points in `Woodev_Test_Viewport_Point_Source`.
+ *
+ * HARD REQUIREMENT this file exists to prove: the unit suite must never make a network call.
+ * Every transport function (`wp_safe_remote_post`, `wp_safe_remote_get`, `is_wp_error`,
+ * `wp_remote_retrieve_response_code`, `wp_remote_retrieve_body`, `get_transient`,
+ * `set_transient`) is stubbed via Brain Monkey below.
+ *
+ * `WOODEV_TEST_POCHTA_SETTINGS_ID` is defined once for the whole process (see
+ * `setUpBeforeClass()`), so every test here exercises the FAST settings-resolution path
+ * (skips `POST /api/sites/public_show` entirely). The `ACCOUNT_ID`-resolution path and the
+ * "no constants at all" guard both need a constant to be ABSENT, which is impossible once
+ * defined in this process — those live in the isolated sibling file
+ * `TestLivePochtaPointSourceAccountGuardTest.php`, each under `@runInSeparateProcess`, the
+ * same split `TestLiveYandexPointSourceTest`/`TestLiveYandexPointSourceTokenGuardTest` use.
+ *
+ * The bbox and coordinate values below are the operator's own measured example from issue
+ * #226's body (central Moscow: `min_lat 55.72, min_lng 37.55, max_lat 55.80, max_lng 37.70`),
+ * not invented — TRAP 1's exact expected wire shape is pinned against that same example.
+ *
+ * @package Woodev\Tests\Unit\Shipping\Pickup
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Pickup;
+
+use Brain\Monkey\Functions;
+use Woodev\Framework\Shipping\Pickup\Point_Query;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/class-plugin-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/api/class-api-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-point.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-point-query.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/interface-point-source.php';
+require_once dirname( __DIR__, 4 ) . '/tests/_fixtures/woodev-test-shipping-method/class-test-live-pochta-point-source.php';
+
+/**
+ * @covers \Woodev_Test_Live_Pochta_Point_Source
+ */
+final class TestLivePochtaPointSourceTest extends TestCase {
+
+	/**
+	 * The measured example bbox from issue #226's body.
+	 */
+	private const BBOX = '55.72,37.55,55.80,37.70';
+
+	/**
+	 * Defines the fast-path settings constant once for the whole process — see the file
+	 * docblock. Deliberately not the operator's real value: nothing here reaches the network
+	 * (transport is stubbed in every test), so the value only has to be numeric.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		if ( ! defined( 'WOODEV_TEST_POCHTA_SETTINGS_ID' ) ) {
+			define( 'WOODEV_TEST_POCHTA_SETTINGS_ID', 41353 );
+		}
+	}
+
+	/**
+	 * A real `russian_post` sparse listing record, matching the measured shape (`id`, `type`,
+	 * `geo`, `address`, `deliveryPointIndex` — and nothing else).
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function sparse_russian_post_record(): array {
+		// VERBATIM from a live capture, 08.08.2026 (`POST /api/pvz`, central-Moscow bbox). Kept
+		// byte-faithful on purpose, including the parts a hand-written fixture gets wrong and
+		// therefore stops testing: `place` carries its own "г. " prefix, `street` already carries
+		// its type ("ш.", "пл.", "ул."), `deliveryPointIndex` is a STRING not an int, the null
+		// slots are present rather than absent, and `address.id` (62170) DIFFERS from the point
+		// `id` (62257) — a mapper reading the wrong one looks correct on other records.
+		// A fixture poorer than production is how s49 hid two of its four map defects.
+		return [
+			'address'            => [
+				'addressType'    => 'DEFAULT',
+				'area'           => null,
+				'building'       => null,
+				'corpus'         => '2',
+				'hotel'          => null,
+				'house'          => '3',
+				'id'             => 62170,
+				'index'          => '111543',
+				'insertedAt'     => '2024-01-25T03:02:48',
+				'letter'         => null,
+				'location'       => null,
+				'manualInput'    => false,
+				'numAddressType' => null,
+				'office'         => null,
+				'place'          => 'г. Москва',
+				'region'         => 'г. Москва',
+				'room'           => null,
+				'slash'          => null,
+				'street'         => 'ш. Энтузиастов',
+				'updatedAt'      => '2026-06-20T03:02:01',
+				'vladenie'       => null,
+			],
+			'addressString'      => null,
+			'deletedAt'          => null,
+			'deliveryPointIndex' => '111543',
+			'geo'                => [
+				'coordinates' => [ 37.692995, 55.748245 ], // [lng, lat] — TRAP 1, confirmed live.
+				'crs'         => [ 'properties' => [ 'name' => 'EPSG:4326' ], 'type' => 'name' ],
+				'type'        => 'Point',
+			],
+			'id'                 => 62257,
+			'type'               => 'russian_post',
+		];
+	}
+
+	/**
+	 * A real `postamat` sparse listing record.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function sparse_postamat_record(): array {
+		// VERBATIM from a live capture, 08.08.2026 (`POST /api/pvz` with `pvzType: ["postamat"]`,
+		// 34 entries over the same central-Moscow bbox). Note `deliveryPointIndex` is "990537" —
+		// postamats carry a 990xxx PSEUDO-index, not a real postal code, so anything that treats
+		// `deliveryPointIndex` as a postcode is wrong for a third of the points on the map.
+		// `address.id` (66698) again differs from the point `id` (66790).
+		return [
+			'address'            => [
+				'addressType'    => 'DEFAULT',
+				'area'           => null,
+				'building'       => null,
+				'corpus'         => null,
+				'hotel'          => null,
+				'house'          => '6',
+				'id'             => 66698,
+				'index'          => '990537',
+				'insertedAt'     => '2025-11-28T03:02:53',
+				'letter'         => null,
+				'location'       => null,
+				'manualInput'    => false,
+				'numAddressType' => null,
+				'office'         => null,
+				'place'          => 'г. Москва',
+				'region'         => 'г. Москва',
+				'room'           => null,
+				'slash'          => null,
+				'street'         => 'ул. 1-я Тверская-Ямская',
+				'updatedAt'      => '2026-06-20T03:02:39',
+				'vladenie'       => null,
+			],
+			'addressString'      => null,
+			'deletedAt'          => null,
+			'deliveryPointIndex' => '990537',
+			'geo'                => [
+				'coordinates' => [ 37.593852, 55.771582 ], // [lng, lat]
+				'crs'         => [ 'properties' => [ 'name' => 'EPSG:4326' ], 'type' => 'name' ],
+				'type'        => 'Point',
+			],
+			'id'                 => 66790,
+			'type'               => 'postamat',
+		];
+	}
+
+	/**
+	 * The full detail record for the russian_post point above.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function full_russian_post_record(): array {
+		// VERBATIM from the live capture of `GET /api/pvz/62257` (HTTP 200, 1987 bytes), the
+		// detail record for the very point `sparse_russian_post_record()` returns. `workTime` is
+		// the real shape and it is NOT what a hand-written fixture guesses: Pochta returns
+		// already-human-readable Russian strings, one per weekday, including days off — nothing
+		// to parse, unlike Yandex's structured `schedule.restrictions`.
+		//
+		// `cashPayment: false` here IS the live proof the lazy-detail path (#219/#223) exists
+		// for: the sparse listing above says nothing about cash on delivery.
+		return array_merge(
+			$this->sparse_russian_post_record(),
+			[
+				'acceptEcom'            => true,
+				'boxSize'               => null,
+				'brandId'               => null,
+				'brandName'             => 'Почта России',
+				'cardPayment'           => false,
+				'cashPayment'           => false,
+				'closed'                => false,
+				'contentsChecking'      => false,
+				'deliveryPointType'     => 'ГОПС',
+				'functionalityChecking' => false,
+				'getto'                 => null,
+				'holidays'              => [
+					[ 'df' => '2026-05-09', 'ds' => '2026-05-09', 'work' => [ [ 'dt' => '2026-05-09', 'nm' => 6 ] ] ],
+				],
+				'insertedAt'            => '2026-08-08T03:00:15',
+				'legalName'             => null,
+				'legalShortName'        => null,
+				'partialRedemption'     => false,
+				'pochtaId'              => null,
+				'returnAvailable'       => false,
+				'temporaryClosed'       => false,
+				'typesizeId'            => null,
+				'typesizeVal'           => null,
+				'updatedAt'             => '2026-08-08T03:01:51',
+				'withFitting'           => false,
+				'workTime'              => [
+					'пн, выходной',
+					'вт, открыто: 10:00 - 19:00',
+					'ср, выходной',
+					'чт, выходной',
+					'пт, выходной',
+					'сб, выходной',
+					'вс, выходной',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Stubs a successful single-page listing transport.
+	 *
+	 * @param array<int, mixed> $data       Raw `data` records.
+	 * @param int                $total_pages `totalPages` to report.
+	 *
+	 * @return void
+	 */
+	private function stub_successful_listing_transport( array $data, int $total_pages = 1 ): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn(
+			json_encode(
+				[
+					'data'         => $data,
+					'pageNumber'   => 1,
+					'totalEntries' => count( $data ),
+					'totalPages'   => $total_pages,
+				]
+			)
+		);
+		Functions\when( 'set_transient' )->justReturn( true );
+	}
+
+	public function test_strategy_is_viewport(): void {
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+
+		$this->assertSame( 'viewport', $source->get_strategy() );
+	}
+
+	/**
+	 * TRAP 1, pinned exactly against the operator's own measured example: the bbox corners
+	 * sent to Pochta are `[lng, lat]`, and TopRight must carry the MAXIMA, BottomLeft the
+	 * MINIMA — reversing either silently returns 0 points in production.
+	 */
+	public function test_bbox_corners_are_sent_as_lng_lat_not_lat_lng(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn(
+			json_encode( [ 'data' => [], 'totalPages' => 1 ] )
+		);
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		Functions\expect( 'wp_safe_remote_post' )->once()->with(
+			'https://widget.pochta.ru/api/pvz',
+			\Mockery::on(
+				static function ( array $args ): bool {
+					$body = json_decode( $args['body'], true );
+
+					return [ 37.70, 55.80 ] === $body['currentTopRightPoint']
+						&& [ 37.55, 55.72 ] === $body['currentBottomLeftPoint'];
+				}
+			)
+		)->andReturn( [ 'fake' => 'response' ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+	}
+
+	public function test_maps_both_russian_post_and_postamat_onto_fixture_type_codes(): void {
+		$this->stub_successful_listing_transport( [ $this->sparse_russian_post_record(), $this->sparse_postamat_record() ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+
+		$this->assertCount( 2, $points );
+
+		$by_id = [];
+		foreach ( $points as $point ) {
+			$by_id[ $point->get_id() ] = $point;
+		}
+
+		// Keyed on the TOP-LEVEL `id` (62257), not `address.id` (62170) — the live capture has
+		// them differing, which is what makes reading the wrong one a silent mis-key.
+		$office = $by_id['62257'];
+		$this->assertSame( [ 'code' => 'PVZ', 'label' => 'Почтовое отделение' ], $office->to_array()['type'] );
+
+		// TRAP 1, pinned against the live record: `geo.coordinates` is [lng, lat], so the
+		// LATITUDE is the SECOND element. Swapping these puts the point in the Indian Ocean.
+		$this->assertSame( 55.748245, $office->get_lat() );
+		$this->assertSame( 37.692995, $office->get_lng() );
+
+		$postamat = $by_id['66790'];
+		$this->assertSame( [ 'code' => 'POSTAMAT', 'label' => 'Почтомат' ], $postamat->to_array()['type'] );
+	}
+
+	/**
+	 * Issue #226 point 1 — the sparse listing carries no name at all; this fixture
+	 * synthesizes one from the type label, the postal index, and the city.
+	 */
+	public function test_sparse_listing_synthesizes_a_name(): void {
+		$this->stub_successful_listing_transport( [ $this->sparse_russian_post_record() ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+
+		// The carrier's own `place` carries its "г. " prefix; we pass it through rather than
+		// second-guessing it. Live values.
+		$this->assertSame( 'Почтовое отделение №111543, г. Москва', $points[0]->to_array()['name'] );
+	}
+
+	/**
+	 * Address composed from the structural fields, matching the real widget's own
+	 * street/house-part composition (verified in the vendored bundle — see the fixture class's
+	 * own ADDRESS COMPOSITION docblock section).
+	 */
+	public function test_sparse_listing_composes_address_from_structural_fields(): void {
+		$this->stub_successful_listing_transport( [ $this->sparse_russian_post_record() ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+
+		// Live values. Note `street` ALREADY carries its type ("ш."), so the composer must not
+		// prepend one of its own — a hand-written fixture using a bare street name never tests
+		// that, and would let "ул. ш. Энтузиастов" through.
+		$this->assertSame( 'г. Москва, ш. Энтузиастов 3 к. 2', $points[0]->get_address() );
+	}
+
+	public function test_each_type_carries_its_own_short_name_for_the_tab_label(): void {
+		$this->stub_successful_listing_transport( [ $this->sparse_russian_post_record(), $this->sparse_postamat_record() ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+
+		$short_by_code = [];
+		foreach ( $points as $point ) {
+			$short_by_code[ $point->to_array()['type']['code'] ] = $point->to_array()['point_short_name'];
+		}
+
+		$this->assertSame( 'Почта', $short_by_code['PVZ'] );
+		$this->assertSame( 'Почтомат', $short_by_code['POSTAMAT'] );
+	}
+
+	/**
+	 * D-10: an empty `get_types()` means "all types" — this fixture sends every known
+	 * `pvzType` value explicitly rather than omitting the parameter (see class docblock).
+	 */
+	public function test_empty_type_filter_requests_every_known_pvz_type(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( json_encode( [ 'data' => [], 'totalPages' => 1 ] ) );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		Functions\expect( 'wp_safe_remote_post' )->once()->with(
+			\Mockery::any(),
+			\Mockery::on(
+				static function ( array $args ): bool {
+					$body = json_decode( $args['body'], true );
+
+					return [ 'russian_post', 'postamat' ] === $body['pvzType'];
+				}
+			)
+		)->andReturn( [ 'fake' => 'response' ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+	}
+
+	/**
+	 * A single-type filter maps back to exactly one `pvzType` value.
+	 */
+	public function test_single_type_filter_maps_to_one_pvz_type(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( json_encode( [ 'data' => [], 'totalPages' => 1 ] ) );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		Functions\expect( 'wp_safe_remote_post' )->once()->with(
+			\Mockery::any(),
+			\Mockery::on(
+				static function ( array $args ): bool {
+					$body = json_decode( $args['body'], true );
+
+					return [ 'postamat' ] === $body['pvzType'];
+				}
+			)
+		)->andReturn( [ 'fake' => 'response' ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX, 'types' => 'POSTAMAT' ] ) );
+	}
+
+	/**
+	 * A type filter naming ONLY codes this source cannot translate must short-circuit to an
+	 * empty result WITHOUT ever touching the network — no carrier type can match, so a request
+	 * would only spend a round trip to learn nothing.
+	 */
+	public function test_unrecognised_type_filter_never_touches_the_network(): void {
+		Functions\expect( 'wp_safe_remote_post' )->never();
+		Functions\expect( 'get_transient' )->never();
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX, 'types' => 'FUTURE_TYPE' ] ) );
+
+		$this->assertSame( [], $points );
+	}
+
+	/**
+	 * Pagination is real — a `totalPages: 2` first response must trigger a second request,
+	 * and the results must merge, bounded per the class's own `MAX_PAGES`.
+	 */
+	public function test_pagination_follows_totalPages_and_merges_results(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$page_one   = json_encode(
+			[ 'data' => [ $this->sparse_russian_post_record() ], 'pageNumber' => 1, 'totalPages' => 2 ]
+		);
+		$page_two   = json_encode(
+			[ 'data' => [ $this->sparse_postamat_record() ], 'pageNumber' => 2, 'totalPages' => 2 ]
+		);
+		$call_count = 0;
+
+		Functions\expect( 'wp_safe_remote_post' )->twice()->andReturnUsing(
+			static function () use ( &$call_count ) {
+				++$call_count;
+				return [ 'fake' => 'response', 'page' => $call_count ];
+			}
+		);
+		Functions\when( 'wp_remote_retrieve_body' )->alias(
+			static function ( $response ) use ( $page_one, $page_two ) {
+				return 1 === $response['page'] ? $page_one : $page_two;
+			}
+		);
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+
+		$this->assertCount( 2, $points );
+	}
+
+	/**
+	 * A malformed record (unrecognised type) must be SKIPPED, not abort the whole fetch.
+	 */
+	public function test_malformed_record_is_skipped_not_fatal(): void {
+		$foreign_record         = $this->sparse_russian_post_record();
+		$foreign_record['type'] = 'additional_pvz';
+
+		$this->stub_successful_listing_transport( [ $foreign_record, $this->sparse_postamat_record() ] );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+
+		$this->assertCount( 1, $points );
+		$this->assertSame( 'POSTAMAT', $points[0]->to_array()['type']['code'] );
+	}
+
+	public function test_transport_failure_throws_api_exception(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( new \WP_Error( 'http_request_failed', 'Connection timed out' ) );
+		Functions\when( 'is_wp_error' )->alias( static fn( $t ) => $t instanceof \WP_Error );
+		Functions\expect( 'set_transient' )->never();
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Pochta_Point_Source() )->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+	}
+
+	public function test_non_200_response_throws_api_exception(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 500 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"error":"internal"}' );
+		Functions\expect( 'set_transient' )->never();
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Pochta_Point_Source() )->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+	}
+
+	public function test_unexpected_body_shape_throws_api_exception(): void {
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $d ) => json_encode( $d ) );
+		Functions\when( 'wp_safe_remote_post' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '{"unexpected":true}' );
+		Functions\expect( 'set_transient' )->never();
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Pochta_Point_Source() )->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+	}
+
+	public function test_cached_response_never_hits_the_transport(): void {
+		Functions\when( 'get_transient' )->justReturn( [ $this->sparse_russian_post_record() ] );
+		Functions\expect( 'wp_safe_remote_post' )->never();
+		Functions\expect( 'set_transient' )->never();
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$points = $source->fetch_points( Point_Query::from_request( [ 'bbox' => self::BBOX ] ) );
+
+		$this->assertCount( 1, $points );
+	}
+
+	// -----------------------------------------------------------------------------
+	// fetch_details() — full record merge, TRAP 2, and the deliberate no-account-gate design.
+	// -----------------------------------------------------------------------------
+
+	private function stub_successful_details_transport( array $body ): void {
+		Functions\when( 'wp_safe_remote_get' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( json_encode( $body ) );
+	}
+
+	/**
+	 * `cashPayment: false` in the full record must reach `accepts_cod` as PHP `false`, and the
+	 * full record's payment methods / work_time / services must all merge onto the point.
+	 */
+	public function test_fetch_details_merges_the_full_record(): void {
+		$this->stub_successful_details_transport( $this->full_russian_post_record() );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+		$point  = $source->fetch_details( '62257' );
+
+		$this->assertNotNull( $point );
+
+		// THE POINT OF THIS WHOLE CARD: the sparse listing said nothing about cash on delivery,
+		// and the live detail record says `cashPayment: false`. This is #219/#223's lazy-detail
+		// path proven against a real carrier instead of a fixture that carried it up front.
+		$this->assertFalse( $point->get_accepts_cod() );
+
+		// Live record has `cardPayment: false` and `acceptEcom: true` — so no card-on-receipt
+		// label. An invented fixture had `cardPayment: true` here and was asserting a label the
+		// real point does not have.
+		$this->assertSame( [], $point->to_array()['payment_methods'] );
+
+		// Pochta returns already-readable Russian strings, one per weekday, days off included —
+		// there is nothing to parse, so the mapper joins them and stops.
+		$this->assertStringContainsString( 'вт, открыто: 10:00 - 19:00', $point->to_array()['work_time'] );
+		$this->assertStringContainsString( 'пн, выходной', $point->to_array()['work_time'] );
+
+		// Every service flag is false on this real record.
+		$this->assertSame( [], $point->to_array()['services'] );
+	}
+
+	/**
+	 * TRAP 2 — a wrong key (the postal index instead of the numeric id) returns HTTP 200 with
+	 * a shapeless 4-byte body (`null`). This must resolve to `null`, NOT a thrown exception —
+	 * nothing failed upstream, this key simply does not resolve to a record.
+	 */
+	public function test_trap_two_empty_success_body_returns_null_not_an_exception(): void {
+		Functions\when( 'wp_safe_remote_get' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( 'null' );
+
+		$source = new \Woodev_Test_Live_Pochta_Point_Source();
+
+		$this->assertNull( $source->fetch_details( '111673' ) );
+	}
+
+	public function test_fetch_details_transport_failure_throws_api_exception(): void {
+		Functions\when( 'wp_safe_remote_get' )->justReturn( new \WP_Error( 'http_request_failed', 'Connection timed out' ) );
+		Functions\when( 'is_wp_error' )->alias( static fn( $t ) => $t instanceof \WP_Error );
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Pochta_Point_Source() )->fetch_details( '26600' );
+	}
+
+	public function test_fetch_details_non_200_throws_api_exception(): void {
+		Functions\when( 'wp_safe_remote_get' )->justReturn( [ 'fake' => 'response' ] );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 404 );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '' );
+
+		$this->expectException( \Woodev_API_Exception::class );
+
+		( new \Woodev_Test_Live_Pochta_Point_Source() )->fetch_details( '26600' );
+	}
+}


### PR DESCRIPTION
Closes #226

The first `STRATEGY_VIEWPORT` source backed by a **real carrier**. Pochta is the
right one because its listing is genuinely sparse — a record carries only `id`,
`type`, `geo`, `address`, `deliveryPointIndex`, with no name, no payment methods
and no hours. So #219's lazy detail fetch and #223's CTA lock finally have real
data to prove them against, instead of three fixture points that carried
everything up front.

Modelled on `class-test-live-yandex-point-source.php`: opt-in behind
`WOODEV_TEST_PICKUP_LIVE_POCHTA`, transient cache, fail-soft through
`\Woodev_API_Exception`, docblock recording the measured payload.

## Credentials

`accountId` / `settings_id` are read at request time from named constants and
appear **nowhere in the tree as literals** (`git grep` for the value returns
nothing). With them undefined the source throws naming the missing constant and
makes **no request at all** — pinned by a `never()` transport assertion under
`@runInSeparateProcess`.

## Both traps, both silent in production

| Trap | Behaviour |
|---|---|
| Coordinates are `[lng, lat]` on the wire **and** in `geo.coordinates`, while `get_bounds()` gives `[min_lat, min_lng, …]` | reversed → the same rectangle returns **0 points** at HTTP 200, no error |
| Details keyed by numeric `id`, never `deliveryPointIndex` | wrong key → HTTP 200 with the **4-byte body `null`** — an empty success, not a 404 |

## Measured, not inferred — and it corrected six things

The card recorded the top-level key *names* of `geo`/`address` but never their
contents, so the first draft rested on reverse-engineering the vendored widget
bundle. I took live captures of `POST /api/pvz` and `GET /api/pvz/{id}` and
replaced the test fixtures with them verbatim. That confirmed the bundle reading
and then corrected expectations written against invented data:

- `place` is `"г. Москва"` — it carries its own prefix.
- `street` **already carries its type** (`"ш. Энтузиастов"`), so a composer that
  prepends one yields "ул. ш. Энтузиастов". A bare-street fixture never tests that.
- `deliveryPointIndex` is a **string**, and for postamats a `990xxx` **pseudo-index**,
  not a postal code — treating it as one is wrong for a third of the map.
- `address.id` **differs** from the point `id` on real records (62170 vs 62257), so
  a mapper reading the wrong one looks correct on whichever record it was first
  tested against.
- `workTime` is already human-readable Russian strings, one per weekday, days off
  included — nothing to parse, unlike Yandex's structured schedule.
- the captured record has `cardPayment: false`, so the invented fixture was
  asserting a payment label the real point does not have.

`cashPayment: false` on that real record is the live proof of the lazy-detail
path: the sparse listing says nothing about cash on delivery, and the verdict can
only flip after the detail call lands.

Both raw captures are kept verbatim in the class docblock and in the test
fixtures, so nobody has to re-derive the shape from a minified bundle.

## Also

Pagination is real and followed, bounded so a misbehaving upstream cannot loop.
The viewport type filter is honoured **on the wire**, as D-10 requires of a
viewport source.

## Verification

`composer test:unit` → **1512** (1490 + 22 new) · `composer phpcs` clean ·
`composer phpstan` clean.

⚠️ **Not yet exercised against the live API from the rig.** That needs your own
constants, and flipping `WOODEV_TEST_PICKUP_LIVE_POCHTA` on would change which
source the rig serves — which I did not want to do silently under your review of
#222–#225 (gotcha `rig-serves-the-working-tree-branch-switch-reverts-fixes`).
Your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mux4YLJ1CrbjsBMR42VT4R