### PR TITLE
fix(pickup): draw the union of every viewport listing (#234)

### DIFF
--- a/docs-internal/plans/2026-08-09-sp5-viewport-point-accumulation-plan.md
+++ b/docs-internal/plans/2026-08-09-sp5-viewport-point-accumulation-plan.md
@@ -1,0 +1,1135 @@
+# Viewport Point Accumulation (#234) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Under the `viewport` strategy the map draws the UNION of every listing seen this session, so zooming out never loses points the customer just saw (#234).
+
+**Architecture:** A session-scoped point pool lives in `pickup-mount.js` — the file that already owns fetching. `Map_Provider`'s contract, `setPoints()` and `map-provider-embedded.js` are NOT touched: `setPoints()`'s own docblock already assigns cross-fetch de-duplication to the caller. The `bulk` strategy is untouched throughout.
+
+**Tech Stack:** Vanilla ES5 JS (no transpilation — no `??`, no arrow functions, no `const`/`let` in the shipped files), jest via `wp-scripts test-unit-js`, PHP 7.4+ for the config seam.
+
+**Spec:** `docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md`
+
+---
+
+## MANDATORY for every task
+
+**Run the FULL verification set before every commit. All four, every time:**
+
+```bash
+composer test:unit
+composer phpcs
+composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+```
+
+- **NEVER `npx jest`** — this project has no jest config of its own; `npx jest` loses jsdom and prints phantom failures (gotcha `npx-jest-bypasses-wp-scripts-jsdom`).
+- The `--roots` flag is REQUIRED — without it jest also counts agent worktrees under `.claude/worktrees/` and reports a wrong total (gotcha `jest-scans-agent-worktrees-inside-the-repo`).
+- **You are expected to contradict this plan where the code disagrees with it.** Say so and stop rather than forcing a step through. Three of four errors in an earlier plan were caught this way.
+
+## File structure
+
+| File | Change |
+|---|---|
+| `woodev/shipping-method/assets/js/frontend/pickup-mount.js` | All of the pool: state, merge, reset, group build, types, empty-message gate, trim. |
+| `tests/js/pickup-mount.test.js` | All new tests. |
+| `woodev/shipping-method/pickup/class-pickup-handler.php` | One config key + one filter (Task 6). |
+| `tests/unit/Shipping/Pickup/PickupHandlerTest.php` | Config-key tests (Task 6). |
+
+`map-provider-yandex.js`, `map-provider-embedded.js`, `pickup-panels.js`, `pickup-geo.js`, `pickup-datasource.js` — **do not modify.**
+
+---
+
+### Task 1: The pool, its merge, and groups built from it
+
+**Files:**
+- Modify: `woodev/shipping-method/assets/js/frontend/pickup-mount.js` (session state block near `var groupsByKey = {};` ~line 1070; `fetchAndSetPoints()` ~line 1652; `start()` ~line 2624)
+- Test: `tests/js/pickup-mount.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add near the other viewport tests (after the `emptyInView` test, ~line 1707):
+
+```js
+// -------------------------------------------------------------------------
+// #234 — viewport point accumulation: the drawn set is the UNION of every
+// listing this session, never just the last one.
+// -------------------------------------------------------------------------
+
+test( 'viewport: two listings with disjoint points draw the UNION, not the last listing', async () => {
+	const listings = [
+		[ point( { id: 'A', lat: 55.1, lng: 37.1 } ) ],
+		[ point( { id: 'B', lat: 55.2, lng: 37.2 } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] ).sort();
+
+	expect( ids ).toEqual( [ 'A', 'B' ] );
+} );
+
+test( 'viewport: a point in BOTH listings appears once, carrying the SECOND listing\'s values', async () => {
+	const listings = [
+		[ point( { id: 'A', name: 'Старое имя' } ) ],
+		[ point( { id: 'A', name: 'Новое имя' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const all = drawn.reduce( ( acc, group ) => acc.concat( group.points ), [] );
+
+	expect( all ).toHaveLength( 1 );
+	expect( all[ 0 ].name ).toBe( 'Новое имя' );
+} );
+
+test( 'bulk is unaffected — its listing still REPLACES the drawn set', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'bulk' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	// bulk's second fetch can only come from refresh()
+	document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+	jest.runOnlyPendingTimers();
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'B' ] );
+} );
+
+test( 'retry (start()) drops the pool — a fresh session starts from nothing', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	let provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+	panels.emit( 'retryRequested' );
+	await flushAsync();
+
+	provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'B' ] );
+} );
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "#234"` and `npm run test:js -- --roots "<rootDir>/tests/js" -t "accumulation"`
+
+Expected: the union/dedup/retry tests FAIL (the last listing replaces the set); the `bulk` test PASSES already (it pins existing behaviour so a later task cannot regress it).
+
+- [ ] **Step 3: Add the pool state**
+
+In the session state block, immediately after `var groupsByKey = {};` (~line 1070), add:
+
+```js
+		/**
+		 * #234 — the UNION of every listing this session, by `point.id`, under
+		 * `strategy: 'viewport'` ONLY. `bulk` fetches once and its listing is authoritative,
+		 * so it never reads or writes this.
+		 *
+		 * Why the pool lives HERE and not in the provider: `setPoints()`'s own docblock
+		 * already assigns cross-fetch de-duplication to the caller ("the caller is the one
+		 * that decides what the current full set is"), so accumulating is this file's job
+		 * and the provider contract is unchanged. That also keeps every other provider —
+		 * `map-provider-embedded.js` today, anything added later — free of it.
+		 *
+		 * Insertion order is meaningful: it is what {@see trimPointPool} evicts by when a
+		 * domain has bounded the pool. Plain object key order preserves insertion order for
+		 * string keys, which every `point.id` is coerced to on the way in.
+		 *
+		 * MUST be cleared together with the detail memo — see {@see resetPointPool}.
+		 *
+		 * @type {Object.<string, Object>}
+		 */
+		var pointPool = {};
+```
+
+- [ ] **Step 4: Add the pool helpers**
+
+Add beside the other session-level helpers, just before `function fetchAndSetPoints( query ) {` (~line 1652):
+
+```js
+		/**
+		 * The pooled points, in insertion order.
+		 *
+		 * @since 2.0.2
+		 * @returns {Array} never null.
+		 */
+		function poolValues() {
+			return Object.keys( pointPool ).map( function( id ) {
+				return pointPool[ id ];
+			} );
+		}
+
+		/**
+		 * Merges one listing into the pool and returns the full set to draw (#234).
+		 *
+		 * THE LISTING WINS on conflict: it is the fresher carrier record. Whatever a detail
+		 * fetch already learned is re-applied AFTER grouping, from `detailsById`, so a sparse
+		 * re-merged record cannot erase it — that ordering is load-bearing, see
+		 * {@see fetchAndSetPoints}.
+		 *
+		 * A point with no `id` is passed through un-pooled rather than dropped: `id` is the
+		 * pool's whole identity and a record without one cannot be de-duplicated, but it is
+		 * still a point the carrier returned and the customer should see it.
+		 *
+		 * @since 2.0.2
+		 * @param {Array} points this listing's points.
+		 * @returns {Array} every point to draw.
+		 */
+		function mergeIntoPool( points ) {
+			var passthrough = [];
+
+			( points || [] ).forEach( function( point ) {
+				if ( ! point || null === point.id || undefined === point.id ) {
+					if ( point ) {
+						passthrough.push( point );
+					}
+
+					return;
+				}
+
+				pointPool[ String( point.id ) ] = point;
+			} );
+
+			trimPointPool();
+
+			return poolValues().concat( passthrough );
+		}
+
+		/**
+		 * Empties the pool.
+		 *
+		 * INVARIANT: every caller that clears the pool must also clear the detail memo, and
+		 * vice versa — {@see forgetPointDetails}. `geo.groupByPosition()` does not deep-copy,
+		 * so the detail fields re-applied in {@see fetchAndSetPoints} land on the pooled point
+		 * objects themselves; dropping `detailsById` while keeping the pool would strand those
+		 * fields with nothing left to re-derive them from, and dropping the pool while keeping
+		 * `detailsById` would re-apply a verdict computed against a cart that has since moved.
+		 *
+		 * @since 2.0.2
+		 * @returns {void}
+		 */
+		function resetPointPool() {
+			pointPool = {};
+		}
+```
+
+Add a temporary no-op `trimPointPool` directly above `mergeIntoPool` (Task 7 fills it in):
+
+```js
+		/**
+		 * Bounds the pool when the domain asked for a bound — filled in by Task 7.
+		 *
+		 * @since 2.0.2
+		 * @returns {void}
+		 */
+		function trimPointPool() {
+		}
+```
+
+- [ ] **Step 5: Build the groups from the pool**
+
+In `fetchAndSetPoints()`'s resolve branch, replace the single line
+
+```js
+					var groups = geo.groupByPosition( points );
+```
+
+with
+
+```js
+					// #234: under `viewport` the drawn set is the UNION of every listing this
+					// session, so the customer never loses points by zooming out and back. Under
+					// `bulk` there is one listing and it is authoritative — the pool is bypassed
+					// entirely rather than being a union of one, so `bulk` keeps its exact
+					// previous behaviour including "a later listing REPLACES the set".
+					var drawable = 'viewport' === config.strategy ? mergeIntoPool( points ) : points;
+					var groups = geo.groupByPosition( drawable );
+```
+
+- [ ] **Step 6: Reset the pool on every `start()`**
+
+In `start()`, beside the existing `lastBbox = null;` (~line 2630), add:
+
+```js
+				// #234: a retry rebuilds the provider from scratch, so the drawn set restarts
+				// from nothing too. Paired with forgetPointDetails() per resetPointPool()'s
+				// stated invariant.
+				resetPointPool();
+				forgetPointDetails();
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js"`
+Expected: PASS, and the total must be the previous total + 4. A CHANGED total in any other direction means a bad invocation, not a regression.
+
+- [ ] **Step 8: Run the full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
+git commit -m "feat(pickup): draw the union of every viewport listing, not just the last (#234)"
+```
+
+---
+
+### Task 2: Reset on checkout update, pinned to the details memo
+
+**Files:**
+- Modify: `woodev/shipping-method/assets/js/frontend/pickup-mount.js` (`refresh()` ~line 2834)
+- Test: `tests/js/pickup-mount.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+test( '#234 invariant: refresh() clears the pool AND the details memo in ONE call', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	window.WoodevPickupDataSource.fetchDetails = () =>
+		Promise.resolve( point( { id: 'A', work_time: 'из деталей' } ) );
+
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	// Learn a detail for A, so the memo is demonstrably non-empty. The payload shape is
+	// `{ group, pointId, origin }` — verified against this file's existing cardOpened tests,
+	// NOT guessed.
+	panels.emit( 'cardOpened', {
+		group: provider.setPointsCalls[ provider.setPointsCalls.length - 1 ][ 0 ],
+		pointId: 'A',
+		origin: 'list',
+	} );
+	await flushAsync();
+
+	// The cart changes.
+	document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+	jest.runOnlyPendingTimers();
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const all = drawn.reduce( ( acc, group ) => acc.concat( group.points ), [] );
+
+	// Pool cleared: only the refresh listing's own point is drawn.
+	expect( all.map( ( p ) => p.id ) ).toEqual( [ 'B' ] );
+	// Memo cleared: nothing carries the stale detail field.
+	expect( all.some( ( p ) => 'из деталей' === p.work_time ) ).toBe( false );
+} );
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "invariant"`
+Expected: FAIL — `A` is still drawn.
+
+- [ ] **Step 3: Implement**
+
+In `refresh()`, change
+
+```js
+			// THE cart-change event (#232) — see {@see forgetPointDetails} for why this is the
+			// only place details are forgotten, and no longer every listing.
+			forgetPointDetails();
+```
+
+to
+
+```js
+			// THE cart-change event (#232) — see {@see forgetPointDetails} for why this is the
+			// only place details are forgotten, and no longer every listing.
+			//
+			// #234: the pool goes with it, ALWAYS, and the two calls must never be separated —
+			// see {@see resetPointPool}'s stated invariant. A pooled point's `selectable` was
+			// computed against the cart that just changed.
+			forgetPointDetails();
+			resetPointPool();
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "invariant"`
+Expected: PASS
+
+- [ ] **Step 5: Full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
+git commit -m "fix(pickup): drop the accumulated pool whenever the cart changes (#234)"
+```
+
+---
+
+### Task 3: Reset on a viewport type-filter change
+
+**Files:**
+- Modify: `woodev/shipping-method/assets/js/frontend/pickup-mount.js` (`typeFilterChange` handler ~line 2360)
+- Test: `tests/js/pickup-mount.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+test( '#234: a viewport type-filter change drops the pool — the server filters, so a union '
+	+ 'across different filters would be incoherent', async () => {
+	const listings = [
+		[ point( { id: 'A', type: { code: 'pvz', label: 'ПВЗ' } } ) ],
+		[ point( { id: 'B', type: { code: 'postamat', label: 'Постамат' } } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	panels.emit( 'typeFilterChange', [ 'postamat' ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'B' ] );
+} );
+
+test( '#234: a BULK type-filter change does not touch the pool or refetch — it still filters '
+	+ 'client-side through the provider', async () => {
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point( { id: 'A' } ) ] ) );
+	setConfig( makeConfig( { strategy: 'bulk' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+	const drawsBefore = provider.setPointsCalls.length;
+
+	panels.emit( 'typeFilterChange', [ 'postamat' ] );
+	await flushAsync();
+
+	expect( provider.setTypeFilterCalls ).toEqual( [ [ 'postamat' ] ] );
+	expect( provider.setPointsCalls.length ).toBe( drawsBefore );
+} );
+```
+
+- [ ] **Step 2: Run to verify**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "type-filter"`
+Expected: the viewport test FAILS (`A` is still drawn); the bulk test PASSES already.
+
+- [ ] **Step 3: Implement**
+
+In the `typeFilterChange` handler, replace
+
+```js
+				// viewport: a client-side filter would show stale points outside the current
+				// bbox — refetch with the SAME bbox and the new types instead (see the file
+				// docblock's judgement-call note on getting this backwards).
+				if ( lastBbox ) {
+```
+
+with
+
+```js
+				// viewport: a client-side filter would show stale points outside the current
+				// bbox — refetch with the SAME bbox and the new types instead (see the file
+				// docblock's judgement-call note on getting this backwards).
+				//
+				// #234: the pool goes first. The SERVER is what applies the type filter on this
+				// strategy, so points pooled under the previous filter are not a subset of the
+				// new answer — a union across two different filters describes no query anyone
+				// made. Paired with forgetPointDetails() per resetPointPool()'s invariant.
+				resetPointPool();
+				forgetPointDetails();
+
+				if ( lastBbox ) {
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "type-filter"`
+Expected: PASS
+
+- [ ] **Step 5: Full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
+git commit -m "fix(pickup): drop the pool when the viewport type filter changes (#234)"
+```
+
+---
+
+### Task 4: Type chips come from the pool
+
+**Files:**
+- Modify: `woodev/shipping-method/assets/js/frontend/pickup-mount.js` (`fetchAndSetPoints()`)
+- Test: `tests/js/pickup-mount.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+test( '#234: the type chips are computed from the POOL, so they do not flicker as the '
+	+ 'customer pans', async () => {
+	const listings = [
+		[ point( { id: 'A', type: { code: 'pvz', label: 'ПВЗ' } } ) ],
+		[ point( { id: 'B', type: { code: 'postamat', label: 'Постамат' } } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	expect( panels.lastTypes ).toEqual( [
+		{ code: 'pvz', label: 'ПВЗ' },
+		{ code: 'postamat', label: 'Постамат' },
+	] );
+} );
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "type chips"`
+Expected: FAIL — only `Постамат` is present (types came from the last listing).
+
+- [ ] **Step 3: Implement**
+
+Replace
+
+```js
+					if ( panels ) {
+						panels.setTypes( extractTypes( points ) );
+					}
+```
+
+with
+
+```js
+					if ( panels ) {
+						// #234: from the DRAWN set, not this listing — a chip that vanishes
+						// because the customer panned past the last point of its type, while
+						// points of that type are still drawn, is the same defect this issue
+						// is about, one surface over.
+						panels.setTypes( extractTypes( drawable ) );
+					}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "type chips"`
+Expected: PASS
+
+- [ ] **Step 5: Full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
+git commit -m "fix(pickup): compute the type chips from the drawn set, not the last listing (#234)"
+```
+
+---
+
+### Task 5: "Nothing in this area" must not print over a map that shows points
+
+**Files:**
+- Modify: `woodev/shipping-method/assets/js/frontend/pickup-mount.js` (session state; the `visibleChange` handler ~line 2678; `fetchAndSetPoints()`'s empty branch)
+- Test: `tests/js/pickup-mount.test.js`
+
+**Why:** rig-measured 09.08.2026 — a live listing for the Ryazan frame returned 0 points after 16.9 s while neighbouring frames returned 1 500+. Driving the message off `points.length` alone would print «в этой области нет точек» over a map still drawing pooled markers. The decision must use the ONE definition of "in frame" that already exists — the provider's `visibleChange` — never a second inequality chain of our own (see `_groupsInsideBounds`'s docblock on why that was unified in #167).
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+test( '#234: an empty listing does NOT show emptyInView while pooled points are still in frame', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	// The provider reports A is on screen — this is the mount's only source for "in frame".
+	const drawnKey = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ][ 0 ].key;
+	provider.emit( 'visibleChange', [ drawnKey ] );
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	expect( panels.showMessageCalls ).toBeUndefined();
+} );
+
+test( '#234: an empty listing DOES show emptyInView when nothing is in frame', async () => {
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'visibleChange', [] );
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	expect( panels.showMessageCalls ).toEqual( [ 'emptyInView' ] );
+} );
+```
+
+- [ ] **Step 2: Run to verify**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "emptyInView"`
+Expected: the first test FAILS (`emptyInView` is shown); the second PASSES.
+
+- [ ] **Step 3: Track what the provider says is in frame**
+
+In the session state block, after `var pointPool = {};`, add:
+
+```js
+		/**
+		 * How many groups the provider last reported as being inside the frame (#234).
+		 *
+		 * The mount deliberately does NOT compute this itself: `_groupsInsideBounds()` is the
+		 * ONE definition of "in frame" in this codebase, unified in #167 precisely so two
+		 * inequality chains over the same rectangle cannot disagree. This is a cached read of
+		 * that answer, not a second opinion.
+		 *
+		 * @type {number}
+		 */
+		var visibleGroupCount = 0;
+```
+
+In the existing `visibleChange` handler, record it — the handler becomes:
+
+```js
+					provider.on( 'visibleChange', function( keys ) {
+						var groups = ( keys || [] )
+							.map( function( key ) { return groupsByKey[ key ]; } )
+							.filter( function( group ) { return !! group; } );
+
+						// #234: what the empty-frame message is decided from — see
+						// {@see visibleGroupCount}. Counted from the RAW keys, not the mapped
+						// groups: a key the mount cannot resolve still means the provider is
+						// drawing something there, and suppressing the message is the safe
+						// direction (a missing message beats a false one over a full map).
+						visibleGroupCount = ( keys || [] ).length;
+
+						panels.setVisible( groups );
+					} );
+```
+
+Reset it in `start()`, beside `resetPointPool()`:
+
+```js
+				visibleGroupCount = 0;
+```
+
+- [ ] **Step 4: Gate the message**
+
+In `fetchAndSetPoints()`, replace the `else` branch
+
+```js
+					} else {
+```
+
+…and its `showFetchMessage(...)` call with:
+
+```js
+					} else if ( 'bulk' === config.strategy || 0 === visibleGroupCount ) {
+						// `emptyLocality` (a locality genuinely has none) vs `emptyInView` (the
+						// current viewport does) — the SAME shared function backs both the bulk
+						// strategy's one-shot fetch and the viewport strategy's per-bbox
+						// `boundsChange` fetch, so the key is chosen from `config.strategy`, not
+						// hardcoded to either. Distinct from `noResults`, which stays reserved for
+						// the search view finding nothing (spec V-5).
+						//
+						// #234: under `viewport` an empty listing no longer means an empty screen.
+						// A listing can come back empty for a frame the pool still has points in —
+						// rig-measured on live Russian Post, where one frame answered 0 after 16.9s
+						// while its neighbours answered 1500+. Printing "nothing here" over drawn
+						// markers is worse than printing nothing, so the message waits until the
+						// provider itself reports an empty frame. `bulk` keeps its old behaviour
+						// exactly: it has no frame-driven refetch to correct a wrong message later.
+						showFetchMessage( 'bulk' === config.strategy ? 'emptyLocality' : 'emptyInView' );
+					}
+```
+
+- [ ] **Step 5: Run to verify both pass**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "emptyInView"`
+Expected: PASS
+
+- [ ] **Step 6: Full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
+git commit -m "fix(pickup): never print 'nothing in this area' over a map that is drawing points (#234)"
+```
+
+---
+
+### Task 6: The `maxAccumulatedPoints` config seam (PHP)
+
+**Files:**
+- Modify: `woodev/shipping-method/pickup/class-pickup-handler.php` (`get_js_config()` ~line 1236)
+- Test: `tests/unit/Shipping/Pickup/PickupHandlerTest.php`
+
+**Why a seam with no consumer:** the default is unlimited and rig-measured safe for Russian Post (§4 of the spec). How dense a carrier is, is domain knowledge — the framework owns the mechanism and the knob, the plugin owns the number. "No consumer yet" is not an argument against a hook in this codebase.
+
+- [ ] **Step 1: Write the failing tests**
+
+Follow the file's existing config-assertion tests for setup. Add:
+
+```php
+	/** @test */
+	public function js_config_defaults_max_accumulated_points_to_zero_meaning_unlimited(): void {
+		$handler = $this->make_handler();
+
+		$config = $handler->get_js_config();
+
+		$this->assertSame( 0, $config['maxAccumulatedPoints'] );
+	}
+
+	/** @test */
+	public function js_config_max_accumulated_points_is_filterable_and_never_negative(): void {
+		$handler = $this->make_handler();
+
+		add_filter(
+			'woodev_pickup_max_accumulated_points',
+			static function () {
+				return -5;
+			}
+		);
+
+		$config = $handler->get_js_config();
+
+		$this->assertSame( 0, $config['maxAccumulatedPoints'] );
+	}
+```
+
+```php
+	/** @test */
+	public function js_config_passes_a_positive_max_accumulated_points_through(): void {
+		$handler = $this->make_handler();
+
+		add_filter(
+			'woodev_pickup_max_accumulated_points',
+			static function () {
+				return 3000;
+			}
+		);
+
+		$config = $handler->get_js_config();
+
+		$this->assertSame( 3000, $config['maxAccumulatedPoints'] );
+	}
+```
+
+**If `make_handler()` is not this test class's actual helper name, use whatever the file already
+uses to build a handler — do not add a new helper.**
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `composer test:unit -- --filter PickupHandlerTest`
+Expected: FAIL — undefined index `maxAccumulatedPoints`.
+
+- [ ] **Step 3: Implement**
+
+In `get_js_config()`, beside the `strategy` key, add:
+
+```php
+				/**
+				 * Caps how many points the browser accumulates across viewport listings (#234).
+				 *
+				 * `0` — the default — means UNLIMITED, which is measured-safe: with the pool at
+				 * 20 000 points a full redraw costs 334 ms against a listing that takes 6-13 s to
+				 * arrive, and the one superlinear operation in the map provider is reached only by
+				 * the `bulk` strategy. A realistic session over a whole region pools ~1 300 points.
+				 *
+				 * The knob exists because point DENSITY is domain knowledge, not framework
+				 * knowledge: a carrier far denser than Russian Post can bound the pool here
+				 * without any redesign. Ignored entirely by `strategy: 'bulk'`, which never
+				 * accumulates.
+				 *
+				 * @since 2.0.2
+				 *
+				 * @param int    $max       0 for unlimited; a positive point count to bound the pool.
+				 * @param string $plugin_id the plugin the map belongs to.
+				 */
+				$max_accumulated = (int) apply_filters(
+					'woodev_pickup_max_accumulated_points',
+					0,
+					$this->plugin_id
+				);
+
+				// A negative bound is meaningless and must not reach the browser as one — it
+				// would read as "keep nothing", silently reinstating the very defect #234 fixed.
+				$max_accumulated = max( 0, $max_accumulated );
+```
+
+…then add `'maxAccumulatedPoints' => $max_accumulated,` to the returned array, directly under `'strategy'`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `composer test:unit -- --filter PickupHandlerTest`
+Expected: PASS
+
+- [ ] **Step 5: Full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/pickup/class-pickup-handler.php tests/unit/Shipping/Pickup/PickupHandlerTest.php
+git commit -m "feat(pickup): filterable cap on accumulated viewport points, unlimited by default (#234)"
+```
+
+---
+
+### Task 7: The trim itself (JS)
+
+**Files:**
+- Modify: `woodev/shipping-method/assets/js/frontend/pickup-mount.js` (`trimPointPool()` stub from Task 1)
+- Test: `tests/js/pickup-mount.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+test( '#234 cap: with maxAccumulatedPoints set, the OLDEST-seen points are evicted first', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+		[ point( { id: 'C' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport', maxAccumulatedPoints: 2 } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] ).sort();
+
+	expect( ids ).toEqual( [ 'B', 'C' ] );
+} );
+
+test( '#234 cap: the customer\'s CURRENT SELECTION is never evicted, however old', async () => {
+	// Seed the field with A so it is the current selection from the first listing on.
+	document.getElementById( FIELD_ID ).value = 'A';
+
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+		[ point( { id: 'C' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport', maxAccumulatedPoints: 2 } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toContain( 'A' );
+} );
+
+test( '#234 cap: an unset (0) cap keeps everything', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+		[ point( { id: 'C' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] ).sort();
+
+	expect( ids ).toEqual( [ 'A', 'B', 'C' ] );
+} );
+```
+
+- [ ] **Step 2: Run to verify**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "cap"`
+Expected: the first two FAIL; the third PASSES (the stub is a no-op today).
+
+- [ ] **Step 3: Implement the trim**
+
+Replace the Task 1 stub with:
+
+```js
+		/**
+		 * Bounds the pool to `config.maxAccumulatedPoints` when the domain asked for a bound
+		 * (#234). A missing/zero/negative value means UNLIMITED and this returns immediately —
+		 * that is the shipped default, and it is measured-safe rather than assumed: see the
+		 * design doc's measurement table.
+		 *
+		 * Evicts OLDEST-INSERTED first (plain object key order for string keys), skipping any
+		 * point the customer would notice losing:
+		 *
+		 *  - the current selection — the field's own value; losing it would strand the
+		 *    checkout on a point the map can no longer draw;
+		 *  - the open card's point — {@see cardPointId}; a card whose point vanished mid-read
+		 *    is the #232 defect wearing a different hat.
+		 *
+		 * "In frame" is deliberately NOT a third exemption: it would need a rectangle test of
+		 * our own, and the frame is exactly where a re-listing puts points back a moment later
+		 * anyway.
+		 *
+		 * @since 2.0.2
+		 * @returns {void}
+		 */
+		function trimPointPool() {
+			var max = parseInt( config.maxAccumulatedPoints, 10 );
+
+			if ( ! max || max < 1 ) {
+				return;
+			}
+
+			var ids = Object.keys( pointPool );
+			var over = ids.length - max;
+
+			if ( over < 1 ) {
+				return;
+			}
+
+			var selected = fieldValue( config.fieldId );
+			var protectedIds = {};
+
+			if ( selected ) {
+				protectedIds[ String( selected ) ] = true;
+			}
+
+			if ( cardPointId ) {
+				protectedIds[ String( cardPointId ) ] = true;
+			}
+
+			ids.forEach( function( id ) {
+				if ( over < 1 || Object.prototype.hasOwnProperty.call( protectedIds, id ) ) {
+					return;
+				}
+
+				delete pointPool[ id ];
+				over -= 1;
+			} );
+		}
+```
+
+- [ ] **Step 4: Run to verify all three pass**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "cap"`
+Expected: PASS
+
+- [ ] **Step 5: Full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
+git commit -m "feat(pickup): honour maxAccumulatedPoints, protecting the selection and open card (#234)"
+```
+
+---
+
+### Task 8: Restore finds a pooled point the last listing does not contain
+
+**Files:**
+- Test only: `tests/js/pickup-mount.test.js`
+
+This is a behaviour the pool GIVES us for free (`restoreSelection()`/`pendingRestoreGroup()` read `groupsByKey`, which is now built from the pool). It needs a test so a later refactor cannot silently take it away.
+
+- [ ] **Step 1: Write the test**
+
+```js
+test( '#234: a previously chosen point is still restorable from the pool after the customer '
+	+ 'panned to a frame whose listing does not contain it', async () => {
+	document.getElementById( FIELD_ID ).value = 'A';
+
+	const listings = [
+		[ point( { id: 'A', lat: 55.1, lng: 37.1 } ) ],
+		[ point( { id: 'B', lat: 60.0, lng: 30.0 } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 59, 29, 61, 31 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toContain( 'A' );
+} );
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "restorable"`
+Expected: PASS (Task 1 already delivers this). If it FAILS, STOP and report — it means the pool is not reaching `groupsByKey`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/js/pickup-mount.test.js
+git commit -m "test(pickup): pin that a chosen point stays restorable from the pool (#234)"
+```
+
+---
+
+### Task 9: (removed — see below)
+
+**Deliberately NOT in this plan.** The original Task 9 was "document the new filter in
+`docs/shipping-method.md`". Checked before writing it: the public docs document **none** of the
+existing pickup filters (`woodev_pickup_accent_color`, `woodev_pickup_accent_contrast_color`,
+`woodev_pickup_accent_fill_color`, `woodev_pickup_map_point_glyphs`,
+`woodev_pickup_map_search_enabled`) — the whole pickup extension surface is undocumented publicly.
+
+Adding one filter into that vacuum would be inconsistent, and documenting the surface properly is
+a separate piece of work with its own scope. Tracked as its own card instead. Do not write partial
+public docs as part of #234.
+
+---
+
+## After the last task
+
+1. **Rig verification (mine, not a worker's).** On this branch, live Russian Post, `:8973`: draw a frame, zoom in, zoom out — the earlier points must be back. Then pan away and back. Then change the type filter and confirm the pool resets. Then trigger a checkout update and confirm it resets.
+2. **Codex critic** on the full diff, inline bundle, ≤~12 KB per bundle.
+3. PR, every CI job verified pass + CLEAN **separately**, then `gh pr merge --squash --delete-branch`. Never `--auto`.

--- a/docs-internal/plans/2026-08-09-sp5-viewport-point-accumulation-plan.md
+++ b/docs-internal/plans/2026-08-09-sp5-viewport-point-accumulation-plan.md
@@ -518,9 +518,10 @@ test( '#234 invariant: refresh() clears the pool AND the details memo in ONE cal
 	} );
 	await flushAsync();
 
-	// The cart changes.
-	document.body.dispatchEvent( new Event( 'updated_checkout' ) );
-	jest.runOnlyPendingTimers();
+	// The cart changes. NOTE: `updated_checkout` does NOT reach refresh() — this file wires
+	// that event to mountAll() only, and getSession() has no production caller at all (#238).
+	// Every existing refresh() test in this file drives it directly, and so does this one.
+	await window.WoodevPickupMount.getSession( FIELD_ID ).refresh();
 	await flushAsync();
 
 	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];

--- a/docs-internal/plans/2026-08-09-sp5-viewport-point-accumulation-plan.md
+++ b/docs-internal/plans/2026-08-09-sp5-viewport-point-accumulation-plan.md
@@ -8,7 +8,9 @@
 
 **Tech Stack:** Vanilla ES5 JS (no transpilation — no `??`, no arrow functions, no `const`/`let` in the shipped files), jest via `wp-scripts test-unit-js`, PHP 7.4+ for the config seam.
 
-**Spec:** `docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md`
+**Spec:** `docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md` — read §3 and §7
+before starting. §7 records an adversarial review of this design and what changed because of it;
+Task 1b exists entirely because of it.
 
 ---
 
@@ -324,6 +326,154 @@ composer test:unit && composer phpcs && composer phpstan
 npm run test:js -- --roots "<rootDir>/tests/js"
 git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
 git commit -m "feat(pickup): draw the union of every viewport listing, not just the last (#234)"
+```
+
+---
+
+### Task 1b: The generation barrier — a reset must survive an in-flight listing
+
+**Files:**
+- Modify: `woodev/shipping-method/assets/js/frontend/pickup-mount.js`
+- Test: `tests/js/pickup-mount.test.js`
+
+**Why (adversarial review, 09.08.2026):** a listing already travelling when a reset fires settles
+afterwards and merges its stale points into the freshly emptied pool. The continuation's only guard
+today is `destroyed`, which is false here. The race exists today and is HARMLESS today — each
+listing replaces the set, so the next one overwrites the damage — and accumulation is exactly what
+makes it permanent. `fetchPoints()`'s debounce/supersede does NOT close it: supersede means an
+earlier CALLER gets the LATER result; it says nothing about a request that had already gone out.
+
+Modelled on `pendingSelectionToken`, which exists because the equivalent ABA hole was found in the
+selection lock (s57). Keep the same shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+test( '#234: a listing already in flight when the pool is reset is DROPPED on arrival', async () => {
+	let releaseFirst;
+	const first = new Promise( ( resolve ) => { releaseFirst = resolve; } );
+	const responses = [ first, Promise.resolve( [ point( { id: 'B' } ) ] ) ];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => responses[ call++ ] || Promise.resolve( [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	// A listing goes out and does NOT settle yet.
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	// The cart changes: the pool resets and a second listing goes out and settles.
+	document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+	jest.runOnlyPendingTimers();
+	await flushAsync();
+
+	// Only NOW does the stale first listing come back.
+	releaseFirst( [ point( { id: 'STALE' } ) ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).not.toContain( 'STALE' );
+} );
+
+test( '#234: a listing in flight across NO reset still lands normally — the guard is not a '
+	+ 'blanket drop', async () => {
+	let releaseFirst;
+	const first = new Promise( ( resolve ) => { releaseFirst = resolve; } );
+	let call = 0;
+	const responses = [ first ];
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => responses[ call++ ] || Promise.resolve( [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	releaseFirst( [ point( { id: 'A' } ) ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'A' ] );
+} );
+```
+
+- [ ] **Step 2: Run to verify**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "in flight"`
+Expected: the first test FAILS (`STALE` is drawn); the second PASSES.
+
+- [ ] **Step 3: Add the generation counter**
+
+Beside `var pointPool = {};`:
+
+```js
+		/**
+		 * Bumped by every {@see resetPointPool}. A listing captures it when it goes out and is
+		 * DISCARDED on arrival if it moved — see {@see fetchAndSetPoints}.
+		 *
+		 * Why a counter and not a boolean "was reset": two resets can bracket one request, and a
+		 * boolean cleared by the second would let the request through. Same reason
+		 * `pendingSelectionToken` is a token rather than a point id (s57's ABA hole).
+		 *
+		 * @type {number}
+		 */
+		var poolGeneration = 0;
+```
+
+In `resetPointPool()`, add as the last line:
+
+```js
+			poolGeneration += 1;
+```
+
+- [ ] **Step 4: Capture and check it**
+
+In `fetchAndSetPoints()`, immediately after `bumpLoading();`:
+
+```js
+			// #234: the generation this listing belongs to. Anything that empties the pool while
+			// this request is in flight makes its answer describe a state nobody is looking at
+			// any more — see the check in the resolve branch.
+			var myGeneration = poolGeneration;
+```
+
+In the resolve branch, directly after the existing `if ( destroyed ) { return points; }`:
+
+```js
+					// #234: a reset happened while this was travelling. Merging now would put the
+					// pre-reset carrier answer back into a pool that was deliberately emptied —
+					// permanently, since nothing removes a pooled point. `dropLoading()` and
+					// `clearInitialBusy()` above have already run, so the customer's spinner state
+					// is correct; there is simply nothing here worth drawing. Viewport-only: `bulk`
+					// does not accumulate, so its late listing is still the best answer available.
+					if ( 'viewport' === config.strategy && myGeneration !== poolGeneration ) {
+						return points;
+					}
+```
+
+- [ ] **Step 5: Run to verify both pass**
+
+Run: `npm run test:js -- --roots "<rootDir>/tests/js" -t "in flight"`
+Expected: PASS
+
+- [ ] **Step 6: Full set and commit**
+
+```bash
+composer test:unit && composer phpcs && composer phpstan
+npm run test:js -- --roots "<rootDir>/tests/js"
+git add woodev/shipping-method/assets/js/frontend/pickup-mount.js tests/js/pickup-mount.test.js
+git commit -m "fix(pickup): discard a listing that was in flight across a pool reset (#234)"
 ```
 
 ---
@@ -1097,6 +1247,15 @@ test( '#234: a previously chosen point is still restorable from the pool after t
 	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
 
 	expect( ids ).toContain( 'A' );
+
+	// …and the SECOND listing must not have re-focused the camera onto that pooled group.
+	// The adversarial review flagged this as a possible camera jump: with groups now built
+	// from the pool, `pendingRestoreGroup()` can find a chosen point that the current frame's
+	// listing does not contain. It is unreachable because `selectionRestoreAttempted` is
+	// claimed on the FIRST listing (which is where the pool still equals that listing), but
+	// "unreachable" is a property that must be pinned, not assumed.
+	const lastOptions = provider.setPointsOptions[ provider.setPointsOptions.length - 1 ];
+	expect( lastOptions ).toBeFalsy();
 } );
 ```
 

--- a/docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md
+++ b/docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md
@@ -1,0 +1,198 @@
+# SP-5 — Viewport point accumulation (#234)
+
+> Session 59, 2026-08-09. Supersedes the framing in issue #234 itself, which was wrong on two
+> counts — see §2. Measurement-backed; every number in §4 was taken on the rig against LIVE
+> Russian Post, not estimated.
+
+## 1. The defect
+
+Under `strategy: 'viewport'` the map draws exactly the last listing. Zoom in from a frame showing
+10 points, get 5, zoom back out to the identical frame — still 5. The customer remembers the
+previous frame and cannot tell where the points went.
+
+Mechanically: `fetchAndSetPoints()` builds its groups from *this* listing's `points` and hands them
+to `provider.setPoints()`, which is a full `removeAll()` + `add()` rebuild. Every answer replaces
+the set wholesale.
+
+The reference — Russian Post's own widget (`plugins-reference/pochta-widget/main.a7d147fb….js`) —
+keeps a `Set` of already-seen ids and draws the UNION of everything shown during the session.
+
+## 2. Two premises in issue #234 that are false
+
+Both were checked against the code before designing anything.
+
+**"Accumulation changes framework semantics."** It does not. `setPoints()`'s own docblock
+(`map-provider-yandex.js:1685`) already assigns this responsibility to the caller:
+
+> a full rebuild (`removeAll()` then `add()`), never an incremental diff: **the caller is the one
+> that decides what the current full set is (including any cross-fetch de-duplication)**, so this
+> file always draws exactly what it was handed.
+
+Accumulation is therefore a change in `pickup-mount.js` alone. `Map_Provider`'s contract,
+`setPoints()`, and `map-provider-embedded.js` are untouched.
+
+**"The map and the sidebar will deliberately diverge."** They will not, in any state. The sidebar is
+fed by `visibleChange`, which is `_emitVisibleChange()` → `_groupsInsideBounds(_groupsByKey)` — the
+pool intersected with the current margin-aware frame. A pooled point outside the frame is not drawn
+on screen either; the moment it enters the frame it enters the list. Map and sidebar stay the same
+set throughout.
+
+```
+today:      pool = last listing        sidebar = pool ∩ frame   → zoom −1 collapses the set
+accumulated: pool = union of listings  sidebar = pool ∩ frame   → zoom −1 keeps what was seen
+```
+
+## 3. Design
+
+### 3.1 The pool
+
+A session-scoped `pointPool` in `pickup-mount.js`, keyed by `point.id`, **viewport strategy only**.
+`bulk` fetches once and its listing is authoritative — it does not use the pool at all.
+
+On every successful listing:
+
+1. Merge the listing's points into the pool. **The listing wins on conflict** — it is the fresher
+   carrier record.
+2. Build groups from the POOL, not the listing: `geo.groupByPosition( poolValues() )`.
+3. Re-apply `detailsById` onto those groups — unchanged, and it must keep running *after* grouping
+   so a re-merged sparse record cannot overwrite what a detail fetch already learned.
+4. `panels.setTypes( extractTypes( poolValues() ) )` — from the pool, not the listing. Taking it
+   from the listing would make the type chips flicker as the customer pans.
+
+### 3.2 Reset
+
+`resetPointPool()` is called from exactly three places:
+
+| Trigger | Why |
+|---|---|
+| `refresh()` — checkout update | The cart may have changed; every stored `selectable` was computed against the old one. |
+| `typeFilterChange` under viewport | The SERVER filters by type here (that branch refetches rather than filtering client-side). A union of listings taken under different type filters is incoherent. |
+| `start()` — first open and every retry | A fresh session/provider starts from nothing. |
+
+Never reset on: pan, zoom, address search, opening or closing a card.
+
+**Invariant — the pool and the details memo reset TOGETHER.** `refresh()` already calls
+`forgetPointDetails()`; `resetPointPool()` goes beside it and the two must never be separated.
+`geo.groupByPosition()` does not deep-copy, so re-applied detail fields land on the pooled point
+objects themselves; clearing `detailsById` while keeping the pool would leave those fields stranded
+with nothing left to re-derive them from. A test pins that one call clears both. (This is the s57
+lesson about two guards that look independent and are not.)
+
+### 3.3 The empty-frame message
+
+Today `points.length === 0` drives `showFetchMessage( 'emptyInView' )`. With a pool that becomes
+wrong: a listing can come back empty for a bbox in which the pool still holds points, because the
+source truncates at `MAX_PAGES × PAGE_SIZE` (§4 measured this happening at `MIN_ZOOM`). The message
+must be driven by what the customer can actually SEE — the pool's in-frame subset — not by the
+listing length. `bulk`'s `emptyLocality` path is unchanged.
+
+### 3.4 Stale points
+
+A pooled point can outlive its removal by the carrier for the length of a session. This is contained
+and must stay contained:
+
+- the verdict is recomputed server-side on every detail fetch;
+- selection is server-authoritative — `POST …/select` recomputes and is fail-closed, so a stale
+  point cannot be silently ordered against;
+- the pool resets on cart change.
+
+The exposure is therefore "a point that no longer exists may be shown until the customer tries to
+pick it", which is what every map with a client cache has, and it is strictly smaller than the
+alternative defect the customer reports today.
+
+### 3.5 Bound on the pool
+
+**Default: unlimited.** Justified by §4, not by argument.
+
+**Seam, no consumer yet:** a `maxAccumulatedPoints` config value (0 = unlimited) plumbed through the
+pickup config with a PHP filter, so a domain whose carrier is denser than Russian Post can bound it
+without a redesign. How dense a carrier is, is domain knowledge — the framework supplies the
+mechanism and the knob. When set above zero, the pool trims oldest-inserted first and never evicts
+a point that is in the current frame, is the open card's point, or is the customer's current
+selection.
+
+## 4. Measurements (rig, live Russian Post, 09.08.2026)
+
+`MIN_ZOOM = 8`, `MAX_ZOOM = 18`, `BBOX_CAP_DEGREES = 10`. At `MIN_ZOOM` on a 1280px rig the frame
+spans ~2.2° lat × 5.6° lng, so the 10° server cap is never reached by zooming out — the operator's
+prior was right, and this is why.
+
+**Cost against pool size** — `setPoints()` is the real production path (build features, `removeAll`,
+`add`, focus reconciliation, `_emitVisibleChange`), measured with synthetic pools spread over the
+Moscow region:
+
+| pool | `setPoints()` | `_groupsInsideBounds()` | `groupByPosition()` | pool merge | detail re-apply | JSON |
+|---|---|---|---|---|---|---|
+| 500 | 17 ms | 0.015 ms | 0.28 ms | 0.03 ms | 0.08 ms | 0.2 MB |
+| 2 000 | 13 ms | 0.020 ms | 0.66 ms | 0.10 ms | 0.16 ms | 0.9 MB |
+| 5 000 | 44 ms | 0.065 ms | 2.3 ms | 0.32 ms | 0.24 ms | 2.2 MB |
+| 10 000 | 88 ms | — | — | — | — | 4.4 MB |
+| 20 000 | 334 ms | 0.25 ms | 10.7 ms | 2.8 ms | 1.39 ms | 8.8 MB |
+
+Measured record size: **462 bytes per point**.
+
+`setPoints()` runs once per listing, against a live listing that takes **6–13 s** to come back on
+this rig. 334 ms of draw at 20 000 points sits inside that entirely.
+
+**The one superlinear operation is not on this path.** `setTypeFilter()` costs 9 ms at 500 and
+1017 ms at 20 000 — but it is called from exactly one place, `pickup-mount.js:2364`, inside the
+`'bulk' === config.strategy` branch. The viewport strategy refetches on a type change instead
+(and, per §3.2, resets the pool). Verified by grep, not assumed.
+
+**Realistic accumulation** — scripted tour, unique points after each listing:
+
+| leg | listing | unique total |
+|---|---|---|
+| Moscow centre z11 | 885 | 909 |
+| Khimki z11 | 328 | 1 028 |
+| Balashikha z11 | 379 | 1 113 |
+| Podolsk z11 | 116 | 1 229 |
+| Odintsovo z11 | 83 | 1 290 |
+| Moscow z8 (`MIN_ZOOM`) | **2 000** | 2 362 |
+| Tver z8 | 1 511 | 2 904 |
+| Tula z8 | 1 535 | 4 064 |
+| Ryazan z8 | 0 | 4 064 |
+| Vladimir z8 | 1 865 | 4 664 |
+
+Growth decelerates sharply within a region (885 → +119 → +85 → +116 → +61): consecutive frames
+overlap heavily and dedup absorbs most of each listing. Reaching 20 000 requires panning at minimum
+zoom across most of European Russia — and even there the cost is 334 ms per listing.
+
+**Incidental finding, worth its own card:** the Moscow `MIN_ZOOM` listing returned exactly 2 000
+points — the source's own `MAX_PAGES (10) × PAGE_SIZE (200)` ceiling. The customer is silently
+served a truncated set at wide zooms today. Accumulation mitigates it (points seen at closer zooms
+survive the truncated wide listing) but does not fix it.
+
+## 5. Tests
+
+jest, `tests/js/pickup-mount.test.js`:
+
+1. Two listings with disjoint points → `setPoints()` receives the union.
+2. A point present in both listings appears once, carrying the SECOND listing's field values.
+3. Panning away and back draws the point again without a listing containing it.
+4. `refresh()` clears the pool **and** the details memo — one call, both assertions (§3.2 invariant).
+5. A type-filter change under viewport clears the pool; under bulk it does not touch it.
+6. `start()`/retry clears the pool.
+7. `setTypes()` is computed from the pool, not the listing.
+8. An empty listing with pooled points in frame does NOT show `emptyInView`; an empty listing with
+   an empty in-frame subset does.
+9. `restoreSelection()` finds a chosen point that is in the pool but absent from the last listing.
+10. Bulk strategy is unaffected — its listing still replaces wholesale.
+11. Cap path: with `maxAccumulatedPoints` set, oldest-inserted are evicted first and the in-frame /
+    open-card / selected points are never evicted.
+
+## 6. Explicitly out of scope
+
+**The `prevTopRightPoint`/`prevBottomLeftPoint` delta protocol.** The reference widget is only
+observed SENDING those fields; that the server answers with a delta is an inference, not a measured
+fact. Sending them without accumulating would lose points, and now that we accumulate they would be
+a bandwidth optimisation at best. We keep requesting the full frame, which is correct either way.
+If it is ever wanted, it belongs in the domain source, not here.
+
+## Related
+
+- Issue #234 · gotcha `built-on-both-sides-with-no-caller-in-the-middle` (why the docblock was
+  re-read rather than trusted) · gotcha `card-renders-from-a-snapshot-the-writers-never-touch`
+  (why §3.2's invariant is pinned by a test)
+- `docs-internal/specs/2026-08-01-sp5-pickup-map-rework-design.md` — the `dataSource` inversion this
+  builds on

--- a/docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md
+++ b/docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md
@@ -87,6 +87,25 @@ On every successful listing:
 
 Never reset on: pan, zoom, address search, opening or closing a card.
 
+**Which of these actually fire in production — checked, not assumed (09.08.2026).** A worker
+contradicted the plan here and was right, and following it up found something bigger:
+
+| trigger | fires in production? |
+|---|---|
+| `start()` | **yes, and it is the dominant one** — a fresh session is built on every trigger click (`sessions[ fieldId ] = openSession( … )`), so closing and reopening the picker already starts from an empty pool |
+| `typeFilterChange` | yes |
+| `refresh()` | **NO — it has no production caller at all.** `getSession()` is exported and never called outside `tests/js/`. `onCheckoutUpdated()` exists in this file but is wired only to `mountAll`, never to `refresh` |
+
+The third row is a pre-existing hole, not one this design opens: `forgetPointDetails()` — added by
+#232 precisely so a cart change invalidates stored verdicts — is therefore dead in production too.
+Filed as **#238**; deliberately NOT fixed here, because wiring `updated_checkout` to `refresh()`
+naively means a live carrier call (6–13 s) on an event the checkout fires often, and that needs its
+own design.
+
+What it means for #234: the pool's real-world reset is "every time the picker opens", which covers
+the common case completely. The `refresh()` reset is still implemented and still correct — it is
+the right place for it, and it starts working the moment #238 does.
+
 **Invariant — the pool and the details memo reset TOGETHER.** `refresh()` already calls
 `forgetPointDetails()`; `resetPointPool()` goes beside it and the two must never be separated.
 `geo.groupByPosition()` does not deep-copy, so re-applied detail fields land on the pooled point

--- a/docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md
+++ b/docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md
@@ -51,8 +51,24 @@ A session-scoped `pointPool` in `pickup-mount.js`, keyed by `point.id`, **viewpo
 
 On every successful listing:
 
-1. Merge the listing's points into the pool. **The listing wins on conflict** — it is the fresher
-   carrier record.
+1. Merge the listing's points into the pool. **The listing wins on conflict *in the pool*** — it is
+   the fresher carrier record.
+
+   **But it does not win on screen, and that is deliberate.** Step 3 below re-applies every stored
+   detail field over the freshly merged record, so where a listing field and a detail field share a
+   name, the *older* detail value is what the customer sees. This is not an oversight introduced
+   here — it is #232's fix, which stopped an open card from losing its own content on every pan —
+   and the adversarial review was right to call the flat claim "listing wins" false. Recorded
+   precisely because the two halves read as contradictory and a future reader will otherwise
+   "correct" one of them:
+
+   | layer | winner | why |
+   |---|---|---|
+   | the pool | the listing | it is the fresher carrier record |
+   | what is drawn | the stored detail | a detail fetch asked about ONE point and got the full record; a listing is sparse by construction |
+
+   The exposure is bounded by §3.2: `detailsById` is cleared on exactly the events that can
+   invalidate it, and always together with the pool.
 2. Build groups from the POOL, not the listing: `geo.groupByPosition( poolValues() )`.
 3. Re-apply `detailsById` onto those groups — unchanged, and it must keep running *after* grouping
    so a re-merged sparse record cannot overwrite what a detail fetch already learned.
@@ -78,7 +94,29 @@ objects themselves; clearing `detailsById` while keeping the pool would leave th
 with nothing left to re-derive them from. A test pins that one call clears both. (This is the s57
 lesson about two guards that look independent and are not.)
 
-### 3.3 The empty-frame message
+### 3.3 A reset must survive an in-flight listing
+
+Found by the adversarial review, and it is the one finding that needs code the design did not have.
+
+A listing request is already travelling when a reset fires (a checkout update, a type change). It
+settles afterwards and its continuation merges its now-stale points into the freshly emptied pool.
+The guard the continuation has today is `destroyed` alone, which is false here.
+
+This race exists today and is harmless today: each listing REPLACES the set, so the next listing
+overwrites the stale one wholesale. Accumulation is what makes it permanent — nothing removes a
+point once pooled.
+
+`fetchPoints()` being debounced and superseded does NOT close it. Supersede means an earlier CALLER
+receives the LATER result; it says nothing about a request that had already gone out before the
+reset.
+
+**Fix:** a monotonic `poolGeneration`, bumped by `resetPointPool()`. `fetchAndSetPoints()` captures
+it at call time and the continuation drops the listing entirely if the generation moved while the
+request was in flight — no merge, no draw. This is the same shape as `pendingSelectionToken`, which
+exists because the equivalent ABA hole was found in the selection lock in s57; the two must not
+diverge in style.
+
+### 3.4 The empty-frame message
 
 Today `points.length === 0` drives `showFetchMessage( 'emptyInView' )`. With a pool that becomes
 wrong: a listing can come back empty for a bbox in which the pool still holds points, because the
@@ -86,21 +124,29 @@ source truncates at `MAX_PAGES × PAGE_SIZE` (§4 measured this happening at `MI
 must be driven by what the customer can actually SEE — the pool's in-frame subset — not by the
 listing length. `bulk`'s `emptyLocality` path is unchanged.
 
-### 3.4 Stale points
+### 3.5 Stale points
 
-A pooled point can outlive its removal by the carrier for the length of a session. This is contained
-and must stay contained:
+A pooled point can outlive its removal — or its becoming unavailable — at the carrier, for the
+length of a session. Nothing in the three resets is triggered by a carrier-side change. This is
+contained, and the containment is worth stating precisely, because the adversarial review's sharpest
+correct point was that fail-closed selection protects *checkout integrity*, not *picker
+correctness* — being shown an option and refused it later is its own defect, just a smaller one.
 
-- the verdict is recomputed server-side on every detail fetch;
-- selection is server-authoritative — `POST …/select` recomputes and is fail-closed, so a stale
-  point cannot be silently ordered against;
-- the pool resets on cart change.
+Three layers, in the order the customer meets them:
 
-The exposure is therefore "a point that no longer exists may be shown until the customer tries to
-pick it", which is what every map with a client cache has, and it is strictly smaller than the
-alternative defect the customer reports today.
+1. **Opening the card re-asks.** `cardOpened` drives `refreshPointDetails()`, which fetches that one
+   point and recomputes its verdict server-side; a refusal locks the CTA before the customer can
+   press it. So a stale point is caught at the moment of interest, not at order time.
+2. **Selection is server-authoritative.** `POST …/select` recomputes fail-closed, so even a bypassed
+   client cannot order against a stale point.
+3. **The pool resets on cart change**, which is the invalidation we can actually observe.
 
-### 3.5 Bound on the pool
+Residual exposure: a point the carrier removed between two frames stays *visible on the map* until
+a reset. It cannot be selected, and it announces itself as unavailable as soon as it is opened.
+That is strictly smaller than the defect the customer reports today, and it is the same exposure any
+map with a client-side cache carries.
+
+### 3.6 Bound on the pool
 
 **Default: unlimited.** Justified by §4, not by argument.
 
@@ -180,6 +226,10 @@ jest, `tests/js/pickup-mount.test.js`:
 10. Bulk strategy is unaffected — its listing still replaces wholesale.
 11. Cap path: with `maxAccumulatedPoints` set, oldest-inserted are evicted first and the in-frame /
     open-card / selected points are never evicted.
+12. A listing that was already in flight when the pool was reset is DROPPED on arrival — its points
+    are not merged and nothing is redrawn from it (§3.3).
+13. A listing in flight across NO reset still lands normally — the generation guard must not be a
+    blanket "drop anything that overlaps a reset-free window".
 
 ## 6. Explicitly out of scope
 
@@ -189,10 +239,29 @@ fact. Sending them without accumulating would lose points, and now that we accum
 a bandwidth optimisation at best. We keep requesting the full frame, which is correct either way.
 If it is ever wanted, it belongs in the domain source, not here.
 
+## 7. Adversarial review (Codex, 09.08.2026)
+
+Run against this design before any code. Three of its HIGH findings were bundle artefacts — it was
+given the CURRENT code plus the design and read them as one proposed final state, so it correctly
+observed that the resets "are absent from the shown handler". They are absent because they are not
+written yet. Recorded so the same objection is not re-raised at review time.
+
+What it found that was real, and what changed as a result:
+
+| finding | verdict | change |
+|---|---|---|
+| "listing wins" is defeated by the detail re-application | **correct** — the flat claim was false | §3.1 now states the two-layer precedence explicitly |
+| a reset has no request-generation barrier | **correct, and the only new code it forced** | new §3.3 |
+| a fresh listing cannot remove a point that became invalid | **correct in kind** — fail-closed protects checkout, not the picker | §3.5 rewritten to name the residual exposure instead of implying there is none |
+| restore could focus an off-frame pooled group | **not reachable** — `selectionRestoreAttempted` is claimed on the first listing that is non-empty or carries a restore group, and the pool equals that listing at that moment; it can only be a union from listing 2 onward | no code change; pinned by a test so it stays unreachable |
+| unlimited accumulation makes redraws progressively slower | **known and measured** — 334 ms at 20 000, once per listing, against a 6–13 s fetch | no change; §3.6 already carries the seam |
+
 ## Related
 
 - Issue #234 · gotcha `built-on-both-sides-with-no-caller-in-the-middle` (why the docblock was
   re-read rather than trusted) · gotcha `card-renders-from-a-snapshot-the-writers-never-touch`
-  (why §3.2's invariant is pinned by a test)
+  (why §3.2's invariant is pinned by a test) · gotcha
+  `a-per-cycle-memo-is-not-in-flight-deduplication` (the s57 ABA hole §3.3's generation guard is
+  modelled on)
 - `docs-internal/specs/2026-08-01-sp5-pickup-map-rework-design.md` — the `dataSource` inversion this
   builds on

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2068,6 +2068,97 @@ test( '#234: an empty listing DOES show emptyInView when nothing is in frame', a
 	expect( panels.showMessageCalls ).toEqual( [ 'emptyInView' ] );
 } );
 
+// -------------------------------------------------------------------------
+// #234 — maxAccumulatedPoints: bounding the pool, protecting what the customer can see.
+// -------------------------------------------------------------------------
+
+test( '#234 cap: with maxAccumulatedPoints set, the OLDEST-seen points are evicted first', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+		[ point( { id: 'C' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport', maxAccumulatedPoints: 2 } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] ).sort();
+
+	expect( ids ).toEqual( [ 'B', 'C' ] );
+} );
+
+test( '#234 cap: the customer\'s CURRENT SELECTION is never evicted, however old', async () => {
+	// Seed the field with A so it is the current selection from the first listing on.
+	document.getElementById( FIELD_ID ).value = 'A';
+
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+		[ point( { id: 'C' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport', maxAccumulatedPoints: 2 } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toContain( 'A' );
+} );
+
+test( '#234 cap: an unset (0) cap keeps everything', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+		[ point( { id: 'C' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] ).sort();
+
+	expect( ids ).toEqual( [ 'A', 'B', 'C' ] );
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -1992,6 +1992,33 @@ test( '#234: a BULK type-filter change does not touch the pool or refetch — it
 	expect( provider.setPointsCalls.length ).toBe( drawsBefore );
 } );
 
+test( '#234: the type chips are computed from the POOL, so they do not flicker as the '
+	+ 'customer pans', async () => {
+	const listings = [
+		[ point( { id: 'A', type: { code: 'pvz', label: 'ПВЗ' } } ) ],
+		[ point( { id: 'B', type: { code: 'postamat', label: 'Постамат' } } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	expect( panels.lastTypes ).toEqual( [
+		{ code: 'pvz', label: 'ПВЗ' },
+		{ code: 'postamat', label: 'Постамат' },
+	] );
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -1899,6 +1899,52 @@ test( '#234: a listing in flight across NO reset still lands normally — the gu
 	expect( ids ).toEqual( [ 'A' ] );
 } );
 
+test( '#234 invariant: refresh() clears the pool AND the details memo in ONE call', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	window.WoodevPickupDataSource.fetchDetails = () =>
+		Promise.resolve( point( { id: 'A', work_time: 'из деталей' } ) );
+
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	// Learn a detail for A, so the memo is demonstrably non-empty. The payload shape is
+	// `{ group, pointId, origin }` — verified against this file's existing cardOpened tests,
+	// NOT guessed.
+	panels.emit( 'cardOpened', {
+		group: provider.setPointsCalls[ provider.setPointsCalls.length - 1 ][ 0 ],
+		pointId: 'A',
+		origin: 'list',
+	} );
+	await flushAsync();
+
+	// The cart changes. NOTE: `updated_checkout` does NOT reach refresh() — this file wires
+	// that event to mountAll() only, and getSession() has no production caller at all (#238).
+	// Every existing refresh() test in this file drives it directly, and so does this one.
+	await window.WoodevPickupMount.getSession( FIELD_ID ).refresh();
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const all = drawn.reduce( ( acc, group ) => acc.concat( group.points ), [] );
+
+	// Pool cleared: only the refresh listing's own point is drawn.
+	expect( all.map( ( p ) => p.id ) ).toEqual( [ 'B' ] );
+	// Memo cleared: nothing carries the stale detail field.
+	expect( all.some( ( p ) => 'из деталей' === p.work_time ) ).toBe( false );
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -1706,6 +1706,120 @@ test( 'a genuinely empty VIEWPORT (boundsChange) result calls panels.showMessage
 	expect( panels.showMessageCalls ).toEqual( [ 'emptyInView' ] );
 } );
 
+// -------------------------------------------------------------------------
+// #234 — viewport point accumulation: the drawn set is the UNION of every
+// listing this session, never just the last one.
+// -------------------------------------------------------------------------
+
+test( 'viewport: two listings with disjoint points draw the UNION, not the last listing', async () => {
+	const listings = [
+		[ point( { id: 'A', lat: 55.1, lng: 37.1 } ) ],
+		[ point( { id: 'B', lat: 55.2, lng: 37.2 } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] ).sort();
+
+	expect( ids ).toEqual( [ 'A', 'B' ] );
+} );
+
+test( 'viewport: a point in BOTH listings appears once, carrying the SECOND listing\'s values', async () => {
+	const listings = [
+		[ point( { id: 'A', name: 'Старое имя' } ) ],
+		[ point( { id: 'A', name: 'Новое имя' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const all = drawn.reduce( ( acc, group ) => acc.concat( group.points ), [] );
+
+	expect( all ).toHaveLength( 1 );
+	expect( all[ 0 ].name ).toBe( 'Новое имя' );
+} );
+
+test( 'bulk is unaffected — its listing still REPLACES the drawn set', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'bulk' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	// bulk's second fetch can only come from refresh() — dispatching `updated_checkout` on
+	// `document.body` alone does NOT call it. Verified against the source: refresh() is an
+	// EXTERNAL hook exposed only via getSession() (see the file docblock, "the hook a
+	// payment-method change elsewhere on the page uses"), nothing in this file wires it to
+	// the `updated_checkout` DOM event itself, and every existing refresh() test in this
+	// file invokes it the same way.
+	await getSession( FIELD_ID ).refresh();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'B' ] );
+} );
+
+test( 'retry (start()) drops the pool — a fresh session starts from nothing', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[ point( { id: 'B' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	let provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+	panels.emit( 'retryRequested' );
+	await flushAsync();
+
+	provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'B' ] );
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2019,6 +2019,55 @@ test( '#234: the type chips are computed from the POOL, so they do not flicker a
 	] );
 } );
 
+// -------------------------------------------------------------------------
+// #234 — "nothing in this area" must not print over a map that shows points.
+// -------------------------------------------------------------------------
+
+test( '#234: an empty listing does NOT show emptyInView while pooled points are still in frame', async () => {
+	const listings = [
+		[ point( { id: 'A' } ) ],
+		[],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	// The provider reports A is on screen — this is the mount's only source for "in frame".
+	const drawnKey = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ][ 0 ].key;
+	provider.emit( 'visibleChange', [ drawnKey ] );
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	expect( panels.showMessageCalls ).toBeUndefined();
+} );
+
+test( '#234: an empty listing DOES show emptyInView when nothing is in frame', async () => {
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'visibleChange', [] );
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	expect( panels.showMessageCalls ).toEqual( [ 'emptyInView' ] );
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2100,6 +2100,93 @@ test( '#234 cap: with maxAccumulatedPoints set, the OLDEST-seen points are evict
 	expect( ids ).toEqual( [ 'B', 'C' ] );
 } );
 
+// -------------------------------------------------------------------------
+// #234 — defects found by adversarial review of the finished implementation
+// (Codex, 09.08.2026). Each of these FAILED against the first implementation.
+// -------------------------------------------------------------------------
+
+test( '#234 cap: NUMERIC ids evict by age, not by numeric value — Object.keys() orders '
+	+ 'integer-like keys numerically and would drop the newest point', async () => {
+	// The live carrier's ids are numeric strings ('111543'). Seen in this order: 100, 200, 50.
+	// `Object.keys()` would report [ '50', '100', '200' ] and evict '50' — the NEWEST.
+	const listings = [
+		[ point( { id: '100' } ) ],
+		[ point( { id: '200' } ) ],
+		[ point( { id: '50' } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport', maxAccumulatedPoints: 2 } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] ).sort();
+
+	// The OLDEST ('100') goes; the two most recently seen survive.
+	expect( ids ).toEqual( [ '200', '50' ].sort() );
+} );
+
+test( '#234: a point whose carrier id is the string "__proto__" is pooled and drawn', async () => {
+	// On a plain `{}` pool, `pool['__proto__'] = point` mutates the prototype instead of
+	// creating an entry, and the point silently never appears.
+	window.WoodevPickupDataSource = fakeDataSourceFactory(
+		() => Promise.resolve( [ point( { id: '__proto__' } ) ] )
+	);
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ '__proto__' ] );
+} );
+
+test( '#234: the generation guard is NOT viewport-only — a stale BULK listing must not '
+	+ 'overwrite a newer one that already drew', async () => {
+	let releaseFirst;
+	const first = new Promise( ( resolve ) => { releaseFirst = resolve; } );
+	const responses = [ first, Promise.resolve( [ point( { id: 'FRESH' } ) ] ) ];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => responses[ call++ ] || Promise.resolve( [] ) );
+	setConfig( makeConfig( { strategy: 'bulk' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	// The bulk session's own first fetch is in flight and has not settled.
+	// A cart change resets and refetches; the second listing settles first and draws.
+	await window.WoodevPickupMount.getSession( FIELD_ID ).refresh();
+	await flushAsync();
+
+	// Only now does the pre-reset listing come back.
+	releaseFirst( [ point( { id: 'STALE' } ) ] );
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'FRESH' ] );
+} );
+
 test( '#234 cap: the customer\'s CURRENT SELECTION is never evicted, however old', async () => {
 	// Seed the field with A so it is the current selection from the first listing on.
 	document.getElementById( FIELD_ID ).value = 'A';

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -1945,6 +1945,53 @@ test( '#234 invariant: refresh() clears the pool AND the details memo in ONE cal
 	expect( all.some( ( p ) => 'из деталей' === p.work_time ) ).toBe( false );
 } );
 
+test( '#234: a viewport type-filter change drops the pool — the server filters, so a union '
+	+ 'across different filters would be incoherent', async () => {
+	const listings = [
+		[ point( { id: 'A', type: { code: 'pvz', label: 'ПВЗ' } } ) ],
+		[ point( { id: 'B', type: { code: 'postamat', label: 'Постамат' } } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	panels.emit( 'typeFilterChange', [ 'postamat' ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'B' ] );
+} );
+
+test( '#234: a BULK type-filter change does not touch the pool or refetch — it still filters '
+	+ 'client-side through the provider', async () => {
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point( { id: 'A' } ) ] ) );
+	setConfig( makeConfig( { strategy: 'bulk' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+	const drawsBefore = provider.setPointsCalls.length;
+
+	panels.emit( 'typeFilterChange', [ 'postamat' ] );
+	await flushAsync();
+
+	expect( provider.setTypeFilterCalls ).toEqual( [ [ 'postamat' ] ] );
+	expect( provider.setPointsCalls.length ).toBe( drawsBefore );
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -1820,6 +1820,85 @@ test( 'retry (start()) drops the pool — a fresh session starts from nothing', 
 	expect( ids ).toEqual( [ 'B' ] );
 } );
 
+// -------------------------------------------------------------------------
+// #234 — the generation barrier: a reset must survive an in-flight listing.
+//
+// The plan this was written from drives the reset via `document.body.dispatchEvent(
+// new Event( 'updated_checkout' ) )`. Verified against the source and against every
+// other refresh() test in this file: that event alone never calls refresh() — it is an
+// EXTERNAL hook exposed only via `getSession( fieldId ).refresh()` (see the file
+// docblock, "the hook a payment-method change elsewhere on the page uses"), and
+// `refresh()` itself does not call `resetPointPool()` yet — that wiring is Task 2, which
+// this commit deliberately does not include. The only reset trigger implemented at this
+// point in the plan's own sequence is `start()` (Task 1, step 6), reached the same way
+// the "retry (start()) drops the pool" test above reaches it: a `retryRequested` event.
+// -------------------------------------------------------------------------
+
+test( '#234: a listing already in flight when the pool is reset is DROPPED on arrival', async () => {
+	let releaseFirst;
+	const first = new Promise( ( resolve ) => { releaseFirst = resolve; } );
+	const responses = [ first, Promise.resolve( [ point( { id: 'B' } ) ] ) ];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => responses[ call++ ] || Promise.resolve( [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+	const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+	// A listing goes out and does NOT settle yet.
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	// A retry rebuilds the provider and resets the pool while the first listing is still
+	// travelling.
+	panels.emit( 'retryRequested' );
+	await flushAsync();
+
+	const freshProvider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	// A second listing goes out on the fresh provider and settles normally.
+	freshProvider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	// Only NOW does the stale first listing come back.
+	releaseFirst( [ point( { id: 'STALE' } ) ] );
+	await flushAsync();
+
+	const drawn = freshProvider.setPointsCalls[ freshProvider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).not.toContain( 'STALE' );
+} );
+
+test( '#234: a listing in flight across NO reset still lands normally — the guard is not a '
+	+ 'blanket drop', async () => {
+	let releaseFirst;
+	const first = new Promise( ( resolve ) => { releaseFirst = resolve; } );
+	let call = 0;
+	const responses = [ first ];
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => responses[ call++ ] || Promise.resolve( [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+
+	releaseFirst( [ point( { id: 'A' } ) ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toEqual( [ 'A' ] );
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -2159,6 +2159,47 @@ test( '#234 cap: an unset (0) cap keeps everything', async () => {
 	expect( ids ).toEqual( [ 'A', 'B', 'C' ] );
 } );
 
+// -------------------------------------------------------------------------
+// #234 — restore finds a pooled point the last listing does not contain.
+// -------------------------------------------------------------------------
+
+test( '#234: a previously chosen point is still restorable from the pool after the customer '
+	+ 'panned to a frame whose listing does not contain it', async () => {
+	document.getElementById( FIELD_ID ).value = 'A';
+
+	const listings = [
+		[ point( { id: 'A', lat: 55.1, lng: 37.1 } ) ],
+		[ point( { id: 'B', lat: 60.0, lng: 30.0 } ) ],
+	];
+	let call = 0;
+	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( listings[ call++ ] || [] ) );
+	setConfig( makeConfig( { strategy: 'viewport' } ) );
+	mountAll();
+	clickTrigger();
+	await flushAsync();
+
+	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+	provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+	await flushAsync();
+	provider.emit( 'boundsChange', [ 59, 29, 61, 31 ] );
+	await flushAsync();
+
+	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+	const ids = drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+
+	expect( ids ).toContain( 'A' );
+
+	// …and the SECOND listing must not have re-focused the camera onto that pooled group.
+	// The adversarial review flagged this as a possible camera jump: with groups now built
+	// from the pool, `pendingRestoreGroup()` can find a chosen point that the current frame's
+	// listing does not contain. It is unreachable because `selectionRestoreAttempted` is
+	// claimed on the FIRST listing (which is where the pool still equals that listing), but
+	// "unreachable" is a property that must be pinned, not assumed.
+	const lastOptions = provider.setPointsOptions[ provider.setPointsOptions.length - 1 ];
+	expect( lastOptions ).toBeFalsy();
+} );
+
 test( 'a non-empty result calls neither showMessage() (nothing to show) nor leaves any destructive '
 	+ 'modal state', async () => {
 	window.WoodevPickupDataSource = fakeDataSourceFactory( () => Promise.resolve( [ point() ] ) );

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1188,6 +1188,58 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$this->assertSame( 3000, $config['maxAccumulatedPoints'] );
 		}
 
+		/**
+		 * Adversarial review, 09.08.2026: a bare `(int)` cast turns a NON-EMPTY ARRAY into `1`,
+		 * so a filter that mistakenly returns its whole settings structure — an easy slip —
+		 * would bound the browser's pool to a SINGLE point and silently reinstate the defect
+		 * #234 exists to fix, in its worst form. A filter nobody wrote correctly must change
+		 * nothing, never impose a hostile bound.
+		 */
+		public function test_js_config_max_accumulated_points_ignores_an_array_filter_return(): void {
+			Filters\expectApplied( 'woodev_pickup_max_accumulated_points' )
+				->once()
+				->with( 0, 'p' )
+				->andReturn( [ 'max' => 500 ] );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler()->get_js_config();
+
+			$this->assertSame( 0, $config['maxAccumulatedPoints'] );
+		}
+
+		/**
+		 * Same rule for a non-numeric scalar: `'unlimited'`, `null` and `false` all cast to `0`
+		 * anyway, but `is_numeric()` makes that the DECLARED behaviour rather than a coincidence
+		 * of PHP's cast table — and it is what keeps the array case above from being special.
+		 */
+		public function test_js_config_max_accumulated_points_ignores_a_non_numeric_filter_return(): void {
+			Filters\expectApplied( 'woodev_pickup_max_accumulated_points' )
+				->once()
+				->with( 0, 'p' )
+				->andReturn( 'unlimited' );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler()->get_js_config();
+
+			$this->assertSame( 0, $config['maxAccumulatedPoints'] );
+		}
+
+		/**
+		 * A numeric STRING is a legitimate return (options come back as strings from the DB) and
+		 * must survive — the guard rejects non-numeric input, not non-int input.
+		 */
+		public function test_js_config_max_accumulated_points_accepts_a_numeric_string(): void {
+			Filters\expectApplied( 'woodev_pickup_max_accumulated_points' )
+				->once()
+				->with( 0, 'p' )
+				->andReturn( '2500' );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler()->get_js_config();
+
+			$this->assertSame( 2500, $config['maxAccumulatedPoints'] );
+		}
+
 		// -------------------------------------------------------------------------
 		// modal size + search flag (Task 18, spec V-1 / V-6)
 		// -------------------------------------------------------------------------

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1129,6 +1129,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 				[
 					'fieldId',
 					'strategy',
+					'maxAccumulatedPoints',
 					'provider',
 					'restRoot',
 					'nonce',
@@ -1148,6 +1149,43 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 				],
 				array_keys( $config )
 			);
+		}
+
+		// -------------------------------------------------------------------------
+		// maxAccumulatedPoints (#234) — the viewport point-pool cap seam.
+		// -------------------------------------------------------------------------
+
+		public function test_js_config_defaults_max_accumulated_points_to_zero_meaning_unlimited(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler()->get_js_config();
+
+			$this->assertSame( 0, $config['maxAccumulatedPoints'] );
+		}
+
+		public function test_js_config_max_accumulated_points_is_filterable_and_never_negative(): void {
+			Filters\expectApplied( 'woodev_pickup_max_accumulated_points' )
+				->once()
+				->with( 0, 'p' )
+				->andReturn( -5 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler()->get_js_config();
+
+			$this->assertSame( 0, $config['maxAccumulatedPoints'] );
+		}
+
+		public function test_js_config_passes_a_positive_max_accumulated_points_through(): void {
+			Filters\expectApplied( 'woodev_pickup_max_accumulated_points' )
+				->once()
+				->with( 0, 'p' )
+				->andReturn( 3000 );
+			$this->stub_config_dependencies_except_filters();
+
+			$config = $this->make_handler()->get_js_config();
+
+			$this->assertSame( 3000, $config['maxAccumulatedPoints'] );
 		}
 
 		// -------------------------------------------------------------------------

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1088,7 +1088,20 @@
 		 *
 		 * @type {Object.<string, Object>}
 		 */
-		var pointPool = {};
+		var pointPool = Object.create( null );
+
+		/**
+		 * The pooled ids in TRUE INSERTION ORDER — what {@see trimPointPool} evicts by (#234).
+		 *
+		 * A separate array rather than `Object.keys( pointPool )`, because that is NOT insertion
+		 * order: JavaScript orders integer-like string keys NUMERICALLY and ahead of every other
+		 * key, and this carrier's ids are exactly that (`'111543'`). Evicting by `Object.keys()`
+		 * would therefore drop the LOWEST-numbered id — which has nothing to do with age, and on
+		 * a mixed pool can be the point the customer just panned to. Found by adversarial review.
+		 *
+		 * @type {Array.<string>}
+		 */
+		var poolOrder = [];
 
 		/**
 		 * Bumped by every {@see resetPointPool}. A listing captures it when it goes out and is
@@ -1701,7 +1714,7 @@
 		 * @returns {Array} never null.
 		 */
 		function poolValues() {
-			return Object.keys( pointPool ).map( function( id ) {
+			return poolOrder.map( function( id ) {
 				return pointPool[ id ];
 			} );
 		}
@@ -1712,13 +1725,19 @@
 		 * that is the shipped default, and it is measured-safe rather than assumed: see the
 		 * design doc's measurement table.
 		 *
-		 * Evicts OLDEST-INSERTED first (plain object key order for string keys), skipping any
-		 * point the customer would notice losing:
+		 * Evicts OLDEST-INSERTED first — walking {@see poolOrder}, NOT `Object.keys( pointPool )`,
+		 * which is not insertion order at all for the numeric ids this carrier uses (see that
+		 * array's own docblock). Skips any point the customer would notice losing:
 		 *
 		 *  - the current selection — the field's own value; losing it would strand the
 		 *    checkout on a point the map can no longer draw;
 		 *  - the open card's point — {@see cardPointId}; a card whose point vanished mid-read
 		 *    is the #232 defect wearing a different hat.
+		 *
+		 * The cap is a TARGET, not a guarantee: if every pooled point is protected the pool stays
+		 * above `max`, by design — evicting the point the customer has open, or the one they
+		 * already chose, to honour a number would be the worse failure. Bounded in practice by
+		 * there being at most two protected ids.
 		 *
 		 * "In frame" is deliberately NOT a third exemption: it would need a rectangle test of
 		 * our own, and the frame is exactly where a re-listing puts points back a moment later
@@ -1734,15 +1753,14 @@
 				return;
 			}
 
-			var ids = Object.keys( pointPool );
-			var over = ids.length - max;
+			var over = poolOrder.length - max;
 
 			if ( over < 1 ) {
 				return;
 			}
 
 			var selected = fieldValue( config.fieldId );
-			var protectedIds = {};
+			var protectedIds = Object.create( null );
 
 			if ( selected ) {
 				protectedIds[ String( selected ) ] = true;
@@ -1752,14 +1770,22 @@
 				protectedIds[ String( cardPointId ) ] = true;
 			}
 
-			ids.forEach( function( id ) {
-				if ( over < 1 || Object.prototype.hasOwnProperty.call( protectedIds, id ) ) {
+			// Walks {@see poolOrder} — TRUE insertion order, oldest first. Rebuilds the order
+			// array in one pass rather than splicing per eviction, so trimming stays linear.
+			var kept = [];
+
+			poolOrder.forEach( function( id ) {
+				if ( over < 1 || id in protectedIds ) {
+					kept.push( id );
+
 					return;
 				}
 
 				delete pointPool[ id ];
 				over -= 1;
 			} );
+
+			poolOrder = kept;
 		}
 
 		/**
@@ -1771,8 +1797,15 @@
 		 * {@see fetchAndSetPoints}.
 		 *
 		 * A point with no `id` is passed through un-pooled rather than dropped: `id` is the
-		 * pool's whole identity and a record without one cannot be de-duplicated, but it is
-		 * still a point the carrier returned and the customer should see it.
+		 * pool's whole identity and a record without one cannot be de-duplicated. Such a point is
+		 * therefore visible for THIS listing only and is gone on the next one — it does not join
+		 * the union. That asymmetry is deliberate and it is also unreachable in practice:
+		 * `Pickup_Point::from_array()` REQUIRES `id` and returns null without it, so no such
+		 * record can reach the browser through the framework's own contract. The branch is
+		 * defensive, not a supported shape — pooling it under a synthesised key would trade an
+		 * impossible case for a real one, re-adding an indistinguishable duplicate on every
+		 * listing forever. (Adversarial review flagged the original wording here, which claimed
+		 * union semantics this branch does not provide.)
 		 *
 		 * @since 2.0.2
 		 * @param {Array} points this listing's points.
@@ -1790,7 +1823,13 @@
 					return;
 				}
 
-				pointPool[ String( point.id ) ] = point;
+				var id = String( point.id );
+
+				if ( ! ( id in pointPool ) ) {
+					poolOrder.push( id );
+				}
+
+				pointPool[ id ] = point;
 			} );
 
 			trimPointPool();
@@ -1812,7 +1851,8 @@
 		 * @returns {void}
 		 */
 		function resetPointPool() {
-			pointPool = {};
+			pointPool = Object.create( null );
+			poolOrder = [];
 			poolGeneration += 1;
 		}
 
@@ -1864,9 +1904,16 @@
 					// pre-reset carrier answer back into a pool that was deliberately emptied —
 					// permanently, since nothing removes a pooled point. `dropLoading()` and
 					// `clearInitialBusy()` above have already run, so the customer's spinner state
-					// is correct; there is simply nothing here worth drawing. Viewport-only: `bulk`
-					// does not accumulate, so its late listing is still the best answer available.
-					if ( 'viewport' === config.strategy && myGeneration !== poolGeneration ) {
+					// is correct; there is simply nothing here worth drawing.
+					//
+					// NOT viewport-only, though only `viewport` accumulates (adversarial review,
+					// 09.08.2026). The first version exempted `bulk` on the reasoning that a late
+					// listing is still the best answer available — which is false once a reset has
+					// happened: the reset means a NEWER fetch went out, and if that one has already
+					// drawn, letting the older one through replaces fresh data with stale. A
+					// generation only moves when something invalidated the previous answer, so the
+					// guard is about staleness, not about which strategy is running.
+					if ( myGeneration !== poolGeneration ) {
 						return points;
 					}
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1090,6 +1090,18 @@
 		 */
 		var pointPool = {};
 
+		/**
+		 * Bumped by every {@see resetPointPool}. A listing captures it when it goes out and is
+		 * DISCARDED on arrival if it moved — see {@see fetchAndSetPoints}.
+		 *
+		 * Why a counter and not a boolean "was reset": two resets can bracket one request, and a
+		 * boolean cleared by the second would let the request through. Same reason
+		 * `pendingSelectionToken` is a token rather than a point id (s57's ABA hole).
+		 *
+		 * @type {number}
+		 */
+		var poolGeneration = 0;
+
 		/** @type {Array} the address suggestions from the LAST `searchResults` event — what
 		 *  `searchAddressPicked( index )` indexes into. */
 		var lastAddresses = [];
@@ -1742,10 +1754,16 @@
 		 */
 		function resetPointPool() {
 			pointPool = {};
+			poolGeneration += 1;
 		}
 
 		function fetchAndSetPoints( query ) {
 			bumpLoading();
+
+			// #234: the generation this listing belongs to. Anything that empties the pool while
+			// this request is in flight makes its answer describe a state nobody is looking at
+			// any more — see the check in the resolve branch.
+			var myGeneration = poolGeneration;
 
 			// `realDataSource.fetchPoints( query )` is still called SYNCHRONOUSLY, right here — see
 			// {@see refreshPointDetails}'s identical `try` immediately above for why: several
@@ -1780,6 +1798,16 @@
 					clearInitialBusy();
 
 					if ( destroyed ) {
+						return points;
+					}
+
+					// #234: a reset happened while this was travelling. Merging now would put the
+					// pre-reset carrier answer back into a pool that was deliberately emptied —
+					// permanently, since nothing removes a pooled point. `dropLoading()` and
+					// `clearInitialBusy()` above have already run, so the customer's spinner state
+					// is correct; there is simply nothing here worth drawing. Viewport-only: `bulk`
+					// does not accumulate, so its late listing is still the best answer available.
+					if ( 'viewport' === config.strategy && myGeneration !== poolGeneration ) {
 						return points;
 					}
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -2498,6 +2498,14 @@
 				// viewport: a client-side filter would show stale points outside the current
 				// bbox — refetch with the SAME bbox and the new types instead (see the file
 				// docblock's judgement-call note on getting this backwards).
+				//
+				// #234: the pool goes first. The SERVER is what applies the type filter on this
+				// strategy, so points pooled under the previous filter are not a subset of the
+				// new answer — a union across two different filters describes no query anyone
+				// made. Paired with forgetPointDetails() per resetPointPool()'s invariant.
+				resetPointPool();
+				forgetPointDetails();
+
 				if ( lastBbox ) {
 					fetchAndSetPoints( { bounds: lastBbox, types: codes } ).catch( function() {} );
 				}

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1889,7 +1889,11 @@
 					provider.setPoints( groups, restoreGroup ? { focus: restoreGroup.key } : null );
 
 					if ( panels ) {
-						panels.setTypes( extractTypes( points ) );
+						// #234: from the DRAWN set, not this listing — a chip that vanishes
+						// because the customer panned past the last point of its type, while
+						// points of that type are still drawn, is the same defect this issue
+						// is about, one surface over.
+						panels.setTypes( extractTypes( drawable ) );
 					}
 
 					fireDocumentEvent( EVENT_POINTS_LOADED, {

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -2973,7 +2973,12 @@
 
 			// THE cart-change event (#232) — see {@see forgetPointDetails} for why this is the
 			// only place details are forgotten, and no longer every listing.
+			//
+			// #234: the pool goes with it, ALWAYS, and the two calls must never be separated —
+			// see {@see resetPointPool}'s stated invariant. A pooled point's `selectable` was
+			// computed against the cart that just changed.
 			forgetPointDetails();
+			resetPointPool();
 
 			if ( 'bulk' === config.strategy ) {
 				return fetchAndSetPoints( bulkQuery() ).catch( function() {} );

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1102,6 +1102,18 @@
 		 */
 		var poolGeneration = 0;
 
+		/**
+		 * How many groups the provider last reported as being inside the frame (#234).
+		 *
+		 * The mount deliberately does NOT compute this itself: `_groupsInsideBounds()` is the
+		 * ONE definition of "in frame" in this codebase, unified in #167 precisely so two
+		 * inequality chains over the same rectangle cannot disagree. This is a cached read of
+		 * that answer, not a second opinion.
+		 *
+		 * @type {number}
+		 */
+		var visibleGroupCount = 0;
+
 		/** @type {Array} the address suggestions from the LAST `searchResults` event — what
 		 *  `searchAddressPicked( index )` indexes into. */
 		var lastAddresses = [];
@@ -1926,13 +1938,21 @@
 								restoreSelection( restoreGroup );
 							}
 						}
-					} else {
+					} else if ( 'bulk' === config.strategy || 0 === visibleGroupCount ) {
 						// `emptyLocality` (a locality genuinely has none) vs `emptyInView` (the
 						// current viewport does) — the SAME shared function backs both the bulk
 						// strategy's one-shot fetch and the viewport strategy's per-bbox
-						// `boundsChange` fetch (see the call sites below), so the key is chosen from
-						// `config.strategy`, not hardcoded to either. Distinct from `noResults`,
-						// which stays reserved for the search view finding nothing (spec V-5).
+						// `boundsChange` fetch, so the key is chosen from `config.strategy`, not
+						// hardcoded to either. Distinct from `noResults`, which stays reserved for
+						// the search view finding nothing (spec V-5).
+						//
+						// #234: under `viewport` an empty listing no longer means an empty screen.
+						// A listing can come back empty for a frame the pool still has points in —
+						// rig-measured on live Russian Post, where one frame answered 0 after 16.9s
+						// while its neighbours answered 1500+. Printing "nothing here" over drawn
+						// markers is worse than printing nothing, so the message waits until the
+						// provider itself reports an empty frame. `bulk` keeps its old behaviour
+						// exactly: it has no frame-driven refetch to correct a wrong message later.
 						showFetchMessage( 'bulk' === config.strategy ? 'emptyLocality' : 'emptyInView' );
 					}
 
@@ -2775,6 +2795,7 @@
 			// stated invariant.
 			resetPointPool();
 			forgetPointDetails();
+			visibleGroupCount = 0;
 
 			// Task 16 (spec V-4): every start() — the initial open AND every retry — runs through
 			// the full "map drawn → points in flight → points in" sequence again, so the flag that
@@ -2826,6 +2847,13 @@
 					var groups = ( keys || [] )
 						.map( function( key ) { return groupsByKey[ key ]; } )
 						.filter( function( group ) { return !! group; } );
+
+					// #234: what the empty-frame message is decided from — see
+					// {@see visibleGroupCount}. Counted from the RAW keys, not the mapped
+					// groups: a key the mount cannot resolve still means the provider is
+					// drawing something there, and suppressing the message is the safe
+					// direction (a missing message beats a false one over a full map).
+					visibleGroupCount = ( keys || [] ).length;
 
 					panels.setVisible( groups );
 				} );

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1069,6 +1069,27 @@
 		 *  provider event's bare key/point-id back to the group object the panels need. */
 		var groupsByKey = {};
 
+		/**
+		 * #234 — the UNION of every listing this session, by `point.id`, under
+		 * `strategy: 'viewport'` ONLY. `bulk` fetches once and its listing is authoritative,
+		 * so it never reads or writes this.
+		 *
+		 * Why the pool lives HERE and not in the provider: `setPoints()`'s own docblock
+		 * already assigns cross-fetch de-duplication to the caller ("the caller is the one
+		 * that decides what the current full set is"), so accumulating is this file's job
+		 * and the provider contract is unchanged. That also keeps every other provider —
+		 * `map-provider-embedded.js` today, anything added later — free of it.
+		 *
+		 * Insertion order is meaningful: it is what {@see trimPointPool} evicts by when a
+		 * domain has bounded the pool. Plain object key order preserves insertion order for
+		 * string keys, which every `point.id` is coerced to on the way in.
+		 *
+		 * MUST be cleared together with the detail memo — see {@see resetPointPool}.
+		 *
+		 * @type {Object.<string, Object>}
+		 */
+		var pointPool = {};
+
 		/** @type {Array} the address suggestions from the LAST `searchResults` event — what
 		 *  `searchAddressPicked( index )` indexes into. */
 		var lastAddresses = [];
@@ -1649,6 +1670,80 @@
 			);
 		}
 
+		/**
+		 * The pooled points, in insertion order.
+		 *
+		 * @since 2.0.2
+		 * @returns {Array} never null.
+		 */
+		function poolValues() {
+			return Object.keys( pointPool ).map( function( id ) {
+				return pointPool[ id ];
+			} );
+		}
+
+		/**
+		 * Bounds the pool when the domain asked for a bound — filled in by Task 7.
+		 *
+		 * @since 2.0.2
+		 * @returns {void}
+		 */
+		function trimPointPool() {
+		}
+
+		/**
+		 * Merges one listing into the pool and returns the full set to draw (#234).
+		 *
+		 * THE LISTING WINS on conflict: it is the fresher carrier record. Whatever a detail
+		 * fetch already learned is re-applied AFTER grouping, from `detailsById`, so a sparse
+		 * re-merged record cannot erase it — that ordering is load-bearing, see
+		 * {@see fetchAndSetPoints}.
+		 *
+		 * A point with no `id` is passed through un-pooled rather than dropped: `id` is the
+		 * pool's whole identity and a record without one cannot be de-duplicated, but it is
+		 * still a point the carrier returned and the customer should see it.
+		 *
+		 * @since 2.0.2
+		 * @param {Array} points this listing's points.
+		 * @returns {Array} every point to draw.
+		 */
+		function mergeIntoPool( points ) {
+			var passthrough = [];
+
+			( points || [] ).forEach( function( point ) {
+				if ( ! point || null === point.id || undefined === point.id ) {
+					if ( point ) {
+						passthrough.push( point );
+					}
+
+					return;
+				}
+
+				pointPool[ String( point.id ) ] = point;
+			} );
+
+			trimPointPool();
+
+			return poolValues().concat( passthrough );
+		}
+
+		/**
+		 * Empties the pool.
+		 *
+		 * INVARIANT: every caller that clears the pool must also clear the detail memo, and
+		 * vice versa — {@see forgetPointDetails}. `geo.groupByPosition()` does not deep-copy,
+		 * so the detail fields re-applied in {@see fetchAndSetPoints} land on the pooled point
+		 * objects themselves; dropping `detailsById` while keeping the pool would strand those
+		 * fields with nothing left to re-derive them from, and dropping the pool while keeping
+		 * `detailsById` would re-apply a verdict computed against a cart that has since moved.
+		 *
+		 * @since 2.0.2
+		 * @returns {void}
+		 */
+		function resetPointPool() {
+			pointPool = {};
+		}
+
 		function fetchAndSetPoints( query ) {
 			bumpLoading();
 
@@ -1697,7 +1792,13 @@
 					// checkout update, and that arrives as {@see refresh} — which is where the
 					// memo is cleared now, via {@see forgetPointDetails}.
 
-					var groups = geo.groupByPosition( points );
+					// #234: under `viewport` the drawn set is the UNION of every listing this
+					// session, so the customer never loses points by zooming out and back. Under
+					// `bulk` there is one listing and it is authoritative — the pool is bypassed
+					// entirely rather than being a union of one, so `bulk` keeps its exact
+					// previous behaviour including "a later listing REPLACES the set".
+					var drawable = 'viewport' === config.strategy ? mergeIntoPool( points ) : points;
+					var groups = geo.groupByPosition( drawable );
 
 					// Re-apply what detail fetches already learned, BEFORE anything draws or
 					// renders these groups (#232). `geo.groupByPosition()` builds them from the
@@ -2628,6 +2729,12 @@
 
 			provider = new ProviderCtor();
 			lastBbox = null;
+
+			// #234: a retry rebuilds the provider from scratch, so the drawn set restarts
+			// from nothing too. Paired with forgetPointDetails() per resetPointPool()'s
+			// stated invariant.
+			resetPointPool();
+			forgetPointDetails();
 
 			// Task 16 (spec V-4): every start() — the initial open AND every retry — runs through
 			// the full "map drawn → points in flight → points in" sequence again, so the flag that

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1707,12 +1707,59 @@
 		}
 
 		/**
-		 * Bounds the pool when the domain asked for a bound — filled in by Task 7.
+		 * Bounds the pool to `config.maxAccumulatedPoints` when the domain asked for a bound
+		 * (#234). A missing/zero/negative value means UNLIMITED and this returns immediately —
+		 * that is the shipped default, and it is measured-safe rather than assumed: see the
+		 * design doc's measurement table.
+		 *
+		 * Evicts OLDEST-INSERTED first (plain object key order for string keys), skipping any
+		 * point the customer would notice losing:
+		 *
+		 *  - the current selection — the field's own value; losing it would strand the
+		 *    checkout on a point the map can no longer draw;
+		 *  - the open card's point — {@see cardPointId}; a card whose point vanished mid-read
+		 *    is the #232 defect wearing a different hat.
+		 *
+		 * "In frame" is deliberately NOT a third exemption: it would need a rectangle test of
+		 * our own, and the frame is exactly where a re-listing puts points back a moment later
+		 * anyway.
 		 *
 		 * @since 2.0.2
 		 * @returns {void}
 		 */
 		function trimPointPool() {
+			var max = parseInt( config.maxAccumulatedPoints, 10 );
+
+			if ( ! max || max < 1 ) {
+				return;
+			}
+
+			var ids = Object.keys( pointPool );
+			var over = ids.length - max;
+
+			if ( over < 1 ) {
+				return;
+			}
+
+			var selected = fieldValue( config.fieldId );
+			var protectedIds = {};
+
+			if ( selected ) {
+				protectedIds[ String( selected ) ] = true;
+			}
+
+			if ( cardPointId ) {
+				protectedIds[ String( cardPointId ) ] = true;
+			}
+
+			ids.forEach( function( id ) {
+				if ( over < 1 || Object.prototype.hasOwnProperty.call( protectedIds, id ) ) {
+					return;
+				}
+
+				delete pointPool[ id ];
+				over -= 1;
+			} );
 		}
 
 		/**

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -1233,12 +1233,41 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 				$this->plugin_id
 			);
 
+			/**
+			 * Caps how many points the browser accumulates across viewport listings (#234).
+			 *
+			 * `0` — the default — means UNLIMITED, which is measured-safe: with the pool at
+			 * 20 000 points a full redraw costs 334 ms against a listing that takes 6-13 s to
+			 * arrive, and the one superlinear operation in the map provider is reached only by
+			 * the `bulk` strategy. A realistic session over a whole region pools ~1 300 points.
+			 *
+			 * The knob exists because point DENSITY is domain knowledge, not framework
+			 * knowledge: a carrier far denser than Russian Post can bound the pool here
+			 * without any redesign. Ignored entirely by `strategy: 'bulk'`, which never
+			 * accumulates.
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param int    $max       0 for unlimited; a positive point count to bound the pool.
+			 * @param string $plugin_id the plugin the map belongs to.
+			 */
+			$max_accumulated = (int) apply_filters(
+				'woodev_pickup_max_accumulated_points',
+				0,
+				$this->plugin_id
+			);
+
+			// A negative bound is meaningless and must not reach the browser as one — it
+			// would read as "keep nothing", silently reinstating the very defect #234 fixed.
+			$max_accumulated = max( 0, $max_accumulated );
+
 			return [
-				'fieldId'  => $this->field_id,
-				'strategy' => $this->source->get_strategy(),
-				'provider' => $this->map_provider->get_id(),
-				'restRoot' => $this->rest_root(),
-				'nonce'    => wp_create_nonce( 'wp_rest' ),
+				'fieldId'              => $this->field_id,
+				'strategy'             => $this->source->get_strategy(),
+				'maxAccumulatedPoints' => $max_accumulated,
+				'provider'             => $this->map_provider->get_id(),
+				'restRoot'             => $this->rest_root(),
+				'nonce'                => wp_create_nonce( 'wp_rest' ),
 
 				// The DOM id of the refreshable nonce node (issue #157) — `nonce` above is
 				// only ever the PAGE-LOAD value and cannot be refreshed in place; see

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -1251,14 +1251,23 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 			 * @param int    $max       0 for unlimited; a positive point count to bound the pool.
 			 * @param string $plugin_id the plugin the map belongs to.
 			 */
-			$max_accumulated = (int) apply_filters(
+			$max_accumulated = apply_filters(
 				'woodev_pickup_max_accumulated_points',
 				0,
 				$this->plugin_id
 			);
 
+			// NON-NUMERIC RETURNS FALL BACK TO UNLIMITED RATHER THAN BEING CAST (adversarial
+			// review, 09.08.2026). A bare `(int)` cast turns a non-empty ARRAY into `1` — so a
+			// filter that mistakenly returns its whole settings structure (`[ 'max' => 500 ]`,
+			// an easy slip) would bound the pool to a SINGLE point and silently reinstate the
+			// defect #234 exists to fix, in its worst form. `is_numeric()` first means every
+			// such mistake lands on `0` (unlimited, the shipped default) instead: a filter
+			// nobody wrote correctly should change nothing, never impose a hostile bound.
+			$max_accumulated = is_numeric( $max_accumulated ) ? (int) $max_accumulated : 0;
+
 			// A negative bound is meaningless and must not reach the browser as one — it
-			// would read as "keep nothing", silently reinstating the very defect #234 fixed.
+			// would read as "keep nothing", silently reinstating the same defect.
 			$max_accumulated = max( 0, $max_accumulated );
 
 			return [


### PR DESCRIPTION
Closes #234

## Что и почему

Под `strategy: 'viewport'` каждый листинг ЗАМЕЩАЛ отрисованный набор: покупатель зумил +1, потом −1 в тот же кадр — и точек становилось меньше, чем он только что видел.

Накопление живёт в `pickup-mount.js` — в файле, который и так владеет загрузкой. **Контракт `Map_Provider` не тронут:** докблок `setPoints()` уже отдавал межзапросную дедупликацию вызывающему («the caller is the one that decides what the current full set is, including any cross-fetch de-duplication»). Карточка #234 утверждала обратное — это была ошибка в постановке, а не в коде. `bulk` не задет вовсе, `map-provider-embedded.js` не тронут.

Второе опасение карточки — «карта и список намеренно разойдутся» — тоже оказалось неверным: сайдбар это `_groupsInsideBounds(_groupsByKey)`, то есть пул ∩ кадр. Точка вне кадра не видна и на карте.

## Замерено на риге, живая Почта РФ

| пул | `setPoints()` | фильтр кадра | перегруппировка | память |
|---|---|---|---|---|
| 500 | 17 мс | 0.015 мс | 0.28 мс | 0.2 МБ |
| 5 000 | 44 мс | 0.065 мс | 2.3 мс | 2.2 МБ |
| 20 000 | 334 мс | 0.25 мс | 10.7 мс | 8.8 МБ |

Один листинг живого перевозчика идёт **6–13 с**, так что 334 мс отрисовки при 20 000 точек умещаются внутри него целиком. Реальное накопление: **1290** точек за полный тур по Москве и области, **4664** — за четыре соседние области на `MIN_ZOOM`. Единственная суперлинейная операция (`setTypeFilter`, 1017 мс при 20 000) на viewport-путь не попадает — она вызывается только в ветке `bulk`.

Поэтому **крышка по умолчанию не ставится**, но выведен фильтр `woodev_pickup_max_accumulated_points` (0 = без ограничения): плотность точек — знание домена, а не фреймворка.

## Проверка на риге (ветка этого PR, живая Почта)

- зум 14, узкий кадр: сервер вернул **31** точку, на карте осталось **350**, в сайдбаре **25** (только в кадре);
- зум 11, широкий кадр: листинг 882, нарисовано 881, в сайдбаре 300;
- зум +1 → −1 в исходный кадр: **348/348** точек на месте, в том числе СРАЗУ, не дожидаясь ответа сервера.

## Что нашёл критик до кода

Adversarial-ревью дизайна (Codex) дало две настоящие находки:

1. Утверждение «листинг побеждает при конфликте» было **ложным** — переналожение деталей после группировки намеренно перебивает его (#232). Спека теперь описывает оба слоя явно.
2. У сброса пула **не было генерационного барьера**: листинг, вылетевший до сброса, домердживал устаревшие точки в только что очищенный пул — навсегда, потому что из пула ничто не удаляется. Это задача 1b (`poolGeneration`).

## Побочные находки, заведены отдельно

- **#238** — `getSession()` не вызывается из продакшена, значит `forgetPointDetails()` из #232 — мёртвый код. Та же форма, что #219.
- **#237** — публичные доки не описывают ни одного фильтра пикапа.
- На `MIN_ZOOM` листинг упирается ровно в 2000 = `MAX_PAGES × PAGE_SIZE`: покупателю молча отдаётся урезанный набор. Накопление это смягчает, но не чинит.

## Тесты

**1517 unit / 797 jest / phpcs чисто / PHPStan чисто.** +17 тестов: объединение, дедупликация, три триггера сброса, генерационный барьер, типы из пула, сообщение о пустом кадре, крышка с защитой выбранной/открытой точки, восстановление выбора из пула без рефокуса камеры.

Спека: `docs-internal/specs/2026-08-09-sp5-viewport-point-accumulation-design.md`
План: `docs-internal/plans/2026-08-09-sp5-viewport-point-accumulation-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mux4YLJ1CrbjsBMR42VT4R