### PR TITLE
fix(pickup): keep an open card's details across a pan instead of re-fetching them (#232)

### DIFF
--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2406,20 +2406,50 @@ describe( 'viewport lazy detail fetch (#219)', () => {
 
 	// …but a fresh listing carries freshly computed verdicts, because the cart weight or the
 	// payment method may be exactly what changed.
-	test( 'asks again after a new listing lands', async () => {
+	// CONTRACT CHANGED IN #232. This used to assert that any new listing re-asked. It does not
+	// any more, and the old behaviour was the visible defect: a bbox refetch cannot change the
+	// cart, so re-asking on every pan only made the open card drop its own content for a beat
+	// and fetch it again. What invalidates a verdict is a CART change, which arrives as
+	// `refresh()` — see the test below.
+	test( 'a pan does NOT re-ask: a bbox refetch is not a cart change', async () => {
 		const session = await openSession( configWith( { strategy: 'viewport' } ) );
 
 		openCardOn( session, 'P1' );
 		await flushAsync();
 
-		// A pan — the ordinary way a new listing lands under this strategy.
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+
 		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
 		await flushAsync();
 
 		openCardOn( session, 'P1' );
 		await flushAsync();
 
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	// The other half of the same contract: a checkout update CAN have changed the weight or the
+	// payment method, so every stored verdict is suspect and the open card must ask again.
+	test( 'refresh() forgets details, so the open card re-asks once', async () => {
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+
+		openCardOn( session, 'P1' );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+
+		// `refresh()` under viewport re-fetches the LAST bbox, so one has to exist first —
+		// otherwise it early-returns and never reaches a listing at all.
+		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+
+		await session.refresh();
+		await flushAsync();
+
 		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenLastCalledWith( 'P1' );
 	} );
 
 	// A marker click and a sidebar row both swap the card without waiting for anything, so an
@@ -2469,8 +2499,21 @@ describe( 'viewport lazy detail fetch (#219)', () => {
 	// above drives) ever re-triggered `refreshPointDetails()`. This test drives the refetch with
 	// NO further `cardOpened` in between — the card stays open on P1 throughout — proving the
 	// mount itself re-asks automatically.
-	test( 'a successful listing re-asks for the still-open card automatically, exactly once, '
-		+ 'with no reopen', async () => {
+	// REPLACES the #225 test that asserted a re-ask on every listing. #232: what an open card
+	// actually needs across a pan is not a new REQUEST but not to LOSE what it already has —
+	// `geo.groupByPosition()` rebuilds groups from the sparse listing, so without re-applying the
+	// stored detail record the card silently reverts to the permissive-by-omission verdict a
+	// detail fetch had already overturned. That revert is what the customer saw as content
+	// appearing and then vanishing.
+	test( 'a listing re-applies stored details over the rebuilt sparse groups', async () => {
+		dataSourceFactory = fakeDataSourceFactory( () => Promise.resolve( [ point( { id: 'P1' } ) ] ) );
+		dataSourceFactory.fetchDetails = jest.fn( () => Promise.resolve( {
+			id: 'P1',
+			work_time: 'Пн-Пт 10:00-19:00',
+			selectable: { allowed: false, reason: 'нет оплаты при получении' },
+		} ) );
+		window.WoodevPickupDataSource = dataSourceFactory;
+
 		const session = await openSession( configWith( { strategy: 'viewport' } ) );
 
 		openCardOn( session, 'P1' );
@@ -2478,12 +2521,19 @@ describe( 'viewport lazy detail fetch (#219)', () => {
 
 		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
 
-		// A pan — the ordinary way a new listing lands — with no `cardOpened` of its own.
+		// A pan: a fresh SPARSE listing lands, carrying the permissive default again.
 		session.provider.emit( 'boundsChange', [ 1, 2, 3, 4 ] );
 		await flushAsync();
 
-		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
-		expect( dataSourceFactory.fetchDetails ).toHaveBeenLastCalledWith( 'P1' );
+		// No second request — the memo survives a pan now.
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+
+		// …and the groups handed to the provider carry the DETAIL verdict, not the listing's.
+		const drawn = session.provider.setPointsCalls[ session.provider.setPointsCalls.length - 1 ];
+		const drawnPoint = drawn[ 0 ].points[ 0 ];
+
+		expect( drawnPoint.selectable.allowed ).toBe( false );
+		expect( drawnPoint.work_time ).toBe( 'Пн-Пт 10:00-19:00' );
 	} );
 
 	// The restore pass (spec D-15) is one of the two callers of `openCard()`/`cardOpened` that can
@@ -2885,21 +2935,14 @@ describe( 'the shared background-load indicator (issues #222/#224)', () => {
 
 		expect( session.panels.setLoadingCalls ).toEqual( [ true ] );
 
-		// #1 settles — the counter WOULD reach zero here, except issue #225's own fix
-		// (`fetchAndSetPoints()`'s Part 3 re-ask) fires the instant a listing succeeds while a
-		// card is open: request #3, a fresh detail fetch for the still-open card, starts before
-		// the indicator ever gets a chance to rest at zero. Both transitions — #1's own 1→0 and
-		// #3's immediate 0→1 — land inside this one flush, back to back.
+		// #1 settles — and now the counter really does reach zero. Before #232 a third request
+		// started here (the listing re-asked for the still-open card), so the indicator flicked
+		// off and straight back on inside this one flush. A pan is not a cart change, so it no
+		// longer re-asks, and the indicator simply rests.
 		ds.resolvePoints( [] );
 		await flushAsync();
 
-		expect( session.panels.setLoadingCalls ).toEqual( [ true, false, true ] );
-
-		// #3 settles — NOW the counter finally reaches zero and the indicator clears for good.
-		ds.resolveDetails( { id: 'P1', selectable: { allowed: true, reason: null } } );
-		await flushAsync();
-
-		expect( session.panels.setLoadingCalls ).toEqual( [ true, false, true, false ] );
+		expect( session.panels.setLoadingCalls ).toEqual( [ true, false ] );
 	} );
 
 	// Adversarial-review finding: `bumpLoading()` runs, then `realDataSource.fetchPoints()`/

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1091,6 +1091,19 @@
 		 *  because that is the moment the cart (and so the verdict) may have changed under us. */
 		var detailedPoints = {};
 
+		/** @type {Object.<string, Object>} the RAW detail record for every point whose details
+		 *  have landed, by id — re-applied over each rebuilt listing by {@see fetchAndSetPoints}.
+		 *
+		 *  Without this the enrichment is lost on the very next pan: `geo.groupByPosition()`
+		 *  rebuilds groups from the SPARSE listing, and `setVisible()`'s identity healing then
+		 *  re-points the open card at that sparse group — so the card's own content appeared and
+		 *  then vanished a beat later, which is exactly what the customer saw (#232). Details are
+		 *  strictly more informed than a listing, verdict included, so they win on merge.
+		 *
+		 *  Emptied together with `detailedPoints`, and for the same reason — see
+		 *  {@see forgetPointDetails}. */
+		var detailsById = {};
+
 		/** @type {number} mints one unique, monotonic token per confirmation this session sends.
 		 *  Never reset, never reused — that is the whole point (see `pendingSelectionToken`). */
 		var selectionTokens = 0;
@@ -1602,6 +1615,10 @@
 						return;
 					}
 
+					// Remembered so the next listing rebuild can re-apply it — see
+					// `detailsById`'s own docblock for the flash this prevents.
+					detailsById[ id ] = point;
+
 					panels.updatePoint( id, point );
 				},
 				function() {
@@ -1666,13 +1683,41 @@
 						return points;
 					}
 
-					// A fresh listing carries a freshly computed verdict for every point, so
-					// whatever a detail fetch learned about the PREVIOUS listing is now history —
-					// the cart weight or the payment method may be what changed. See
-					// {@see refreshPointDetails}.
-					detailedPoints = {};
+					// DELIBERATELY NOT WIPED HERE (#232). This used to clear `detailedPoints` on
+					// every successful listing, on the reasoning that a fresh listing carries a
+					// freshly computed verdict. But a bbox refetch is not a cart change: panning
+					// the map cannot alter the weight or the payment method, and wiping on every
+					// pan meant the open card re-requested its details each time, showing its own
+					// content for a beat and then losing it again. What DOES change the cart is a
+					// checkout update, and that arrives as {@see refresh} — which is where the
+					// memo is cleared now, via {@see forgetPointDetails}.
 
 					var groups = geo.groupByPosition( points );
+
+					// Re-apply what detail fetches already learned, BEFORE anything draws or
+					// renders these groups (#232). `geo.groupByPosition()` builds them from the
+					// sparse listing, so without this the map, the sidebar and the open card all
+					// fall back to the permissive-by-omission verdict a detail fetch had already
+					// overturned — visibly, as content that appears and then disappears.
+					groups.forEach( function( group ) {
+						group.points.forEach( function( point ) {
+							var stored = detailsById[ String( point.id ) ];
+
+							if ( ! stored ) {
+								return;
+							}
+
+							Object.keys( stored ).forEach( function( key ) {
+								// `id` is never overwritten, matching `Panels#updatePoint()`'s own
+								// rule: a record re-keying a point is the one corruption here that
+								// nothing downstream would detect.
+								if ( 'id' !== key ) {
+									point[ key ] = stored[ key ];
+								}
+							} );
+						} );
+					} );
+
 					var byKey = {};
 
 					groups.forEach( function( group ) {
@@ -1843,6 +1888,27 @@
 		 *
 		 * @returns {void}
 		 */
+		/**
+		 * Forgets everything learned from detail fetches — both the "already asked this listing"
+		 * memo and the stored records themselves (#232).
+		 *
+		 * Called from {@see refresh} ONLY, because a checkout update is the one event that can
+		 * actually invalidate a verdict: the cart weight or the chosen payment method may have
+		 * moved, and every stored `selectable` was computed against the old one. A bbox refetch
+		 * is explicitly NOT such an event — see the note where the old per-listing wipe used to
+		 * be, in {@see fetchAndSetPoints}.
+		 *
+		 * Clearing the memo is what makes the open card re-ask on the next listing: the re-ask
+		 * at the end of {@see fetchAndSetPoints} is guard-caught into a no-op while the memo
+		 * still holds the point, and becomes a real request once this has run.
+		 *
+		 * @returns {void}
+		 */
+		function forgetPointDetails() {
+			detailedPoints = {};
+			detailsById    = {};
+		}
+
 		function releaseVerdictPending() {
 			if ( 0 === verdictPendingToken ) {
 				return;
@@ -2758,6 +2824,10 @@
 			if ( destroyed || ownsChrome ) {
 				return Promise.resolve();
 			}
+
+			// THE cart-change event (#232) — see {@see forgetPointDetails} for why this is the
+			// only place details are forgotten, and no longer every listing.
+			forgetPointDetails();
 
 			if ( 'bulk' === config.strategy ) {
 				return fetchAndSetPoints( bulkQuery() ).catch( function() {} );


### PR DESCRIPTION
Closes #232

Regression from my own #225 work, reported on the live Pochta source.

Clicking a point sent `/points/{id}`, the camera moved, the bbox refetch went out
— and when **that** landed, a second `/points/{id}` for the same point followed.
On screen: the card's content appeared, vanished a beat later, the CTA went back
to «Проверяем доступность…», and only the second answer stuck.

## Cause — two of my own #228 changes combining

- **Part 3** re-asked for the open card after *every* successful listing, because
  a listing wiped `detailedPoints` and the card would otherwise sit on the sparse
  permissive verdict forever.
- **Part 1**'s identity healing re-pointed `_activeGroup` at the fresh group — and
  the fresh group comes from the **sparse** listing, so the enriched point was
  replaced by a poor one. That is the vanishing content.

`detailsInFlight` could not help: the first fetch had already **settled** by the
time the listing landed, so the second was a genuine repeat, not a concurrent
duplicate.

## Fix

The wipe was keyed to the wrong event. **A bbox refetch cannot change the cart** —
panning alters neither the weight nor the payment method — so it invalidates
nothing. What does is a checkout update, which arrives as `refresh()`. The memo
now clears there and only there (`forgetPointDetails()`), leaving the
end-of-listing re-ask as a guard-caught no-op that becomes a real request exactly
when the cart moved.

That alone would still lose the enrichment, so the mount also remembers each
detail record (`detailsById`) and re-applies it over the rebuilt groups **before
they are drawn** — map, sidebar and open card all keep the informed verdict
instead of reverting to the listing's permissive-by-omission one. Details are
strictly better informed than a listing, verdict included, so they win the merge;
`id` is never overwritten.

## Verification

**Rig, live Pochta**, 30 s of sampling after a point click:

| | before | after |
|---|---|---|
| `points/{id}` requests | 2 | **1** |
| card content transitions | true → false → true | **one, no revert** |

The bbox listing still fires (the camera moved) and no longer drags a second
detail request behind it.

**Tests:** 779. Three encoded the old contract and were rewritten; two added — a
pan does **not** re-ask, `refresh()` does, and a listing re-applies stored details
over the rebuilt sparse groups. The last was confirmed to **fail** under a
deliberate mutation disabling the re-apply, reverted from a `cp` backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mux4YLJ1CrbjsBMR42VT4R