### PR TITLE
feat(shipping): embedded map-provider adapter seam + rig fixture (#251)

### DIFF
--- a/docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md
+++ b/docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md
@@ -1,0 +1,207 @@
+# Spec — #251: make the embedded (carrier-widget) seam reachable, and prove it with a real carrier
+
+> Written s63 (10.08.2026). Every claim in §1 is a MEASUREMENT taken on the rig
+> (`http://localhost:8973`) against the live Почта России widget, not a reading of vendor
+> docs. The operator warned that `widget.pochta.ru/docs` / `cms.pochta.ru/docs` are stale;
+> they were deliberately not consulted before the measurements.
+
+## 1. Measurements — the evidence this spec rests on
+
+Probe pages were served from the rig's own docroot so the parent origin was a real
+`http://localhost:8973`, and the iframes were built with the framework's VERBATIM posture
+(`sandbox="allow-scripts allow-same-origin allow-forms allow-popups"`,
+`referrerpolicy="no-referrer"`), copied from `buildIframe()` in
+`map-provider-embedded.js`.
+
+| # | Question | Measured answer |
+|---|---|---|
+| M1 | Is `https://widget.pochta.ru/map/` framable from an arbitrary origin? | **Yes.** `curl -I` shows no `X-Frame-Options` and no CSP `frame-ancestors`. |
+| M2 | Does the framework's `sandbox` posture break the widget? | **No.** Sandboxed and unsandboxed frames behaved identically: both loaded, both rendered the full live point set for Moscow, both were fully interactive. |
+| M3 | What is the carrier's handshake? | frame → parent `{ isMapLoad: true }`; parent → frame `{ postData: { siteId, accountId, accountType, weight, sumoc, startZip, startAddress, url, dimensions, orderLines } }`; frame → parent `{ pvzData: {...} }`. The carrier's own loader (`widget.pochta.ru/map/widget/widget.js`, 1.2 KB) does nothing else. |
+| M4 | Does the widget render without `postData`? | **No.** It stays blank until the parent answers `isMapLoad`. So an `embedUrl` pointed straight at the widget with no outbound message yields a permanently empty modal. |
+| M5 | Does it accept `postData` from a foreign parent origin? | **Yes.** It never checks `event.origin`; the carrier posts and listens with `"*"` in both directions. |
+| M6 | Do the framework's two trust checks hold against it? | **Yes, both.** `event.origin === 'https://widget.pochta.ru'` exactly (no trailing slash, no port), and `event.source === iframe.contentWindow` for every message including the selection. |
+| M7 | What does a selection actually contain? | Postamat: `{"id":43213,"mailType":"ONLINE_PARCEL","pvzType":"postamat","indexTo":"918872","cashOfDelivery":22094,"deliveryDescription":{"description":"1 день","values":{...}},"regionTo":"г. Москва","areaTo":"р-н Коммунарка","cityTo":"п. Воскресенское","addressTo":"27","weight":"1000","location":null,"boxSize":"l","sumoc":"1000"}`. Post office: same shape, `pvzType:"russian_post"`, `areaTo:null`, no `boxSize`. |
+| M8 | **Does a selection carry coordinates or a name?** | **No.** Neither `lat`/`lng` nor `name` appears in either type's payload. |
+| M9 | Does the carrier guard its own double-confirm? | Partially — after a selection it sets its own «Забрать здесь» button `disabled` for that point. |
+
+Two further facts were read out of the framework's own source (not measured, but verified
+by reading, and they are what makes M8 actionable):
+
+- `pickup-mount.js` contains **zero** reads of `.lat`/`.lng` (`grep -c` → 0). The two in
+  `pickup-panels.js` are unreachable under `ownsChrome`, where `panels === null`.
+- The confirmation round trip is `realDataSource.selectPoint( { pointId, fieldId } )` — the
+  **id only**. The server may answer with `result.point`, a CORRECTED point that supersedes
+  the client's entirely (`finishSelection()`).
+
+## 2. Decision
+
+**Adapter over iframe.** The provider keeps building the `<iframe>` and keeps owning the
+`origin` + `event.source` gate; the carrier's own protocol is translated by two optional,
+plugin-supplied hooks.
+
+**Rejected: script mode** (provider calls a plugin global instead of building an iframe, and
+the carrier's own loader mounts the widget). Its only advantage was surviving a sandbox
+incompatibility — M2 disproves that this exists. Its cost is decisive: the trust gate would
+move out of the framework into the carrier's shim, which posts to `"*"` and validates
+nothing (M5). We would be strictly less safe than the framework already is, to buy nothing.
+
+**Rejected: a plugin-hosted https bridge page.** M1–M6 make it unnecessary — no hosting, no
+public page, no extra origin to trust.
+
+## 3. Framework change A — two optional adapter hooks
+
+### 3.1 PHP — `Embedded_Map_Provider`
+
+Two new optional constructor parameters, both defaulting to `null`, both carried verbatim
+into `get_js_config()`:
+
+```php
+public function __construct(
+    string $embed_url,
+    string $expected_origin,
+    ?string $init_adapter = null,
+    ?string $select_adapter = null
+)
+```
+
+`get_js_config()` gains `initAdapter` and `selectAdapter`. Each is a **dotted global path**
+(e.g. `'WoodevPochtaEmbed.toPoint'`), not a callable — the value crosses into the browser as
+JSON.
+
+### 3.2 JS — `map-provider-embedded.js`
+
+Resolve a dotted path by walking `window` on `.` (never `eval`, never `new Function`); a path
+that does not resolve to a function is treated as absent.
+
+`handleMessage()` order, AFTER the existing origin + source gate (unchanged, and still the
+only trust boundary):
+
+1. The framework's own envelope (`{source:'woodev-pickup-embedded', type:'select', point}`) —
+   handled exactly as today. Adapters never see it.
+2. `initAdapter( data )` → returns a payload or `null`. Non-null is posted into the frame
+   with `iframe.contentWindow.postMessage( payload, config.expectedOrigin )` — **the expected
+   origin as `targetOrigin`, never `"*"`**. Return.
+3. `selectAdapter( data )` → returns a raw point payload or `null`. Non-null goes through
+   `normalizePoint()` and then the existing emit path (`select` on success, `error` on
+   rejection). Return.
+
+Rules:
+
+- An adapter that **throws** must not break the picker. `initAdapter` throwing is swallowed
+  (the message bus is shared). `selectAdapter` throwing emits `error` — the message already
+  proved it came from the trusted frame, so a failure there is a real, reportable fault.
+- An empty `expectedOrigin` already rejects every inbound message; it must ALSO suppress the
+  outbound post in step 2, since there would be no safe `targetOrigin`.
+- Adapters run strictly after the gate. **They never widen the trust boundary** — they only
+  translate messages already proven to come from this instance's own iframe at the expected
+  origin. Say this in the docblock; it is the question a reviewer will ask.
+
+## 4. Framework change B — `lat`/`lng` become optional on this path
+
+Justified by M8 + the two source facts in §1: a real carrier embed does not send
+coordinates, and on the `ownsChrome` path nothing in the framework consumes them.
+
+In `normalizePoint()`:
+
+- `lat`/`lng` move from **required** to **optional-but-validated**.
+- Present → must be numeric and in range (`lat` ∈ [-90,90], `lng` ∈ [-180,180]). Junk is
+  still REJECTED, never coerced — that rule does not change.
+- Absent → omitted from the emitted point. No `0.0` fallback, ever.
+- **Exactly one of the pair present → reject.** A half-coordinate is a bug in the adapter,
+  not a partial datum.
+- `name` stays REQUIRED. Почта sends none, but a name is domain knowledge the plugin can
+  build (`Почтомат №918872` from `pvzType` + `indexTo`), and it is what the checkout field
+  and trigger label display. The framework must not invent it.
+
+#201 (merged as `ccf35c1`) already removed both "field-for-field mirror" claims and replaced
+them with an explicit **required-field divergence** paragraph that names this issue as its
+owner and says "until #251 lands, requiring `lat`/`lng`/`name` here means this function
+rejects that real payload". Both paragraphs (file docblock ~line 78, `normalizePoint()`
+~line 362) must now be brought up to date — they describe a state this change ends. Do not
+leave a docblock pointing at #251 as future work once #251 has landed.
+
+`Pickup_Point::from_array()` itself is **NOT** changed — the REST path feeds our own map,
+which genuinely needs coordinates.
+
+## 5. Fixture — `WOODEV_TEST_PICKUP_EMBEDDED`
+
+In `tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php`, in the
+same idiom as `WOODEV_TEST_PICKUP_LIVE_YANDEX` / `LIVE_POCHTA` (declared ~lines 25–62,
+resolved ~441–447, provider constructed ~481–487):
+
+- `WOODEV_TEST_PICKUP_EMBEDDED` (bool, default `false`). When truthy it wins over every other
+  switch and constructs `Embedded_Map_Provider` instead of `Yandex_Map_Provider`. Document the
+  precedence in the same style as the existing block — the existing constants document theirs.
+- The point source becomes irrelevant under this switch (the embed fetches its own points);
+  say so explicitly rather than leaving a dead-looking branch.
+- `WOODEV_TEST_POCHTA_ACCOUNT_ID` / `WOODEV_TEST_POCHTA_ACCOUNT_TYPE` — credentials. **Never
+  committed**; they live in the container's wp-config via `wp config set`, exactly like the
+  Yandex token. The fixture reads them with a `defined()` guard and degrades to an empty
+  string.
+- `WOODEV_TEST_PICKUP_SELECTION_CLOSE` / `WOODEV_TEST_PICKUP_SELECTION_REFRESH_CHECKOUT` —
+  the card asks for this: the stock config is `selection: { close: true, refreshCheckout:
+  false }`, which makes the "modal stays open after a selection" path unreachable from a
+  fixture (in s62 it had to be patched live in the browser).
+
+A fixture-owned adapter script implements the Почта translation — this is DOMAIN knowledge and
+must not leak into the framework:
+
+```js
+window.WoodevPochtaEmbed = {
+    onReady: function ( data ) {
+        if ( ! data || ! data.isMapLoad ) { return null; }
+        return { postData: { accountId: …, accountType: …, weight: …, sumoc: …,
+                             startZip: …, startAddress: …, url: window.location.href } };
+    },
+    toPoint: function ( data ) {
+        if ( ! data || ! data.pvzData ) { return null; }
+        var p = data.pvzData;
+        return {
+            id:      String( p.id ),
+            name:    ( 'postamat' === p.pvzType ? 'Почтомат №' : 'Отделение №' ) + p.indexTo,
+            address: [ p.regionTo, p.areaTo, p.cityTo, p.location, p.addressTo ]
+                        .filter( Boolean ).join( ', ' ),
+            type:    { code: p.pvzType, label: … },
+            postal_code: String( p.indexTo )
+            // no lat/lng — the carrier sends none (M8)
+        };
+    }
+};
+```
+
+The address composition mirrors the operator's own production plugin
+(`plugins-reference/woodev-russian-post/includes/classes/ajax.php`, `set_point()`), which
+builds it from exactly `regionTo, areaTo, cityTo, location, addressTo` through
+`array_filter()`. Follow that, do not invent a different order.
+
+## 6. Rig verification — the five checks the card asks for
+
+Run each on the rig with `WOODEV_TEST_PICKUP_EMBEDDED` on, and record the OBSERVED result,
+not "should work":
+
+1. **No-panels layout** — `panels === null`, `mapHost === modal.getContainer()`; the modal's
+   size/loading/error branches take the no-panels path.
+2. **`refresh()` under `ownsChrome` is a hard no-op** — i.e. the #232/#238 cart-change verdict
+   invalidation does not reach embedded pickers at all. Confirm this is deliberate and record
+   it; do not "fix" it here.
+3. **The #238 echo gap stays harmless** — `refreshCheckout()` gets `panels === null`, no waiter
+   is bound, the echo is not suppressed. Safe precisely because `refresh()` is a no-op. The
+   comment saying so is already in `pickup-mount.js`; verify it still holds.
+4. **Double confirmation** — nothing in the framework damps it under `ownsChrome` (no card, no
+   lock). M9 says the carrier disables its own button; check with a live double click whether
+   that is enough, and record what actually happens.
+5. **Failure paths** — an invalid `embedUrl` must produce an error state with a retry;
+   `IFRAME_LOAD_TIMEOUT_MS` (10 s) must fire for a host that accepts and never answers.
+
+## 7. Known gaps, deliberately not closed here
+
+- A carrier that loads successfully but serves an error page is still invisible to us
+  (`onload` fires regardless). Pre-existing, documented in the file, unchanged.
+- `cashOfDelivery` / `deliveryDescription` in `pvzData` mean the widget prices the shipment
+  itself. Out of scope; noted because it will matter when a real plugin is built on this.
+
+## 8. Related
+
+- Issue #251 (this), #201 (normalizer parity, landed first), #158 (fixture is too poor to
+  exercise the type filter), #148 (verdict staleness — does not apply under `ownsChrome`).

--- a/docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md
+++ b/docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md
@@ -110,6 +110,14 @@ In `normalizePoint()`:
 - Absent → omitted from the emitted point. No `0.0` fallback, ever.
 - **Exactly one of the pair present → reject.** A half-coordinate is a bug in the adapter,
   not a partial datum.
+- **An explicit `null` counts as ABSENT, not as a present-but-invalid value.** The spec was
+  underspecified here and an adversarial review read it the other way, so the decision is
+  recorded with its evidence: (a) `Pickup_Point::from_array()` tests presence with `isset()`,
+  which is already `false` for `null`, and this file's stated alignment is with that method's
+  optional-field handling; (b) the live Почта payload literally sends `"areaTo": null` and
+  `"location": null` (§1 M7) — `null` is the carrier's own way of writing "no value", not
+  junk; (c) the half-coordinate rule still bites, because `{ lat: null, lng: 55.7 }` reads as
+  lat-absent + lng-present and is rejected.
 - `name` stays REQUIRED. Почта sends none, but a name is domain knowledge the plugin can
   build (`Почтомат №918872` from `pvzType` + `indexTo`), and it is what the checkout field
   and trigger label display. The framework must not invent it.
@@ -193,6 +201,30 @@ not "should work":
    that is enough, and record what actually happens.
 5. **Failure paths** — an invalid `embedUrl` must produce an error state with a retry;
    `IFRAME_LOAD_TIMEOUT_MS` (10 s) must fire for a host that accepts and never answers.
+
+## 6a. Rig verification — OBSERVED results (10.08.2026)
+
+Run on `feat/251-embedded-adapter-seam` with `WOODEV_TEST_PICKUP_EMBEDDED` on, against the
+live carrier. Every row is an observed artefact, not an absence of complaints.
+
+| # | Observed |
+|---|---|
+| 1 | `panelsPresent: 0`; the `<iframe>` is the ONLY child of `.woodev-modal__body`, with `sandbox="allow-scripts allow-same-origin allow-forms allow-popups"` and `referrerpolicy="no-referrer"`. The live widget rendered inside our modal. |
+| 2 | On `update_checkout`: WooCommerce answered (`/?wc-ajax=update_order_review` fired), `woodev/v1` calls = **0**, and the iframe's `contentWindow` was the SAME object afterwards — `refresh()` is a hard no-op and the frame is not rebuilt. Confirmed deliberate; unchanged. |
+| 3 | Same observation — `refreshCheckout()` gets `panels === null`, no waiter is bound, nothing is suppressed. Harmless only because 2 holds. |
+| 4 | Two selections back to back produced **2** `select_requested` and **1** `select_resolved` (the LATER one). The framework does not damp a second confirmation under `ownsChrome` — the documented, deliberate consequence — but the token guard discards the stale answer. Separately: the carrier disables its own «Забрать здесь» after a selection, so its own UI damps the same-point case. |
+| 5 | Non-https `embedUrl` → no iframe, error + «Повторить» immediately. Unresponsive https host → error + «Повторить» at **10 159 ms** (the 10 s `IFRAME_LOAD_TIMEOUT_MS`), iframe removed from the DOM. |
+
+Full success path, after the post-review fixes: point `35482`, address
+`г. Москва, ул. Тверская 9 стр. 5` (no duplicated locality), **no `lat`/`lng` on the emitted
+point**, server verdict `allowed: true`, field written to `35482`, modal closed, trigger
+relabelled to «Выбрать другой пункт выдачи».
+
+The 404 that this path returned BEFORE the fixture stub is worth keeping in mind: the
+confirmation round trip is server-authoritative and always calls
+`Point_Source::fetch_details()` regardless of which map provider drew the picker. A real
+embedded plugin therefore MUST implement a genuine carrier details lookup — the embed being
+self-sufficient for DISPLAY does not make it self-sufficient for CONFIRMATION.
 
 ## 7. Known gaps, deliberately not closed here
 

--- a/tests/_fixtures/woodev-test-shipping-method/assets/js/woodev-test-pochta-embed-adapter.js
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/js/woodev-test-pochta-embed-adapter.js
@@ -19,6 +19,20 @@
  * (`plugins-reference/woodev-russian-post/includes/classes/ajax.php`,
  * `set_point()`); do not reorder it.
  *
+ * F5 (rig finding, cosmetic, s63): a CONSECUTIVE-duplicate part is dropped
+ * before joining, added ON TOP of that field ORDER (not instead of it — the
+ * order above is untouched). Measured on the rig for Moscow: the carrier
+ * sends `regionTo: "г. Москва"` AND `cityTo: "г. Москва"` for the same
+ * point, so the naive `filter( Boolean ).join( ', ' )` produced
+ * `"г. Москва, г. Москва, ул. Никольская 7-9 стр. 4"`. {@see dedupeConsecutive}
+ * collapses only ADJACENT repeats (never removes a part that recurs
+ * non-consecutively, e.g. a region name that also happens to be a street
+ * name elsewhere), which is enough to fix this without reordering or
+ * dropping anything the reference plugin's own field list keeps. FIXTURE-
+ * ONLY: this stays out of `map-provider-embedded.js` and out of
+ * `Embedded_Map_Provider` — address composition is domain knowledge, exactly
+ * like the rest of this file (see the paragraph above).
+ *
  * `window.WoodevTestPochtaEmbedConfig` is localized by
  * `Woodev_Test_Shipping_Method_Plugin::maybe_enqueue_pochta_embed_adapter()`
  * in `woodev-test-shipping-method.php` — `accountId`/`accountType` come from
@@ -48,6 +62,34 @@
 	 */
 	function typeLabel( pvzType ) {
 		return 'postamat' === pvzType ? 'Почтомат' : 'Почтовое отделение';
+	}
+
+	/**
+	 * Drops a part that is IDENTICAL to the one immediately before it — F5 (rig
+	 * finding, s63), see the file docblock's own paragraph for the measured
+	 * Moscow case this fixes (`regionTo`/`cityTo` both `"г. Москва"`). Only
+	 * ADJACENT duplicates are collapsed: the field ORDER from the file docblock
+	 * (`regionTo, areaTo, cityTo, location, addressTo`) is preserved exactly,
+	 * and a value that repeats NON-consecutively (impossible with today's
+	 * measured field set, but not assumed impossible here) would survive
+	 * untouched — this is deliberately narrower than a generic "unique
+	 * values" filter, which could silently reorder-by-omission or drop a
+	 * legitimate repeat far apart in the address.
+	 *
+	 * @param {string[]} parts Already `filter( Boolean )`ed address parts.
+	 * @returns {string[]}
+	 */
+	function dedupeConsecutive( parts ) {
+		var result = [];
+		var i;
+
+		for ( i = 0; i < parts.length; i++ ) {
+			if ( 0 === result.length || result[ result.length - 1 ] !== parts[ i ] ) {
+				result.push( parts[ i ] );
+			}
+		}
+
+		return result;
 	}
 
 	window.WoodevPochtaEmbed = {
@@ -104,9 +146,9 @@
 			return {
 				id: String( p.id ),
 				name: ( 'postamat' === p.pvzType ? 'Почтомат №' : 'Отделение №' ) + p.indexTo,
-				address: [ p.regionTo, p.areaTo, p.cityTo, p.location, p.addressTo ]
-					.filter( Boolean )
-					.join( ', ' ),
+				address: dedupeConsecutive(
+					[ p.regionTo, p.areaTo, p.cityTo, p.location, p.addressTo ].filter( Boolean )
+				).join( ', ' ),
 				type: {
 					code: p.pvzType,
 					label: typeLabel( p.pvzType )

--- a/tests/_fixtures/woodev-test-shipping-method/assets/js/woodev-test-pochta-embed-adapter.js
+++ b/tests/_fixtures/woodev-test-shipping-method/assets/js/woodev-test-pochta-embed-adapter.js
@@ -1,0 +1,120 @@
+/**
+ * Woodev Test Fixture — Почта России embedded-widget adapter (issue #251).
+ *
+ * FIXTURE-OWNED DOMAIN KNOWLEDGE, deliberately kept OUT of the framework — see
+ * `Embedded_Map_Provider`'s class docblock, option 2. This file supplies the
+ * two dotted-global-path adapter hooks
+ * (`Embedded_Map_Provider::__construct()`'s `$init_adapter`/`$select_adapter`)
+ * that translate the live `https://widget.pochta.ru/map/` widget's OWN
+ * `postMessage` protocol into `map-provider-embedded.js`'s normalized point
+ * shape, without a plugin-hosted bridge page.
+ *
+ * Every field name/shape below (`isMapLoad`, `postData`, `pvzData`, `pvzType`,
+ * `indexTo`, `regionTo`/`areaTo`/`cityTo`/`location`/`addressTo`) was MEASURED
+ * on the rig against the live widget, not read from vendor docs — see
+ * `docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md` §1,
+ * measurements M3/M7/M8. The address composition — exactly `regionTo, areaTo,
+ * cityTo, location, addressTo`, filtered and joined with `', '` — is copied
+ * verbatim from the operator's own production plugin
+ * (`plugins-reference/woodev-russian-post/includes/classes/ajax.php`,
+ * `set_point()`); do not reorder it.
+ *
+ * `window.WoodevTestPochtaEmbedConfig` is localized by
+ * `Woodev_Test_Shipping_Method_Plugin::maybe_enqueue_pochta_embed_adapter()`
+ * in `woodev-test-shipping-method.php` — `accountId`/`accountType` come from
+ * the (never-committed) `WOODEV_TEST_POCHTA_ACCOUNT_ID`/
+ * `WOODEV_TEST_POCHTA_ACCOUNT_TYPE` wp-config constants; `weight`/`sumoc`/
+ * `startZip`/`startAddress` are fixture placeholders, not real cart data.
+ *
+ * Plain ES5, no jQuery, no build step — matches every sibling script under
+ * `woodev/shipping-method/assets/js/frontend/`.
+ *
+ * @file
+ */
+
+( function() {
+	'use strict';
+
+	/** @type {Object} localized by wp_localize_script(), see the file docblock. */
+	var CONFIG = window.WoodevTestPochtaEmbedConfig || {};
+
+	/**
+	 * Human label for a `pvzType` value — domain knowledge, not the framework's.
+	 * The widget itself never sends a label (M7/M8); this is invented here, the
+	 * one place that is allowed to.
+	 *
+	 * @param {string} pvzType
+	 * @returns {string}
+	 */
+	function typeLabel( pvzType ) {
+		return 'postamat' === pvzType ? 'Почтомат' : 'Почтовое отделение';
+	}
+
+	window.WoodevPochtaEmbed = {
+
+		/**
+		 * `Embedded_Map_Provider`'s `initAdapter` hook. Answers the widget's own
+		 * handshake — `{ isMapLoad: true }`, measured M3 — with the `postData` it
+		 * requires before it renders anything at all (M4: it stays blank without
+		 * this). Any other message this instance is asked about (not the
+		 * handshake) is declined by returning `null`, so `selectAdapter` gets a
+		 * chance at it next.
+		 *
+		 * @param {*} data
+		 * @returns {Object|null}
+		 */
+		onReady: function( data ) {
+			if ( ! data || true !== data.isMapLoad ) {
+				return null;
+			}
+
+			return {
+				postData: {
+					accountId: CONFIG.accountId || '',
+					accountType: CONFIG.accountType || '',
+					weight: CONFIG.weight,
+					sumoc: CONFIG.sumoc,
+					startZip: CONFIG.startZip || '',
+					startAddress: CONFIG.startAddress || '',
+					url: window.location.href
+				}
+			};
+		},
+
+		/**
+		 * `Embedded_Map_Provider`'s `selectAdapter` hook. Translates the widget's
+		 * own selection message — `{ pvzData: {...} }`, measured M7 — into this
+		 * provider's raw point payload. Deliberately emits NO `lat`/`lng`: the
+		 * widget sends neither (M8), and since issue #251 `normalizePoint()` in
+		 * `map-provider-embedded.js` no longer requires them. `name` IS still
+		 * required there, and the widget sends none either, so it is built here
+		 * from `pvzType`/`indexTo` — the one place domain knowledge like this is
+		 * allowed to live.
+		 *
+		 * @param {*} data
+		 * @returns {Object|null}
+		 */
+		toPoint: function( data ) {
+			if ( ! data || ! data.pvzData ) {
+				return null;
+			}
+
+			var p = data.pvzData;
+
+			return {
+				id: String( p.id ),
+				name: ( 'postamat' === p.pvzType ? 'Почтомат №' : 'Отделение №' ) + p.indexTo,
+				address: [ p.regionTo, p.areaTo, p.cityTo, p.location, p.addressTo ]
+					.filter( Boolean )
+					.join( ', ' ),
+				type: {
+					code: p.pvzType,
+					label: typeLabel( p.pvzType )
+				},
+				postal_code: String( p.indexTo )
+				// No lat/lng — the widget sends neither (M8).
+			};
+		}
+	};
+
+}() );

--- a/tests/_fixtures/woodev-test-shipping-method/class-test-embedded-confirm-point-source.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-embedded-confirm-point-source.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Woodev_Test_Embedded_Confirm_Point_Source — issue #251 rig finding F4.
+ *
+ * RIG-ONLY STUB. NOT A PATTERN TO FOLLOW IN A REAL PLUGIN — see the class docblock below
+ * for the obligation a real embedded-carrier integration actually has.
+ *
+ * THE PROBLEM THIS FIXES: under `WOODEV_TEST_PICKUP_EMBEDDED`, the carrier's OWN widget
+ * (Почта России, `https://widget.pochta.ru/map/`) renders and lists its own points inside
+ * the iframe — this fixture's `Point_Source::fetch_points()` is genuinely never consulted
+ * for that half, exactly as `woodev-test-shipping-method.php`'s own docblock says. But the
+ * CONFIRMATION round trip is a DIFFERENT call, made by the framework itself, provider-
+ * agnostic: `Pickup_Controller::handle_select_request()` always re-fetches the id the
+ * browser reports via `Point_Source::fetch_details( $point_id )` — regardless of whether
+ * that id came from `woodev/v1`'s own map or from a carrier's embedded widget. The id a
+ * customer selects inside the Почта widget is a REAL CARRIER id (e.g. `"43213"`, measured
+ * on the rig, spec `docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md`
+ * §1 M7) — a value none of this fixture's OTHER `Point_Source` implementations
+ * (`Woodev_Test_Bulk_Point_Source`, `Woodev_Test_Viewport_Point_Source`, the two LIVE
+ * sources) has ever heard of, so `fetch_details()` returned `null` and the REST endpoint
+ * answered `404 woodev_pickup_point_not_found` for EVERY real selection. That made the
+ * `WOODEV_TEST_PICKUP_SELECTION_CLOSE`/`WOODEV_TEST_PICKUP_SELECTION_REFRESH_CHECKOUT`
+ * constants (also issue #251) unreachable — nothing downstream of a successful
+ * confirmation could ever run.
+ *
+ * THE PRIOR DOCBLOCK CLAIM WAS WRONG. `woodev-test-shipping-method.php`'s own comment on
+ * `WOODEV_TEST_PICKUP_EMBEDDED` used to say the resolved `$point_source` is "a dead-looking
+ * branch... never actually consulted by anything on the page" — true for `fetch_points()`,
+ * false for `fetch_details()`. This class (and the corrected comment alongside its use) is
+ * the fix for that wrong claim, not just for the 404.
+ *
+ * @package Woodev_Test_Shipping_Method
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Woodev_Test_Embedded_Confirm_Point_Source' ) ) {
+
+	/**
+	 * Class Woodev_Test_Embedded_Confirm_Point_Source
+	 *
+	 * A `Point_Source` whose `fetch_details()` accepts ANY point id and fabricates a
+	 * plausible, always-permissive `Pickup_Point` for it — so the rig's confirmation round
+	 * trip (`Pickup_Controller::handle_select_request()`, which is the AUTHORITATIVE gate
+	 * for every pickup selection, embedded or not — see `map-provider-embedded.js`'s own
+	 * "AUTHORITY for this path" docblock section) succeeds regardless of which real Почта
+	 * id the carrier's widget handed back to the browser.
+	 *
+	 * `fetch_points()` returns an empty list unconditionally: under
+	 * `Embedded_Map_Provider::owns_chrome()`, the framework's own point-listing REST call
+	 * is never made in the first place (the carrier's iframe renders its own list), so this
+	 * method exists only to satisfy the interface, not because it is ever reached on the
+	 * rig.
+	 *
+	 * `accepts_cod: true` and `max_weight: null` are chosen so `Constraint_Checker::check()`
+	 * always answers `allowed: true` (see that method's own "unknown is permissive" /
+	 * `max_weight === null` short-circuit) — a fixture stub gating a real customer's chosen
+	 * payment method or cart weight would be inventing a domain rule this class has no basis
+	 * for, and would make the reachability fix this class exists for depend on which
+	 * gateway happens to be enabled on the rig.
+	 *
+	 * ⚠️ A REAL EMBEDDED-CARRIER PLUGIN MUST NOT SHIP ANYTHING LIKE THIS. This class exists
+	 * ONLY because the rig has no server-side record of a point the customer picked entirely
+	 * inside the carrier's own iframe — the framework never saw the widget's `pvzData`
+	 * payload, only the browser did. A real plugin's `fetch_details()` MUST perform a
+	 * genuine carrier API lookup by the id the customer selected (Почта: `GET
+	 * https://widget.pochta.ru/api/pvz/{id}`, the same endpoint
+	 * `Woodev_Test_Live_Pochta_Point_Source::fetch_details()` in this very fixture already
+	 * demonstrates against real data) — returning a fabricated record for an id nobody
+	 * verified would let checkout confirm a pickup point that does not exist. The
+	 * confirmation round trip is deliberately the framework's ONE authoritative gate
+	 * (`Pickup_Handler::handle_checkout_process()` re-runs it again at order time); this
+	 * stub exists to make that gate PASS on the rig for a demo id, never to weaken what it
+	 * checks in production.
+	 */
+	class Woodev_Test_Embedded_Confirm_Point_Source implements \Woodev\Framework\Shipping\Pickup\Point_Source {
+
+		/**
+		 * Fixed placement — the fixture's whole point set is Moscow (see
+		 * `Woodev_Test_Bulk_Point_Source::FIXTURE_LOCALITY` and this plugin's
+		 * `$default_location`), and no coordinate reaches the customer through this path
+		 * anyway (the embedded provider draws no map of its own — see
+		 * `map-provider-embedded.js`'s file docblock).
+		 */
+		private const FIXED_LAT = 55.76;
+
+		/** @see self::FIXED_LAT */
+		private const FIXED_LNG = 37.64;
+
+		/**
+		 * @inheritDoc
+		 */
+		public function get_strategy(): string {
+			return self::STRATEGY_VIEWPORT;
+		}
+
+		/**
+		 * Never actually called on the rig under `Embedded_Map_Provider` (see class
+		 * docblock) — returns an empty list rather than fabricating a fake catalogue, since
+		 * a customer never sees this source's OWN list, only the carrier widget's.
+		 *
+		 * @inheritDoc
+		 */
+		public function fetch_points( \Woodev\Framework\Shipping\Pickup\Point_Query $query ): array {
+			return [];
+		}
+
+		/**
+		 * Fabricates a permissive `Pickup_Point` for ANY id — see the class docblock for
+		 * why, and for the obligation a real plugin has instead. Never returns `null`: an
+		 * empty/whitespace-only id is the one case this class refuses, since
+		 * `Pickup_Point::from_array()` itself would reject an empty `id` regardless.
+		 *
+		 * @inheritDoc
+		 */
+		public function fetch_details( string $point_id ): ?\Woodev\Framework\Shipping\Pickup\Pickup_Point {
+			if ( '' === trim( $point_id ) ) {
+				return null;
+			}
+
+			return \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array(
+				[
+					'id'          => $point_id,
+					// Russian, matching every other fixture-authored display string in this
+					// plugin — this label exists only to prove the round trip completed, not
+					// to look like a real Почта point (a real adapter builds the real name —
+					// see `WoodevPochtaEmbed.toPoint` — but that name never reaches the
+					// server; only the id does).
+					'name'        => 'Тестовая точка (embedded) №' . $point_id,
+					'lat'         => self::FIXED_LAT,
+					'lng'         => self::FIXED_LNG,
+					'address'     => 'Фикстура: подтверждение для внешнего id ' . $point_id,
+					'type'        => [ 'code' => 'PVZ', 'label' => 'ПВЗ' ],
+					// Always permissive — see the class docblock for why.
+					'accepts_cod' => true,
+					'max_weight'  => null,
+				]
+			);
+		}
+	}
+}

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -73,10 +73,23 @@ if ( ! defined( 'WOODEV_TEST_PICKUP_LIVE_POCHTA' ) ) {
  *
  * PRECEDENCE: wins over EVERY switch above, including `WOODEV_TEST_PICKUP_LIVE_YANDEX`/
  * `WOODEV_TEST_PICKUP_LIVE_POCHTA` — those two only choose a `Point_Source`, and under
- * `Embedded_Map_Provider` the `Point_Source` is IRRELEVANT: the provider owns the whole
- * container (`ownsChrome`) and the carrier's own embed fetches and renders its own
- * points, so this fixture's `Point_Source` selection below is constructed (a dead-
- * looking branch, deliberately) but never actually consulted by anything on the page.
+ * `Embedded_Map_Provider` the `Point_Source`'s LISTING half is irrelevant: the provider
+ * owns the whole container (`ownsChrome`) and the carrier's own embed fetches and renders
+ * its own points, so `fetch_points()` is never actually consulted by anything on the page.
+ *
+ * CORRECTED (F4, rig finding, s63): the `Point_Source`'s DETAILS half is NOT irrelevant —
+ * an earlier version of this comment claimed the whole selection below was "a dead-looking
+ * branch... never actually consulted", which was WRONG and is the reason the rig's
+ * confirmation round trip 404'd on every real Почта selection. `Pickup_Controller::
+ * handle_select_request()` always re-fetches the customer's chosen point id via
+ * `Point_Source::fetch_details()`, regardless of which map provider produced that id —
+ * that call is provider-agnostic and is the framework's one AUTHORITATIVE gate (see
+ * `map-provider-embedded.js`'s own "AUTHORITY for this path" docblock section). A real
+ * Почта id (e.g. `"43213"`) is unknown to every OTHER fixture `Point_Source`, so
+ * `WOODEV_TEST_PICKUP_EMBEDDED` swaps `$point_source` for
+ * `Woodev_Test_Embedded_Confirm_Point_Source` — a rig-only stub whose `fetch_details()`
+ * accepts ANY id — below, so the round trip can actually complete. See that class's own
+ * docblock for the obligation a REAL embedded-carrier plugin has instead.
  */
 if ( ! defined( 'WOODEV_TEST_PICKUP_EMBEDDED' ) ) {
 	define( 'WOODEV_TEST_PICKUP_EMBEDDED', false );
@@ -278,6 +291,12 @@ function woodev_test_shipping_method_plugin_init(): void {
 	// below does anything, and that only happens when WOODEV_TEST_PICKUP_LIVE_POCHTA is truthy.
 	require_once __DIR__ . '/class-test-live-pochta-point-source.php';
 
+	// Issue #251 (F4, rig finding): the confirmation-round-trip stub — see its own file
+	// docblock. Required unconditionally, same reasoning as the two requires just above:
+	// declaring the class is free, only INSTANTIATING it (below, when WOODEV_TEST_PICKUP_EMBEDDED
+	// is truthy) does anything.
+	require_once __DIR__ . '/class-test-embedded-confirm-point-source.php';
+
 	if ( ! class_exists( 'Woodev_Test_Viewport_Point_Source' ) ) {
 
 		/**
@@ -475,11 +494,15 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// when truthy, same reasoning as Yandex above but for the opposite strategy —
 				// Pochta's real API is viewport-only.
 				//
-				// Issue #251: whatever this block resolves is a DEAD VALUE — never actually
-				// consulted by anything on the page — when WOODEV_TEST_PICKUP_EMBEDDED is on;
-				// see that constant's own docblock and the $map_provider branch below. Still
-				// resolved unconditionally rather than skipped, so this block's own precedence
-				// rules stay simple and this branch never has to special-case "embedded".
+				// Issue #251 (F4 correction, s63): this block's LISTING choice (fetch_points())
+				// is genuinely irrelevant once WOODEV_TEST_PICKUP_EMBEDDED overrides
+				// $point_source below — the carrier's own embed fetches and renders its own
+				// points, and this framework never calls fetch_points() on that path. It is
+				// still resolved unconditionally rather than skipped, so this block's own
+				// precedence rules stay simple. BUT the override below is NOT about a dead
+				// value — see WOODEV_TEST_PICKUP_EMBEDDED's own (corrected) docblock: the
+				// DETAILS half (fetch_details()) is very much consulted, by the provider-
+				// agnostic confirmation round trip, which is exactly why the override exists.
 				$viewport_strategy = \Woodev\Framework\Shipping\Pickup\Point_Source::STRATEGY_VIEWPORT;
 
 				if ( WOODEV_TEST_PICKUP_LIVE_YANDEX ) {
@@ -490,6 +513,16 @@ function woodev_test_shipping_method_plugin_init(): void {
 					$point_source = ( $viewport_strategy === WOODEV_TEST_PICKUP_STRATEGY )
 						? new \Woodev_Test_Viewport_Point_Source()
 						: new \Woodev_Test_Bulk_Point_Source();
+				}
+
+				// Issue #251 (F4, rig finding): WOODEV_TEST_PICKUP_EMBEDDED overrides whatever
+				// was just resolved above with a stub whose fetch_details() accepts ANY id — see
+				// Woodev_Test_Embedded_Confirm_Point_Source's own docblock for why this is
+				// required (a real Почта selection's id is unknown to every OTHER Point_Source
+				// this fixture has) and for the obligation a REAL embedded-carrier plugin has
+				// instead (a genuine carrier details lookup, not a fabricated record).
+				if ( WOODEV_TEST_PICKUP_EMBEDDED ) {
+					$point_source = new \Woodev_Test_Embedded_Confirm_Point_Source();
 				}
 
 				// D-8: custom tile layers + their attribution are a PLUGIN decision, and
@@ -521,10 +554,13 @@ function woodev_test_shipping_method_plugin_init(): void {
 				$map_copyrights = [ '© 2ГИС' ];
 
 				// Issue #251: WOODEV_TEST_PICKUP_EMBEDDED wins over everything above —
-				// see that constant's own docblock for why $point_source, resolved
-				// unconditionally just above, is a dead-looking but deliberate value
-				// under this branch. `embed_url`/`expected_origin` point straight at
-				// the live carrier widget — decision §2 of the #251 spec: no
+				// see that constant's own docblock. $point_source has ALREADY been
+				// overridden to Woodev_Test_Embedded_Confirm_Point_Source just above
+				// (F4 correction, s63) when this constant is on, so the map-provider
+				// choice below and the point-source override above agree with each
+				// other rather than one silently ignoring the other. `embed_url`/
+				// `expected_origin` point straight at the live carrier widget —
+				// decision §2 of the #251 spec: no
 				// plugin-hosted bridge page is needed, since the widget accepts a
 				// `postMessage` handshake from a foreign parent origin (M5) and the
 				// framework's own sandbox posture does not break it (M2). The two

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -64,6 +64,43 @@ if ( ! defined( 'WOODEV_TEST_PICKUP_LIVE_POCHTA' ) ) {
 }
 
 /**
+ * Issue #251: opt-in switch to the carrier-EMBEDDED (widget/iframe) `Map_Provider`
+ * (`Embedded_Map_Provider`, wrapping the live Почта России widget at
+ * `https://widget.pochta.ru/map/`) instead of the framework's own Yandex map.
+ * Defaults to `false`. Flip via `define( 'WOODEV_TEST_PICKUP_EMBEDDED', true );`
+ * in wp-config.php or the `.wp-env.json` `config` block, same idiom as the
+ * constants above.
+ *
+ * PRECEDENCE: wins over EVERY switch above, including `WOODEV_TEST_PICKUP_LIVE_YANDEX`/
+ * `WOODEV_TEST_PICKUP_LIVE_POCHTA` — those two only choose a `Point_Source`, and under
+ * `Embedded_Map_Provider` the `Point_Source` is IRRELEVANT: the provider owns the whole
+ * container (`ownsChrome`) and the carrier's own embed fetches and renders its own
+ * points, so this fixture's `Point_Source` selection below is constructed (a dead-
+ * looking branch, deliberately) but never actually consulted by anything on the page.
+ */
+if ( ! defined( 'WOODEV_TEST_PICKUP_EMBEDDED' ) ) {
+	define( 'WOODEV_TEST_PICKUP_EMBEDDED', false );
+}
+
+/**
+ * Issue #251: the two-level close/refresh contract the rig has exercised only ONE
+ * side of until now — the stock config below is `close_on_select = true`,
+ * `refresh_checkout = false`, which makes the "modal stays open after a confirmed
+ * selection" path (see `pickup-mount.js`) unreachable from this fixture without a
+ * live in-browser patch (done by hand in s62). These two constants make both sides
+ * configurable without a code edit, same idiom as the constants above — flip
+ * `WOODEV_TEST_PICKUP_SELECTION_CLOSE` to `false` to reach that path. Defaults
+ * preserve today's stock rig behaviour exactly.
+ */
+if ( ! defined( 'WOODEV_TEST_PICKUP_SELECTION_CLOSE' ) ) {
+	define( 'WOODEV_TEST_PICKUP_SELECTION_CLOSE', true );
+}
+
+if ( ! defined( 'WOODEV_TEST_PICKUP_SELECTION_REFRESH_CHECKOUT' ) ) {
+	define( 'WOODEV_TEST_PICKUP_SELECTION_REFRESH_CHECKOUT', false );
+}
+
+/**
  * Определяем корневую директорию фреймворка.
  *
  * В wp-env контейнере: WOODEV_FRAMEWORK_DIR задаётся через config в .wp-env.json
@@ -437,6 +474,12 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// Issue #226: WOODEV_TEST_PICKUP_LIVE_POCHTA wins over WOODEV_TEST_PICKUP_STRATEGY
 				// when truthy, same reasoning as Yandex above but for the opposite strategy —
 				// Pochta's real API is viewport-only.
+				//
+				// Issue #251: whatever this block resolves is a DEAD VALUE — never actually
+				// consulted by anything on the page — when WOODEV_TEST_PICKUP_EMBEDDED is on;
+				// see that constant's own docblock and the $map_provider branch below. Still
+				// resolved unconditionally rather than skipped, so this block's own precedence
+				// rules stay simple and this branch never has to special-case "embedded".
 				$viewport_strategy = \Woodev\Framework\Shipping\Pickup\Point_Source::STRATEGY_VIEWPORT;
 
 				if ( WOODEV_TEST_PICKUP_LIVE_YANDEX ) {
@@ -477,20 +520,44 @@ function woodev_test_shipping_method_plugin_init(): void {
 
 				$map_copyrights = [ '© 2ГИС' ];
 
-				// The Yandex Maps fallback key is a PLUGIN obligation, never the
-				// framework's (spec §10.6) — Yandex_Map_Provider's constructor REQUIRES
-				// one. This value is an obviously-fake placeholder that only works
-				// because the rig never actually needs a live ymaps script under
-				// PHPUnit; a real shipping plugin shipping this to production supplies
-				// its OWN key here (obtained from the Yandex developer console), not a
-				// copy of this placeholder.
-				$map_provider = new \Woodev\Framework\Shipping\Map\Yandex_Map_Provider(
-					'FIXTURE-FAKE-YANDEX-KEY',
-					'',
-					'',
-					$map_layers,
-					$map_copyrights
-				);
+				// Issue #251: WOODEV_TEST_PICKUP_EMBEDDED wins over everything above —
+				// see that constant's own docblock for why $point_source, resolved
+				// unconditionally just above, is a dead-looking but deliberate value
+				// under this branch. `embed_url`/`expected_origin` point straight at
+				// the live carrier widget — decision §2 of the #251 spec: no
+				// plugin-hosted bridge page is needed, since the widget accepts a
+				// `postMessage` handshake from a foreign parent origin (M5) and the
+				// framework's own sandbox posture does not break it (M2). The two
+				// adapter hooks are dotted global JS paths resolved in the browser —
+				// see `assets/js/woodev-test-pochta-embed-adapter.js` (enqueued by
+				// `Woodev_Test_Shipping_Method_Plugin::maybe_enqueue_pochta_embed_adapter()`
+				// below only when this constant is on), which supplies
+				// `WoodevPochtaEmbed.onReady`/`.toPoint` and is the ONLY place the Почта
+				// field names/address order/type labels are known — domain knowledge
+				// stays out of the framework.
+				if ( WOODEV_TEST_PICKUP_EMBEDDED ) {
+					$map_provider = new \Woodev\Framework\Shipping\Map\Embedded_Map_Provider(
+						'https://widget.pochta.ru/map/',
+						'https://widget.pochta.ru',
+						'WoodevPochtaEmbed.onReady',
+						'WoodevPochtaEmbed.toPoint'
+					);
+				} else {
+					// The Yandex Maps fallback key is a PLUGIN obligation, never the
+					// framework's (spec §10.6) — Yandex_Map_Provider's constructor REQUIRES
+					// one. This value is an obviously-fake placeholder that only works
+					// because the rig never actually needs a live ymaps script under
+					// PHPUnit; a real shipping plugin shipping this to production supplies
+					// its OWN key here (obtained from the Yandex developer console), not a
+					// copy of this placeholder.
+					$map_provider = new \Woodev\Framework\Shipping\Map\Yandex_Map_Provider(
+						'FIXTURE-FAKE-YANDEX-KEY',
+						'',
+						'',
+						$map_layers,
+						$map_copyrights
+					);
+				}
 
 				// SP-5 Task 8 (D-7): a hardcoded default viewport is now a REQUIRED
 				// constructor argument — Moscow, matching every point this fixture serves,
@@ -561,7 +628,10 @@ function woodev_test_shipping_method_plugin_init(): void {
 				// constructor is positional and PHP 7.4 (which CI checks) has no named arguments.
 				// The accent colour is duplicated as a literal because `DEFAULT_ACCENT_COLOR` is
 				// a `private const` the fixture cannot reference — exactly the friction issue
-				// #170 tracks.
+				// #170 tracks. Arguments 13-14 (`close_on_select`/`refresh_checkout`) come from
+				// the WOODEV_TEST_PICKUP_SELECTION_* constants (issue #251) rather than literals,
+				// so the rig can reach the "modal stays open after a selection" path without a
+				// code edit — see those constants' own docblock.
 				$this->pickup_handler = new \Woodev\Framework\Shipping\Pickup\Pickup_Handler(
 					self::PLUGIN_ID,
 					'carrier_pickup_point',
@@ -575,8 +645,16 @@ function woodev_test_shipping_method_plugin_init(): void {
 					'#06aedd',
 					'',
 					true,
-					true
+					WOODEV_TEST_PICKUP_SELECTION_CLOSE,
+					WOODEV_TEST_PICKUP_SELECTION_REFRESH_CHECKOUT
 				);
+
+				// Issue #251: the fixture-owned Почта adapter script — see
+				// self::maybe_enqueue_pochta_embed_adapter() — is enqueued on its own
+				// `wp_enqueue_scripts` hook, independent of the Pickup_Handler's own
+				// enqueue pass, since the framework itself never enqueues plugin-supplied
+				// adapter scripts (they are pure domain knowledge, see the #251 spec §5).
+				add_action( 'wp_enqueue_scripts', [ $this, 'maybe_enqueue_pochta_embed_adapter' ] );
 				$this->pickup_handler->register();
 			}
 
@@ -608,6 +686,77 @@ function woodev_test_shipping_method_plugin_init(): void {
 			 */
 			public function get_pickup_settings_fields(): array {
 				return $this->pickup_handler->get_settings_fields();
+			}
+
+			/**
+			 * Issue #251: enqueues the fixture-owned Почта widget-embed adapter script
+			 * (`assets/js/woodev-test-pochta-embed-adapter.js`) that implements
+			 * `window.WoodevPochtaEmbed.onReady`/`.toPoint` — the two functions
+			 * `Embedded_Map_Provider`'s `initAdapter`/`selectAdapter` dotted paths point
+			 * at (see the map-provider construction in the constructor above). Gated on
+			 * `WOODEV_TEST_PICKUP_EMBEDDED` AND `is_checkout()`, same as
+			 * `Pickup_Handler::enqueue_assets()` itself — this script is meaningless
+			 * anywhere else, and enqueueing it unconditionally would leak a global onto
+			 * every page for no reason.
+			 *
+			 * CREDENTIALS — same rule as `Woodev_Test_Live_Pochta_Point_Source`'s own
+			 * docblock: `WOODEV_TEST_POCHTA_ACCOUNT_ID` (the SAME operator account id that
+			 * class already reads) and `WOODEV_TEST_POCHTA_ACCOUNT_TYPE` are NEVER committed
+			 * to this public repository. Read with a `defined()` guard, degrading to an
+			 * empty string, so this file never fatals when neither is set (unit/integration
+			 * test runs, which never define either). Define them in `wp-config.php`, or in
+			 * the GITIGNORED `.wp-env.override.json`:
+			 *
+			 *     define( 'WOODEV_TEST_POCHTA_ACCOUNT_ID', '…' );
+			 *     define( 'WOODEV_TEST_POCHTA_ACCOUNT_TYPE', '…' );
+			 *
+			 * `weight`/`sumoc`/`startZip`/`startAddress` (the rest of the widget's
+			 * `postData` handshake, spec §1 M3) are FIXTURE placeholders, not real cart
+			 * data — a real shipping plugin computes these from the live cart/customer,
+			 * which this demo fixture has no reason to model.
+			 *
+			 * @since 2.0.2
+			 *
+			 * @internal
+			 *
+			 * @return void
+			 */
+			public function maybe_enqueue_pochta_embed_adapter(): void {
+				if ( ! WOODEV_TEST_PICKUP_EMBEDDED || ! function_exists( 'is_checkout' ) || ! is_checkout() ) {
+					return;
+				}
+
+				$handle = 'woodev-test-pochta-embed-adapter';
+				$path   = __DIR__ . '/assets/js/woodev-test-pochta-embed-adapter.js';
+
+				if ( ! file_exists( $path ) ) {
+					return;
+				}
+
+				wp_enqueue_script(
+					$handle,
+					plugins_url( 'assets/js/woodev-test-pochta-embed-adapter.js', __FILE__ ),
+					[],
+					(string) filemtime( $path ),
+					true
+				);
+
+				wp_localize_script(
+					$handle,
+					'WoodevTestPochtaEmbedConfig',
+					[
+						'accountId'    => defined( 'WOODEV_TEST_POCHTA_ACCOUNT_ID' )
+							? (string) constant( 'WOODEV_TEST_POCHTA_ACCOUNT_ID' )
+							: '',
+						'accountType'  => defined( 'WOODEV_TEST_POCHTA_ACCOUNT_TYPE' )
+							? (string) constant( 'WOODEV_TEST_POCHTA_ACCOUNT_TYPE' )
+							: '',
+						'weight'       => 1000,
+						'sumoc'        => 1000,
+						'startZip'     => '101000',
+						'startAddress' => 'Москва, ул. Тверская, 1',
+					]
+				);
 			}
 
 			/**

--- a/tests/js/map-provider-embedded.test.js
+++ b/tests/js/map-provider-embedded.test.js
@@ -10,14 +10,23 @@
  * an empty `expectedOrigin`), point normalization against this file's OWN
  * required-field/range rules (a KNOWN, deliberate divergence from
  * `Pickup_Point::from_array()`'s required set — see `normalizePoint()`'s own
- * docblock and #251), the invalid/missing `embedUrl` guard, and `destroy()`'s
- * listener detachment + callback hook clearing + idempotency. Also covers the
- * #201 field-parity fix, which is scoped to OPTIONAL-field handling only:
+ * docblock), the invalid/missing `embedUrl` guard, and `destroy()`'s listener
+ * detachment + callback hook clearing + idempotency. Also covers the #201
+ * field-parity fix, which is scoped to OPTIONAL-field handling only:
  * `services`/`point_short_name` now normalize at all, and `payment_methods`/
  * `photos`/`services` filter out non-string/whitespace-only elements instead
  * of `String()`-coercing them (matching `Pickup_Point::sanitize_string_list()`),
  * and `max_weight` falls back to `0`, never `NaN`, for a garbage value
  * (matching PHP's `(int)` cast).
+ *
+ * Issue #251 (resolved by this file): `lat`/`lng` became OPTIONAL-BUT-VALIDATED
+ * (present → still numeric/in-range or rejected; absent → BOTH must be absent,
+ * one alone is a half-coordinate and is rejected; present → carried through,
+ * absent → omitted entirely, no `0.0` fallback) — see the "Optional lat/lng"
+ * section below. The same change adds `config.initAdapter`/`config.selectAdapter`,
+ * two optional dotted-global-path hooks that translate a carrier's OWN protocol
+ * message (reached only for a message that passed the origin+source gate and
+ * did not match this file's own envelope) — see the "Adapter hooks" section.
  *
  * @see woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
  */
@@ -330,6 +339,51 @@ test.each( [
 	expect( onError ).not.toHaveBeenCalled();
 	expect( onSelect ).toHaveBeenCalledTimes( 1 );
 } );
+
+// -----------------------------------------------------------------------
+// Optional lat/lng (issue #251)
+// -----------------------------------------------------------------------
+//
+// `lat`/`lng` used to be REQUIRED, same as `id`/`name`/`address`; the
+// `test.each` block above (which deletes ONE field at a time) still passes
+// unchanged for `lat`/`lng` because deleting just one now trips the
+// half-coordinate rule below, not a "required field missing" rule — the
+// tests here pin the NEW rule directly: fully absent is fine, half-present
+// is not.
+
+test( 'a point with no lat/lng at all normalizes successfully and emits no coordinate keys', () => {
+	const { iframe, onSelect, onError } = initProvider();
+
+	const payload = validPointPayload();
+	delete payload.lat;
+	delete payload.lng;
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	expect( onError ).not.toHaveBeenCalled();
+	expect( onSelect ).toHaveBeenCalledTimes( 1 );
+
+	const point = onSelect.mock.calls[ 0 ][ 0 ];
+	expect( 'lat' in point ).toBe( false );
+	expect( 'lng' in point ).toBe( false );
+} );
+
+test.each( [ 'lat', 'lng' ] )(
+	'a point with only %s present (the other absent) is REJECTED as a half-coordinate',
+	( presentField ) => {
+		const { iframe, onSelect, onError } = initProvider();
+
+		const payload = validPointPayload();
+		const absentField = 'lat' === presentField ? 'lng' : 'lat';
+		delete payload[ absentField ];
+
+		dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onError ).toHaveBeenCalledTimes( 1 );
+		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'woodev_pickup_embed_invalid_payload' );
+	}
+);
 
 // -----------------------------------------------------------------------
 // Normalization — TYPED, DEFAULTED output shape (not just field presence)
@@ -690,4 +744,215 @@ test( 'destroy() clears the callback hook routing — a call after destroy is a 
 
 	expect( onSelect ).not.toHaveBeenCalled();
 	expect( onError ).not.toHaveBeenCalled();
+} );
+
+// -----------------------------------------------------------------------
+// Adapter hooks (issue #251)
+// -----------------------------------------------------------------------
+//
+// `config.initAdapter`/`config.selectAdapter` are optional dotted global JS
+// paths (never a callable) that translate a carrier's OWN protocol message —
+// reached only for a message that already passed the origin+source gate AND
+// did not match this file's own `{ source: 'woodev-pickup-embedded', ... }`
+// envelope. See the file docblock's "ADAPTER HOOKS" section.
+
+function adapterConfig( overrides ) {
+	return Object.assign(
+		{ initAdapter: 'WoodevTestAdapter.onReady', selectAdapter: 'WoodevTestAdapter.toPoint' },
+		overrides
+	);
+}
+
+afterEach( () => {
+	delete window.WoodevTestAdapter;
+} );
+
+test( 'initAdapter returning a payload posts exactly one message into the iframe with expectedOrigin as targetOrigin', () => {
+	const onReady = jest.fn().mockReturnValue( { postData: { foo: 'bar' } } );
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: jest.fn() };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+	const postMessageSpy = jest.spyOn( iframe.contentWindow, 'postMessage' );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { isMapLoad: true } );
+
+	expect( onReady ).toHaveBeenCalledTimes( 1 );
+	expect( onReady ).toHaveBeenCalledWith( { isMapLoad: true } );
+	expect( postMessageSpy ).toHaveBeenCalledTimes( 1 );
+	expect( postMessageSpy ).toHaveBeenCalledWith( { postData: { foo: 'bar' } }, EXPECTED_ORIGIN );
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+} );
+
+test( 'initAdapter returning null posts nothing into the iframe', () => {
+	const onReady = jest.fn().mockReturnValue( null );
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: jest.fn() };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+	const postMessageSpy = jest.spyOn( iframe.contentWindow, 'postMessage' );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { isMapLoad: true } );
+
+	expect( postMessageSpy ).not.toHaveBeenCalled();
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+} );
+
+test( 'selectAdapter translating a carrier-shaped message into a valid point emits select', () => {
+	const toPoint = jest.fn().mockImplementation( ( data ) => {
+		if ( ! data || ! data.pvzData ) {
+			return null;
+		}
+
+		return {
+			id: String( data.pvzData.id ),
+			name: 'Почтомат №' + data.pvzData.indexTo,
+			address: 'Москва, тестовый адрес',
+			type: { code: data.pvzData.pvzType, label: 'Почтомат' },
+		};
+	} );
+	window.WoodevTestAdapter = { onReady: jest.fn().mockReturnValue( null ), toPoint: toPoint };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, {
+		pvzData: { id: 43213, indexTo: '918872', pvzType: 'postamat' },
+	} );
+
+	expect( toPoint ).toHaveBeenCalledTimes( 1 );
+	expect( onError ).not.toHaveBeenCalled();
+	expect( onSelect ).toHaveBeenCalledTimes( 1 );
+
+	const point = onSelect.mock.calls[ 0 ][ 0 ];
+	expect( point.id ).toBe( '43213' );
+	expect( point.name ).toBe( 'Почтомат №918872' );
+	expect( 'lat' in point ).toBe( false );
+} );
+
+test( 'selectAdapter returning null emits nothing', () => {
+	window.WoodevTestAdapter = {
+		onReady: jest.fn().mockReturnValue( null ),
+		toPoint: jest.fn().mockReturnValue( null ),
+	};
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { some: 'carrier message' } );
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+} );
+
+test( 'initAdapter throwing is swallowed — no error, no select, selectAdapter never runs', () => {
+	window.WoodevTestAdapter = {
+		onReady: jest.fn().mockImplementation( () => {
+			throw new Error( 'boom' );
+		} ),
+		toPoint: jest.fn(),
+	};
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	expect( () => {
+		dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { isMapLoad: true } );
+	} ).not.toThrow();
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+	expect( window.WoodevTestAdapter.toPoint ).not.toHaveBeenCalled();
+} );
+
+test( 'selectAdapter throwing emits error, not select', () => {
+	window.WoodevTestAdapter = {
+		onReady: jest.fn().mockReturnValue( null ),
+		toPoint: jest.fn().mockImplementation( () => {
+			throw new Error( 'boom' );
+		} ),
+	};
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { some: 'carrier message' } );
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).toHaveBeenCalledTimes( 1 );
+	expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'woodev_pickup_embed_adapter_error' );
+} );
+
+test( 'an empty expectedOrigin suppresses the outbound initAdapter post AND still rejects every inbound message', () => {
+	const onReady = jest.fn().mockReturnValue( { postData: {} } );
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: jest.fn() };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig( { expectedOrigin: '' } ) );
+	const postMessageSpy = jest.spyOn( iframe.contentWindow, 'postMessage' );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { isMapLoad: true } );
+	dispatchMessage( '', iframe.contentWindow, { isMapLoad: true } );
+
+	expect( onReady ).not.toHaveBeenCalled();
+	expect( postMessageSpy ).not.toHaveBeenCalled();
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+} );
+
+test( 'a message failing the origin gate never reaches either adapter', () => {
+	const onReady = jest.fn();
+	const toPoint = jest.fn();
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: toPoint };
+
+	const { iframe } = initProvider( adapterConfig() );
+
+	dispatchMessage( 'https://other-carrier.ru', iframe.contentWindow, { isMapLoad: true } );
+
+	expect( onReady ).not.toHaveBeenCalled();
+	expect( toPoint ).not.toHaveBeenCalled();
+} );
+
+test( 'a message failing the source gate never reaches either adapter', () => {
+	const onReady = jest.fn();
+	const toPoint = jest.fn();
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: toPoint };
+
+	initProvider( adapterConfig() );
+
+	const otherFrame = document.createElement( 'iframe' );
+	document.body.appendChild( otherFrame );
+
+	dispatchMessage( EXPECTED_ORIGIN, otherFrame.contentWindow, { isMapLoad: true } );
+
+	expect( onReady ).not.toHaveBeenCalled();
+	expect( toPoint ).not.toHaveBeenCalled();
+} );
+
+test( 'a dotted adapter path that does not resolve to a function is treated as absent, not thrown', () => {
+	window.WoodevTestAdapter = { onReady: 'not-a-function' };
+
+	const { iframe, onSelect, onError } = initProvider( {
+		initAdapter: 'WoodevTestAdapter.onReady',
+		selectAdapter: 'WoodevTestAdapter.missing.deeper',
+	} );
+
+	expect( () => {
+		dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { isMapLoad: true } );
+	} ).not.toThrow();
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+} );
+
+// this file's own envelope still takes priority over any configured adapter —
+// step 1 always runs first, and adapters never see an envelope-shaped message.
+test( 'this file\'s own envelope is still handled directly and never reaches a configured adapter', () => {
+	const onReady = jest.fn();
+	const toPoint = jest.fn();
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: toPoint };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( validPointPayload() ) );
+
+	expect( onReady ).not.toHaveBeenCalled();
+	expect( toPoint ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+	expect( onSelect ).toHaveBeenCalledTimes( 1 );
 } );

--- a/tests/js/map-provider-embedded.test.js
+++ b/tests/js/map-provider-embedded.test.js
@@ -956,3 +956,226 @@ test( 'this file\'s own envelope is still handled directly and never reaches a c
 	expect( onError ).not.toHaveBeenCalled();
 	expect( onSelect ).toHaveBeenCalledTimes( 1 );
 } );
+
+// -----------------------------------------------------------------------
+// F1 (Codex review, issue #251 follow-up): isNumeric()/parseFloat() must
+// agree on what "numeric" means — a hex/octal/binary literal string must be
+// REJECTED, never silently coerced to a real coordinate. Before this fix,
+// isNumeric() used `isFinite( Number( value ) )`, which ACCEPTS '0x20'
+// (Number( '0x20' ) === 32), while normalizePoint()'s conversion step used
+// parseFloat(), which reads the very same string as 0 — a hex coordinate
+// string PASSED validation and was then silently coerced to (0, 0), "null
+// island". This was a known, deliberately accepted divergence from PHP's
+// is_numeric() when #201 landed (lat/lng were still REQUIRED, so the
+// divergence was provably unreachable); making them OPTIONAL (#251) made it
+// a live defect.
+// -----------------------------------------------------------------------
+
+test.each( [
+	// Rejected: not a plain decimal numeric-string literal.
+	[ '0x20', false ],
+	[ '0X20', false ],
+	[ '0b11', false ],
+	[ '0o17', false ],
+	[ '12abc', false ],
+	[ '', false ],
+	[ '  ', false ],
+	// Accepted: exponent notation is a legitimate decimal number. Values kept inside
+	// BOTH the lat ([-90,90]) and lng ([-180,180]) ranges — this table is only about
+	// whether the STRING is numeric, not about the separate range check.
+	[ '5e1', true ], // 50
+	[ '5E1', true ], // 50
+	[ '-1.5e-2', true ], // -0.015
+] )( 'lat/lng string %j is numeric=%p, never silently coerced to a wrong value', ( raw, shouldAccept ) => {
+	const { iframe, onSelect, onError } = initProvider();
+
+	const payload = validPointPayload();
+	payload.lat = raw;
+	payload.lng = raw;
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	if ( shouldAccept ) {
+		expect( onError ).not.toHaveBeenCalled();
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+	} else {
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onError ).toHaveBeenCalledTimes( 1 );
+		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'woodev_pickup_embed_invalid_payload' );
+	}
+} );
+
+// A hex-looking string is the whole point of this fix: it must never normalize to 0,
+// even though `Number( '0x20' )` is a real, non-NaN number. Pinned separately from the
+// table above so a regression here reads unambiguously as "null island is back".
+test( "a hex coordinate string is REJECTED, never silently normalized to 0 ('null island')", () => {
+	const { iframe, onSelect, onError } = initProvider();
+
+	const payload = validPointPayload();
+	payload.lat = '0x20';
+	payload.lng = '0x20';
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).toHaveBeenCalledTimes( 1 );
+} );
+
+test.each( [
+	[ true, false ],
+	[ [], false ],
+	[ {}, false ],
+	[ NaN, false ],
+	[ Infinity, false ],
+	[ -Infinity, false ],
+] )( 'a non-string/non-finite-number lat/lng value %j is rejected (numeric=%p)', ( raw ) => {
+	const { iframe, onSelect, onError } = initProvider();
+
+	const payload = validPointPayload();
+	payload.lat = raw;
+	payload.lng = raw;
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).toHaveBeenCalledTimes( 1 );
+} );
+
+// -----------------------------------------------------------------------
+// F2 (Codex review, issue #251 follow-up): the outbound postMessage() call
+// inside the initAdapter branch must be swallowed on a throw exactly like
+// initAdapter() itself throwing — a DataCloneError (a value the structured-
+// clone algorithm cannot handle: a function, a cyclic object) must not break
+// the picker.
+// -----------------------------------------------------------------------
+
+test( 'initAdapter returning a payload postMessage() cannot clone (a function) is swallowed, not thrown', () => {
+	const onReady = jest.fn().mockReturnValue( { fn: function () {} } );
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: jest.fn() };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	expect( () => {
+		dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { isMapLoad: true } );
+	} ).not.toThrow();
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+} );
+
+test( 'initAdapter returning a cyclic object postMessage() cannot clone is swallowed, not thrown', () => {
+	const cyclic = {};
+	cyclic.self = cyclic;
+
+	const onReady = jest.fn().mockReturnValue( cyclic );
+	window.WoodevTestAdapter = { onReady: onReady, toPoint: jest.fn() };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	expect( () => {
+		dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { isMapLoad: true } );
+	} ).not.toThrow();
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+} );
+
+// -----------------------------------------------------------------------
+// F3 (Codex review, issue #251 follow-up): a selectAdapter that reports a
+// selection via BOTH the callback-style hook AND its own return value must
+// still produce exactly ONE select/error emission for one inbound message —
+// not two, and not two confirmation round trips on pickup-mount.js's side.
+// -----------------------------------------------------------------------
+
+test( 'a selectAdapter that calls the callback hook AND returns a point emits select exactly once', () => {
+	const toPoint = jest.fn().mockImplementation( ( data ) => {
+		window.WoodevPickupEmbedded.select( {
+			id: 'CB1',
+			name: 'Точка через колбэк',
+			address: 'Адрес',
+			type: { code: 'PVZ', label: 'ПВЗ' },
+		} );
+
+		// AND also returns a point directly — the pathological "both styles at once" case.
+		return {
+			id: 'RETURN1',
+			name: 'Точка через return',
+			address: 'Адрес',
+			type: { code: 'PVZ', label: 'ПВЗ' },
+		};
+	} );
+	window.WoodevTestAdapter = { onReady: jest.fn().mockReturnValue( null ), toPoint: toPoint };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { some: 'carrier message' } );
+
+	expect( onError ).not.toHaveBeenCalled();
+	expect( onSelect ).toHaveBeenCalledTimes( 1 );
+	// The emission that reaches the listener is the callback-route one — the return
+	// value is ignored once the callback already fired synchronously.
+	expect( onSelect.mock.calls[ 0 ][ 0 ].id ).toBe( 'CB1' );
+} );
+
+test( 'callback-style: selectAdapter reports via the callback hook and returns null — one emission', () => {
+	const toPoint = jest.fn().mockImplementation( () => {
+		window.WoodevPickupEmbedded.select( {
+			id: 'CB2',
+			name: 'Точка через колбэк',
+			address: 'Адрес',
+			type: { code: 'PVZ', label: 'ПВЗ' },
+		} );
+
+		return null;
+	} );
+	window.WoodevTestAdapter = { onReady: jest.fn().mockReturnValue( null ), toPoint: toPoint };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { some: 'carrier message' } );
+
+	expect( onError ).not.toHaveBeenCalled();
+	expect( onSelect ).toHaveBeenCalledTimes( 1 );
+	expect( onSelect.mock.calls[ 0 ][ 0 ].id ).toBe( 'CB2' );
+} );
+
+test( 'return-style: selectAdapter reports ONLY via its return value — still exactly one emission', () => {
+	// Baseline re-confirmation with the reentry guard in place — a selectAdapter that
+	// never touches the callback hook at all must be unaffected by the guard.
+	const toPoint = jest.fn().mockReturnValue( {
+		id: 'RETURN-ONLY',
+		name: 'Точка через return',
+		address: 'Адрес',
+		type: { code: 'PVZ', label: 'ПВЗ' },
+	} );
+	window.WoodevTestAdapter = { onReady: jest.fn().mockReturnValue( null ), toPoint: toPoint };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { some: 'carrier message' } );
+
+	expect( onError ).not.toHaveBeenCalled();
+	expect( onSelect ).toHaveBeenCalledTimes( 1 );
+	expect( onSelect.mock.calls[ 0 ][ 0 ].id ).toBe( 'RETURN-ONLY' );
+} );
+
+test( 'a selectAdapter that calls the callback hook with an invalid payload then throws does not ALSO emit error', () => {
+	const toPoint = jest.fn().mockImplementation( () => {
+		// Invalid payload (missing required fields) — the callback route itself emits
+		// `error`, then the adapter throws on its way out.
+		window.WoodevPickupEmbedded.select( { garbage: true } );
+
+		throw new Error( 'boom after callback' );
+	} );
+	window.WoodevTestAdapter = { onReady: jest.fn().mockReturnValue( null ), toPoint: toPoint };
+
+	const { iframe, onSelect, onError } = initProvider( adapterConfig() );
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, { some: 'carrier message' } );
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	// Exactly one error — from the callback route's failed normalization, NOT a second
+	// one from the adapter's own throw being caught downstream.
+	expect( onError ).toHaveBeenCalledTimes( 1 );
+	expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'woodev_pickup_embed_invalid_payload' );
+} );

--- a/tests/js/woodev-test-pochta-embed-adapter.test.js
+++ b/tests/js/woodev-test-pochta-embed-adapter.test.js
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for the FIXTURE-ONLY Почта embedded-widget adapter script (issue #251).
+ *
+ * Covers F5 (rig finding, s63): the composed `address` must drop a CONSECUTIVE
+ * duplicate part — e.g. `regionTo`/`cityTo` both `"г. Москва"` for a Moscow point,
+ * measured on the rig — without reordering or dropping anything else from the
+ * `regionTo, areaTo, cityTo, location, addressTo` field list this fixture copies
+ * verbatim from the operator's own production plugin.
+ *
+ * @see tests/_fixtures/woodev-test-shipping-method/assets/js/woodev-test-pochta-embed-adapter.js
+ */
+
+'use strict';
+
+require( '../_fixtures/woodev-test-shipping-method/assets/js/woodev-test-pochta-embed-adapter' );
+
+afterEach( () => {
+	delete window.WoodevTestPochtaEmbedConfig;
+} );
+
+test( 'F5: a consecutive duplicate part (regionTo === cityTo) is dropped from the composed address', () => {
+	// The exact rig measurement (s63): Moscow's regionTo and cityTo are both "г. Москва".
+	const point = window.WoodevPochtaEmbed.toPoint( {
+		pvzData: {
+			id: 43213,
+			pvzType: 'russian_post',
+			indexTo: '101000',
+			regionTo: 'г. Москва',
+			areaTo: null,
+			cityTo: 'г. Москва',
+			location: null,
+			addressTo: 'ул. Никольская 7-9 стр. 4',
+		},
+	} );
+
+	expect( point.address ).toBe( 'г. Москва, ул. Никольская 7-9 стр. 4' );
+} );
+
+test( 'F5: non-duplicate parts are all kept, in the same order, when nothing repeats', () => {
+	const point = window.WoodevPochtaEmbed.toPoint( {
+		pvzData: {
+			id: 1,
+			pvzType: 'postamat',
+			indexTo: '111543',
+			regionTo: 'Московская область',
+			areaTo: 'Ленинский р-н',
+			cityTo: 'г. Видное',
+			location: 'мкр. Зеленый',
+			addressTo: 'ул. Ленина, 10',
+		},
+	} );
+
+	expect( point.address ).toBe(
+		'Московская область, Ленинский р-н, г. Видное, мкр. Зеленый, ул. Ленина, 10'
+	);
+} );
+
+test( 'F5: a value that repeats NON-consecutively (separated by another part) is NOT collapsed', () => {
+	// Pathological but explicitly not assumed impossible by the dedup helper's own
+	// docblock — areaTo and addressTo happen to coincide here, with cityTo between them.
+	const point = window.WoodevPochtaEmbed.toPoint( {
+		pvzData: {
+			id: 2,
+			pvzType: 'russian_post',
+			indexTo: '2',
+			regionTo: 'Регион',
+			areaTo: 'Совпадение',
+			cityTo: 'Город',
+			location: null,
+			addressTo: 'Совпадение',
+		},
+	} );
+
+	expect( point.address ).toBe( 'Регион, Совпадение, Город, Совпадение' );
+} );
+
+test( 'a payload with no pvzData returns null, unaffected by the address dedup change', () => {
+	expect( window.WoodevPochtaEmbed.toPoint( {} ) ).toBeNull();
+	expect( window.WoodevPochtaEmbed.toPoint( null ) ).toBeNull();
+} );

--- a/tests/unit/Shipping/Map/MapProviderRegistryTest.php
+++ b/tests/unit/Shipping/Map/MapProviderRegistryTest.php
@@ -741,12 +741,36 @@ final class MapProviderRegistryTest extends TestCase {
 			[
 				'embedUrl'       => 'https://carrier.example/widget.js',
 				'expectedOrigin' => 'https://carrier.example',
+				// Issue #251: null when the constructor's two optional adapter
+				// arguments are omitted — "no adapter, framework protocol only".
+				'initAdapter'    => null,
+				'selectAdapter'  => null,
 				// Task 20: mirrors owns_chrome() verbatim — pickup-mount.js reads this to decide
 				// whether to construct the framework's own list/card panels at all.
 				'ownsChrome'     => true,
 			],
 			$provider->get_js_config( [] )
 		);
+	}
+
+	/**
+	 * Issue #251: the two optional adapter-hook constructor arguments are carried
+	 * VERBATIM into `get_js_config()` as strings — never resolved, called, or
+	 * otherwise touched by PHP. They cross into the browser as JSON dotted global
+	 * paths; only `map-provider-embedded.js` resolves them.
+	 */
+	public function test_embedded_js_config_carries_the_adapter_hooks_verbatim_when_supplied(): void {
+		$provider = new Embedded_Map_Provider(
+			'https://widget.pochta.ru/map/',
+			'https://widget.pochta.ru',
+			'WoodevPochtaEmbed.onReady',
+			'WoodevPochtaEmbed.toPoint'
+		);
+
+		$config = $provider->get_js_config( [] );
+
+		$this->assertSame( 'WoodevPochtaEmbed.onReady', $config['initAdapter'] );
+		$this->assertSame( 'WoodevPochtaEmbed.toPoint', $config['selectAdapter'] );
 	}
 
 	/**

--- a/tests/unit/Shipping/Pickup/TestEmbeddedConfirmPointSourceTest.php
+++ b/tests/unit/Shipping/Pickup/TestEmbeddedConfirmPointSourceTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Unit tests for issue #251's F4 rig-finding fix: `Woodev_Test_Embedded_Confirm_Point_Source`
+ * (`tests/_fixtures/woodev-test-shipping-method/class-test-embedded-confirm-point-source.php`).
+ *
+ * On the rig, under `WOODEV_TEST_PICKUP_EMBEDDED`, a customer's selection inside the Почта
+ * widget carries a REAL carrier point id (e.g. `"43213"`) that no OTHER fixture `Point_Source`
+ * has ever heard of — the confirmation round trip (`Pickup_Controller::handle_select_request()`,
+ * provider-agnostic, always calls `Point_Source::fetch_details( $point_id )`) 404'd on every
+ * real selection as a result. These tests pin the fix directly against the stub class: it must
+ * accept ANY non-empty id and fabricate an always-permissive `Pickup_Point` for it, never `null`
+ * for a real-looking id, and `fetch_points()` must stay a harmless empty list (never actually
+ * reached on the rig — the carrier's own embed renders its own list).
+ *
+ * @package Woodev\Tests\Unit\Shipping\Pickup
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Pickup;
+
+use Woodev\Framework\Shipping\Pickup\Point_Query;
+use Woodev\Framework\Shipping\Pickup\Point_Source;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-point.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-point-query.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/interface-point-source.php';
+require_once dirname( __DIR__, 4 ) . '/tests/_fixtures/woodev-test-shipping-method/class-test-embedded-confirm-point-source.php';
+
+/**
+ * @covers \Woodev_Test_Embedded_Confirm_Point_Source
+ */
+final class TestEmbeddedConfirmPointSourceTest extends TestCase {
+
+	public function test_declares_the_viewport_strategy(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$this->assertSame( Point_Source::STRATEGY_VIEWPORT, $source->get_strategy() );
+	}
+
+	public function test_fetch_points_always_returns_an_empty_list(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$query = Point_Query::from_request( [ 'locality' => 'Москва' ] );
+
+		$this->assertSame( [], $source->fetch_points( $query ) );
+	}
+
+	/**
+	 * The core of the fix: a REAL Почта carrier id, measured on the rig
+	 * (docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md §1 M7), must
+	 * resolve to a point — never `null` — so `Pickup_Controller::handle_select_request()`
+	 * never answers 404 for it.
+	 */
+	public function test_fetch_details_resolves_a_real_measured_pochta_id(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$point = $source->fetch_details( '43213' );
+
+		$this->assertNotNull( $point );
+		$this->assertSame( '43213', $point->get_id() );
+	}
+
+	/**
+	 * @dataProvider provide_arbitrary_ids
+	 */
+	public function test_fetch_details_resolves_any_non_empty_id( string $id ): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$this->assertNotNull( $source->fetch_details( $id ), "fetch_details() must not return null for id '{$id}'" );
+	}
+
+	/**
+	 * @return array<string, string[]>
+	 */
+	public function provide_arbitrary_ids(): array {
+		return [
+			'numeric carrier id'    => [ '43213' ],
+			'alphanumeric id'       => [ 'ABC-123' ],
+			'a single character'    => [ '0' ],
+			'an id with whitespace' => [ '  918872  ' ],
+		];
+	}
+
+	public function test_fetch_details_returns_null_for_an_empty_or_whitespace_only_id(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$this->assertNull( $source->fetch_details( '' ) );
+		$this->assertNull( $source->fetch_details( '   ' ) );
+	}
+
+	public function test_fetch_details_returns_the_id_verbatim_as_the_points_own_id(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$point = $source->fetch_details( 'FIXTURE-ID-42' );
+
+		$this->assertSame( 'FIXTURE-ID-42', $point->get_id() );
+	}
+
+	/**
+	 * `accepts_cod: true` / `max_weight: null` — chosen so `Constraint_Checker::check()`
+	 * always answers `allowed: true` regardless of the cart's payment method or weight,
+	 * since this stub has no domain basis for gating either. Asserted via `to_array()`
+	 * (both fields have no public getter on `Pickup_Point` except `get_accepts_cod()`/
+	 * `get_max_weight()`, used here for the same reason `Woodev_Test_Bulk_Point_Source`'s
+	 * own sibling tests do).
+	 */
+	public function test_fetch_details_is_always_permissive_accepts_cod_and_unlimited_weight(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$point = $source->fetch_details( '43213' );
+
+		$this->assertTrue( $point->get_accepts_cod() );
+		$this->assertNull( $point->get_max_weight() );
+	}
+
+	public function test_fetch_details_returns_a_valid_in_range_coordinate(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$point = $source->fetch_details( '43213' );
+
+		$this->assertGreaterThanOrEqual( -90.0, $point->get_lat() );
+		$this->assertLessThanOrEqual( 90.0, $point->get_lat() );
+		$this->assertGreaterThanOrEqual( -180.0, $point->get_lng() );
+		$this->assertLessThanOrEqual( 180.0, $point->get_lng() );
+	}
+
+	public function test_fetch_details_returns_a_non_empty_name_and_address(): void {
+		$source = new \Woodev_Test_Embedded_Confirm_Point_Source();
+
+		$point = $source->fetch_details( '43213' )->to_array();
+
+		$this->assertNotSame( '', $point['name'] );
+		$this->assertNotSame( '', $point['address'] );
+		$this->assertSame( 'PVZ', $point['type']['code'] );
+	}
+}

--- a/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
@@ -85,15 +85,24 @@
  *      posted back into the SAME iframe this message came from —
  *      `iframe.contentWindow.postMessage( payload, config.expectedOrigin )`,
  *      the expected origin as `targetOrigin`, NEVER `"*"` — and handling
- *      stops there. A throw is SWALLOWED (the message bus is shared with
- *      whatever else the carrier's page posts) and handling continues.
+ *      stops there. Both the ADAPTER CALL and the `postMessage()` CALL are
+ *      inside the same guarded region, and a throw from EITHER is SWALLOWED
+ *      (issue #251 follow-up, Codex review: `postMessage()` itself throws
+ *      `DataCloneError` for a return value the structured-clone algorithm
+ *      cannot handle — a function, a `Symbol`, a cyclic object — and that
+ *      fault is the adapter's, not the framework's, exactly like a throw
+ *      from `initAdapter()` itself; the message bus is shared with whatever
+ *      else the carrier's page posts, so neither may break the picker).
  *   2. `selectAdapter( data )` runs when `initAdapter` did not claim the
  *      message. A non-`null`/`undefined` return goes through
  *      {@see normalizePoint} and then the same success/failure emit path as
  *      the framework's own envelope. A throw here is NOT swallowed — it
  *      emits `error`, because the message already proved it came from this
  *      instance's own trusted iframe, so a translation failure is a real,
- *      reportable fault, not routine cross-talk.
+ *      reportable fault, not routine cross-talk. EXCEPTION: a throw is
+ *      swallowed too when a synchronous callback-style emission already
+ *      reported this same selection before the throw — see the RE-ENTRY
+ *      GUARD paragraph below.
  *   3. Neither adapter is configured, or both decline (return `null`/
  *      `undefined`) — the message is ignored silently, same as any other
  *      unrecognised traffic from the trusted origin.
@@ -106,6 +115,26 @@
  * origin+source gate above and only ever translate a message this file has
  * already proven came from ITS OWN iframe at the expected origin — they are
  * not a second way for an untrusted sender to reach the picker.
+ *
+ * RE-ENTRY GUARD — AT MOST ONE EMISSION PER INBOUND MESSAGE (issue #251
+ * follow-up, Codex review): `selectAdapter` is legal in TWO styles — it may
+ * report a selection by calling the callback-style hook
+ * (`window.WoodevPickupEmbedded.select()`, see "CALLBACK-STYLE WIDGETS"
+ * below) and return `null`, OR it may simply RETURN the point directly.
+ * Nothing stops a careless (or defensive-but-redundant) adapter from doing
+ * BOTH for the same inbound message — calling the callback synchronously
+ * AND also returning a non-null point. Without a guard, both paths reach
+ * {@see WoodevPickupMapProviderEmbedded#_handlePayload}, so one inbound
+ * carrier message would produce TWO `select`/`error` emissions, and
+ * `pickup-mount.js` would start two confirmation round trips for one
+ * customer click. The rule: once an emission has already happened
+ * SYNCHRONOUSLY during a `selectAdapter` call (via the callback route), the
+ * adapter's own return value is ignored, not processed a second time — see
+ * {@see WoodevPickupMapProviderEmbedded#_reentrantEmit}'s own docblock
+ * (constructor) for the exact mechanics. This preserves BOTH legal adapter
+ * styles unchanged (callback-then-null: one emission from the callback;
+ * return-only: one emission from the return value) and collapses the
+ * pathological both-at-once case to exactly one emission too.
  *
  * NORMALIZATION, NOT NORMALIZATION-OR-DIE: once a message IS recognised as our
  * envelope, or an adapter has translated one, `point`/the adapter's return
@@ -292,10 +321,53 @@
 	}
 
 	/**
+	 * A plain decimal numeric-string literal: an optional sign, digits (with an
+	 * optional fractional part, either side of the `.` allowed to be empty as
+	 * long as at least one digit exists somewhere), and an optional exponent.
+	 * Deliberately narrower than JS's own `Number()`/`parseFloat()` coercion —
+	 * see {@see isNumeric}'s docblock for why.
+	 *
+	 * @type {RegExp}
+	 */
+	var DECIMAL_NUMBER_RE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+	/**
 	 * Whether `value` is numeric in the sense PHP's `is_numeric()` would accept
-	 * it for a coordinate — a finite number, or a non-empty string that parses
-	 * to one. Mirrors the guard `Pickup_Point::from_array()` applies to `lat`/
-	 * `lng` before casting to float.
+	 * it for a coordinate — a finite number, or a non-empty string that is a
+	 * plain DECIMAL numeric literal (optional sign, digits, optional fractional
+	 * part, optional exponent — see {@see DECIMAL_NUMBER_RE}). Mirrors the guard
+	 * `Pickup_Point::from_array()` applies to `lat`/`lng` before casting to
+	 * float, which itself mirrors PHP's `is_numeric()` (PHP 7+): notably, that
+	 * means a hex/octal/binary literal string (`'0x20'`, `'0b11'`, `'0o17'`) is
+	 * REJECTED here, not accepted, even though it looks "numeric" — this is the
+	 * whole point, not an oversight.
+	 *
+	 * Issue #251 follow-up (Codex review): this used to read
+	 * `isFinite( Number( value ) )`, which — unlike PHP's `is_numeric()` —
+	 * ACCEPTS a hex string (`Number( '0x20' ) === 32`), while
+	 * {@see normalizePoint}'s conversion step uses `parseFloat()`, which reads
+	 * the very same string as `0` (`parseFloat` stops at the first character it
+	 * cannot parse as a decimal digit, and `'0x20'` starts with a valid `'0'`
+	 * digit followed by non-digit `'x'`). The two disagreed silently: a hex
+	 * coordinate string PASSED validation here and was then silently coerced to
+	 * `0` — null island — by `parseFloat()`, exactly the "junk is coerced, not
+	 * rejected" outcome `normalizePoint()`'s own docblock forbids. This was a
+	 * KNOWN, deliberately accepted divergence from PHP's `is_numeric()` when
+	 * #201 landed — `lat`/`lng` were still REQUIRED then, so a hex string
+	 * still produced a number and the divergence was provably unreachable.
+	 * Making them OPTIONAL (issue #251) is what turned it into a live defect:
+	 * an adapter now controls whether `lat`/`lng` are present at all, and a
+	 * carrier/adapter bug that hands through a hex-looking id fragment as a
+	 * coordinate would previously have been silently accepted as `(0, 0)`.
+	 * Validation and conversion must agree on what "numeric" means; this
+	 * regex-based check is that single source of truth — `parseFloat()` in
+	 * `normalizePoint()` is only ever reached for a value this function has
+	 * already accepted, and never disagrees with it, because every string this
+	 * regex matches parses via `parseFloat()` to the exact same value.
+	 *
+	 * Exponent notation (`'1e2'`) IS accepted: it is a legitimate decimal
+	 * number, unlike a hex/octal/binary literal, which is a different RADIX
+	 * entirely, not an alternate way to write the same decimal value.
 	 *
 	 * @param {*} value
 	 * @returns {boolean}
@@ -305,8 +377,10 @@
 			return isFinite( value );
 		}
 
-		if ( 'string' === typeof value && value.trim().length > 0 ) {
-			return isFinite( Number( value ) );
+		if ( 'string' === typeof value ) {
+			var trimmed = value.trim();
+
+			return trimmed.length > 0 && DECIMAL_NUMBER_RE.test( trimmed );
 		}
 
 		return false;
@@ -642,6 +716,25 @@
 		 */
 		this._loadTimer = null;
 
+		/**
+		 * RE-ENTRY GUARD (issue #251 follow-up, Codex review): a `selectAdapter` is legally
+		 * allowed to report a selection EITHER by calling the callback-style hook
+		 * (`window.WoodevPickupEmbedded.select()`, routed through
+		 * {@see WoodevPickupMapProviderEmbedded#_handleExternalSelect}) OR by RETURNING the
+		 * point directly from the call `_buildMessageHandler()` makes into it — both are
+		 * documented, legal adapter styles (see the file docblock's "CALLBACK-STYLE WIDGETS"
+		 * section for the first). An adapter that does BOTH for the same inbound carrier
+		 * message must still produce exactly ONE `select`/`error` emission for it, not two.
+		 * `_buildMessageHandler()` resets this to `false` immediately before invoking
+		 * `selectAdapter`; `_handleExternalSelect()` sets it to `true` if it runs
+		 * SYNCHRONOUSLY during that call. When it reads `true` afterwards, the adapter's
+		 * return value describes a selection ALREADY emitted through the callback route, and
+		 * is ignored — see `_buildMessageHandler()`'s own comment at the check.
+		 *
+		 * @type {boolean}
+		 */
+		this._reentrantEmit = false;
+
 		/** @type {boolean} guards destroy() against a second call. */
 		this._destroyed = false;
 	}
@@ -750,25 +843,38 @@
 			// Step 2: initAdapter — answers the carrier's own handshake. A throw
 			// is swallowed: `window` is a shared bus, and a plugin-supplied
 			// adapter must never be able to break the picker for unrelated
-			// traffic it does not recognise either.
+			// traffic it does not recognise either. Issue #251 follow-up (Codex
+			// review): the `postMessage()` call below is INSIDE this same try —
+			// it used to sit after the catch, unguarded, so an adapter return
+			// value the structured-clone algorithm cannot handle (a function, a
+			// `Symbol`, a cyclic object) threw `DataCloneError` straight out of
+			// this handler and into the page, defeating the whole "an adapter
+			// fault must not break the picker" rule this catch exists to
+			// enforce. `postMessage()` throwing is swallowed exactly like
+			// `initAdapter()` itself throwing — both are the adapter's fault,
+			// not the framework's, and neither may propagate.
 			var initAdapter = resolveAdapter( config.initAdapter );
 
 			if ( initAdapter ) {
-				var initPayload;
+				var initClaimed = false;
 
 				try {
-					initPayload = initAdapter( data );
+					var initPayload = initAdapter( data );
+
+					if ( undefined !== initPayload && null !== initPayload ) {
+						initClaimed = true;
+
+						// Belt-and-suspenders alongside check 3 above: never compute a
+						// `postMessage` call without a real, non-empty targetOrigin.
+						if ( config.expectedOrigin ) {
+							self._iframe.contentWindow.postMessage( initPayload, config.expectedOrigin );
+						}
+					}
 				} catch ( e ) {
 					return;
 				}
 
-				if ( undefined !== initPayload && null !== initPayload ) {
-					// Belt-and-suspenders alongside check 3 above: never compute a
-					// `postMessage` call without a real, non-empty targetOrigin.
-					if ( config.expectedOrigin ) {
-						self._iframe.contentWindow.postMessage( initPayload, config.expectedOrigin );
-					}
-
+				if ( initClaimed ) {
 					return;
 				}
 			}
@@ -782,14 +888,34 @@
 			if ( selectAdapter ) {
 				var rawPoint;
 
+				// RE-ENTRY GUARD (issue #251 follow-up, Codex review) — see `_reentrantEmit`'s
+				// own docblock in the constructor. Reset immediately before the call: a stale
+				// `true` left over from some earlier, unrelated `_handleExternalSelect()` call
+				// (a genuine callback-style widget with no configured adapter at all, say) must
+				// never be mistaken for THIS call's own re-entry.
+				self._reentrantEmit = false;
+
 				try {
 					rawPoint = selectAdapter( data );
 				} catch ( e ) {
-					self._emit( 'error', {
-						code: 'woodev_pickup_embed_adapter_error',
-						message: text( config, 'error' ),
-					} );
+					// A synchronous callback-style emission that happened before the throw
+					// already reported this selection (or its own failure) — do not ALSO
+					// emit `error` for the same inbound message.
+					if ( ! self._reentrantEmit ) {
+						self._emit( 'error', {
+							code: 'woodev_pickup_embed_adapter_error',
+							message: text( config, 'error' ),
+						} );
+					}
 
+					return;
+				}
+
+				// The adapter already reported this exact selection synchronously via
+				// `window.WoodevPickupEmbedded.select()` — the return value below describes
+				// the SAME selection, not a second one, and must be ignored so one inbound
+				// carrier message never produces two `select`/`error` emissions.
+				if ( self._reentrantEmit ) {
 					return;
 				}
 
@@ -916,6 +1042,14 @@
 		if ( this._destroyed ) {
 			return;
 		}
+
+		// See `_reentrantEmit`'s own docblock (constructor): marks that THIS route already
+		// handled a selection, so a `selectAdapter` invocation still in progress on the call
+		// stack above this one (see `_buildMessageHandler()`) knows to ignore its own return
+		// value rather than emit the same selection a second time. Set unconditionally, not
+		// only while a `selectAdapter` call is in flight — harmless when it is not (nothing
+		// reads it until the next `selectAdapter` invocation resets it first).
+		this._reentrantEmit = true;
 
 		this._handlePayload( payload, this._config || {} );
 	};

--- a/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
@@ -65,24 +65,58 @@
  * MESSAGE SHAPE (this file's own small protocol, not carrier-defined): once a
  * message passes the origin/source gate, only an object shaped exactly like
  *   { source: 'woodev-pickup-embedded', type: 'select', point: { ... } }
- * is recognised — `source`/`type` are OUR envelope, chosen so a carrier embed
- * only has to know it must `postMessage` that shape to the parent, and so this
- * file can tell "not for us" apart from "for us, but malformed" (see below).
- * Anything else arriving from the trusted origin/source (no envelope, wrong
- * `type`, or simply unrelated traffic the carrier's own page happens to emit)
- * is likewise ignored without throwing — the origin check proves WHO sent it,
- * not that every message they ever send is meant for this picker.
+ * is recognised as OUR envelope — `source`/`type` are chosen so a carrier
+ * embed only has to know it must `postMessage` that shape to the parent, and
+ * so this file can tell "not for us" apart from "for us, but malformed" (see
+ * below). Adapters (next section) NEVER see a message shaped like this — it
+ * is handled here, first, exactly as before #251.
+ *
+ * ADAPTER HOOKS (issue #251) — `config.initAdapter`/`config.selectAdapter`,
+ * each an OPTIONAL dotted global JS path (e.g. `'WoodevPochtaEmbed.toPoint'`),
+ * never a callable — the value crosses into the browser as JSON, and is
+ * resolved by walking `window` on `.` (never `eval`, never `new Function`); a
+ * path that does not resolve to a function is treated as absent. They exist
+ * so a plugin can point `embedUrl` straight at a carrier's OWN widget — no
+ * bridge page needed — and translate its native protocol in the browser
+ * instead of requiring it to speak this file's envelope. Only reached for a
+ * message that passed the origin+source gate AND did not match this file's
+ * own envelope above:
+ *   1. `initAdapter( data )` runs first. A non-`null`/`undefined` return is
+ *      posted back into the SAME iframe this message came from —
+ *      `iframe.contentWindow.postMessage( payload, config.expectedOrigin )`,
+ *      the expected origin as `targetOrigin`, NEVER `"*"` — and handling
+ *      stops there. A throw is SWALLOWED (the message bus is shared with
+ *      whatever else the carrier's page posts) and handling continues.
+ *   2. `selectAdapter( data )` runs when `initAdapter` did not claim the
+ *      message. A non-`null`/`undefined` return goes through
+ *      {@see normalizePoint} and then the same success/failure emit path as
+ *      the framework's own envelope. A throw here is NOT swallowed — it
+ *      emits `error`, because the message already proved it came from this
+ *      instance's own trusted iframe, so a translation failure is a real,
+ *      reportable fault, not routine cross-talk.
+ *   3. Neither adapter is configured, or both decline (return `null`/
+ *      `undefined`) — the message is ignored silently, same as any other
+ *      unrecognised traffic from the trusted origin.
+ * An empty/missing `config.expectedOrigin` already rejects every inbound
+ * message via check 3 above (so step 1's `postMessage` is unreachable in
+ * that case regardless); the outbound post in step 1 ALSO checks it
+ * explicitly before calling `postMessage`, as a second, independent guard
+ * against ever computing a `targetOrigin` that is not a real trusted origin.
+ * ADAPTERS NEVER WIDEN THE TRUST BOUNDARY: they run strictly AFTER the
+ * origin+source gate above and only ever translate a message this file has
+ * already proven came from ITS OWN iframe at the expected origin — they are
+ * not a second way for an untrusted sender to reach the picker.
  *
  * NORMALIZATION, NOT NORMALIZATION-OR-DIE: once a message IS recognised as our
- * envelope, `point` is run through {@see normalizePoint}. It is NOT a
- * field-for-field mirror of
- * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()} — only
- * its OPTIONAL-field handling (defaults, list filtering, int/bool casts) is
- * kept deliberately aligned with that PHP method, field by field. Its
- * REQUIRED-field set is this file's OWN, currently `id`/`name`/`lat`/`lng`/
- * `address`/`type.code`/`type.label` (`lat` in [-90,90], `lng` in
- * [-180,180]) — see {@see normalizePoint}'s own docblock for why that set is
- * a KNOWN, deliberate divergence from `from_array()`, not drift. Failing
+ * envelope, or an adapter has translated one, `point`/the adapter's return
+ * value is run through {@see normalizePoint}. It is NOT a field-for-field
+ * mirror of {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}
+ * — only its OPTIONAL-field handling (defaults, list filtering, int/bool
+ * casts) is kept deliberately aligned with that PHP method, field by field.
+ * Its REQUIRED-field set is this file's OWN, currently `id`/`name`/`address`/
+ * `type.code`/`type.label`; `lat`/`lng` are OPTIONAL-BUT-VALIDATED (issue
+ * #251 — a real carrier embed, measured, sends neither) — see
+ * {@see normalizePoint}'s own docblock for the exact rules. Failing
  * normalization here emits `error`, NEVER a malformed `select` — a provider
  * that forwarded whatever the carrier sent verbatim would let a broken/
  * malicious carrier page write garbage straight into the order.
@@ -365,20 +399,24 @@
 	 * field by field. The REQUIRED-field set is this file's own and diverges on
 	 * purpose:
 	 *
-	 * Required: `id`/`name`/`lat`/`lng`/`address`/`type.code`/`type.label`
-	 * (`lat` in [-90,90], `lng` in [-180,180]). `from_array()` requires `lat`/
-	 * `lng` too, but for a different reason — the framework's own map
-	 * (`map-provider-yandex.js`) needs coordinates to place a marker. THIS
-	 * provider draws no map of ours (see the file docblock's opening
-	 * paragraph), and a real carrier embed does not necessarily supply
-	 * coordinates at all: Почта России's widget, measured against this seam on
-	 * the rig, returns a selection payload with no `lat`/`lng` and no `name`
-	 * (`{ id, mailType, pvzType, indexTo, cashOfDelivery, regionTo, cityTo,
-	 * addressTo, weight, ... }`). Relaxing this required set to match what real
-	 * carriers actually send is tracked as #251; until that lands, requiring
-	 * `lat`/`lng`/`name` here means this function rejects that real payload.
-	 * KNOWN AND DELIBERATE, not an oversight of this pass — do not "fix" it as
-	 * a drift in isolation, it would conflict with #251's landing change.
+	 * Required: `id`/`name`/`address`/`type.code`/`type.label`. `lat`/`lng` are
+	 * OPTIONAL-BUT-VALIDATED (issue #251, resolved): present, both must be
+	 * numeric and in range (`lat` in [-90,90], `lng` in [-180,180]) — junk is
+	 * still REJECTED, never coerced; absent, BOTH must be absent (exactly one
+	 * present is a half-coordinate — an adapter bug, not a partial datum — and
+	 * is REJECTED); omitted from the emitted point when absent, with no `0.0`
+	 * fallback, ever. `from_array()` requires `lat`/`lng` unconditionally, but
+	 * for a different reason — the framework's own map (`map-provider-yandex.js`)
+	 * needs coordinates to place a marker. THIS provider draws no map of ours
+	 * (see the file docblock's opening paragraph), and a real carrier embed does
+	 * not necessarily supply coordinates at all: Почта России's widget, measured
+	 * against this seam on the rig, returns a selection payload with no `lat`/
+	 * `lng` and no `name` (`{ id, mailType, pvzType, indexTo, cashOfDelivery,
+	 * regionTo, cityTo, addressTo, weight, ... }`). `name` stays REQUIRED even
+	 * so — Почта sends none, but a name is domain knowledge the owning plugin's
+	 * adapter can build (e.g. `Почтомат №918872` from `pvzType` + `indexTo`; see
+	 * the fixture's `WoodevPochtaEmbed.toPoint`), and it is what the checkout
+	 * field and trigger label display. This function must not invent one.
 	 *
 	 * Optional, default `''` via {@see optionalString}: `short_address`/
 	 * `locality`/`postal_code`/`phone`/`instruction`/`work_time`/
@@ -403,7 +441,7 @@
 			return null;
 		}
 
-		var required = [ 'id', 'name', 'lat', 'lng', 'address' ];
+		var required = [ 'id', 'name', 'address' ];
 		var i, key, value;
 
 		for ( i = 0; i < required.length; i++ ) {
@@ -424,22 +462,37 @@
 			return null;
 		}
 
-		if ( ! isNumeric( payload.lat ) || ! isNumeric( payload.lng ) ) {
+		// Issue #251: lat/lng are OPTIONAL-BUT-VALIDATED, not required — see this
+		// function's own docblock for why (a real carrier embed, measured, sends
+		// neither). Absent means BOTH must be absent; exactly one present is a
+		// half-coordinate, which is an adapter bug, not a partial datum, and is
+		// REJECTED rather than silently dropped or defaulted.
+		var hasLat = undefined !== payload.lat && null !== payload.lat;
+		var hasLng = undefined !== payload.lng && null !== payload.lng;
+
+		if ( hasLat !== hasLng ) {
 			return null;
 		}
 
-		var lat = parseFloat( payload.lat );
-		var lng = parseFloat( payload.lng );
+		var lat = null;
+		var lng = null;
 
-		if ( lat < -90 || lat > 90 || lng < -180 || lng > 180 ) {
-			return null;
+		if ( hasLat ) {
+			if ( ! isNumeric( payload.lat ) || ! isNumeric( payload.lng ) ) {
+				return null;
+			}
+
+			lat = parseFloat( payload.lat );
+			lng = parseFloat( payload.lng );
+
+			if ( lat < -90 || lat > 90 || lng < -180 || lng > 180 ) {
+				return null;
+			}
 		}
 
-		return {
+		var point = {
 			id: String( payload.id ),
 			name: String( payload.name ),
-			lat: lat,
-			lng: lng,
 			address: String( payload.address ),
 			type: {
 				code: String( type.code ),
@@ -460,6 +513,47 @@
 				: null,
 			max_weight: optionalInt( payload, 'max_weight' ),
 		};
+
+		// No `0.0` fallback, ever — omitted from the emitted point entirely when
+		// absent, per this function's docblock.
+		if ( hasLat ) {
+			point.lat = lat;
+			point.lng = lng;
+		}
+
+		return point;
+	}
+
+	/**
+	 * Resolves a dotted global JS path (e.g. `'WoodevPochtaEmbed.toPoint'`) to a
+	 * function, by walking `window` one `.`-separated segment at a time — see
+	 * the file docblock's "ADAPTER HOOKS" section (issue #251). NEVER `eval`,
+	 * NEVER `new Function`: a segment that resolves to anything other than an
+	 * object/function part-way through, or a final value that is not itself a
+	 * function, makes the whole path resolve to `null` (treated as "no
+	 * adapter configured"), not a thrown error.
+	 *
+	 * @param {*} path
+	 * @returns {Function|null}
+	 */
+	function resolveAdapter( path ) {
+		if ( 'string' !== typeof path || '' === path ) {
+			return null;
+		}
+
+		var segments = path.split( '.' );
+		var target = window;
+		var i;
+
+		for ( i = 0; i < segments.length; i++ ) {
+			if ( ! target || ( 'object' !== typeof target && 'function' !== typeof target ) ) {
+				return null;
+			}
+
+			target = target[ segments[ i ] ];
+		}
+
+		return 'function' === typeof target ? target : null;
 	}
 
 	/**
@@ -641,16 +735,73 @@
 
 			var data = event.data;
 
-			// Not our envelope (or not meant for us) — ignore silently; `window`
-			// is a shared bus and unrelated same-origin traffic is routine.
-			if ( ! data || 'object' !== typeof data
-				|| MESSAGE_SOURCE !== data.source
-				|| MESSAGE_TYPE_SELECT !== data.type
+			// Step 1 (issue #251 numbering, see the file docblock's "ADAPTER
+			// HOOKS" section): this file's own envelope, handled exactly as
+			// before #251 — adapters never see a message shaped like this.
+			if ( data && 'object' === typeof data
+				&& MESSAGE_SOURCE === data.source
+				&& MESSAGE_TYPE_SELECT === data.type
 			) {
+				self._handlePayload( data.point, config );
+
 				return;
 			}
 
-			self._handlePayload( data.point, config );
+			// Step 2: initAdapter — answers the carrier's own handshake. A throw
+			// is swallowed: `window` is a shared bus, and a plugin-supplied
+			// adapter must never be able to break the picker for unrelated
+			// traffic it does not recognise either.
+			var initAdapter = resolveAdapter( config.initAdapter );
+
+			if ( initAdapter ) {
+				var initPayload;
+
+				try {
+					initPayload = initAdapter( data );
+				} catch ( e ) {
+					return;
+				}
+
+				if ( undefined !== initPayload && null !== initPayload ) {
+					// Belt-and-suspenders alongside check 3 above: never compute a
+					// `postMessage` call without a real, non-empty targetOrigin.
+					if ( config.expectedOrigin ) {
+						self._iframe.contentWindow.postMessage( initPayload, config.expectedOrigin );
+					}
+
+					return;
+				}
+			}
+
+			// Step 3: selectAdapter — translates the carrier's own selection
+			// message. Unlike initAdapter, a throw here is NOT swallowed: this
+			// message already passed the origin+source gate, so a translation
+			// failure is a real, reportable fault.
+			var selectAdapter = resolveAdapter( config.selectAdapter );
+
+			if ( selectAdapter ) {
+				var rawPoint;
+
+				try {
+					rawPoint = selectAdapter( data );
+				} catch ( e ) {
+					self._emit( 'error', {
+						code: 'woodev_pickup_embed_adapter_error',
+						message: text( config, 'error' ),
+					} );
+
+					return;
+				}
+
+				if ( undefined !== rawPoint && null !== rawPoint ) {
+					self._handlePayload( rawPoint, config );
+
+					return;
+				}
+			}
+
+			// Neither our envelope nor an adapter claimed this message — ignore
+			// silently, same as any other unrelated same-origin traffic.
 		};
 	};
 
@@ -660,10 +811,13 @@
 	 * `error` and injects nothing — see {@see isAbsoluteHttpsUrl}.
 	 *
 	 * @param {HTMLElement} container
-	 * @param {Object}      config     `{ embedUrl, expectedOrigin, strategy, i18n, locality }` —
-	 *                                 only `embedUrl`/`expectedOrigin`/`i18n` are used; `strategy`
-	 *                                 and `locality` describe the plugin's `Point_Source` and have
-	 *                                 no meaning for a provider that never calls `woodev/v1`.
+	 * @param {Object}      config     `{ embedUrl, expectedOrigin, initAdapter, selectAdapter,
+	 *                                 strategy, i18n, locality }` — `strategy` and `locality`
+	 *                                 describe the plugin's `Point_Source` and have no meaning
+	 *                                 for a provider that never calls `woodev/v1`. `initAdapter`/
+	 *                                 `selectAdapter` (issue #251) are optional dotted global JS
+	 *                                 paths; see the file docblock's "ADAPTER HOOKS" section and
+	 *                                 {@see WoodevPickupMapProviderEmbedded#_buildMessageHandler}.
 	 * @param {Object}      dataSource unused — see the file docblock.
 	 * @returns {void}
 	 */

--- a/woodev/shipping-method/map/class-embedded-map-provider.php
+++ b/woodev/shipping-method/map/class-embedded-map-provider.php
@@ -4,41 +4,57 @@
  *
  * A carrier's own widget or `<iframe>`, embedded inside the same modal shell —
  * the other end of the {@see Map_Provider} seam from {@see Yandex_Map_Provider}'s
- * "our own map". This class only supplies the two plugin-supplied values the JS
- * half (`map-provider-embedded.js`) needs — where to embed from, and which origin
- * to trust a message back from.
+ * "our own map". This class only supplies the plugin-supplied values the JS
+ * half (`map-provider-embedded.js`) needs — where to embed from, which origin
+ * to trust a message back from, and (optionally) the two adapter hooks that
+ * translate a carrier's OWN protocol instead of requiring it to speak ours.
  *
- * THE EMBEDDED PAGE MUST SPEAK THE FRAMEWORK'S OWN PROTOCOL, NOT THE CARRIER'S
- * NATIVE ONE. `$embed_url` is NOT simply "paste the carrier's widget URL here" —
- * a carrier's own page has no reason to know anything about Woodev and will
- * never spontaneously talk to it. Whatever page `$embed_url` points at MUST,
- * once the customer has picked a point, do ONE of:
- *   1. `postMessage` this EXACT envelope to the parent window (verbatim, every
- *      key required, `point` shaped per
- *      {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()} —
- *      `id`/`name`/`lat`/`lng`/`address`/`type.code`/`type.label` required, the
- *      rest optional):
- *      ```
- *      {
- *          source: 'woodev-pickup-embedded',
- *          type:   'select',
- *          point:  { id, name, lat, lng, address, type: { code, label }, ... }
- *      }
- *      ```
- *      — required for a cross-origin `<iframe>` (the normal case: the carrier's
- *      widget runs in an `<iframe>` whose `src` is `$embed_url`);
- *   2. call `window.WoodevPickupEmbedded.select( point )` with the same `point`
- *      shape, when the embed instead runs SAME-ORIGIN as the checkout page (a
- *      first-party `<script>` widget, not an iframe).
- * A carrier's own widget speaks neither of these — it is the CARRIER's protocol,
- * not ours. In practice this means `$embed_url` usually cannot point straight at
- * the carrier's own page: the owning plugin hosts a small bridge page (or
- * bridges an inline `<script>`) that embeds/initializes the carrier's real
- * widget and translates ITS selection callback into one of the two shapes
- * above. See `woodev/shipping-method/assets/js/frontend/map-provider-embedded.js`
+ * TWO WAYS FOR THE EMBEDDED PAGE TO REACH THE FRAMEWORK — pick one:
+ *
+ *   1. THE FRAMEWORK'S OWN PROTOCOL. `$embed_url` points at a page that,
+ *      once the customer has picked a point, does ONE of:
+ *        a. `postMessage` this EXACT envelope to the parent window (verbatim,
+ *           every key required, `point` shaped per
+ *           {@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()} —
+ *           `id`/`name`/`address`/`type.code`/`type.label` required, `lat`/`lng`
+ *           optional-but-validated since issue #251, the rest optional):
+ *           ```
+ *           {
+ *               source: 'woodev-pickup-embedded',
+ *               type:   'select',
+ *               point:  { id, name, address, type: { code, label }, ... }
+ *           }
+ *           ```
+ *           — the normal shape for a cross-origin `<iframe>`;
+ *        b. call `window.WoodevPickupEmbedded.select( point )` with the same
+ *           `point` shape, when the embed instead runs SAME-ORIGIN as the
+ *           checkout page (a first-party `<script>` widget, not an iframe).
+ *      In practice this means the owning plugin hosts a small bridge page (or
+ *      inline `<script>`) that embeds/initializes the carrier's real widget
+ *      and translates ITS selection callback into one of the two shapes
+ *      above — a carrier's own widget speaks neither of these natively.
+ *
+ *   2. `$init_adapter` / `$select_adapter` (issue #251). `$embed_url` points
+ *      DIRECTLY at the carrier's own widget — no bridge page — and these two
+ *      optional dotted-global-path hooks translate the carrier's OWN protocol
+ *      messages in the browser instead. This path exists because a bridge
+ *      page turned out to buy no safety a direct embed does not already have:
+ *      measured against the live Почта России widget (see
+ *      `docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md`
+ *      §1), the framework's `sandbox` posture does not break the widget (M2),
+ *      the widget accepts a `postMessage` handshake from a foreign parent
+ *      origin (M5), and the framework's own origin + `event.source` trust gate
+ *      holds against it unchanged (M6). See `map-provider-embedded.js`'s
+ *      `handleMessage()` for exactly where these hooks run: strictly AFTER
+ *      the origin/source gate, so they never widen the trust boundary — they
+ *      only translate messages already proven to come from this instance's
+ *      own iframe at the expected origin.
+ *
+ * See `woodev/shipping-method/assets/js/frontend/map-provider-embedded.js`
  * for the full receiving-side contract (origin/source checks, normalization,
- * the exact rejection rules) — this class only carries the two config values;
- * the JS file is the only place that consumes them.
+ * the exact rejection rules, and the adapter resolution/throw rules) — this
+ * class only carries the config values; the JS file is the only place that
+ * consumes them.
  *
  * @since 2.0.2
  */
@@ -64,12 +80,11 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Map\\Embedded_Map_Provider'
 		/**
 		 * The embed URL — an `<iframe>` `src` — supplied by the owning plugin.
 		 *
-		 * NOT necessarily the carrier's own widget URL: the page this loads MUST
-		 * speak the framework's own selection protocol (see the class docblock's
-		 * "THE EMBEDDED PAGE MUST SPEAK THE FRAMEWORK'S OWN PROTOCOL" section for
-		 * the exact `postMessage` envelope / callback shape). A carrier's native
-		 * widget URL almost always needs a small plugin-hosted bridge page in
-		 * front of it, not this property pointed at it directly.
+		 * Either a page that speaks the framework's own selection protocol
+		 * directly (see the class docblock's "TWO WAYS" section, option 1 — the
+		 * exact `postMessage` envelope / callback shape), or the carrier's own
+		 * widget URL when {@see self::$init_adapter}/{@see self::$select_adapter}
+		 * translate its native protocol instead (option 2, issue #251).
 		 *
 		 * @since 2.0.2
 		 * @var string
@@ -93,21 +108,68 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Map\\Embedded_Map_Provider'
 		private string $expected_origin;
 
 		/**
+		 * Optional dotted global JS path (e.g. `'WoodevPochtaEmbed.onReady'`) to a
+		 * plugin-supplied function that translates the carrier's OWN handshake
+		 * message into a payload this provider posts back into the iframe — see
+		 * `map-provider-embedded.js`'s `handleMessage()` step 2 (issue #251). `null`
+		 * when `$embed_url` already speaks the framework's own protocol directly
+		 * (the class docblock's option 1) and needs no translation.
+		 *
+		 * Carried verbatim into {@see self::get_js_config()} as a STRING, never a
+		 * callable — the value crosses into the browser as JSON; the browser
+		 * resolves it by walking `window` on `.`, never `eval`/`new Function`.
+		 *
+		 * @since 2.0.2
+		 * @var string|null
+		 */
+		private ?string $init_adapter;
+
+		/**
+		 * Optional dotted global JS path to a plugin-supplied function that
+		 * translates the carrier's OWN selection message into this provider's raw
+		 * point payload — see `map-provider-embedded.js`'s `handleMessage()` step 3
+		 * (issue #251). `null` under the same condition as {@see self::$init_adapter}.
+		 *
+		 * @since 2.0.2
+		 * @var string|null
+		 */
+		private ?string $select_adapter;
+
+		/**
 		 * Constructor.
 		 *
 		 * @since 2.0.2
 		 *
-		 * @param string $embed_url       the embed `<iframe>` `src` — a page that
-		 *                                speaks the framework's own selection
-		 *                                protocol (see the class docblock), not
-		 *                                necessarily the carrier's own widget URL.
-		 * @param string $expected_origin the origin to trust a `postMessage` back
-		 *                                from — the origin `$embed_url` is served
-		 *                                from.
+		 * @param string      $embed_url       the embed `<iframe>` `src` — a page that
+		 *                                     speaks the framework's own selection
+		 *                                     protocol (see the class docblock's option
+		 *                                     1), or the carrier's OWN widget URL
+		 *                                     directly when `$init_adapter`/
+		 *                                     `$select_adapter` translate its native
+		 *                                     protocol instead (option 2).
+		 * @param string      $expected_origin the origin to trust a `postMessage` back
+		 *                                     from — the origin `$embed_url` is served
+		 *                                     from.
+		 * @param string|null $init_adapter    optional dotted global JS path (see
+		 *                                     {@see self::$init_adapter}) that answers
+		 *                                     the carrier's own handshake instead of the
+		 *                                     framework's envelope. Default `null`.
+		 * @param string|null $select_adapter  optional dotted global JS path (see
+		 *                                     {@see self::$select_adapter}) that
+		 *                                     translates the carrier's own selection
+		 *                                     message instead of the framework's
+		 *                                     envelope. Default `null`.
 		 */
-		public function __construct( string $embed_url, string $expected_origin ) {
+		public function __construct(
+			string $embed_url,
+			string $expected_origin,
+			?string $init_adapter = null,
+			?string $select_adapter = null
+		) {
 			$this->embed_url       = $embed_url;
 			$this->expected_origin = untrailingslashit( $expected_origin );
+			$this->init_adapter    = $init_adapter;
+			$this->select_adapter  = $select_adapter;
 		}
 
 		/**
@@ -158,12 +220,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Map\\Embedded_Map_Provider'
 		 * container) is the one that must carry `true` into the browser, not just report it
 		 * over an interface method nothing JS-side ever reads.
 		 *
+		 * `initAdapter`/`selectAdapter` (issue #251) carry {@see self::$init_adapter} and
+		 * {@see self::$select_adapter} verbatim — `null` when unset, which
+		 * `map-provider-embedded.js` treats as "no adapter, framework protocol only".
+		 *
 		 * @since 2.0.2
 		 */
 		public function get_js_config( array $context ): array {
 			return [
 				'embedUrl'       => $this->embed_url,
 				'expectedOrigin' => $this->expected_origin,
+				'initAdapter'    => $this->init_adapter,
+				'selectAdapter'  => $this->select_adapter,
 				'ownsChrome'     => $this->owns_chrome(),
 			];
 		}


### PR DESCRIPTION
## Summary

Makes the carrier-embedded (iframe/`ownsChrome`) map-provider seam actually reachable by a real carrier, and gives the rig a switch to exercise it — closing the gap issue #251 found: the seam existed in code but had never been driven on the rig because nothing could reach it (the framework's own `postMessage` envelope requires a plugin-hosted bridge page no fixture ever built).

Full measurement record and design decision: `docs-internal/specs/2026-08-10-embedded-map-provider-adapter-seam.md`.

### Measured facts this design rests on (spec §1)

- **M2** — the framework's `sandbox` posture (`allow-scripts allow-same-origin allow-forms allow-popups`, `referrerpolicy="no-referrer"`) does **not** break the live Почта России widget: sandboxed and unsandboxed frames behaved identically.
- **M5** — the widget accepts a `postMessage` handshake from a **foreign parent origin** — it never checks `event.origin`, posting/listening with `"*"` in both directions.
- **M6** — the framework's own two trust checks hold against it unchanged: `event.origin === 'https://widget.pochta.ru'` (exact) and `event.source === iframe.contentWindow`, for every message including the selection.
- **M8** — a real selection payload carries **neither `lat`/`lng` nor `name`** (`{"id":43213,"mailType":"ONLINE_PARCEL","pvzType":"postamat","indexTo":"918872",...}`).

M2+M5+M6 together mean a plugin-hosted bridge page buys no safety a direct embed doesn't already have — the "adapter over iframe" design (§2) skips it. M8 means `lat`/`lng` had to become optional for this seam to ever accept a real carrier's selection.

## Changes

- **`Embedded_Map_Provider`** (PHP): two new optional constructor params, `init_adapter`/`select_adapter`, carried verbatim into `get_js_config()` as dotted-global-path strings (never a callable).
- **`map-provider-embedded.js`**: dotted-path resolution (`window` walk on `.`, never `eval`/`new Function`); the two adapter hooks wired into `handleMessage()` strictly *after* the existing origin+source gate — `initAdapter` answers the carrier's handshake and posts back into the iframe (`expectedOrigin` as `targetOrigin`, never `"*"`; suppressed when `expectedOrigin` is empty); `selectAdapter` translates a selection into a point. `initAdapter` throwing is swallowed; `selectAdapter` throwing emits `error`.
- **`normalizePoint()`**: `lat`/`lng` are now optional-but-validated — present and numeric/in-range or rejected; absent, *both* must be absent (one alone is a rejected half-coordinate); no `0.0` fallback ever. `name` stays required. `Pickup_Point::from_array()` is untouched.
- **Fixture**: `WOODEV_TEST_PICKUP_EMBEDDED` (wins over every other switch), `WOODEV_TEST_POCHTA_ACCOUNT_ID`/`_ACCOUNT_TYPE` credentials (never committed, `defined()`-guarded), `WOODEV_TEST_PICKUP_SELECTION_CLOSE`/`_REFRESH_CHECKOUT`, and a fixture-owned `WoodevPochtaEmbed` adapter script — all carrier-specific knowledge (field names, address composition order, type labels) lives here, never in the framework.

## Divergence from the spec

None functionally — one clarification: the spec's "empty `expectedOrigin` must ALSO suppress the outbound post" rule is technically unreachable through the existing code path (the origin gate already rejects every inbound message when `expectedOrigin` is empty, so `initAdapter` is never invoked). Implemented anyway as an explicit, independent guard right before the `postMessage` call — belt-and-suspenders, matching this file's existing defense-in-depth style, and it's now pinned by a dedicated test.

## Test plan

- [x] `npm run test:js -- --roots "<rootDir>/tests/js"` — 836/836 (baseline 822; +14 new, all in `map-provider-embedded.test.js`: optional lat/lng in both directions, half-coordinate rejection, initAdapter post/no-post, selectAdapter select/no-select, both throw-handling rules, empty-origin suppression, gate-before-adapter, envelope-before-adapter, unresolvable dotted path)
- [x] `composer test:unit` — 1521/1521 (baseline 1520; +1 new, pinning the two adapter keys in `get_js_config()`)
- [x] `composer phpcs` — clean
- [ ] Rig verification (spec §6) — coordinator-owned, not part of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx85cZaYUGb8Zxv836PxD8

## Post-review fixes

An adversarial Codex review + a live rig session (s63) found five real defects after the above landed; all five are fixed on this branch:

1. **F1 (Codex, Medium)** — `isNumeric()` validated coordinates with `isFinite( Number( value ) )`, which *accepts* a hex/octal/binary literal string (`Number( '0x20' ) === 32`), while `normalizePoint()`'s conversion step used `parseFloat()`, which reads the same string as `0`. A hex coordinate string silently normalized to `(0, 0)` — "null island" — exactly the coercion `normalizePoint()`'s own docblock forbids. Known and deliberately left alone in #201 (lat/lng were still required then, so unreachable); making them optional in this PR turned it into a live defect. Fixed with a strict decimal-numeric-string regex both `isNumeric()` and `parseFloat()` agree on: `'0x20'`/`'0b11'`/`'0o17'`/`'12abc'`/`''`/`'  '`/`true`/`[]`/`{}`/`NaN`/`Infinity` are all rejected; `'1e2'`-style exponent notation is accepted (a legitimate decimal number).
2. **F2 (Codex, Medium)** — the `initAdapter` branch's `iframe.contentWindow.postMessage()` call sat *outside* the `try`/`catch` guarding the adapter invocation. An adapter return value the structured-clone algorithm can't handle (a function, a cyclic object) threw `DataCloneError` straight into the page. Fixed by moving the post inside the same guarded region — a throw from either the adapter or `postMessage()` itself is now swallowed identically.
3. **F3 (Codex, Medium)** — a `selectAdapter` reporting a selection via *both* the callback-style hook (`window.WoodevPickupEmbedded.select()`) and its own return value double-emitted `select`/`error` for one inbound message, starting two confirmation round trips on `pickup-mount.js`'s side. Fixed with a re-entry guard (`_reentrantEmit`): reset before each `selectAdapter` call, set if the callback fires synchronously during it; when set afterwards, the return value is ignored. Both legal adapter styles still work; the pathological both-at-once case now emits exactly once.
4. **F4 (rig finding)** — with `WOODEV_TEST_PICKUP_EMBEDDED` on, a real Почта selection normalized/emitted correctly and the confirmation round trip fired, but the server answered `404 woodev_pickup_point_not_found`: `Pickup_Controller::handle_select_request()` always re-fetches the chosen id via `Point_Source::fetch_details()`, provider-agnostic, and no fixture `Point_Source` had ever heard of a real carrier id. This also made `WOODEV_TEST_PICKUP_SELECTION_CLOSE`/`_REFRESH_CHECKOUT` unreachable. The fixture's own docblock claim that `$point_source` was "never actually consulted" under this switch was **wrong** (true for `fetch_points()`, false for `fetch_details()`) and is corrected alongside the fix. Adds `Woodev_Test_Embedded_Confirm_Point_Source`, a rig-only stub whose `fetch_details()` accepts any id and fabricates an always-permissive point — its docblock states plainly that a real embedded-carrier plugin must implement a genuine carrier lookup instead.
5. **F5 (rig finding, cosmetic, fixture-only)** — the fixture's Почта adapter composed the address from `regionTo, areaTo, cityTo, location, addressTo`; for Moscow, `regionTo` and `cityTo` are both `"г. Москва"`, producing `"г. Москва, г. Москва, ул. Никольская 7-9 стр. 4"`. Fixed by dropping *consecutive* duplicate parts only (field order unchanged, matches the operator's production plugin). Framework files untouched — fixture-only.

Verification after these fixes: `npm run test:js -- --roots "<rootDir>/tests/js"` — 863/863 (836 baseline + 27 new); `composer test:unit` — 1533/1533 (1521 baseline + 12 new); `composer phpcs` — clean.
