### PR TITLE
fix(pickup): убрать оверлей загрузки сайдбара на мобильном (#234 follow-up)

### DIFF
--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -2072,6 +2072,27 @@
 		border-radius: 0;
 	}
 
+	/* THE SIDEBAR'S OWN LOADING OVERLAY IS SUPPRESSED AT THIS WIDTH (#234 follow-up, operator
+	   09.08.2026). On desktop that overlay dims a 320px column beside a visible map. Here the
+	   panel owns the entire stage (see the rule above), so the same overlay dims the WHOLE
+	   SCREEN — rig-measured at 500x844: 500x796, 94% of the viewport, search box included, with
+	   a spinner floating in the middle of a page the customer can no longer read.
+
+	   Nothing replaces it because nothing needs to: `.woodev-pickup-progress` is already a 3px
+	   strip along the top edge of the stage at `z-index: 7`, above the list's own `z-index: 2`,
+	   and it is shown for ANY background load (#222/#224). At this width the panel starts at the
+	   same y as the map, so that strip lands exactly on the sidebar's top edge with no new
+	   element and no new state — measured on the rig at x0 y48 500x3 while the list was open.
+
+   	   Same selector as the ACTIVE rule it overrides, relying on source order rather than a
+	   specificity bump: this file's own convention is that `display` inside
+	   `.woodev-pickup-stage` is an `!important`-only property (gotcha
+	   `hostile-theme-button-display-none-needs-important`, s54 addendum), and between two
+	   equally-specific `!important` declarations the later one wins. */
+	.woodev-pickup-stage.is-loading.is-open:not( .is-card ) .woodev-pickup-list__loading {
+		display: none !important;
+	}
+
 	/* Room for the bar below, so the last row can scroll clear of it instead of hiding under it —
 	   the panel is `bottom: 0` now and the bar floats over its own bottom edge. The reference
 	   reserves the same way (`.drawer-control__drawer { padding-bottom: 28px }`,


### PR DESCRIPTION
⚠️ **НУЖНА РУЧНАЯ ПРОВЕРКА ОПЕРАТОРА** — это чисто визуальное решение, не мерджу без твоего слова.

## Что было

На десктопе оверлей загрузки гасит колонку 320px рядом с видимой картой. На мобильном панель занимает всю сцену (#168), поэтому тот же оверлей гасил **весь экран**. Замер на риге при 500×844: оверлей 500×796 — **94% вьюпорта**, вместе с полем поиска, со спиннером посреди страницы, которую покупатель уже не может прочитать.

## Что стало

Оверлей на этой ширине не показывается вовсе. Замены не потребовалось: `.woodev-pickup-progress` — уже полоска 3px по верхней кромке сцены с `z-index: 7` над списком (`z-index: 2`), и она показывается на ЛЮБУЮ фоновую загрузку (#222/#224). На мобильном панель начинается на том же `y`, что и карта, поэтому полоска и так ложится ровно на верхнюю кромку сайдбара — замерено на риге: `x0 y48 500×3` при открытом списке. Твой выбор от 09.08.2026.

Селектор тот же, что у перебиваемого активного правила — расчёт на порядок в файле, а не на утяжеление специфичности: в этом файле `display` внутри `.woodev-pickup-stage` считается свойством только с `!important` (готча `hostile-theme-button-display-none-needs-important`, дополнение s54).

## Проверено на риге, живая Почта, 500×844

- оверлей исчез, список читается во время дозагрузки, полоска прогресса идёт;
- **совмещённая группа**: два таба «Почтомат 1» / «Почтомат 2» по 231–235px — помещаются;
- **замок CTA**: «Проверяем доступность…» 468×40 — не переполняет;
- заодно закрыта непроверенная половина **#233**: постамат живьём при «Оплате при получении» отдаёт «В этом пункте выдачи недоступна оплата при получении», CTA заблокирована; переключение таба немедленно уводит CTA в «Проверяем доступность…», то есть догрузка второй точки группы работает.

## Замечание, менять не стал

На мобильном между «Часами работы» и плашкой отказа зияет большая пустота — следствие панели во всю высоту при малом содержимом. Это вкусовое, решай сам.

**1514 unit / 781 jest / phpcs чисто** (базовые числа `main`: ветка от `main`, без работы #234).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mux4YLJ1CrbjsBMR42VT4R