### PR TITLE
fix(shipping): wire #232 cart-change verdict invalidation to a real signal (#238)

### DIFF
--- a/docs-internal/GOTCHAS.md
+++ b/docs-internal/GOTCHAS.md
@@ -1,6 +1,13 @@
 # Gotchas — Woodev Plugin Framework
-> **115 atomic gotchas, 21 namespaces (27 index sections)** — update when adding/removing.
-> Last updated: 2026-08-09 (session 60, docs audit + rig source switches: +1 file, existing
+> **116 atomic gotchas, 21 namespaces (27 index sections)** — update when adding/removing.
+> Last updated: 2026-08-10 (session 62, #238 rig verification: +1 file, existing namespace
+> `[build/*]` — `modal-script-versioned-by-version-constant-not-filemtime` (`woodev-modal.js` is
+> registered with the raw `self::VERSION`, not `get_assets_version()`, so editing it never busts
+> the browser cache between releases — while its own stylesheet three lines below IS versioned by
+> `filemtime()` and states the rule in a comment. The rule was written down for one half of a
+> shared handle and not applied to the other. Cost a false verification signal: `isOpen()` was in
+> the file on disk and absent on the running prototype, so a working fix read as broken).
+> Prior: 2026-08-09 (session 60, docs audit + rig source switches: +1 file, existing
 > namespace `[testing/integration]` — `wpenv-resolves-environment-from-cwd` (wp-env hashes the
 > config found from the CURRENT WORKING DIRECTORY; any `npx wp-env run` from a subdirectory fails
 > with "Environment not initialized" while the containers are up. This was the real cause behind
@@ -214,6 +221,7 @@
 - [build/ci] A PR that conflicts with base (`mergeStateStatus: DIRTY`) runs NO `pull_request` CI — only `pull_request_target`; "all green" can mean the matrix never ran. Check `gh pr view --json mergeable,mergeStateStatus`; rebase onto the new base after a squash-merge → [gotchas/pr-conflict-skips-pull-request-ci.md](gotchas/pr-conflict-skips-pull-request-ci.md) (session 2)
 - [build/js] `@wordpress/scripts` default (automatic) JSX runtime depends on the `react-jsx-runtime` script handle — registered only in WP ≥ 6.6; for WP 6.3+ support force the classic runtime via `babel.config.js` and import `createElement`/`Fragment` in every JSX file → [gotchas/wp-scripts-jsx-runtime-wp66.md](gotchas/wp-scripts-jsx-runtime-wp66.md) (s8)
 - [build/assets-eol] Rebuilding the license-page bundle on Windows can commit CRLF while Linux CI rebuilds LF → "Assets build parity" fails on identical content. `.gitattributes` pins `woodev/assets/build/** text eol=lf` → [gotchas/build-artifacts-eol-lf-windows-parity.md](gotchas/build-artifacts-eol-lf-windows-parity.md) (s14)
+- [build/assets-version] `woodev-modal.js` is registered with the raw `self::VERSION` constant, not `get_assets_version()` — so editing it NEVER busts the browser cache between releases, while its own stylesheet three lines below IS versioned by `filemtime()` and carries the correct rule in a comment. Cost a false verification signal in s62: `isOpen()` was present in the file on disk and absent on the running prototype, and the fix looked broken. In production a patched modal ships stale to every returning visitor unless `Woodev_Plugin::VERSION` moves. Tell: a runtime symbol missing while a `cache: 'no-store'` fetch of the same URL has it → reload ignoring cache before debugging the source → [gotchas/modal-script-versioned-by-version-constant-not-filemtime.md](gotchas/modal-script-versioned-by-version-constant-not-filemtime.md) (s62)
 - [build/css-enqueue-version] wp-scripts emits `style-index.css` separately from `index.js`; enqueuing CSS with the JS bundle's `index.asset.php` hash means SCSS-only rebuilds never bust the browser cache — version the stylesheet by its own `filemtime` → [gotchas/wp-scripts-css-enqueue-version-by-mtime.md](gotchas/wp-scripts-css-enqueue-version-by-mtime.md) (s31)
 
 ### [admin-ui/*] — Admin pages / React UI

--- a/docs-internal/gotchas/modal-script-versioned-by-version-constant-not-filemtime.md
+++ b/docs-internal/gotchas/modal-script-versioned-by-version-constant-not-filemtime.md
@@ -1,0 +1,96 @@
+# `woodev-modal.js` is versioned by `self::VERSION`, so editing it never busts the browser cache
+
+**Namespace:** `[build/assets-version]`
+**Found:** s62 (2026-08-10), during the rig verification of #238.
+
+## What happened
+
+The #238 rig pass opened the pickup picker and asked the live session for its modal state:
+
+```js
+window.WoodevPickupMount.getSession( 'carrier_pickup_point' ).modal.isOpen()
+// TypeError: s.modal.isOpen is not a function
+```
+
+`isOpen()` had been added to `woodev-modal.js` on the branch the rig was serving, and the file
+on disk demonstrably contained it:
+
+```js
+{ protoHasIsOpen: "undefined",            // what the running page had
+  fetched: { hasIsOpenInFile: true } }    // what a no-store fetch of the same URL returned
+```
+
+The browser was running a **cached copy from a previous session**. A reload with
+`ignoreCache: true` fixed it instantly and `protoHasIsOpen` became `"function"`.
+
+## Root cause
+
+`Woodev_Plugin::frontend_enqueue_scripts()` registers the script with the raw constant:
+
+```php
+wp_register_script(
+    'woodev-modal',
+    $this->get_framework_assets_url() . '/js/frontend/woodev-modal.js',
+    [],
+    self::VERSION          // ← never changes between releases
+);
+```
+
+Three lines below, the modal's **stylesheet** — the other half of the same shared
+`woodev-modal` handle — is versioned by `filemtime()`, and the comment there states the rule
+correctly:
+
+> Versioned by the file's own `filemtime()`, not `self::VERSION`: a CSS-only tweak must bust
+> the browser cache on its own
+
+The rule was written down for the CSS and not applied to the JS sitting immediately above it.
+
+Everything else in the framework goes through `Woodev_Plugin::get_assets_version()`, which
+returns `time()` under `SCRIPT_DEBUG`/`WP_DEBUG` and the version otherwise — so every other
+asset busts in development. This one file does not.
+
+## Why it bites twice
+
+- **On the rig / in development:** any edit to `woodev-modal.js` is invisible to a browser that
+  has loaded the page before. Nothing errors, nothing warns — the page simply runs the old file.
+  Verification then reports a defect that does not exist, or (worse) reports a fix as working
+  when the browser is running the old code that happened to behave the same way.
+- **In production:** the framework's `VERSION` only moves on a release. A plugin shipping a
+  patched `woodev-modal.js` without bumping `Woodev_Plugin::VERSION` serves the stale script to
+  every returning visitor.
+
+## ❌ Wrong
+
+```php
+wp_register_script( 'woodev-modal', $url . '/js/frontend/woodev-modal.js', [], self::VERSION );
+```
+
+## ✅ Correct
+
+```php
+wp_register_script( 'woodev-modal', $url . '/js/frontend/woodev-modal.js', [], $this->get_assets_version() );
+```
+
+`get_assets_version()` already carries the debug-mode `time()` branch, so this both fixes the
+development trap and keeps the release behaviour identical for an unchanged file.
+
+## How to notice it next time
+
+A runtime symbol missing while the file on disk has it is the tell. Confirm in one call before
+suspecting the code:
+
+```js
+await ( await fetch( scriptUrl, { cache: 'no-store' } ) ).text()  // what is on disk
+typeof window.WoodevModal.prototype.isOpen                        // what is running
+```
+
+If those disagree, reload with cache ignored — do not start debugging the source.
+
+## Related
+
+- [wp-scripts-css-enqueue-version-by-mtime.md](wp-scripts-css-enqueue-version-by-mtime.md) — the
+  same class of bug for `style-index.css`, and where the `filemtime()` rule came from.
+- [rig-serves-the-working-tree-branch-switch-reverts-fixes.md](rig-serves-the-working-tree-branch-switch-reverts-fixes.md)
+  — the other reason the rig can be running code you did not expect.
+- [chrome-devtools-png-cache-stale] (s105, woodev-theme) — the same cache trap for a re-generated
+  PNG at an unchanged `file://` URL.

--- a/docs-internal/specs/2026-08-09-238-cart-change-verdict-invalidation.md
+++ b/docs-internal/specs/2026-08-09-238-cart-change-verdict-invalidation.md
@@ -3,6 +3,13 @@
 > Written s61 (2026-08-09). Supersedes the framing in issue #238 on two points — see
 > "Where the card is wrong" below. Design decisions here are grounded in a code sweep
 > (agent report, s61); every claim carries a `file:line` in the issue thread or below.
+>
+> **§3 WAS WRONG AND IS SUPERSEDED (s62, 2026-08-10).** The implementation matched this spec
+> exactly and a spec-compliance review returned "COMPLIANT, zero findings" — then a Codex pass
+> on the same code returned two HIGH defects, both inherent to the MECHANISM §3 chose, not to
+> how it was carried out. §3 is rewritten below; the rest of the document still stands. The
+> lesson is recorded because it generalises: conformance to a spec is not correctness, and a
+> compliance review cannot find a defect the spec itself specified.
 
 ## The defect
 
@@ -73,17 +80,53 @@ flight" state is the `refreshWaiter`/`refreshTimer`/`refreshBusyPanels` closure 
 (`pickup-mount.js:1238-1251`), and the object `getSession()` returns is only
 `{ modal, refresh, destroy }` (`pickup-mount.js:3130-3170`).
 
-**Mechanism: a one-shot echo token per session.** `refreshCheckout()` sets it when it triggers
-`update_checkout`; the module subscriber **consumes** it (reads and clears) and skips that session
-for that event. One-shot, so a genuine later cart change is not swallowed.
+**Mechanism (s62, corrected): read the session's existing in-flight state. No token.**
+`refreshCheckout()` already arms `refreshWaiter`/`refreshTimer` at the moment it triggers
+`update_checkout`, and `dropRefreshWaiter()` settles them on *every* path — WooCommerce
+answering, `REFRESH_TIMEOUT_MS` expiring, a newer refresh superseding this one, `destroy()`.
+`isSelfRefreshInFlight()` is a read-only predicate over that state, with no lifetime of its own.
+The module subscriber calls it per session, at event time.
 
-Do **not** implement suppression by checking `refreshWaiter !== null` at debounce-fire time: our
-module handler is bound at load, before any session's `one()` waiter, so it runs first — but the
-debounced body runs *after* the waiter has already self-cleared, and the check would read `null`
-and fail to suppress. The decision must be captured at event time, not at fire time.
+Read it **at event time, inside `handleCartChanged()`**, never in the debounced body — the
+original §3 was right about that and the reasoning is unchanged: our module handler is bound at
+load, before any session's `one()` waiter, so jQuery runs it first while the waiter is still
+outstanding; by the time the debounce fires, that waiter has settled and the state reads the same
+for an echo as for a genuine change. The binding order is invisible at the call site and is
+commented in the source for exactly that reason.
+
+**Why the one-shot token this replaced was wrong** (both found by Codex, s61):
+
+- **H1** — a bare boolean is not tied to the request that set it, so it consumed whichever
+  `updated_checkout` arrived first, whatever its origin.
+- **H2** — nothing cleared it when WooCommerce never answered at all, so it stayed armed for as
+  long as the picker stayed open and silently ate that session's next genuine cart change. The
+  file's own docblock already stated the governing fact — a `one()` self-cleans only if the event
+  fires, which is why *that* waiter is paired with `REFRESH_TIMEOUT_MS`. The token was given no
+  such pairing.
+
+**H1 is downgraded, not eliminated, and that is accepted.** An `updated_checkout` carries no
+origin; no design can separate our echo from a foreign change at the DOM. What the fix guarantees
+is the *window*: suppression lasts exactly as long as our refresh is outstanding, and the first
+event settles it either way. A foreign change landing inside the window costs one event of delay
+— a cart change always produces an `updated_checkout` — and is never dropped.
+
+**Verification note (s62):** H2 is independently observable and its regression test fails on the
+pre-fix commit (`5f0d4c8`). H1 is **not** independently observable — measured, not assumed: the
+scenario the s61 handoff proposed for it produces exactly one refresh under both the old and the
+new mechanism. Its test is therefore a characterisation test pinning "delay, not loss"; it passes
+on both. H1's fix is structural — the flag can no longer outlive the request that armed it — and
+is what the H2 test proves.
 
 Also note `refreshCheckout()` binds its waiter only when the modal stays open; when a selection
 closes the modal, `closeSession()` has already removed the session, so there is nothing to suppress.
+
+**One real gap, verified and accepted (s62).** `refreshCheckout()` is handed `panels`, which is
+`null` under `ownsChrome` — so an embedded provider triggers `update_checkout` with the modal open
+and **no waiter bound**, and its echo is not suppressed. Harmless only because `refresh()` is
+itself a no-op under `ownsChrome` (`pickup-mount.js`, `refresh()`'s first guard): the unsuppressed
+event reaches a function that does nothing. Recorded in the source so a future `ownsChrome`
+behaviour in `refresh()` does not silently turn this into a live defect. This path has never been
+rig-run at all — tracked separately.
 
 ## Out of scope — file as a separate card, do not fix here
 

--- a/docs-internal/specs/2026-08-09-238-cart-change-verdict-invalidation.md
+++ b/docs-internal/specs/2026-08-09-238-cart-change-verdict-invalidation.md
@@ -1,0 +1,113 @@
+# Spec — #238: wire cart-change verdict invalidation to a real cart-change signal
+
+> Written s61 (2026-08-09). Supersedes the framing in issue #238 on two points — see
+> "Where the card is wrong" below. Design decisions here are grounded in a code sweep
+> (agent report, s61); every claim carries a `file:line` in the issue thread or below.
+
+## The defect
+
+`forgetPointDetails()` — the whole cart-change verdict invalidation built for #232 — is
+called from exactly one place, `refresh()` (`pickup-mount.js:3114`). `refresh()` is reachable
+only through `getSession()`, which has **zero production callers**. So the invalidation has
+never run in production.
+
+## Where the card is wrong
+
+1. **`getSession()` is not dead code to be deleted.** It is a deliberate extension point
+   (Task 20), documented at `pickup-mount.js:222-228` as the hook external code — e.g. a
+   payment-method-change listener — uses to reach `refresh()` without this file knowing
+   anything about payment methods. Project rule: a hook without a consumer yet is not a
+   YAGNI argument for removal. It stays.
+
+2. **"Sessions only exist while the modal is open" is false**, and this is the fact that
+   decides the design. `handleModalClosed()` (`pickup-mount.js:2511-2517`) calls only
+   `invalidateSelection()`. A modal dismissed via Escape / backdrop / close button leaves the
+   entry in `sessions`, leaves `destroyed === false`, and leaves `panels`/`provider` alive with
+   their DOM detached. Entries are removed **only** by `closeSession()`, called from just two
+   sites: the next trigger click (`pickup-mount.js:3203`) and a selection that successfully
+   closed the modal (`pickup-mount.js:2379-2381`).
+
+   Consequence: a naive `updated_checkout` → "refresh every session" subscriber would fire live
+   carrier requests for pickers the customer had already dismissed — invisible, and against the
+   merchant's quota. This is the storm the card feared, arriving by a route the card did not name.
+
+## What actually needs to happen
+
+A dismissed session needs **nothing**: the next trigger click calls `closeSession()` then
+`openSession()` (`pickup-mount.js:3201-3205`), rebuilding everything from scratch. So the
+exposure is exactly the card's stated window — the cart changing while the picker is **open**.
+
+Therefore: on `updated_checkout`, refresh only sessions whose modal is **currently open**.
+
+## Design
+
+### 1. `WoodevModal.prototype.isOpen()`
+
+`woodev-modal.js` tracks `_isOpen` privately (`:261`, `:347`, `:373`, `:402`) with no public
+accessor. Add one — a trivial `return this._isOpen;` getter. Reaching into `session.modal._isOpen`
+from `pickup-mount.js` instead would couple this file to a private; the modal shell is framework
+mechanism and an open-state query is a legitimate part of its contract.
+
+### 2. A second `updated_checkout` subscriber, module scope
+
+Registered next to the existing one (`pickup-mount.js:3243`, which does `mountAll` only, deferred
+60ms). Walks `sessions` and calls `refresh()` on each session whose modal reports open.
+
+**Debounced.** `updated_checkout` fires in bursts on a live checkout. `pickup-datasource.js`'s own
+300ms trailing debounce (`:80`, `:468-479`) collapses the resulting *network* calls, but not the
+pool resets: `refresh()` has no reentrancy guard, so each call independently runs
+`forgetPointDetails()` + `resetPointPool()` and bumps `poolGeneration` (research C.11). Debounce on
+our side, at module scope.
+
+### 3. Echo suppression — the trap the card did not see
+
+This file's own selection flow causes the very event we are subscribing to.
+`refreshCheckout()` (`pickup-mount.js:2443`) does
+`window.jQuery( document.body ).trigger( 'update_checkout' )`; WooCommerce answers asynchronously
+with `updated_checkout` on the same node. Without suppression, confirming a point in a picker that
+stays open (`selection.close === false`) would immediately wipe the pool and refetch — destroying
+the result the customer just produced, on every single selection.
+
+No existing suppressor is reachable from module scope: the per-session "a refresh we caused is in
+flight" state is the `refreshWaiter`/`refreshTimer`/`refreshBusyPanels` closure variables
+(`pickup-mount.js:1238-1251`), and the object `getSession()` returns is only
+`{ modal, refresh, destroy }` (`pickup-mount.js:3130-3170`).
+
+**Mechanism: a one-shot echo token per session.** `refreshCheckout()` sets it when it triggers
+`update_checkout`; the module subscriber **consumes** it (reads and clears) and skips that session
+for that event. One-shot, so a genuine later cart change is not swallowed.
+
+Do **not** implement suppression by checking `refreshWaiter !== null` at debounce-fire time: our
+module handler is bound at load, before any session's `one()` waiter, so it runs first — but the
+debounced body runs *after* the waiter has already self-cleared, and the check would read `null`
+and fail to suppress. The decision must be captured at event time, not at fire time.
+
+Also note `refreshCheckout()` binds its waiter only when the modal stays open; when a selection
+closes the modal, `closeSession()` has already removed the session, so there is nothing to suppress.
+
+## Out of scope — file as a separate card, do not fix here
+
+Under `viewport`, `refresh()` runs `forgetPointDetails()` + `resetPointPool()` **unconditionally**
+but only refetches when `lastBbox` is non-null (`pickup-mount.js:3117-3125`). With `lastBbox === null`
+the pool and detail memo are wiped with nothing scheduled to repopulate them until the next
+`boundsChange`. Pre-existing, independent of this change.
+
+## Tests
+
+- an open picker + `updated_checkout` → that session's details are forgotten and a refetch runs
+- a **dismissed** picker (modal closed, session still registered) + `updated_checkout` → **no**
+  network call, no pool reset. This is the regression the whole design exists to prevent
+- a burst of `updated_checkout` events collapses to one refresh
+- a selection that keeps the modal open → the resulting echo does **not** refresh that session
+- a genuine cart change *after* that echo **does** refresh it (proves the token is one-shot)
+- `isOpen()` on the modal: false before open, true while open, false after close
+
+The suite has no real jQuery (`tests/js/pickup-mount.test.js:26-29`), so `onCheckoutUpdated` falls
+back to a native event and tests fire `document.body.dispatchEvent( new Event( 'updated_checkout' ) )`
+(`:1055-1066`). `openPicker()` installs a jQuery double recording `.one()`/`.off()`/`.trigger()`
+(`:869-874`) — that double is what an echo test drives.
+
+## Related
+
+- #232 (introduced `forgetPointDetails()`), #234 (surfaced this), #219 (same shape)
+- Gotcha `built-on-both-sides-with-no-caller-in-the-middle` — this is its s59 addendum, now fixed

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -1776,12 +1776,10 @@ test( 'bulk is unaffected — its listing still REPLACES the drawn set', async (
 
 	const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
 
-	// bulk's second fetch can only come from refresh() — dispatching `updated_checkout` on
-	// `document.body` alone does NOT call it. Verified against the source: refresh() is an
-	// EXTERNAL hook exposed only via getSession() (see the file docblock, "the hook a
-	// payment-method change elsewhere on the page uses"), nothing in this file wires it to
-	// the `updated_checkout` DOM event itself, and every existing refresh() test in this
-	// file invokes it the same way.
+	// This test's subject is the UNION/replace behaviour itself, not the `updated_checkout`
+	// wiring — driving refresh() directly, like every other refresh() test in this file,
+	// keeps it isolated from the cart-change subscriber's debounce/echo-suppression timing
+	// (that subscriber has its own describe block, #238).
 	await getSession( FIELD_ID ).refresh();
 
 	const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
@@ -1930,9 +1928,10 @@ test( '#234 invariant: refresh() clears the pool AND the details memo in ONE cal
 	} );
 	await flushAsync();
 
-	// The cart changes. NOTE: `updated_checkout` does NOT reach refresh() — this file wires
-	// that event to mountAll() only, and getSession() has no production caller at all (#238).
-	// Every existing refresh() test in this file drives it directly, and so does this one.
+	// The cart changes. This test's subject is refresh()'s own pool/memo invariant, not the
+	// `updated_checkout` wiring (that is the "cart-change verdict invalidation" describe
+	// block, #238) — driving refresh() directly here, like every other refresh() test in
+	// this file, keeps it isolated from that subscriber's debounce/echo-suppression timing.
 	await window.WoodevPickupMount.getSession( FIELD_ID ).refresh();
 	await flushAsync();
 
@@ -5062,5 +5061,176 @@ describe( 'restoring a previous selection', () => {
 
 		expect( provider.setPointsOptions ).toEqual( [ { focus: g2.key }, null ] );
 		expect( panels.openCardCalls ).toBe( 1 );
+	} );
+} );
+
+// -------------------------------------------------------------------------
+// #238 — the cart-change verdict invalidation built for #232 wired to a REAL signal: a
+// second, module-scope `updated_checkout` subscriber (alongside the mountAll() one) walks
+// `sessions` and calls `refresh()` on whichever ones report their modal OPEN
+// ({@see WoodevModal#isOpen}). Debounced (a burst collapses to one refresh per session), and
+// echo-suppressed (this file's OWN refreshCheckout()-triggered `update_checkout` must not
+// refetch the picker the customer just used it to confirm).
+// -------------------------------------------------------------------------
+
+describe( 'cart-change verdict invalidation wired to updated_checkout (#238)', () => {
+	test( 'an OPEN session forgets memoized details and refetches on updated_checkout', async () => {
+		const listings = [
+			[ point( { id: 'A' } ) ],
+			[ point( { id: 'B' } ) ],
+		];
+		let call = 0;
+		const fetchPoints = jest.fn( () => Promise.resolve( listings[ call++ ] || [] ) );
+		window.WoodevPickupDataSource = fakeDataSourceFactory( fetchPoints );
+		window.WoodevPickupDataSource.fetchDetails = () =>
+			Promise.resolve( point( { id: 'A', work_time: 'из деталей' } ) );
+
+		setConfig( makeConfig( { strategy: 'bulk' } ) );
+		mountAll();
+		clickTrigger();
+		await flushAsync();
+
+		const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+		const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+		expect( getSession( FIELD_ID ).modal.isOpen() ).toBe( true );
+
+		// Learn a detail for A, so the memo is demonstrably non-empty — same setup as the
+		// #234 invariant test above, which drives refresh() directly; this test drives it
+		// through the real `updated_checkout` signal instead.
+		panels.emit( 'cardOpened', {
+			group: provider.setPointsCalls[ provider.setPointsCalls.length - 1 ][ 0 ],
+			pointId: 'A',
+			origin: 'list',
+		} );
+		await flushAsync();
+
+		expect( fetchPoints ).toHaveBeenCalledTimes( 1 );
+
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		expect( fetchPoints ).toHaveBeenCalledTimes( 2 );
+
+		const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ];
+		const all = drawn.reduce( ( acc, group ) => acc.concat( group.points ), [] );
+
+		// Pool cleared: only the refresh listing's own point is drawn.
+		expect( all.map( ( p ) => p.id ) ).toEqual( [ 'B' ] );
+		// Memo cleared: nothing carries the stale detail field.
+		expect( all.some( ( p ) => 'из деталей' === p.work_time ) ).toBe( false );
+	} );
+
+	test( 'a DISMISSED session (modal closed, still registered) gets NO network call and NO '
+		+ 'pool reset on updated_checkout — the regression this design exists to prevent', async () => {
+		const fetchPoints = jest.fn( () => Promise.resolve( [ point( { id: 'A' } ) ] ) );
+		window.WoodevPickupDataSource = fakeDataSourceFactory( fetchPoints );
+
+		setConfig( makeConfig( { strategy: 'bulk' } ) );
+		mountAll();
+		clickTrigger();
+		await flushAsync();
+
+		const session = getSession( FIELD_ID );
+		expect( session.modal.isOpen() ).toBe( true );
+
+		// Dismissed via Escape/backdrop/close button — handleModalClosed() runs ONLY
+		// invalidateSelection() (see the file docblock and the #238 spec): the session stays
+		// registered, `destroyed` stays false, until the next trigger click.
+		session.modal.close( 'escape' );
+
+		expect( session.modal.isOpen() ).toBe( false );
+		expect( getSession( FIELD_ID ) ).toBe( session ); // still registered, not torn down
+		expect( fetchPoints ).toHaveBeenCalledTimes( 1 ); // the opening fetch only, so far
+
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		// No refetch AT ALL. `refresh()` is the ONLY thing that would forget the memo/pool, so
+		// proving it never ran proves both halves of "no network call, no pool reset" at once.
+		expect( fetchPoints ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'a burst of updated_checkout events collapses into ONE refresh per session', async () => {
+		const listings = [
+			[ point( { id: 'A' } ) ],
+			[ point( { id: 'B' } ) ],
+			[ point( { id: 'C' } ) ],
+		];
+		let call = 0;
+		const fetchPoints = jest.fn( () => Promise.resolve( listings[ call++ ] || [] ) );
+		window.WoodevPickupDataSource = fakeDataSourceFactory( fetchPoints );
+
+		setConfig( makeConfig( { strategy: 'bulk' } ) );
+		mountAll();
+		clickTrigger();
+		await flushAsync();
+
+		expect( fetchPoints ).toHaveBeenCalledTimes( 1 );
+
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 50 );
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 50 );
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		// Three raw events, but the pool-reset-and-refetch work refresh() does only ran ONCE —
+		// the debounce's whole job (`refresh()` has no reentrancy guard of its own).
+		expect( fetchPoints ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'a selection that keeps the modal open — the resulting update_checkout echo does '
+		+ 'NOT refresh that session', async () => {
+		const { provider, emitSelect, resolveSelect } = openPicker( {
+			selection: { close: false, refreshCheckout: true },
+		} );
+		await flushAsync();
+
+		const callsBefore = provider.setPointsCalls.length;
+
+		emitSelect( { id: 'P1' } );
+		await resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
+
+		// WooCommerce's asynchronous answer to the `update_checkout` refreshCheckout() just
+		// triggered — the SAME `updated_checkout` this file's own cart-change subscriber
+		// listens for (see the jq double's `.trigger()` recording `update_checkout`, distinct
+		// from the `updated_checkout` WooCommerce answers with).
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		expect( provider.setPointsCalls.length ).toBe( callsBefore );
+	} );
+
+	test( 'a genuine cart change AFTER that echo still refreshes — the token is one-shot, not '
+		+ 'a permanent mute', async () => {
+		const { provider, emitSelect, resolveSelect } = openPicker( {
+			selection: { close: false, refreshCheckout: true },
+		} );
+		await flushAsync();
+
+		const callsBefore = provider.setPointsCalls.length;
+
+		emitSelect( { id: 'P1' } );
+		await resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
+
+		// The echo — consumed and suppressed, exactly like the previous test.
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		expect( provider.setPointsCalls.length ).toBe( callsBefore );
+
+		// A SECOND, genuine `updated_checkout` — nothing of this file's own caused it. The
+		// echo token was already consumed by the first event, so this one is not swallowed.
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		expect( provider.setPointsCalls.length ).toBe( callsBefore + 1 );
 	} );
 } );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -868,8 +868,24 @@ function openPicker( overrides ) {
 	// WooCommerce ever answers (a `one()` that never fires never cleans itself up).
 	const jq = { triggered: [], one: [], off: [] };
 	window.jQuery = () => ( {
-		one: ( type, handler ) => jq.one.push( { type, handler } ),
-		off: ( type, handler ) => jq.off.push( { type, handler } ),
+		one: ( type, handler ) => {
+			jq.one.push( { type, handler } );
+
+			// Recorded AND bound for real (#238). `handleCartChanged` decides echo suppression
+			// by reading whether this session's own checkout refresh is still in flight, and
+			// the thing that ends that flight is THIS waiter firing. A double that only
+			// records would leave it pending forever, so every test that dispatches
+			// `updated_checkout` would silently be testing a page WooCommerce never answered
+			// on. Bound AFTER the module subscriber — that one registered at import time — so
+			// dispatch order here matches jQuery's bind order in production, which is what
+			// makes the event-time read see a waiter the debounced body no longer would.
+			jqBoundListeners.push( { type, handler } );
+			document.body.addEventListener( type, handler, { once: true } );
+		},
+		off: ( type, handler ) => {
+			jq.off.push( { type, handler } );
+			document.body.removeEventListener( type, handler );
+		},
 		trigger: ( type ) => jq.triggered.push( type ),
 	} );
 
@@ -992,6 +1008,17 @@ function openPicker( overrides ) {
  */
 let dataSourceFactory;
 
+/**
+ * Every listener {@see openPicker}'s jQuery double bound on `document.body` — cleared in
+ * `afterEach`, because `document.body.innerHTML = ''` removes the DOM under the body, never
+ * listeners on the body itself. A waiter left pending when a test ends (WooCommerce never
+ * answered, the session never torn down) would otherwise survive into a LATER test and fire
+ * there against a dead session.
+ *
+ * @type {Array<{type: string, handler: Function}>}
+ */
+let jqBoundListeners = [];
+
 beforeEach( () => {
 	StubProvider.instances = [];
 	StubPanels.instances = [];
@@ -1004,6 +1031,8 @@ beforeEach( () => {
 } );
 
 afterEach( () => {
+	jqBoundListeners.forEach( ( { type, handler } ) => document.body.removeEventListener( type, handler ) );
+	jqBoundListeners = [];
 	document.body.innerHTML = '';
 	delete window.woodev_pickup_config_p;
 	delete window.WoodevPickupMapProviders;
@@ -5206,8 +5235,8 @@ describe( 'cart-change verdict invalidation wired to updated_checkout (#238)', (
 		expect( provider.setPointsCalls.length ).toBe( callsBefore );
 	} );
 
-	test( 'a genuine cart change AFTER that echo still refreshes — the token is one-shot, not '
-		+ 'a permanent mute', async () => {
+	test( 'a genuine cart change AFTER that echo still refreshes — suppression ends with the '
+		+ 'refresh that opened it, it is not a permanent mute', async () => {
 		const { provider, emitSelect, resolveSelect } = openPicker( {
 			selection: { close: false, refreshCheckout: true },
 		} );
@@ -5218,15 +5247,93 @@ describe( 'cart-change verdict invalidation wired to updated_checkout (#238)', (
 		emitSelect( { id: 'P1' } );
 		await resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
 
-		// The echo — consumed and suppressed, exactly like the previous test.
+		// The echo — suppressed, exactly like the previous test.
 		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
 		jest.advanceTimersByTime( 1000 );
 		await flushAsync();
 
 		expect( provider.setPointsCalls.length ).toBe( callsBefore );
 
-		// A SECOND, genuine `updated_checkout` — nothing of this file's own caused it. The
-		// echo token was already consumed by the first event, so this one is not swallowed.
+		// A SECOND, genuine `updated_checkout` — nothing of this file's own caused it. Our own
+		// refresh settled on the first event, so the suppression window is already shut.
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		expect( provider.setPointsCalls.length ).toBe( callsBefore + 1 );
+	} );
+
+	// H2 (Codex, s61). Suppression must not outlive the request that armed it. A dedicated
+	// one-shot boolean had no way to learn that its refresh had given up, so a checkout ajax
+	// WooCommerce never answered left the session muted for the whole time it stayed open — the
+	// next genuine cart change vanished with no error and nothing visibly wrong. The session
+	// already carried the bounded state that fixes this: `refreshWaiter`/`refreshTimer`, settled
+	// by `dropRefreshWaiter()` on every path including REFRESH_TIMEOUT_MS.
+	test( 'WooCommerce never answering does NOT mute the session — the next genuine cart change '
+		+ 'still refreshes (H2)', async () => {
+		const { provider, emitSelect, resolveSelect, jq } = openPicker( {
+			selection: { close: false, refreshCheckout: true },
+		} );
+		await flushAsync();
+
+		const callsBefore = provider.setPointsCalls.length;
+
+		emitSelect( { id: 'P1' } );
+		await resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
+
+		// The refresh went out and its waiter is bound...
+		expect( jq.triggered ).toContain( 'update_checkout' );
+		expect( jq.one ).toHaveLength( 1 );
+		expect( jq.off ).toHaveLength( 0 );
+
+		// ...and WooCommerce never answers it. Nothing is dispatched here ON PURPOSE: a failed
+		// or superseded checkout ajax is free never to fire `updated_checkout` at all, which is
+		// precisely the case a `one()` cannot clean up after itself.
+		jest.advanceTimersByTime( 10000 );
+
+		// The bounded failure path settled it instead.
+		expect( jq.off ).toHaveLength( 1 );
+
+		// A GENUINE cart change now — a coupon applied, a quantity edited in another tab. The
+		// suppression window ended with the refresh that opened it, so this must be honoured.
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		expect( provider.setPointsCalls.length ).toBe( callsBefore + 1 );
+	} );
+
+	// H1 (Codex, s61). An `updated_checkout` carries no origin: our own echo and a real cart
+	// change are the same type on the same node, so no design can tell them apart at the DOM.
+	// What the fix guarantees is the WINDOW — suppression lasts exactly as long as our refresh
+	// is in flight, and that flight ends on the first event either way. So a foreign change
+	// landing inside the window costs one event of DELAY and is never dropped.
+	test( 'a foreign cart change landing while our own refresh is in flight is DELAYED, never '
+		+ 'lost (H1)', async () => {
+		const { provider, emitSelect, resolveSelect, jq } = openPicker( {
+			selection: { close: false, refreshCheckout: true },
+		} );
+		await flushAsync();
+
+		const callsBefore = provider.setPointsCalls.length;
+
+		emitSelect( { id: 'P1' } );
+		await resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
+
+		expect( jq.one ).toHaveLength( 1 );
+
+		// A foreign `updated_checkout` arrives BEFORE our own echo. It is suppressed — and it
+		// settles our waiter, exactly as jQuery's `one()` does for whichever event lands first.
+		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
+		jest.advanceTimersByTime( 1000 );
+		await flushAsync();
+
+		expect( provider.setPointsCalls.length ).toBe( callsBefore );
+		expect( jq.off ).toHaveLength( 1 );
+
+		// Our echo lands second, with the window now closed, so it refreshes — and that is the
+		// correct outcome, not a leak: the cart really did change, and this is the first event
+		// after the window able to carry that fact to the open picker.
 		document.body.dispatchEvent( new Event( 'updated_checkout' ) );
 		jest.advanceTimersByTime( 1000 );
 		await flushAsync();

--- a/tests/js/woodev-modal.test.js
+++ b/tests/js/woodev-modal.test.js
@@ -311,6 +311,19 @@ test( 'body gets a scroll-lock class while open, removed on close', () => {
 	modal.destroy();
 } );
 
+test( 'isOpen() reports false before open(), true while open, and false again after close() (#238)', () => {
+	const modal = new WoodevModal( { title: 'T' } );
+	expect( modal.isOpen() ).toBe( false );
+
+	modal.open();
+	expect( modal.isOpen() ).toBe( true );
+
+	modal.close();
+	expect( modal.isOpen() ).toBe( false );
+
+	modal.destroy();
+} );
+
 test( 'open() twice does not produce two dialogs', () => {
 	const modal = new WoodevModal( { title: 'T' } );
 	modal.open();

--- a/woodev/assets/js/frontend/woodev-modal.js
+++ b/woodev/assets/js/frontend/woodev-modal.js
@@ -416,6 +416,22 @@
 	};
 
 	/**
+	 * Whether the dialog is currently open — the public read of the `_isOpen` state
+	 * `open()`/`close()`/`teardownDialog()` track privately. Added so external code (e.g.
+	 * `pickup-mount.js`'s cart-change refresh subscriber, #238) can query a session's modal
+	 * without reaching into `session.modal._isOpen` — `_isOpen` is this instance's own
+	 * implementation detail, not a contract another file should couple to. An open-state
+	 * query is a legitimate part of the modal shell's public contract.
+	 *
+	 * @since 2.0.2
+	 *
+	 * @returns {boolean}
+	 */
+	WoodevModal.prototype.isOpen = function() {
+		return this._isOpen;
+	};
+
+	/**
 	 * The element the map provider mounts into. Stable across the instance's
 	 * whole lifecycle (same node before the first open(), while open, and
 	 * after close()) — the provider can hold this reference and rely on it

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -208,14 +208,37 @@
  * THE SUBSCRIBER MUST ALSO IGNORE ITS OWN ECHO: {@see refreshCheckout} triggers WooCommerce's
  * `update_checkout` after a selection that leaves the modal open, and WooCommerce answers with
  * the very `updated_checkout` this subscriber listens for — without suppression, confirming a
- * point would immediately wipe the pool it was just drawn into, on every single selection. Each
- * session therefore carries a ONE-SHOT echo token ({@see consumeEcho}), set by
- * `refreshCheckout()` at the moment it triggers `update_checkout` and consumed by the
- * subscriber the first time it sees that session's modal open — captured at EVENT time (inside
- * {@see handleCartChanged}, run once per raw event, undebounced), never at the debounced body's
- * fire time: by then a `one()`-bound waiter has long since self-cleared, so a check made there
- * could never tell an echo from a genuine change. One-shot, so a genuine cart change arriving
- * after the echo still refreshes normally.
+ * point would immediately wipe the pool it was just drawn into, on every single selection.
+ *
+ * SUPPRESSION KEEPS NO STATE OF ITS OWN. A session already knows when a checkout refresh it
+ * caused is outstanding — that is exactly what `refreshWaiter`/`refreshTimer` are, and
+ * {@see dropRefreshWaiter} settles them on every path there is: WooCommerce answering,
+ * {@see REFRESH_TIMEOUT_MS} expiring, a newer refresh superseding this one, `destroy()`.
+ * {@see isSelfRefreshInFlight} is a read of that and nothing else. An earlier design used a
+ * dedicated one-shot boolean, and a separate lifetime made two defects unavoidable: the flag
+ * was not tied to the request that set it, so it consumed whichever `updated_checkout` happened
+ * to arrive first; and nothing cleared it when WooCommerce never answered AT ALL, so it stayed
+ * armed for as long as the picker stayed open and silently ate that session's next genuine cart
+ * change. Deriving the answer removes both by construction.
+ *
+ * THE READ HAPPENS AT EVENT TIME, in {@see handleCartChanged} (once per raw event, undebounced),
+ * never in {@see flushCartChangeRefresh}'s debounced body — and that rests on a BINDING ORDER
+ * nothing at the call site shows. jQuery dispatches handlers in bind order; this subscriber is
+ * bound once at module load, long before any session's `one()` waiter can be, so it runs FIRST
+ * and still sees the waiter outstanding. By the time a debounce timer fires, that waiter has
+ * settled and the state reads identically for an echo and for a genuine change. Do NOT "simplify"
+ * the check down into the debounced body.
+ *
+ * THE RESIDUAL IS ACCEPTED AND DELIBERATE: an `updated_checkout` carries no origin, so a genuine
+ * cart change landing while our own refresh is outstanding is suppressed too. It is not lost —
+ * a cart change always produces an `updated_checkout`, and the first event also settles the
+ * waiter, so the NEXT one is honoured. One event of delay, never a dropped update.
+ *
+ * UNDER `ownsChrome` NO WAITER IS EVER BOUND (`refreshCheckout()` is handed a null `panels`),
+ * so an echo is not suppressed there at all. Harmless, because {@see refresh} is itself a no-op
+ * under `ownsChrome` — the embed loads its own points and this file fetches nothing for it — so
+ * the unsuppressed event reaches a function that does nothing. If `refresh()` ever gains an
+ * `ownsChrome` behaviour, this stops being harmless and needs a waiter (or an equivalent) there.
  *
  * EVERY LISTENER THIS FILE ATTACHS DIES WITH THE SESSION: the provider's own
  * event handlers are re-registered fresh on every `start()` (initial open AND
@@ -394,15 +417,16 @@
 	 * open, and this map is what lets the NEXT click — on whichever button is
 	 * currently mounted — still find and tear down the SAME session.
 	 *
-	 * @type {Object.<string, {modal: Object, refresh: Function, consumeEcho: Function, destroy: Function}>}
+	 * @type {Object.<string, {modal: Object, refresh: Function, isSelfRefreshInFlight: Function, destroy: Function}>}
 	 */
 	var sessions = {};
 
 	/**
 	 * Field ids awaiting a debounced cart-change refresh (#238) — accumulated by
-	 * {@see handleCartChanged} at EVENT time (echo suppression happens there too, per
-	 * session, via `consumeEcho()` — NOT in the debounced body), then drained together once
-	 * {@see CART_CHANGE_DEBOUNCE_MS} of quiet passes. See {@see flushCartChangeRefresh}.
+	 * {@see handleCartChanged} at EVENT time (echo suppression is decided there too, per
+	 * session, via `isSelfRefreshInFlight()` — NOT in the debounced body, where the state it
+	 * reads has already settled), then drained together once {@see CART_CHANGE_DEBOUNCE_MS} of
+	 * quiet passes. See {@see flushCartChangeRefresh}.
 	 *
 	 * @type {Object.<string, boolean>}
 	 */
@@ -1032,7 +1056,7 @@
 	 *
 	 * @param {Object}      config
 	 * @param {HTMLElement} triggerEl element focus returns to on close.
-	 * @returns {{modal: Object, refresh: Function, consumeEcho: Function, destroy: Function}}
+	 * @returns {{modal: Object, refresh: Function, isSelfRefreshInFlight: Function, destroy: Function}}
 	 */
 	function openSession( config, triggerEl ) {
 		// `config.modal` sizes the dialog before any content exists (spec V-1) — the PHP
@@ -1057,10 +1081,10 @@
 		var providers = window.WoodevPickupMapProviders || {};
 		var ProviderCtor = config && providers[ config.provider ];
 		var noopRefresh = function() { return Promise.resolve(); };
-		// #238: these two degraded sessions never call refreshCheckout(), so their echo
-		// token can never be set — a permanent `false` is exactly as correct as a real
-		// closure variable would be, without needing one.
-		var noopConsumeEcho = function() { return false; };
+		// #238: these two degraded sessions never call refreshCheckout(), so no waiter of
+		// theirs can ever be in flight — a permanent `false` is exactly as correct as reading
+		// a closure variable that would never change.
+		var noopSelfRefreshInFlight = function() { return false; };
 
 		if ( 'function' !== typeof ProviderCtor ) {
 			modal.showError( text( config, 'error' ) );
@@ -1068,7 +1092,7 @@
 			return {
 				modal: modal,
 				refresh: noopRefresh,
-				consumeEcho: noopConsumeEcho,
+				isSelfRefreshInFlight: noopSelfRefreshInFlight,
 				destroy: function() { modal.destroy(); },
 			};
 		}
@@ -1081,7 +1105,7 @@
 			return {
 				modal: modal,
 				refresh: noopRefresh,
-				consumeEcho: noopConsumeEcho,
+				isSelfRefreshInFlight: noopSelfRefreshInFlight,
 				destroy: function() { modal.destroy(); },
 			};
 		}
@@ -1321,15 +1345,6 @@
 		 *  was locked (it may not be `panels` — the refresh is skipped entirely when the modal
 		 *  has just closed; see {@see finishSelection}'s own call site). */
 		var refreshBusyPanels = null;
-
-		/** @type {boolean} #238's one-shot echo-suppression token: true for exactly one
-		 *  `updated_checkout` after THIS session's own {@see refreshCheckout} triggers
-		 *  `update_checkout` — set there, consumed (read + cleared) by
-		 *  {@see consumeEcho}, which the module-scope cart-change subscriber calls once per
-		 *  event, at EVENT time, for every session whose modal is open (see the file
-		 *  docblock). Never set again until the NEXT confirmation-triggered refresh, so a
-		 *  genuine cart change arriving after it is never swallowed. */
-		var echoExpected = false;
 
 		/** @type {boolean} Task 16 (spec V-4 stage 2/3): has THIS start() cycle's busy overlay
 		 *  already been cleared? Reset at the top of every {@see start} call (initial open AND
@@ -2521,33 +2536,34 @@
 				}, REFRESH_TIMEOUT_MS );
 			}
 
-			// #238: marks the NEXT `updated_checkout` as THIS session's own echo, at the moment
-			// we cause it — see {@see consumeEcho} and the file docblock's "MUST ALSO IGNORE ITS
-			// OWN ECHO" section. Set unconditionally (even when `openPanels` is null, i.e. the
-			// modal already closed and `closeSession()` has already dropped this session from
-			// `sessions`): the module-scope subscriber only ever reads this for a session it can
-			// still find, so setting it on one nobody will ask again is harmless.
-			echoExpected = true;
-
+			// #238 echo suppression needs NOTHING set here: the waiter armed just above IS the
+			// "a refresh we caused is in flight" signal {@see isSelfRefreshInFlight} reads, and
+			// it is armed before the trigger below can produce anything to suppress.
 			window.jQuery( document.body ).trigger( 'update_checkout' );
 		}
 
 		/**
-		 * Reads and clears {@see echoExpected} in one step (#238) — the module-scope
-		 * cart-change subscriber ({@see handleCartChanged}) calls this, once per raw
-		 * `updated_checkout`, for every session whose modal is open, at EVENT time, before its
-		 * debounce timer ever fires. A plain read (without the clear) would suppress every
-		 * SUBSEQUENT genuine cart change too, not just the one this session's own
-		 * {@see refreshCheckout} caused.
+		 * Is a checkout refresh THIS session caused still in flight (#238)? Read-only, with no
+		 * lifetime of its own: `refreshWaiter` already IS the answer — armed by
+		 * {@see refreshCheckout} at the moment it triggers `update_checkout`, and cleared by
+		 * {@see dropRefreshWaiter} on every settle path there is (WooCommerce answering,
+		 * {@see REFRESH_TIMEOUT_MS} expiring, a newer refresh superseding this one, and
+		 * `destroy()`).
 		 *
-		 * @returns {boolean} true when this event is this session's own echo.
+		 * Deriving it is the whole fix. A dedicated token needs its own clearing rules, and the
+		 * one this replaced had no rule for "WooCommerce never answered at all" — so it stayed
+		 * armed for as long as the picker stayed open and silently ate that session's next
+		 * genuine cart change. Nothing here can outlive the request that armed it.
+		 *
+		 * Called once per raw `updated_checkout` by {@see handleCartChanged}, at EVENT time.
+		 * Never call it from the debounced body — see the file docblock on the binding order
+		 * that is what makes an event-time read able to tell the two apart at all.
+		 *
+		 * @returns {boolean} true while our own refresh is outstanding, i.e. this event may be
+		 *                    its echo.
 		 */
-		function consumeEcho() {
-			var wasExpected = echoExpected;
-
-			echoExpected = false;
-
-			return wasExpected;
+		function isSelfRefreshInFlight() {
+			return null !== refreshWaiter;
 		}
 
 		/**
@@ -3237,7 +3253,7 @@
 		return {
 			modal: modal,
 			refresh: refresh,
-			consumeEcho: consumeEcho,
+			isSelfRefreshInFlight: isSelfRefreshInFlight,
 			destroy: function() {
 				// EVERY card lock a session can be holding — an in-flight confirmation's, an
 				// in-flight checkout refresh's, and (issue #223) an in-flight detail fetch's — is
@@ -3338,7 +3354,7 @@
 	 * `sessions` being module-private.
 	 *
 	 * @param {string} fieldId
-	 * @returns {{modal: Object, refresh: Function, consumeEcho: Function, destroy: Function}|null}
+	 * @returns {{modal: Object, refresh: Function, isSelfRefreshInFlight: Function, destroy: Function}|null}
 	 */
 	function getSession( fieldId ) {
 		return sessions[ fieldId ] || null;
@@ -3377,10 +3393,12 @@
 	 * AUTOMATICALLY ON A GENUINE CART CHANGE" section.
 	 *
 	 * Runs on EVERY raw event, undebounced — echo suppression is decided HERE, at event time,
-	 * per session, via {@see consumeEcho}, never inside {@see flushCartChangeRefresh}'s
+	 * per session, via {@see isSelfRefreshInFlight}, never inside {@see flushCartChangeRefresh}'s
 	 * debounced body: by the time a debounce timer fires, a session's own `refreshCheckout()`
-	 * waiter has long since self-cleared, so a check made there could never tell an echo from a
-	 * genuine change.
+	 * waiter has already settled, so a check made there could never tell an echo from a genuine
+	 * change. The read works here, and only here, because this subscriber is bound at module
+	 * load and therefore runs BEFORE the per-session waiter jQuery dispatches next — see the
+	 * file docblock's note on that binding order.
 	 *
 	 * A DISMISSED session (modal closed, `destroyed` still false — see
 	 * {@see handleModalClosed}) is skipped entirely: no echo check, no pending entry, nothing.
@@ -3398,7 +3416,7 @@
 				return;
 			}
 
-			if ( session.consumeEcho() ) {
+			if ( session.isSelfRefreshInFlight() ) {
 				return;
 			}
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -192,6 +192,31 @@
  * no-op, guarded the same way every other post-close continuation in this
  * file is).
  *
+ * `refresh()` NOW ALSO RUNS AUTOMATICALLY ON A GENUINE CART CHANGE (#238), not only through
+ * {@see getSession}: a SECOND, permanent `updated_checkout` subscriber — bound once at module
+ * scope, alongside the `mountAll()` one at the bottom of this file, never per-session — walks
+ * `sessions` on every event and calls `refresh()` on whichever ones report their modal OPEN via
+ * {@see WoodevModal#isOpen} ({@see handleCartChanged}). A DISMISSED session
+ * (`handleModalClosed()` below runs only `invalidateSelection()` — the entry survives in
+ * `sessions` until the next trigger click) is deliberately left untouched: refreshing it would
+ * fire a live carrier request for a picker the customer can no longer see, against the
+ * merchant's quota, for nothing the next trigger click would not already rebuild from scratch.
+ * The subscriber is DEBOUNCED ({@see CART_CHANGE_DEBOUNCE_MS}) — `refresh()` has no reentrancy
+ * guard of its own, so an undebounced burst (WooCommerce fires `updated_checkout` more than
+ * once per totals recalculation) would independently wipe the point pool once per event.
+ *
+ * THE SUBSCRIBER MUST ALSO IGNORE ITS OWN ECHO: {@see refreshCheckout} triggers WooCommerce's
+ * `update_checkout` after a selection that leaves the modal open, and WooCommerce answers with
+ * the very `updated_checkout` this subscriber listens for — without suppression, confirming a
+ * point would immediately wipe the pool it was just drawn into, on every single selection. Each
+ * session therefore carries a ONE-SHOT echo token ({@see consumeEcho}), set by
+ * `refreshCheckout()` at the moment it triggers `update_checkout` and consumed by the
+ * subscriber the first time it sees that session's modal open — captured at EVENT time (inside
+ * {@see handleCartChanged}, run once per raw event, undebounced), never at the debounced body's
+ * fire time: by then a `one()`-bound waiter has long since self-cleared, so a check made there
+ * could never tell an echo from a genuine change. One-shot, so a genuine cart change arriving
+ * after the echo still refreshes normally.
+ *
  * EVERY LISTENER THIS FILE ATTACHS DIES WITH THE SESSION: the provider's own
  * event handlers are re-registered fresh on every `start()` (initial open AND
  * every retry) and go away when that provider instance is destroyed (a real
@@ -254,6 +279,20 @@
 
 	/** @type {number} defer, in ms, after `updated_checkout` before re-mounting — see the file docblock. */
 	var MOUNT_DEFER_MS = 60;
+
+	/**
+	 * Debounce window, in ms, for the cart-change refresh subscriber (#238) — see
+	 * {@see handleCartChanged}. WooCommerce fires `updated_checkout` in bursts during a single
+	 * totals recalculation, and `refresh()` has no reentrancy guard of its own (see its own
+	 * docblock): every call independently wipes the point pool and detail memo. Collapsing a
+	 * burst into ONE refresh per session is this constant's whole job —
+	 * `pickup-datasource.js`'s own 300ms trailing debounce (`:80`, `:468-479`) already
+	 * collapses the resulting NETWORK calls, but only after `refresh()` has already run the
+	 * pool reset that many times.
+	 *
+	 * @type {number}
+	 */
+	var CART_CHANGE_DEBOUNCE_MS = 300;
 
 	/**
 	 * How long, in ms, a post-selection checkout refresh may hold the card's busy lock before it is
@@ -355,9 +394,28 @@
 	 * open, and this map is what lets the NEXT click — on whichever button is
 	 * currently mounted — still find and tear down the SAME session.
 	 *
-	 * @type {Object.<string, {modal: Object, refresh: Function, destroy: Function}>}
+	 * @type {Object.<string, {modal: Object, refresh: Function, consumeEcho: Function, destroy: Function}>}
 	 */
 	var sessions = {};
+
+	/**
+	 * Field ids awaiting a debounced cart-change refresh (#238) — accumulated by
+	 * {@see handleCartChanged} at EVENT time (echo suppression happens there too, per
+	 * session, via `consumeEcho()` — NOT in the debounced body), then drained together once
+	 * {@see CART_CHANGE_DEBOUNCE_MS} of quiet passes. See {@see flushCartChangeRefresh}.
+	 *
+	 * @type {Object.<string, boolean>}
+	 */
+	var pendingCartChangeRefresh = {};
+
+	/**
+	 * The debounce timer backing {@see handleCartChanged} — restarted on every raw
+	 * `updated_checkout`, so a burst of them collapses into one {@see flushCartChangeRefresh}
+	 * call. `null` when no refresh is currently pending.
+	 *
+	 * @type {number|null}
+	 */
+	var cartChangeDebounceTimer = null;
 
 	// -------------------------------------------------------------------------
 	// Small helpers
@@ -974,7 +1032,7 @@
 	 *
 	 * @param {Object}      config
 	 * @param {HTMLElement} triggerEl element focus returns to on close.
-	 * @returns {{modal: Object, refresh: Function, destroy: Function}}
+	 * @returns {{modal: Object, refresh: Function, consumeEcho: Function, destroy: Function}}
 	 */
 	function openSession( config, triggerEl ) {
 		// `config.modal` sizes the dialog before any content exists (spec V-1) — the PHP
@@ -999,11 +1057,20 @@
 		var providers = window.WoodevPickupMapProviders || {};
 		var ProviderCtor = config && providers[ config.provider ];
 		var noopRefresh = function() { return Promise.resolve(); };
+		// #238: these two degraded sessions never call refreshCheckout(), so their echo
+		// token can never be set — a permanent `false` is exactly as correct as a real
+		// closure variable would be, without needing one.
+		var noopConsumeEcho = function() { return false; };
 
 		if ( 'function' !== typeof ProviderCtor ) {
 			modal.showError( text( config, 'error' ) );
 
-			return { modal: modal, refresh: noopRefresh, destroy: function() { modal.destroy(); } };
+			return {
+				modal: modal,
+				refresh: noopRefresh,
+				consumeEcho: noopConsumeEcho,
+				destroy: function() { modal.destroy(); },
+			};
 		}
 
 		var DataSourceFactory = window.WoodevPickupDataSource;
@@ -1011,7 +1078,12 @@
 		if ( 'function' !== typeof DataSourceFactory ) {
 			modal.showError( text( config, 'error' ) );
 
-			return { modal: modal, refresh: noopRefresh, destroy: function() { modal.destroy(); } };
+			return {
+				modal: modal,
+				refresh: noopRefresh,
+				consumeEcho: noopConsumeEcho,
+				destroy: function() { modal.destroy(); },
+			};
 		}
 
 		var realDataSource = DataSourceFactory( {
@@ -1249,6 +1321,15 @@
 		 *  was locked (it may not be `panels` — the refresh is skipped entirely when the modal
 		 *  has just closed; see {@see finishSelection}'s own call site). */
 		var refreshBusyPanels = null;
+
+		/** @type {boolean} #238's one-shot echo-suppression token: true for exactly one
+		 *  `updated_checkout` after THIS session's own {@see refreshCheckout} triggers
+		 *  `update_checkout` — set there, consumed (read + cleared) by
+		 *  {@see consumeEcho}, which the module-scope cart-change subscriber calls once per
+		 *  event, at EVENT time, for every session whose modal is open (see the file
+		 *  docblock). Never set again until the NEXT confirmation-triggered refresh, so a
+		 *  genuine cart change arriving after it is never swallowed. */
+		var echoExpected = false;
 
 		/** @type {boolean} Task 16 (spec V-4 stage 2/3): has THIS start() cycle's busy overlay
 		 *  already been cleared? Reset at the top of every {@see start} call (initial open AND
@@ -2440,7 +2521,33 @@
 				}, REFRESH_TIMEOUT_MS );
 			}
 
+			// #238: marks the NEXT `updated_checkout` as THIS session's own echo, at the moment
+			// we cause it — see {@see consumeEcho} and the file docblock's "MUST ALSO IGNORE ITS
+			// OWN ECHO" section. Set unconditionally (even when `openPanels` is null, i.e. the
+			// modal already closed and `closeSession()` has already dropped this session from
+			// `sessions`): the module-scope subscriber only ever reads this for a session it can
+			// still find, so setting it on one nobody will ask again is harmless.
+			echoExpected = true;
+
 			window.jQuery( document.body ).trigger( 'update_checkout' );
+		}
+
+		/**
+		 * Reads and clears {@see echoExpected} in one step (#238) — the module-scope
+		 * cart-change subscriber ({@see handleCartChanged}) calls this, once per raw
+		 * `updated_checkout`, for every session whose modal is open, at EVENT time, before its
+		 * debounce timer ever fires. A plain read (without the clear) would suppress every
+		 * SUBSEQUENT genuine cart change too, not just the one this session's own
+		 * {@see refreshCheckout} caused.
+		 *
+		 * @returns {boolean} true when this event is this session's own echo.
+		 */
+		function consumeEcho() {
+			var wasExpected = echoExpected;
+
+			echoExpected = false;
+
+			return wasExpected;
 		}
 
 		/**
@@ -3130,6 +3237,7 @@
 		return {
 			modal: modal,
 			refresh: refresh,
+			consumeEcho: consumeEcho,
 			destroy: function() {
 				// EVERY card lock a session can be holding — an in-flight confirmation's, an
 				// in-flight checkout refresh's, and (issue #223) an in-flight detail fetch's — is
@@ -3230,10 +3338,78 @@
 	 * `sessions` being module-private.
 	 *
 	 * @param {string} fieldId
-	 * @returns {{modal: Object, refresh: Function, destroy: Function}|null}
+	 * @returns {{modal: Object, refresh: Function, consumeEcho: Function, destroy: Function}|null}
 	 */
 	function getSession( fieldId ) {
 		return sessions[ fieldId ] || null;
+	}
+
+	/**
+	 * Refreshes every session accumulated in {@see pendingCartChangeRefresh} — the debounced
+	 * half of {@see handleCartChanged}, run once {@see CART_CHANGE_DEBOUNCE_MS} of quiet has
+	 * passed since the last raw `updated_checkout`.
+	 *
+	 * Re-checks `isOpen()` here too, not just at event time in `handleCartChanged`: a session
+	 * added to the pending set can still close — or be torn down and replaced by a fresh
+	 * trigger click — before this timer fires.
+	 *
+	 * @returns {void}
+	 */
+	function flushCartChangeRefresh() {
+		cartChangeDebounceTimer = null;
+
+		var pending = pendingCartChangeRefresh;
+
+		pendingCartChangeRefresh = {};
+
+		Object.keys( pending ).forEach( function( fieldId ) {
+			var session = sessions[ fieldId ];
+
+			if ( session && session.modal.isOpen() ) {
+				session.refresh();
+			}
+		} );
+	}
+
+	/**
+	 * The module-scope `updated_checkout` subscriber that wires #232's cart-change verdict
+	 * invalidation to a real signal (#238) — see the file docblock's "REFRESH() NOW ALSO RUNS
+	 * AUTOMATICALLY ON A GENUINE CART CHANGE" section.
+	 *
+	 * Runs on EVERY raw event, undebounced — echo suppression is decided HERE, at event time,
+	 * per session, via {@see consumeEcho}, never inside {@see flushCartChangeRefresh}'s
+	 * debounced body: by the time a debounce timer fires, a session's own `refreshCheckout()`
+	 * waiter has long since self-cleared, so a check made there could never tell an echo from a
+	 * genuine change.
+	 *
+	 * A DISMISSED session (modal closed, `destroyed` still false — see
+	 * {@see handleModalClosed}) is skipped entirely: no echo check, no pending entry, nothing.
+	 * The next trigger click rebuilds it from scratch; refreshing it here would fire a live
+	 * carrier request the customer cannot see, against the merchant's quota, for a picker they
+	 * already dismissed.
+	 *
+	 * @returns {void}
+	 */
+	function handleCartChanged() {
+		Object.keys( sessions ).forEach( function( fieldId ) {
+			var session = sessions[ fieldId ];
+
+			if ( ! session.modal.isOpen() ) {
+				return;
+			}
+
+			if ( session.consumeEcho() ) {
+				return;
+			}
+
+			pendingCartChangeRefresh[ fieldId ] = true;
+		} );
+
+		if ( null !== cartChangeDebounceTimer ) {
+			window.clearTimeout( cartChangeDebounceTimer );
+		}
+
+		cartChangeDebounceTimer = window.setTimeout( flushCartChangeRefresh, CART_CHANGE_DEBOUNCE_MS );
 	}
 
 	// -------------------------------------------------------------------------
@@ -3243,6 +3419,12 @@
 	onCheckoutUpdated( function() {
 		window.setTimeout( mountAll, MOUNT_DEFER_MS );
 	} );
+
+	// #238: a second, independent, permanent `updated_checkout` subscriber — see
+	// {@see handleCartChanged}. Deliberately its own onCheckoutUpdated() registration rather
+	// than folded into the one above: the two run on unrelated schedules (a flat 60ms defer vs
+	// a restarting debounce) and over unrelated state (§8 anchors vs `sessions`).
+	onCheckoutUpdated( handleCartChanged );
 
 	// Initial mount: on a real checkout page this script runs in the footer,
 	// after §8's own ready handler has already placed every anchor, but the


### PR DESCRIPTION
Closes #238

## Что было сломано

`forgetPointDetails()` — вся инвалидация вердикта по смене корзины, построенная в #232 — вызывалась только из `refresh()`, а `refresh()` достижим только через `getSession()`, у которого **ноль продакшен-вызывающих**. Инвалидация не работала в проде никогда.

## Что сделано

Модульный подписчик на `updated_checkout` (второй, рядом с `mountAll()`-овским), дебаунс 300 мс, обновляет только те сессии, чья модалка **открыта**. Отброшенная сессия (Escape/бэкдроп) остаётся в `sessions`, но не трогается: следующий клик по триггеру пересоберёт её с нуля, а живой запрос к перевозчику за невидимый покупателю пикер — трата чужой квоты.

Плюс `WoodevModal.prototype.isOpen()` — публичный аксессор вместо чтения приватного `_isOpen` снаружи.

## Подавление собственного эха — без отдельного состояния

`refreshCheckout()` сам дёргает `update_checkout`, и WooCommerce отвечает тем самым `updated_checkout`. Без подавления подтверждение точки стирало бы пул, в который её только что нарисовали.

Первая реализация (`5f0d4c8`, по спеке) использовала одноразовый булев токен. Codex нашёл в нём два HIGH — оба неизбежны для механизма с собственным временем жизни:

* **H1** — токен не связан с породившим его запросом, поэтому съедал первый пришедший `updated_checkout`, каким бы тот ни был.
* **H2** — ничто не сбрасывало его, если WooCommerce не отвечал вовсе: он оставался взведён всё время, пока пикер открыт, и молча съедал следующую настоящую смену корзины.

Токен удалён. `isSelfRefreshInFlight()` читает уже существующее `refreshWaiter`, которое `refreshCheckout()` взводит, а `dropRefreshWaiter()` гасит на **всех** путях — ответ WooCommerce, `REFRESH_TIMEOUT_MS`, вытеснение более новым обновлением, `destroy()`. Пережить свой запрос теперь нечему.

Чтение осталось **в момент события**, в `handleCartChanged()`. Это держится на порядке привязки (модульный подписчик привязан при загрузке, раньше сессионного `one()`), который на месте вызова не виден — он теперь описан комментарием.

## Честно про H1

H1 **понижен, а не устранён**, и это осознанно: у `updated_checkout` нет происхождения, отличить наше эхо от чужой смены корзины на уровне DOM невозможно. Гарантируется **окно**: подавление длится ровно столько, сколько наше обновление в полёте. Чужая смена, попавшая в окно, стоит одного события задержки и не теряется.

## Проверка

* **H2-тест падает на `5f0d4c8`** (`Expected 2, Received 1`) и проходит после правки.
* **H1 независимо ненаблюдаем — это замерено, а не предположено:** сценарий, предложенный для него, даёт ровно одно обновление и на старом, и на новом механизме. Его тест оставлен как характеризующий, фиксирующий «задержка, не потеря».
* jest **808** (было 806), полный прогон `npm run test:js -- --roots "<rootDir>/tests/js"`.

Дубль jQuery в тестах теперь **реально** привязывает `one()` на `document.body`, а не только записывает вызов: срабатывание waiter'а — это и есть то, что закрывает окно подавления, и дубль-регистратор моделировал страницу, на которой WooCommerce не отвечает никогда. Слушатели снимаются в `afterEach` (`innerHTML = ''` не снимает слушателей с самого `body`).

## Найденная дыра — проверена и принята

Под `ownsChrome` в `refreshCheckout()` приходит `panels === null`, waiter не привязывается, эхо не подавляется. Безвредно **только** потому, что `refresh()` под `ownsChrome` сам no-op. Записано в исходнике, чтобы будущее поведение `refresh()` для `ownsChrome` не превратило это в живой дефект. Этот путь ни разу не гонялся на риге — отдельной задачей.

## Спека исправлена

`docs-internal/specs/2026-08-09-238-cart-change-verdict-invalidation.md` §3 переписан. Реализация ей соответствовала идеально, spec-ревью вернуло «COMPLIANT, ноль находок» — неверен был сам выбранный спекой механизм. Соответствие спеке не есть корректность.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx85cZaYUGb8Zxv836PxD8