### PR TITLE
fix(shipping): restore normalizePoint() field parity with Pickup_Point::from_array()

### DIFF
--- a/tests/js/map-provider-embedded.test.js
+++ b/tests/js/map-provider-embedded.test.js
@@ -10,7 +10,12 @@
  * an empty `expectedOrigin`), point normalization mirroring
  * `Pickup_Point::from_array()`'s required-field/range rules, the invalid/
  * missing `embedUrl` guard, and `destroy()`'s listener detachment + callback
- * hook clearing + idempotency.
+ * hook clearing + idempotency. Also covers the #201 field-parity fix:
+ * `services`/`point_short_name` now normalize at all, and `payment_methods`/
+ * `photos`/`services` filter out non-string/whitespace-only elements instead
+ * of `String()`-coercing them (matching `Pickup_Point::sanitize_string_list()`),
+ * and `max_weight` falls back to `0`, never `NaN`, for a garbage value
+ * (matching PHP's `(int)` cast).
  *
  * @see woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
  */
@@ -367,28 +372,91 @@ test( 'absent optional fields default to the empty-string/empty-array/null shape
 	expect( point.phone ).toBe( '' );
 	expect( point.instruction ).toBe( '' );
 	expect( point.work_time ).toBe( '' );
+	expect( point.point_short_name ).toBe( '' );
 	expect( point.payment_methods ).toEqual( [] );
 	expect( point.photos ).toEqual( [] );
+	expect( point.services ).toEqual( [] );
 	expect( point.accepts_cod ).toBeNull();
 	expect( point.max_weight ).toBeNull();
 } );
 
-test( 'payment_methods/photos containing non-strings come out String()-mapped', () => {
+test( 'point_short_name, when present, passes through as a string (issue #199/#201 card label source)', () => {
 	const { iframe, onSelect, onError } = initProvider();
 
 	const payload = validPointPayload();
-	payload.payment_methods = [ 'card', 42, true ];
-	payload.photos = [ 7, null ];
+	payload.point_short_name = 'ПВЗ у дома';
 
 	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
 
 	expect( onError ).not.toHaveBeenCalled();
 	const point = onSelect.mock.calls[ 0 ][ 0 ];
-	expect( point.payment_methods ).toEqual( [ 'card', '42', 'true' ] );
-	expect( point.photos ).toEqual( [ '7', 'null' ] );
-	point.payment_methods.forEach( ( value ) => expect( typeof value ).toBe( 'string' ) );
-	point.photos.forEach( ( value ) => expect( typeof value ).toBe( 'string' ) );
+	expect( point.point_short_name ).toBe( 'ПВЗ у дома' );
 } );
+
+test( 'point_short_name, when a non-string scalar, is coerced via String() like every other optional string field', () => {
+	const { iframe, onSelect, onError } = initProvider();
+
+	const payload = validPointPayload();
+	payload.point_short_name = 12345;
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	expect( onError ).not.toHaveBeenCalled();
+	const point = onSelect.mock.calls[ 0 ][ 0 ];
+	expect( point.point_short_name ).toBe( '12345' );
+} );
+
+test( 'services, when present with valid strings, passes through unchanged (issue #201: was never read at all)', () => {
+	const { iframe, onSelect, onError } = initProvider();
+
+	const payload = validPointPayload();
+	payload.services = [ 'Примерка', 'Хранение' ];
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	expect( onError ).not.toHaveBeenCalled();
+	const point = onSelect.mock.calls[ 0 ][ 0 ];
+	expect( point.services ).toEqual( [ 'Примерка', 'Хранение' ] );
+} );
+
+// Mirrors `Pickup_Point::sanitize_string_list()` exactly (not the old naive `.map( String )`
+// this file used to apply to `payment_methods`/`photos` before #201): non-string elements
+// are DROPPED, not coerced into "42"/"true"/"[object Object]"; a whitespace-only entry is
+// dropped too; the string '0' is a legitimate label and must survive.
+test.each( [ 'payment_methods', 'photos', 'services' ] )(
+	'%s filters out non-string and whitespace-only elements, keeps the string \'0\'',
+	( field ) => {
+		const { iframe, onSelect, onError } = initProvider();
+
+		const payload = validPointPayload();
+		payload[ field ] = [ 'Наличные', 42, true, null, [ 'nested' ], { obj: 1 }, '   ', '0', 'Карта' ];
+
+		dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+		expect( onError ).not.toHaveBeenCalled();
+		const point = onSelect.mock.calls[ 0 ][ 0 ];
+		expect( point[ field ] ).toEqual( [ 'Наличные', '0', 'Карта' ] );
+		point[ field ].forEach( ( value ) => expect( typeof value ).toBe( 'string' ) );
+	}
+);
+
+// A non-array value for any of the three list fields (a carrier sending an object or a
+// bare string instead of an array) must degrade to `[]`, not throw.
+test.each( [ 'payment_methods', 'photos', 'services' ] )(
+	'a non-array %s normalizes to an empty list rather than throwing',
+	( field ) => {
+		const { iframe, onSelect, onError } = initProvider();
+
+		const payload = validPointPayload();
+		payload[ field ] = 'not-an-array';
+
+		dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+		expect( onError ).not.toHaveBeenCalled();
+		const point = onSelect.mock.calls[ 0 ][ 0 ];
+		expect( point[ field ] ).toEqual( [] );
+	}
+);
 
 test.each( [
 	[ 1, true ],
@@ -421,6 +489,24 @@ test( 'max_weight as a numeric string normalizes to an integer', () => {
 	const point = onSelect.mock.calls[ 0 ][ 0 ];
 	expect( point.max_weight ).toBe( 15 );
 	expect( Number.isInteger( point.max_weight ) ).toBe( true );
+} );
+
+// PHP `(int) "abc"` is `0`, never a fatal or a NaN — `Pickup_Point::from_array()`'s
+// `(int) $payload['max_weight']` cast is that lenient, and `pickup-panels.js`'s
+// `formatWeightKg()` has no NaN guard of its own, so letting `NaN` through here would
+// print the literal text "NaN kg" in the confirmation card (issue #201 audit finding).
+test( 'max_weight as a non-numeric garbage string normalizes to 0, never NaN', () => {
+	const { iframe, onSelect, onError } = initProvider();
+
+	const payload = validPointPayload();
+	payload.max_weight = 'abc';
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	expect( onError ).not.toHaveBeenCalled();
+	const point = onSelect.mock.calls[ 0 ][ 0 ];
+	expect( point.max_weight ).toBe( 0 );
+	expect( Number.isNaN( point.max_weight ) ).toBe( false );
 } );
 
 // -----------------------------------------------------------------------

--- a/tests/js/map-provider-embedded.test.js
+++ b/tests/js/map-provider-embedded.test.js
@@ -7,10 +7,12 @@
  *
  * Covers SP-5 Task 14: the `postMessage` origin/source security boundary
  * (exact-match, not prefix; the iframe's own `contentWindow`; fail-closed on
- * an empty `expectedOrigin`), point normalization mirroring
- * `Pickup_Point::from_array()`'s required-field/range rules, the invalid/
- * missing `embedUrl` guard, and `destroy()`'s listener detachment + callback
- * hook clearing + idempotency. Also covers the #201 field-parity fix:
+ * an empty `expectedOrigin`), point normalization against this file's OWN
+ * required-field/range rules (a KNOWN, deliberate divergence from
+ * `Pickup_Point::from_array()`'s required set — see `normalizePoint()`'s own
+ * docblock and #251), the invalid/missing `embedUrl` guard, and `destroy()`'s
+ * listener detachment + callback hook clearing + idempotency. Also covers the
+ * #201 field-parity fix, which is scoped to OPTIONAL-field handling only:
  * `services`/`point_short_name` now normalize at all, and `payment_methods`/
  * `photos`/`services` filter out non-string/whitespace-only elements instead
  * of `String()`-coercing them (matching `Pickup_Point::sanitize_string_list()`),

--- a/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
@@ -77,10 +77,11 @@
  * envelope, `point` is run through {@see normalizePoint}, which mirrors
  * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}'s rules
  * field-for-field (required `id`/`name`/`lat`/`lng`/`address`/`type.code`/
- * `type.label`, `lat` in [-90,90], `lng` in [-180,180]). Failing normalization
- * here emits `error`, NEVER a malformed `select` — a provider that forwarded
- * whatever the carrier sent verbatim would let a broken/malicious carrier page
- * write garbage straight into the order.
+ * `type.label`, `lat` in [-90,90], `lng` in [-180,180]; see that function's own
+ * docblock for the full optional-field list). Failing normalization here emits
+ * `error`, NEVER a malformed `select` — a provider that forwarded whatever the
+ * carrier sent verbatim would let a broken/malicious carrier page write
+ * garbage straight into the order.
  *
  * `selectable` IS DELIBERATELY OMITTED from every point this file emits: it is
  * a server-computed constraint verdict ({@see Constraint_Checker}) that only
@@ -98,6 +99,16 @@
  * what (if anything) this provider showed the customer. This mirrors the A2
  * lesson: a client-side gate must never be the only gate, and here there isn't
  * even a client-side one.
+ *
+ * `icons` IS ALSO DELIBERATELY OMITTED, for a narrower reason than
+ * `selectable`: {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}'s
+ * `icons` field only ever feeds map PIN rendering — `map-provider-yandex.js`'s
+ * own `_buildProperties()` is its only reader anywhere in this codebase
+ * (neither `pickup-panels.js`'s confirmation card nor `pickup-mount.js` ever
+ * reads `point.icons`). This file draws no map of its own (see the top of
+ * this docblock), so there is no pin to skin and nothing would ever read the
+ * field if it were added — carrying it through would be dead weight, not
+ * parity.
  *
  * NO HTML IS EVER BUILT FROM A NORMALIZED POINT HERE. Unlike the `woodev/v1`
  * REST path — where every string is `esc_html`'d server-side exactly once,
@@ -279,6 +290,66 @@
 	}
 
 	/**
+	 * Reads an optional integer field off a raw payload — `null` when
+	 * absent/null, matching `Pickup_Point::from_array()`'s own
+	 * `isset(...) ? (int) ... : null` treatment of `max_weight`. Falls back to
+	 * `0` for a present-but-unparseable value (`parseInt` returning `NaN`),
+	 * mirroring PHP's lenient `(int)` cast of a non-numeric string (`(int)
+	 * "abc" === 0`) rather than letting `NaN` leak into `max_weight` and print
+	 * as the literal text "NaN" wherever `pickup-panels.js`'s
+	 * `formatWeightKg()` renders it.
+	 *
+	 * @param {Object} payload
+	 * @param {string} key
+	 * @returns {number|null}
+	 */
+	function optionalInt( payload, key ) {
+		var value = payload[ key ];
+
+		if ( undefined === value || null === value ) {
+			return null;
+		}
+
+		var parsed = parseInt( value, 10 );
+
+		return isNaN( parsed ) ? 0 : parsed;
+	}
+
+	/**
+	 * Filters a raw carrier list down to non-empty strings — mirrors
+	 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::sanitize_string_list()}
+	 * exactly: a non-string element (a nested object/array a carrier adapter
+	 * forgot to flatten, a stray number or boolean) is DROPPED, not coerced —
+	 * unlike a naive `.map( String )`, which would turn a nested array into the
+	 * literal text "" and an object into "[object Object]", either of which
+	 * could reach the customer as a payment method or photo URL (the JS
+	 * analogue of PHP's `(string)` "Array" bug, issue #154; see that PHP
+	 * method's docblock for the full rationale, including why this replaced
+	 * this file's own former `payment_methods`/`photos` coercion pattern). A
+	 * whitespace-only entry is treated as absent and dropped via `trim()`; the
+	 * string `'0'` is a legitimate label and is deliberately kept.
+	 *
+	 * @param {*} value Raw `payment_methods`/`photos`/`services` payload value.
+	 * @returns {string[]}
+	 */
+	function sanitizeStringList( value ) {
+		if ( ! Array.isArray( value ) ) {
+			return [];
+		}
+
+		var result = [];
+		var i;
+
+		for ( i = 0; i < value.length; i++ ) {
+			if ( 'string' === typeof value[ i ] && '' !== value[ i ].trim() ) {
+				result.push( value[ i ] );
+			}
+		}
+
+		return result;
+	}
+
+	/**
 	 * Normalizes a raw carrier payload into the framework's point shape, or
 	 * returns `null` when it cannot be — mirroring
 	 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}
@@ -286,9 +357,21 @@
 	 * deliberate re-implementation, not a call into PHP, since the carrier's
 	 * embed talks to the BROWSER directly and never touches `woodev/v1`).
 	 *
+	 * Required: `id`/`name`/`lat`/`lng`/`address`/`type.code`/`type.label`.
+	 * Optional, default `''` via {@see optionalString}: `short_address`/
+	 * `locality`/`postal_code`/`phone`/`instruction`/`work_time`/
+	 * `point_short_name`. Optional, default `[]`, filtered through
+	 * {@see sanitizeStringList} exactly like `Pickup_Point::sanitize_string_list()`
+	 * — non-string and whitespace-only elements DROPPED, not coerced:
+	 * `payment_methods`/`photos`/`services`. Optional, default `null`:
+	 * `accepts_cod` (`Boolean()`-cast) and `max_weight` (via
+	 * {@see optionalInt}, PHP `(int)`-cast parity).
+	 *
 	 * `selectable` is never added — see the file docblock's "AUTHORITY for
 	 * this path" section for why the server re-check at
 	 * `Pickup_Handler::handle_checkout_process()` is what actually gates this.
+	 * `icons` is never added either — see the file docblock's "`icons` IS ALSO
+	 * DELIBERATELY OMITTED" paragraph.
 	 *
 	 * @param {*} payload
 	 * @returns {Object|null}
@@ -346,16 +429,14 @@
 			phone: optionalString( payload, 'phone' ),
 			instruction: optionalString( payload, 'instruction' ),
 			work_time: optionalString( payload, 'work_time' ),
-			payment_methods: Array.isArray( payload.payment_methods )
-				? payload.payment_methods.map( String )
-				: [],
-			photos: Array.isArray( payload.photos ) ? payload.photos.map( String ) : [],
+			point_short_name: optionalString( payload, 'point_short_name' ),
+			payment_methods: sanitizeStringList( payload.payment_methods ),
+			photos: sanitizeStringList( payload.photos ),
+			services: sanitizeStringList( payload.services ),
 			accepts_cod: undefined !== payload.accepts_cod && null !== payload.accepts_cod
 				? Boolean( payload.accepts_cod )
 				: null,
-			max_weight: undefined !== payload.max_weight && null !== payload.max_weight
-				? parseInt( payload.max_weight, 10 )
-				: null,
+			max_weight: optionalInt( payload, 'max_weight' ),
 		};
 	}
 

--- a/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
@@ -74,14 +74,18 @@
  * not that every message they ever send is meant for this picker.
  *
  * NORMALIZATION, NOT NORMALIZATION-OR-DIE: once a message IS recognised as our
- * envelope, `point` is run through {@see normalizePoint}, which mirrors
- * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}'s rules
- * field-for-field (required `id`/`name`/`lat`/`lng`/`address`/`type.code`/
- * `type.label`, `lat` in [-90,90], `lng` in [-180,180]; see that function's own
- * docblock for the full optional-field list). Failing normalization here emits
- * `error`, NEVER a malformed `select` — a provider that forwarded whatever the
- * carrier sent verbatim would let a broken/malicious carrier page write
- * garbage straight into the order.
+ * envelope, `point` is run through {@see normalizePoint}. It is NOT a
+ * field-for-field mirror of
+ * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()} — only
+ * its OPTIONAL-field handling (defaults, list filtering, int/bool casts) is
+ * kept deliberately aligned with that PHP method, field by field. Its
+ * REQUIRED-field set is this file's OWN, currently `id`/`name`/`lat`/`lng`/
+ * `address`/`type.code`/`type.label` (`lat` in [-90,90], `lng` in
+ * [-180,180]) — see {@see normalizePoint}'s own docblock for why that set is
+ * a KNOWN, deliberate divergence from `from_array()`, not drift. Failing
+ * normalization here emits `error`, NEVER a malformed `select` — a provider
+ * that forwarded whatever the carrier sent verbatim would let a broken/
+ * malicious carrier page write garbage straight into the order.
  *
  * `selectable` IS DELIBERATELY OMITTED from every point this file emits: it is
  * a server-computed constraint verdict ({@see Constraint_Checker}) that only
@@ -350,14 +354,32 @@
 	}
 
 	/**
-	 * Normalizes a raw carrier payload into the framework's point shape, or
-	 * returns `null` when it cannot be — mirroring
-	 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}
-	 * field-for-field (see that class for the authoritative rules; this is a
-	 * deliberate re-implementation, not a call into PHP, since the carrier's
-	 * embed talks to the BROWSER directly and never touches `woodev/v1`).
+	 * Normalizes a raw carrier payload into this provider's point shape, or
+	 * returns `null` when it cannot be. This is a deliberate re-implementation,
+	 * not a call into PHP, since the carrier's embed talks to the BROWSER
+	 * directly and never touches `woodev/v1`.
 	 *
-	 * Required: `id`/`name`/`lat`/`lng`/`address`/`type.code`/`type.label`.
+	 * NOT a field-for-field mirror of
+	 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()} — only
+	 * the OPTIONAL-field handling below is kept aligned with that PHP method,
+	 * field by field. The REQUIRED-field set is this file's own and diverges on
+	 * purpose:
+	 *
+	 * Required: `id`/`name`/`lat`/`lng`/`address`/`type.code`/`type.label`
+	 * (`lat` in [-90,90], `lng` in [-180,180]). `from_array()` requires `lat`/
+	 * `lng` too, but for a different reason — the framework's own map
+	 * (`map-provider-yandex.js`) needs coordinates to place a marker. THIS
+	 * provider draws no map of ours (see the file docblock's opening
+	 * paragraph), and a real carrier embed does not necessarily supply
+	 * coordinates at all: Почта России's widget, measured against this seam on
+	 * the rig, returns a selection payload with no `lat`/`lng` and no `name`
+	 * (`{ id, mailType, pvzType, indexTo, cashOfDelivery, regionTo, cityTo,
+	 * addressTo, weight, ... }`). Relaxing this required set to match what real
+	 * carriers actually send is tracked as #251; until that lands, requiring
+	 * `lat`/`lng`/`name` here means this function rejects that real payload.
+	 * KNOWN AND DELIBERATE, not an oversight of this pass — do not "fix" it as
+	 * a drift in isolation, it would conflict with #251's landing change.
+	 *
 	 * Optional, default `''` via {@see optionalString}: `short_address`/
 	 * `locality`/`postal_code`/`phone`/`instruction`/`work_time`/
 	 * `point_short_name`. Optional, default `[]`, filtered through


### PR DESCRIPTION
## Summary

`normalizePoint()` in `map-provider-embedded.js` claimed (in its own docblock) to mirror
`Pickup_Point::from_array()` field-for-field, but had drifted. This PR does the full
field-by-field audit the issue asked for and fixes every OPTIONAL-field divergence found,
not just the two called out in the issue text.

**Scope correction made mid-PR, from a rig measurement in the main session:** a real
carrier embed (Почта России's widget) was run against this seam, and its selection payload
has no `lat`/`lng` and no `name` at all. `Pickup_Point::from_array()` requires `lat`/`lng`
because the framework's own map (`map-provider-yandex.js`) needs coordinates to place a
marker — this provider draws no map of its own and a real carrier embed does not
necessarily supply coordinates. So the "field-for-field mirror" claim was wrong in
*principle* for the REQUIRED-field set, not merely drifted: this file's required-field set
is deliberately its own, and always was going to have to be. Relaxing it to match what
real carriers actually send is tracked separately as **#251** (with the rig measurement as
its justification) — **this PR does not touch required-field logic**, only rewords the
docblocks to stop asserting a false parity claim and to point at #251 instead of leaving it
looking like unfixed drift.

- `services` — was never read from the payload at all.
- `point_short_name` — added to `Pickup_Point::from_array()`/`to_browser_array()` for
  #199, never mirrored here, so a point selected through the embedded provider never got
  a card label override (`pickup-panels.js` line ~1122 reads `point.point_short_name`).
- `payment_methods`/`photos` — used a stale `.map(String)` coercion pattern that predates
  `Pickup_Point::sanitize_string_list()`'s #154 rewrite. PHP now **filters** non-string
  elements (drops them) instead of coercing them to `"42"`/`"true"`/`"[object Object]"`.
  Fixed via a shared `sanitizeStringList()` helper, reused for the new `services` field.
- `max_weight` — used `parseInt()` directly, which returns `NaN` for a garbage string
  where PHP's lenient `(int)` cast returns `0`. `pickup-panels.js`'s `formatWeightKg()`
  has no `NaN` guard, so this would have printed the literal text **"NaN"** in the
  confirmation card for a malformed carrier payload.
- `icons` — newly documented (file docblock) as a deliberate omission, same category as
  the existing `selectable` one: it only ever feeds `map-provider-yandex.js`'s own pin
  rendering, and this file draws no map of its own.

## Field-by-field divergence audit — PHP `Pickup_Point::from_array()` vs JS `normalizePoint()`

| Field | PHP (`Pickup_Point::from_array()`) | JS before | JS after | Verdict |
|---|---|---|---|---|
| `id` | required, `is_scalar`, non-empty → `(string)` | required | unchanged | OK — both require it, coincidentally |
| `name` | required, `is_scalar`, non-empty → `(string)` | required | unchanged | **KNOWN deliberate divergence, pending #251** — a real carrier payload (Почта России) has no `name`; PHP requires it because it needs a card title, this file's real-world need for it is unverified. Not touched in this PR; #251 owns relaxing it. |
| `lat` | required, `is_numeric`, range `[-90,90]` → `(float)` | required | unchanged | **KNOWN deliberate divergence, pending #251** — PHP requires it for `map-provider-yandex.js`'s own marker placement; this provider draws no map of ours and a real carrier embed (measured: Почта России) does not supply coordinates at all. Not touched in this PR — relaxing it is #251's job, doing it here would conflict with that PR. |
| `lng` | required, `is_numeric`, range `[-180,180]` → `(float)` | required | unchanged | same as `lat` — **KNOWN deliberate divergence, pending #251** |
| `address` | required, `is_scalar`, non-empty → `(string)` | required | unchanged | Not flagged by the rig measurement — Почта России's payload does carry an address-shaped value (`addressTo`), even though the exact field name differs and would need integrator-side mapping. Unchanged in this PR either way. |
| `type.code` / `type.label` | required, `isset()` (empty string allowed) → `(string)` | required | unchanged | Not addressed by this PR or by the rig measurement report — the measured payload has no `{code, label}`-shaped field, only flat `mailType`/`pvzType` strings, but no verdict on this field was given to me and I'm not extending #251's scope on my own read of the raw payload. Left exactly as-is. |
| `short_address` | optional, `isset() ? (string) : ''` | matches | matches | OK |
| `locality` | optional, `isset() ? (string) : ''` | matches | matches | OK |
| `postal_code` | optional, `isset() ? (string) : ''` | matches | matches | OK |
| `phone` | optional, `isset() ? (string) : ''` | matches | matches | OK |
| `instruction` | optional, `isset() ? (string) : ''` | matches | matches | OK |
| `work_time` | optional, `isset() ? (string) : ''` | matches | matches | OK |
| `point_short_name` | optional, `isset() ? (string) : ''` (added for #199) | **missing entirely** | `optionalString()` | **fixed** |
| `payment_methods` | `sanitize_string_list()` — filters to non-empty strings, drops non-string elements | `.map(String)` — coerced, never dropped | `sanitizeStringList()` — filters | **fixed** (behavior corrected, not just added) |
| `photos` | `sanitize_string_list()` | `.map(String)` — coerced | `sanitizeStringList()` | **fixed** (same correction) |
| `services` | `sanitize_string_list()` | **missing entirely** | `sanitizeStringList()` | **fixed** |
| `accepts_cod` | optional, `isset() ? (bool) : null` | `Boolean()` cast | unchanged | OK (see note below) |
| `max_weight` | optional, `isset() ? (int) : null` | `parseInt()`, → `NaN` on garbage | `optionalInt()` → `0` on garbage, matching PHP `(int)"abc" === 0` | **fixed** |
| `icons` | optional, `sanitize_icons()` → `{default, active}` or `null` | omitted, undocumented | omitted, **now documented** as deliberate (only consumer anywhere is `map-provider-yandex.js`'s pin rendering; this file draws no map) | **documented**, not added |
| `selectable` | not part of `Pickup_Point` at all — a server-computed constraint verdict attached elsewhere | omitted, already documented at length | unchanged | OK — pre-existing, correct |

### Minor edge cases identified, deliberately left unfixed (documented here, not in code)

These are genuine PHP-vs-JS coercion differences but only surface for carrier payloads
shaped nothing like a real point (a boolean where a coordinate is expected, a hex-string
coordinate, an array where a cod-flag is expected). Fixing them would mean re-implementing
PHP's full scalar-cast semantics in JS for no realistic gain:

- `is_numeric()` (PHP) vs the JS `isNumeric()` helper: `Number("0x1A")` parses as `26` in
  JS, but PHP's `is_numeric("0x1A")` is `false`. Only reachable if a carrier sent a
  hex-string coordinate.
- `(string)` cast of a boolean: PHP `(string)true === "1"`, `(string)false === ""`; JS
  `String(true) === "true"`. Only reachable if a carrier sent a boolean for `id`/`name`/
  `address`/`type.code`/`type.label` instead of a string/number.
- `(bool)` cast of an array: PHP `(bool)[] === false`; JS `Boolean([]) === true` (objects
  are always truthy). Only reachable if a carrier sent an array for `accepts_cod`.

## Tests

`tests/js/map-provider-embedded.test.js` — added coverage for every field touched, both
present-and-valid and absent/garbage:
- `services` present with valid strings; absent (via the existing default-shape test).
- `point_short_name` present as a string; present as a non-string scalar (coerced);
  absent (via the existing default-shape test).
- `payment_methods`/`photos`/`services` filtering: non-string/whitespace-only elements
  dropped, `'0'` kept, non-array payload degrades to `[]` — run against all three fields
  via `test.each`.
- `max_weight` garbage string → `0`, never `NaN`.
- Replaced the old test that pinned the incorrect `.map(String)` coercion behavior.

Local run: `npm run test:js -- --roots "<rootDir>/tests/js"` — **813 → 822 tests, all green**.

`composer phpcs` and `composer test:unit` also run clean (no PHP touched by this change).

## Test plan

- [x] `npm run test:js -- --roots "<rootDir>/tests/js"` green (822/822)
- [x] `composer phpcs` clean
- [x] `composer test:unit` green (1520/1520, 66 skipped as before)
- [ ] Operator smoke-check: select a point through an embedded-provider carrier sandbox
      and confirm the card shows the short name / services chips when the carrier
      payload supplies them

Closes #201
