### PR TITLE
fix(pickup): report a tab switch as a card move, and take Pochta's COD rule from the domain (#233)

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/class-test-live-pochta-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-live-pochta-point-source.php
@@ -58,8 +58,8 @@
  *     `type`, `geo`, `address`, `deliveryPointIndex`. No name, no payment methods, no hours:
  *     this is the whole reason this fixture exists, proving #219's lazy-detail fetch against a
  *     real carrier instead of three fixture points that already carried everything up front.
- *  3. `GET /api/pvz/{id}` -> the full record, adding `cashPayment` (bool — this IS
- *     `accepts_cod`), `cardPayment`, `acceptEcom`, `workTime` (list of strings), `holidays`,
+ *  3. `GET /api/pvz/{id}` -> the full record, adding `cashPayment`, `cardPayment`,
+ *     `acceptEcom`, `workTime` (list of strings), `holidays`,
  *     `closed`, `temporaryClosed`, `brandName`, `deliveryPointType`, `withFitting`,
  *     `partialRedemption`, `returnAvailable`, `contentsChecking`, `boxSize`, `typesizeVal`.
  *
@@ -127,9 +127,32 @@
  * weekday. There is nothing to reconstruct — joining them is the whole job, and inventing a
  * parser for them would be a way to introduce bugs, not remove them.
  *
- * `cashPayment: false` on this real record is the live proof the lazy-detail path (#219/#223)
- * was built for: the sparse listing says nothing about cash on delivery, the detail call says
- * "no", and the verdict flips only after that second request lands.
+ * CASH ON DELIVERY — decided by the point's TYPE, not by `cashPayment` (#233).
+ *
+ * This first mapped `cashPayment` straight onto `accepts_cod`, on the strength of issue #226's
+ * own wording ("this IS `accepts_cod`"). Live data says otherwise: `cashPayment` is `false` on
+ * EVERY point measured — 6 `russian_post` and 6 `postamat` — and so is `cardPayment`. A field
+ * that never varies carries no information, and mapping it to a customer-facing verdict made
+ * every post office refuse cash on delivery, which is backwards.
+ *
+ * The authority is the operator's own production plugin,
+ * `plugins-reference/woodev-russian-post`, in `includes/classes/checkout.php`:
+ *
+ *     if ( 'cod' == $data['payment_method']
+ *          && ( 'postamat' == $customer_delivery_point->get_type()
+ *               || $customer_delivery_point->get_mail_type() == 'ECOM_MARKETPLACE' ) ) {
+ *         // refuse: "unavailable for Postamat and ECOM shipping type"
+ *     }
+ *
+ * COD is refused for a PARCEL LOCKER (and for the ECOM_MARKETPLACE shipment type); an ordinary
+ * post office takes it. `mail_type` is a property of the SHIPMENT in his Otpravka integration
+ * and has no counterpart in this widget API, so only the type half is expressible here — and it
+ * is the half that separates the two kinds of point on the map. `acceptEcom` (true for offices,
+ * false for lockers) is a different flag and is deliberately NOT used for this.
+ *
+ * The lazy-detail path (#219/#223) is still proven on real data, just by a different field: the
+ * sparse listing carries no payment information at all, so a locker's `accepts_cod: false` can
+ * still only reach the customer once the detail call lands.
  *
  * TRAP 2 re-confirmed in the same capture: `GET /api/pvz/111543` (this point's own postal
  * index) returned HTTP 200 with the 4-byte body `null`.
@@ -884,10 +907,10 @@ if ( ! class_exists( 'Woodev_Test_Live_Pochta_Point_Source' ) ) {
 					'work_time'        => $this->format_work_time( $raw_point ),
 					'payment_methods'  => $this->map_payment_methods( $raw_point ),
 					'services'         => $this->map_services( $raw_point ),
-					// cashPayment (bool) IS accepts_cod — see file docblock PAYLOAD section.
-					// Absent entirely means "the carrier did not say", matching
-					// Pickup_Point::from_array()'s own null default.
-					'accepts_cod'      => isset( $raw_point['cashPayment'] ) ? (bool) $raw_point['cashPayment'] : null,
+					// COD IS DECIDED BY POINT TYPE, NOT BY `cashPayment` — see the file docblock's own
+					// CASH ON DELIVERY section for the measurement and for the authority (the operator's
+					// own production plugin) behind this rule.
+					'accepts_cod'      => 'postamat' !== (string) ( $raw_point['type'] ?? '' ),
 					'photos'           => [],
 				]
 			);

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2452,6 +2452,37 @@ describe( 'viewport lazy detail fetch (#219)', () => {
 		expect( dataSourceFactory.fetchDetails ).toHaveBeenLastCalledWith( 'P1' );
 	} );
 
+	// #233: the SECOND point of a co-located group. A tab click reports `cardOpened` with origin
+	// `'tab'`, so this funnel must treat it like any other move — fetch that point's details —
+	// while skipping the camera, since every point in the group shares one coordinate.
+	test( "a tab switch fetches the new point's details and moves no camera", async () => {
+		const session = await openSession( configWith( { strategy: 'viewport' } ) );
+		const group = {
+			key: 'g1',
+			lat: 55.75,
+			lng: 37.61,
+			points: [ { id: 'OFFICE' }, { id: 'LOCKER' } ],
+		};
+
+		session.panels.emit( 'cardOpened', { group: group, pointId: 'OFFICE', origin: 'list' } );
+		await flushAsync();
+
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 1 );
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenLastCalledWith( 'OFFICE' );
+
+		session.provider.focusGroupCalls.length = 0;
+
+		session.panels.emit( 'cardOpened', { group: group, pointId: 'LOCKER', origin: 'tab' } );
+		await flushAsync();
+
+		// The whole defect: before this, the second point was never asked about at all.
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenCalledTimes( 2 );
+		expect( dataSourceFactory.fetchDetails ).toHaveBeenLastCalledWith( 'LOCKER' );
+
+		// …and the camera stays put — same coordinate, nothing to move to.
+		expect( session.provider.focusGroupCalls ).toHaveLength( 0 );
+	} );
+
 	// A marker click and a sidebar row both swap the card without waiting for anything, so an
 	// answer can land about a point the customer is no longer reading.
 	test( 'a late answer is dropped when the card has moved to another point', async () => {

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -1690,6 +1690,31 @@ it( 'renders one tab per point, labelled by type, first active', () => {
 	expect( tabs[ 0 ].classList.contains( 'is-active' ) ).toBe( true );
 } );
 
+// #233: a tab click moves the card onto a DIFFERENT POINT, and until this fix it only
+// re-rendered — the mount never learned, so under the viewport strategy the second tab's details
+// were never fetched and its CTA stayed live on a permissive-by-omission verdict while the first
+// tab's went correctly dead. Reported live on Pochta, where one building holds an office and a
+// parcel locker with different COD rules.
+it( 'reports the move through cardOpened when a tab is clicked', () => {
+	const panels = mount( cardConfig );
+	const seen = [];
+
+	panels.on( 'cardOpened', ( payload ) => seen.push( payload ) );
+	panels.openCard( two );
+
+	seen.length = 0;
+	panels.root.querySelectorAll( '.woodev-pickup-card__tab' )[ 1 ].click();
+
+	expect( seen ).toHaveLength( 1 );
+	expect( String( seen[ 0 ].pointId ) ).toBe( String( two.points[ 1 ].id ) );
+
+	// A dedicated origin, so the mount can skip the camera move: every point in a co-located
+	// group shares one coordinate, so a focus would move nothing and would re-enter the s52
+	// draw-vs-move race for no gain.
+	expect( seen[ 0 ].origin ).toBe( 'tab' );
+	expect( seen[ 0 ].group ).toBe( two );
+} );
+
 it( 'swaps the body when a tab is clicked', () => {
 	const panels = mount( cardConfig );
 	panels.openCard( two );

--- a/tests/unit/Shipping/Pickup/TestLivePochtaPointSourceTest.php
+++ b/tests/unit/Shipping/Pickup/TestLivePochtaPointSourceTest.php
@@ -546,7 +546,8 @@ final class TestLivePochtaPointSourceTest extends TestCase {
 		$point = ( new \Woodev_Test_Live_Pochta_Point_Source() )->fetch_details( '62257' );
 
 		$this->assertNotNull( $point );
-		$this->assertFalse( $point->get_accepts_cod() );
+		// A cached OFFICE record — offices take COD (#233).
+		$this->assertTrue( $point->get_accepts_cod() );
 	}
 
 	// -----------------------------------------------------------------------------
@@ -577,10 +578,12 @@ final class TestLivePochtaPointSourceTest extends TestCase {
 
 		$this->assertNotNull( $point );
 
-		// THE POINT OF THIS WHOLE CARD: the sparse listing said nothing about cash on delivery,
-		// and the live detail record says `cashPayment: false`. This is #219/#223's lazy-detail
-		// path proven against a real carrier instead of a fixture that carried it up front.
-		$this->assertFalse( $point->get_accepts_cod() );
+		// #233: COD follows the point TYPE, not `cashPayment`. This record is a `russian_post`
+		// office, and an office DOES take cash on delivery — per the operator's own production
+		// plugin (`plugins-reference/woodev-russian-post`, checkout.php), which refuses COD only
+		// for `postamat` and the ECOM_MARKETPLACE shipment type. `cashPayment` is `false` on
+		// every point measured, office and locker alike, so it cannot be the flag.
+		$this->assertTrue( $point->get_accepts_cod() );
 
 		// Live record has `cardPayment: false` and `acceptEcom: true` — so no card-on-receipt
 		// label. An invented fixture had `cardPayment: true` here and was asserting a label the
@@ -594,6 +597,24 @@ final class TestLivePochtaPointSourceTest extends TestCase {
 
 		// Every service flag is false on this real record.
 		$this->assertSame( [], $point->to_array()['services'] );
+	}
+
+	/**
+	 * The other half of the #233 rule, and the one the customer actually hits: a parcel locker
+	 * refuses cash on delivery. Sparse listings carry no payment information at all, so this
+	 * verdict can only reach the card through the detail fetch — which is exactly what #219/#223
+	 * exist for, now proven on a real carrier by a field that genuinely varies.
+	 */
+	public function test_a_parcel_locker_refuses_cash_on_delivery(): void {
+		$locker = array_merge( $this->full_russian_post_record(), $this->sparse_postamat_record() );
+
+		$this->stub_successful_details_transport( $locker );
+
+		$point = ( new \Woodev_Test_Live_Pochta_Point_Source() )->fetch_details( '66790' );
+
+		$this->assertNotNull( $point );
+		$this->assertSame( 'postamat', $locker['type'] );
+		$this->assertFalse( $point->get_accepts_cod() );
 	}
 
 	/**

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1498,8 +1498,13 @@
 		 * card open would be pure waste against the merchant's carrier quota.
 		 *
 		 * ONCE PER POINT PER LISTING. Re-opening a card, switching tabs inside a co-located group
-		 * and re-entering from the map all funnel through `cardOpened`, and none of them learn
-		 * anything new. The memo is emptied whenever a listing fetch succeeds, because that is the
+		 * and re-entering from the map all funnel through `cardOpened`, and re-entering the SAME
+		 * point learns nothing new.
+		 *
+		 * (That sentence was a FOSSIL until #233: a tab click only re-rendered the card and never
+		 * emitted `cardOpened`, so the second point of a co-located group was never fetched at
+		 * all and kept its permissive listing verdict forever. `buildTabs()` now reports the move
+		 * like every other route does — see its own comment.) The memo is emptied whenever a listing fetch succeeds, because that is the
 		 * moment the cart — and therefore the verdict — may have moved underneath us.
 		 *
 		 * DEGRADES TO EXACTLY TODAY'S BEHAVIOUR ON FAILURE, which is why it stays quiet: the
@@ -2329,7 +2334,13 @@
 				// to `focusGroup()` here would issue a SECOND move on top of it, re-entering the
 				// s52 draw-vs-move race the ordering exists to avoid, for a camera that is already
 				// exactly where this move would put it.
-				if ( 'restore' === payload.origin ) {
+				// `'restore'` and `'tab'` are the two origins that move no camera at all.
+				// `'restore'`'s move already went out ahead of the draw, as
+				// `setPoints( groups, { focus } )` — see {@see restoreSelection}; falling through
+				// would issue a SECOND move on top of it and re-enter the s52 draw-vs-move race.
+				// `'tab'` (#233) needs none either: every point in a co-located group shares one
+				// coordinate, so the camera is already exactly where a focus would put it.
+				if ( 'restore' === payload.origin || 'tab' === payload.origin ) {
 					return;
 				}
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -1141,6 +1141,29 @@
 			tab.addEventListener( 'click', function() {
 				self._activeIndex = index;
 				renderCard( self );
+
+				// AND TELL THE MOUNT (#233). Switching tabs moves the card onto a DIFFERENT
+				// POINT, which is exactly the event `cardOpened` exists to report — but this
+				// handler used to only re-render, so the mount never learned. Under the viewport
+				// strategy that meant the second tab's details were never fetched: it kept the
+				// sparse listing's permissive-by-omission verdict forever, and its CTA stayed
+				// live while the first tab's (correctly) went dead. Reported live on Pochta,
+				// where a building holds an office and a parcel locker with different rules.
+				//
+				// `pickup-mount.js`'s docblock claimed tab switches already funnelled through
+				// here. They did not — a FOSSIL claim of the same kind as the s56 gotcha
+				// `built-on-both-sides-with-no-caller-in-the-middle`; that comment is corrected
+				// in the same commit as this line.
+				//
+				// Origin `'tab'` (not `'list'`/`'marker'`) so the mount can skip the camera move:
+				// every point in a co-located group shares one coordinate, so the camera is
+				// already exactly where a focus would put it, and re-issuing one would re-enter
+				// the s52 draw-vs-move race for no gain.
+				self._emit( 'cardOpened', {
+					group: group,
+					pointId: point.id,
+					origin: 'tab',
+				} );
 			} );
 			tabs.appendChild( tab );
 		} );


### PR DESCRIPTION
Closes #233

Two defects behind one report: in a co-located group the **first** tab's CTA was
always dead and the **second's** always live.

## Framework — a tab click never told anyone

```js
tab.addEventListener( 'click', function () {
    self._activeIndex = index;
    renderCard( self );
} );
```

That was the whole handler. No `cardOpened`. So the mount never learned the card
had moved onto a **different point**: `cardPointId` stayed on the first one, and
under the viewport strategy the second point's details were **never fetched at
all** — it kept the sparse listing's permissive-by-omission verdict forever,
which is exactly why its CTA never went dead.

`refreshPointDetails()`'s own docblock asserted that tab switches "funnel through
`cardOpened`". They did not — a **fossil claim** of the same kind as the s56
gotcha `built-on-both-sides-with-no-caller-in-the-middle`. Corrected here
alongside the wiring.

The click now emits `cardOpened` with origin `'tab'`, so every existing consumer
does its job: the detail fetch, the #223 verdict lock, the staleness guard.
`'tab'` joins `'restore'` as an origin that moves **no camera** — every point in a
co-located group shares one coordinate, so a focus would move nothing and would
re-enter the s52 draw-vs-move race for free.

## Fixture — the COD rule was inverted

`accepts_cod` was mapped straight from `cashPayment`, on the strength of #226's
own wording ("this IS `accepts_cod`"). Live data refutes it:

| type | cashPayment | cardPayment |
|---|---|---|
| `russian_post` ×6 | false | false |
| `postamat` ×6 | false | false |

A field that never varies carries no information, and mapping it to a
customer-facing verdict made **every post office refuse cash on delivery** —
backwards, as the operator said.

The authority is his own production plugin,
`plugins-reference/woodev-russian-post`, `includes/classes/checkout.php`:

```php
if ( 'cod' == $data['payment_method']
     && ( 'postamat' == $customer_delivery_point->get_type()
          || $customer_delivery_point->get_mail_type() == 'ECOM_MARKETPLACE' ) ) {
    // refuse
}
```

COD is refused for a **parcel locker** (and the ECOM_MARKETPLACE shipment type);
an office takes it. `mail_type` has no counterpart in the widget API, so only the
type half is expressible — and it is the half that separates the two kinds of
point on the map. `acceptEcom` is a different flag and is deliberately not used.

## Verification

**Rig, live Pochta**, a real co-located pair: clicking the second tab now fires
`points/1322` — a request that never happened before — locks the CTA with
«Проверяем доступность…», and releases it with the hours filled in.

⚠️ **Not verified on the rig:** a parcel locker's card — the type filter would not
put one on screen during the pass. That half of the rule is covered by a unit
test instead; the office half, which is the inversion actually reported, is
confirmed live.

**781 jest / 1514 unit / phpcs + PHPStan clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mux4YLJ1CrbjsBMR42VT4R