### PR TITLE
fix(pickup): attach the embedded provider's message listener before the frame

### DIFF
--- a/tests/js/map-provider-embedded.test.js
+++ b/tests/js/map-provider-embedded.test.js
@@ -647,6 +647,79 @@ test( 'onerror firing before the timeout suppresses a SECOND error from the time
 } );
 
 // -----------------------------------------------------------------------
+// init() wiring order (issue #259)
+// -----------------------------------------------------------------------
+
+// `appendChild()` is what starts the carrier's load, and since #251 the carrier's
+// FIRST message is its readiness handshake — the one `initAdapter` must answer or the
+// widget never initialises (measured: an empty map, forever, with no console error).
+// The old order (append, then listen) was safe ONLY because both statements ran in one
+// synchronous task; this test removes the dependency on that reasoning, so a future
+// refactor that puts anything asynchronous between them fails here instead of shipping
+// a silently dead picker. jsdom never loads the cross-origin frame, but the ORDER of
+// our own two calls is fully observable, which is the invariant at stake.
+test( 'the message listener is attached BEFORE the iframe enters the DOM', () => {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+
+	const order = [];
+	const realAddEventListener = window.addEventListener.bind( window );
+	const realAppendChild = container.appendChild.bind( container );
+
+	window.addEventListener = function ( type, listener, options ) {
+		if ( 'message' === type ) {
+			order.push( 'listen' );
+		}
+
+		return realAddEventListener( type, listener, options );
+	};
+
+	container.appendChild = function ( node ) {
+		order.push( 'append' );
+
+		return realAppendChild( node );
+	};
+
+	const provider = new WoodevPickupMapProviderEmbedded();
+
+	try {
+		provider.init( container, baseConfig(), {} );
+	} finally {
+		delete window.addEventListener;
+		delete container.appendChild;
+	}
+
+	expect( order ).toEqual( [ 'listen', 'append' ] );
+
+	provider.destroy();
+} );
+
+// The source check must IDENTIFY the sending window, not merely fail to disagree with
+// it: an iframe with no browsing context reports `contentWindow === null`, and
+// `event.source` is `null` for a message posted by a window that has since closed, so a
+// bare `!==` comparison of the two passes VACUOUSLY and pins the message to nothing.
+// Now that the listener is attached before `appendChild()` (issue #259), the provider
+// can legitimately hold a frame in that state while a message arrives.
+//
+// The contextless frame is stubbed rather than produced by `iframe.remove()`: jsdom
+// THROWS (`Cannot read properties of null (reading '_history')`) when `contentWindow` is
+// read off a detached iframe, where a real browser simply returns `null`. That is a
+// jsdom limitation, not a shape the production code has to survive — so the stub is the
+// only way to exercise the real browser's behaviour here.
+test( 'a null-source message is rejected when the iframe has no browsing context', () => {
+	const { provider, onSelect, onError } = initProvider();
+
+	provider._iframe = { contentWindow: null };
+
+	dispatchMessage( EXPECTED_ORIGIN, null, envelope( validPointPayload() ) );
+
+	expect( onSelect ).not.toHaveBeenCalled();
+	expect( onError ).not.toHaveBeenCalled();
+
+	provider.destroy();
+} );
+
+// -----------------------------------------------------------------------
 // destroy()
 // -----------------------------------------------------------------------
 

--- a/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
@@ -822,7 +822,17 @@
 
 			// Check 2: the message must come from THIS instance's own iframe, not
 			// merely from some other window that shares the trusted origin.
-			if ( ! self._iframe || event.source !== self._iframe.contentWindow ) {
+			//
+			// The explicit `! self._iframe.contentWindow` clause is NOT redundant
+			// (issue #259): a DETACHED iframe has no browsing context, so its
+			// `contentWindow` is `null` — and `event.source` is ALSO `null` for a
+			// message posted by a window that has since closed (this sandbox grants
+			// `allow-popups`). Without the clause those two nulls compare EQUAL and
+			// check 2 passes vacuously, pinning the message to nothing. Attaching
+			// this listener before `appendChild()` (same issue) is what makes the
+			// detached state reachable here at all — it is still zero-length at
+			// runtime today, but the gate must not depend on that.
+			if ( ! self._iframe || ! self._iframe.contentWindow || event.source !== self._iframe.contentWindow ) {
 				return;
 			}
 
@@ -1022,12 +1032,26 @@
 			} );
 		};
 
-		container.appendChild( this._iframe );
-
+		// ORDER IS LOAD-BEARING (issue #259): the `message` listener MUST be attached
+		// BEFORE the iframe enters the DOM, because `appendChild()` is what starts the
+		// carrier's load — and since #251 the carrier's FIRST message is its readiness
+		// handshake (Почта: `{ isMapLoad: true }`), which `initAdapter` has to answer
+		// with the payload the widget needs to initialise at all. Measured on the rig:
+		// without that answer the widget's map stays empty FOREVER. So missing the
+		// first message is no longer a merely-late `select` — it is a dead picker,
+		// with an empty frame and not one console error to debug from, because the
+		// load and the carrier's handshake both completed normally and simply had no
+		// listener. The pre-#259 order (append first, listen second) was safe only
+		// because both statements ran in ONE synchronous task and a `message` event is
+		// delivered in a later task; any future `await`/`setTimeout`/promise-wrapped
+		// frame construction inserted between them would have broken it silently.
+		// Attaching first removes the dependency on that reasoning entirely.
 		activeInstance = this;
 
 		this._onMessage = this._buildMessageHandler( String( cfg.expectedOrigin || '' ), cfg );
 		window.addEventListener( 'message', this._onMessage );
+
+		container.appendChild( this._iframe );
 	};
 
 	/**


### PR DESCRIPTION
Closes #259.

## Что и почему

`appendChild()` — это то, что запускает загрузку карьера, а после #251 **первое** сообщение карьера это его рукопожатие готовности (`{isMapLoad:true}` у Почты), на которое `initAdapter` обязан ответить — иначе виджет не инициализируется вообще. Замерено на риге: без ответа `postData` карта Почты пустая навсегда.

То есть пропуск первого сообщения перестал быть «поздним select» и стал **мёртвым пикером**: пустой фрейм и ни одной ошибки в консоли, потому что и загрузка, и рукопожатие отработали штатно — просто некому было услышать.

Старый порядок был безопасен ровно по одной причине: обе строки в одной синхронной задаче, а `message` доставляется отдельной. Любой `await` / `setTimeout` / вынос построения фрейма в промис, вставленный будущим рефакторингом между ними, ломал бы это молча.

## Изменения

1. **Порядок** — слушатель и `activeInstance` до `appendChild()`, с комментарием, объясняющим, что порядок несущий (16 строк — цена ошибки того стоит).
2. **Гейт источника, попутно** — `event.source === iframe.contentWindow` проходил **вакуумно**, когда обе стороны `null`: у фрейма без browsing context `contentWindow` это `null`, и `event.source` тоже `null` для сообщения от уже закрытого окна (`allow-popups` в песочнице выдан). Пока слушатель вешался после вставки, состояние было недостижимо; после перестановки — достижимо в принципе, поэтому check 2 теперь отвергает пустой `contentWindow` явно.

## Проверка

Оба теста **проверены мутацией** — каждый падает на неисправленном коде:

| Мутация | Результат |
|---|---|
| вернуть порядок `appendChild` → `addEventListener` | `× the message listener is attached BEFORE the iframe enters the DOM` |
| убрать клаузу `! self._iframe.contentWindow` | `× a null-source message is rejected when the iframe has no browsing context` |

Jest: **865 passed / 865** (было 863, +2). Карточка утверждала, что «тестом это не ловится в jsdom» — это верно про загрузку cross-origin фрейма, но порядок **наших собственных двух вызовов** полностью наблюдаем, поэтому инвариант закреплён тестом, а не только комментарием.

Отдельно зафиксировано в тесте, почему отсоединённый фрейм там стенд-дубль, а не `iframe.remove()`: jsdom **бросает** `Cannot read properties of null (reading '_history')` при чтении `contentWindow` у отсоединённого фрейма, тогда как живой браузер просто возвращает `null`.

PHP не тронут, ассеты не пересобирались (файл enqueue-ится напрямую, не бандлится).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx85cZaYUGb8Zxv836PxD8