### PR TITLE
fix(assets): version woodev-modal.js via get_assets_version(), not the bare VERSION constant

### DIFF
--- a/tests/unit/WoocommercePluginTest.php
+++ b/tests/unit/WoocommercePluginTest.php
@@ -419,12 +419,24 @@ class WoocommercePluginTest extends TestCase {
 		// Vanilla ES5, no jQuery/Backbone — see woodev-modal.js's own docblock. Do not copy
 		// `jquery` in by reflex; the modal genuinely has zero script dependencies.
 		$this->assertSame( [], $registered['woodev-modal']['deps'] );
-		$this->assertSame( \Woodev_Plugin::VERSION, $registered['woodev-modal']['ver'] );
+		// Must be versioned via get_assets_version() — which busts the cache under
+		// SCRIPT_DEBUG/WP_DEBUG — not the bare self::VERSION constant, which only changes on a
+		// framework release and left `woodev-modal.js` edits invisible to a browser that had
+		// already loaded the page (gotcha modal-script-versioned-by-version-constant-not-filemtime).
+		// The test plugin's own version ('1.0.0') intentionally differs from the framework's
+		// \Woodev_Plugin::VERSION ('2.0.1') so a regression to the bare constant is caught here.
+		$this->assertSame( $plugin->get_assets_version(), $registered['woodev-modal']['ver'] );
+		$this->assertNotSame( \Woodev_Plugin::VERSION, $registered['woodev-modal']['ver'] );
 
 		// The two pre-existing framework registrations in the same method must survive
 		// untouched — this test guards against the modal's addition breaking its neighbours.
 		$this->assertArrayHasKey( 'jquery-suggestions', $registered );
 		$this->assertArrayHasKey( 'woodev-dadata-suggestions', $registered );
+		// The dadata-suggestions handle had the same bare-self::VERSION defect as the modal
+		// script (same file, same method) — pin it too so the fix cannot regress on one half
+		// of the pair while leaving the other unfixed.
+		$this->assertSame( $plugin->get_assets_version(), $registered['woodev-dadata-suggestions']['ver'] );
+		$this->assertNotSame( \Woodev_Plugin::VERSION, $registered['woodev-dadata-suggestions']['ver'] );
 	}
 
 	/**
@@ -433,8 +445,8 @@ class WoocommercePluginTest extends TestCase {
 	 * FRAMEWORK's own assets path — never `shipping-method/`. `Pickup_Handler` (see
 	 * PickupHandlerTest) only ever DECLARES `woodev-modal` as a style dependency; this is the
 	 * one and only place that registers the handle. Unlike the script (versioned by
-	 * `self::VERSION`), the style is versioned by its own `filemtime()` — a CSS-only tweak must
-	 * bust the browser cache without a framework version bump (gotcha
+	 * `get_assets_version()`), the style is versioned by its own `filemtime()` — a CSS-only
+	 * tweak must bust the browser cache without a framework version bump (gotcha
 	 * wp-scripts-css-enqueue-version-by-mtime).
 	 *
 	 * @return void

--- a/woodev/class-plugin.php
+++ b/woodev/class-plugin.php
@@ -512,7 +512,7 @@ if ( ! class_exists( 'Woodev_Plugin' ) ) :
 		public function frontend_enqueue_scripts() {
 
 			wp_register_script( 'jquery-suggestions', $this->get_framework_assets_url() . '/js/frontend/jquery.suggestions.js', [ 'jquery' ], '22.6.0' );
-			wp_register_script( 'woodev-dadata-suggestions', $this->get_framework_assets_url() . '/js/frontend/woodev-dadata-suggestions.js', [ 'jquery-suggestions' ], self::VERSION );
+			wp_register_script( 'woodev-dadata-suggestions', $this->get_framework_assets_url() . '/js/frontend/woodev-dadata-suggestions.js', [ 'jquery-suggestions' ], $this->get_assets_version() );
 
 			// The generic modal shell (D-13): registered here, framework-side, exactly once,
 			// so every subsystem that needs a dialog (Pickup_Handler today, others later) only
@@ -523,7 +523,7 @@ if ( ! class_exists( 'Woodev_Plugin' ) ) :
 				'woodev-modal',
 				$this->get_framework_assets_url() . '/js/frontend/woodev-modal.js',
 				[],
-				self::VERSION
+				$this->get_assets_version()
 			);
 
 			// The modal's chrome stylesheet follows the same D-13 rule: registered once here,


### PR DESCRIPTION
## Summary

`Woodev_Plugin::frontend_enqueue_scripts()` registered the `woodev-modal` script with the bare `self::VERSION` constant, which only changes on a framework release. Three lines below, the sibling `woodev-modal` stylesheet correctly versions itself by `filemtime()` — so a CSS-only tweak busts the browser cache, but a JS-only tweak to `woodev-modal.js` did not, even in development (`SCRIPT_DEBUG`/`WP_DEBUG`).

Root cause and reproduction details: `docs-internal/gotchas/modal-script-versioned-by-version-constant-not-filemtime.md`.

- `woodev-modal` script: `self::VERSION` → `$this->get_assets_version()`
- **Scope sweep of the same file** (per the recorded lesson that this exact rule was previously applied to only one half of a pair): found `woodev-dadata-suggestions`, registered three lines above the modal script in the same method, with the identical bare `self::VERSION` defect. Fixed it too.

`get_assets_version()` already returns `time()` under `SCRIPT_DEBUG`/`WP_DEBUG` and falls back to the plugin version otherwise (`woodev/class-plugin.php`), so this both fixes the development cache-busting trap and keeps release behavior unchanged for an unchanged file.

### Out of scope (found, deliberately left alone)

`enqueue_scripts()` (the plugin-settings-page method, same file) versions `admin-confirm.css` and `woodev-admin-script.js` via `$this->get_version()` instead of `$this->get_assets_version()` — same underlying defect class (no dev-mode cache-busting), but `$this->get_version()` (not `get_assets_version()`) is the established pattern for first-party assets in **8+ other files** across the framework (`class-admin-pages.php`, `class-ui-kit-gallery-page.php`, `class-payment-gateway.php`, `class-settings-page-registry.php`, `class-setup-wizard.php`, `class-woodev-job-batch-handler.php`, etc.). Fixing only the two instances inside `class-plugin.php` while leaving the identical pattern everywhere else would be an inconsistent, partial fix and is outside this issue's scope (`woodev/class-plugin.php` only, per the `frontend_enqueue_scripts()` defect). Recommend a separate, repo-wide issue if this is worth normalizing.

## Test plan

- [x] `composer phpcs` — clean
- [x] `composer test:unit` — 1520 tests, 4055 assertions (was 4052), 66 skipped, green (ran 3x to rule out flake)
- [x] `npm run test:js -- --roots "<rootDir>/tests/js"` — 813 tests, green
- [x] Extended `tests/unit/WoocommercePluginTest.php::test_frontend_enqueue_scripts_registers_the_generic_modal_handle` to pin the new version source (`$plugin->get_assets_version()`, not the bare `\Woodev_Plugin::VERSION`) for both `woodev-modal` and `woodev-dadata-suggestions`, discriminated by the test plugin's own version (`1.0.0`) intentionally differing from the framework's `VERSION` constant (`2.0.1`)
- Did not run `composer phpstan` locally (known Windows segfault) — Linux CI is the authoritative gate

Closes #250