### PR TITLE
test(pickup): pin the viewport refresh() pool invariant instead of "fixing" it

### DIFF
--- a/tests/js/pickup-datasource.test.js
+++ b/tests/js/pickup-datasource.test.js
@@ -106,6 +106,25 @@ test( 'fetchPoints() bbox is bounds joined lat1,lng1,lat2,lng2 — exact separat
 	expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toBe( expectedUrl );
 } );
 
+// Issue #248: the load-bearing negative of the positive above. A `bounds` that is not a
+// 4-element array is OMITTED, never sent malformed — so a viewport query built from a
+// falsy bbox reaches the server with no addressing mode at all, and
+// `Point_Query::from_request()` refuses it (`PointQueryTest`: a request naming neither
+// `locality` nor `bbox` returns null). That refusal is what keeps a provider emitting a
+// junk bbox from ever putting points into the mount's pool — see the `#248` block in
+// `pickup-mount.test.js`.
+test( 'fetchPoints() omits bbox entirely for a bounds that is not a 4-element array', async () => {
+	jest.useFakeTimers();
+	const fetchMock = mockFetchOnce( 200, { points: [] } );
+
+	const ds = WoodevPickupDataSource( { restRoot: REST_ROOT, nonce: NONCE } );
+	const promise = ds.fetchPoints( { bounds: null, types: [ 'pvz' ] } );
+	jest.advanceTimersByTime( 300 );
+	await promise;
+
+	expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toBe( REST_ROOT + '?types=' + encodeURIComponent( 'pvz' ) );
+} );
+
 test( 'fetchPoints() with locality, bounds AND q together emits all three in locality, bbox, q order', async () => {
 	jest.useFakeTimers();
 	const fetchMock = mockFetchOnce( 200, { points: [] } );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -5341,3 +5341,159 @@ describe( 'cart-change verdict invalidation wired to updated_checkout (#238)', (
 		expect( provider.setPointsCalls.length ).toBe( callsBefore + 1 );
 	} );
 } );
+
+// -------------------------------------------------------------------------
+// #248 — refresh() under `viewport` empties the pool UNCONDITIONALLY but refetches only
+// when `lastBbox` is set, so the card asked whether a cart change arriving before the
+// customer has panned wipes points nothing will bring back.
+//
+// It cannot: **a non-empty pool implies a non-null `lastBbox`, by construction.** The
+// pool's only writer is a resolved listing (`mergeIntoPool()`, viewport-only), and under
+// `viewport` every fetch that can reach it comes from one of three places — the
+// `boundsChange` handler, which assigns `lastBbox` on the line BEFORE it fetches; the
+// type-filter handler, itself wrapped in `if ( lastBbox )`; and `refresh()`'s own
+// conditional half. `lastBbox = null` happens in exactly ONE place, `start()`, which
+// empties the pool two lines later in the same synchronous run — and bumps the pool
+// generation, so a listing still in flight across that reset is dropped on arrival
+// instead of repopulating the pool behind it (the '#234: a listing already in flight'
+// test above pins that drop).
+//
+// The one route this reasoning did not originally cover is a provider — the
+// `Map_Provider` seam is a documented extension point — emitting `boundsChange` with a
+// FALSY bbox: `lastBbox` would stay null while a fetch went out anyway. That route is
+// closed one layer down rather than here: the data source omits a `bounds` that is not a
+// 4-element array (`pickup-datasource.test.js`), so the query reaches the server with no
+// addressing mode, and `Point_Query::from_request()` refuses it (`PointQueryTest`). No
+// points come back, so the pool stays empty and the implication survives.
+//
+// These tests therefore pin the reachable state space rather than a fix: the wipe in the
+// described window is a no-op on an empty pool, and wherever the pool is NOT empty the
+// refetch always runs.
+// -------------------------------------------------------------------------
+
+describe( 'viewport refresh(): the unconditional wipe never outruns the conditional refetch (#248)', () => {
+	/**
+	 * Installs a viewport data source that records every query it is handed and answers
+	 * them from `listings` in order; an exhausted list answers `[]`.
+	 *
+	 * @param {Array} listings
+	 * @returns {Array} the recorded queries, in order.
+	 */
+	function recordingSource( listings ) {
+		const queries = [];
+		let call = 0;
+
+		window.WoodevPickupDataSource = fakeDataSourceFactory( ( query ) => {
+			queries.push( query );
+
+			return Promise.resolve( listings[ call++ ] || [] );
+		} );
+
+		return queries;
+	}
+
+	function drawnIds( provider ) {
+		const drawn = provider.setPointsCalls[ provider.setPointsCalls.length - 1 ] || [];
+
+		return drawn.reduce( ( acc, group ) => acc.concat( group.points.map( ( p ) => p.id ) ), [] );
+	}
+
+	function openViewport() {
+		setConfig( makeConfig( { strategy: 'viewport' } ) );
+		mountAll();
+		clickTrigger();
+	}
+
+	// The card's literal window: the session is open at its initial position and the cart
+	// changes before the customer has panned. Nothing has been fetched, so nothing can be
+	// in the pool to lose — and the session recovers in full on the first bounds report.
+	test( 'a cart change before the first boundsChange wipes nothing, and the first bounds '
+		+ 'report still draws the whole listing', async () => {
+		const queries = recordingSource( [ [ point( { id: 'A' } ) ] ] );
+		openViewport();
+		await flushAsync();
+
+		const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+		// The pool's only writer is a resolved listing; under viewport nothing fetches
+		// before the first `boundsChange`, so the pool is empty by construction here.
+		expect( queries ).toHaveLength( 0 );
+		expect( provider.setPointsCalls ).toHaveLength( 0 );
+
+		await window.WoodevPickupMount.getSession( FIELD_ID ).refresh();
+		await flushAsync();
+
+		// The card's complaint, confirmed: refresh() ran its destructive half and issued
+		// no fetch. It destroyed nothing, because there was nothing there.
+		expect( queries ).toHaveLength( 0 );
+		expect( provider.setPointsCalls ).toHaveLength( 0 );
+
+		provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+		await flushAsync();
+
+		expect( drawnIds( provider ) ).toEqual( [ 'A' ] );
+	} );
+
+	// The contrapositive, and the half that actually matters to a customer: the moment
+	// there IS something in the pool, `lastBbox` is set too, so the refetch runs and the
+	// wiped points come back re-verdicted against the new cart.
+	test( 'a pool with anything in it always comes with a bbox, so refresh() refetches', async () => {
+		const queries = recordingSource( [ [ point( { id: 'A' } ) ], [ point( { id: 'B' } ) ] ] );
+		openViewport();
+		await flushAsync();
+
+		const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+		provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+		await flushAsync();
+
+		expect( drawnIds( provider ) ).toEqual( [ 'A' ] );
+
+		await window.WoodevPickupMount.getSession( FIELD_ID ).refresh();
+		await flushAsync();
+
+		expect( queries ).toHaveLength( 2 );
+		expect( queries[ 1 ].bounds ).toEqual( [ 55, 37, 56, 38 ] );
+		expect( drawnIds( provider ) ).toEqual( [ 'B' ] );
+	} );
+
+	// The only sequence that could produce "pool non-empty while `lastBbox` is null": a
+	// listing in flight when `start()` nulls the bbox, landing afterwards. The pool
+	// generation is what forbids it. Probed with an EMPTY listing, because under viewport
+	// an empty listing draws exactly the pool and nothing else — so this reads the pool
+	// itself, not some later fetch's answer.
+	test( 'a listing in flight across a retry cannot repopulate the pool behind the nulled '
+		+ 'bbox', async () => {
+		let releaseFirst;
+		const first = new Promise( ( resolve ) => { releaseFirst = resolve; } );
+		let call = 0;
+		const responses = [ first, Promise.resolve( [] ) ];
+
+		window.WoodevPickupDataSource = fakeDataSourceFactory(
+			() => responses[ call++ ] || Promise.resolve( [] )
+		);
+		openViewport();
+		await flushAsync();
+
+		const provider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+		const panels = StubPanels.instances[ StubPanels.instances.length - 1 ];
+
+		provider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+		await flushAsync();
+
+		// The retry nulls `lastBbox` and empties the pool in one synchronous run.
+		panels.emit( 'retryRequested' );
+		await flushAsync();
+
+		const freshProvider = StubProvider.instances[ StubProvider.instances.length - 1 ];
+
+		releaseFirst( [ point( { id: 'STALE' } ) ] );
+		await flushAsync();
+
+		// Read the pool: an empty listing under viewport draws the pool's contents verbatim.
+		freshProvider.emit( 'boundsChange', [ 55, 37, 56, 38 ] );
+		await flushAsync();
+
+		expect( drawnIds( freshProvider ) ).toEqual( [] );
+	} );
+} );

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -3234,6 +3234,37 @@
 			// #234: the pool goes with it, ALWAYS, and the two calls must never be separated —
 			// see {@see resetPointPool}'s stated invariant. A pooled point's `selectable` was
 			// computed against the cart that just changed.
+			//
+			// #248 — WHY THE DESTRUCTIVE HALF SITS ABOVE THE `viewport` CONDITION BELOW, AND
+			// MUST STAY THERE. It reads like a hole: under `viewport` with `lastBbox` still
+			// null the pool is emptied and nothing refetches it. It is not one, because
+			//
+			//     A NON-EMPTY POOL IMPLIES A NON-NULL `lastBbox`.
+			//
+			// The pool's only writer is a resolved listing ({@see mergeIntoPool}, reached only
+			// under `viewport`), and every fetch that can reach it comes from one of three
+			// places: the provider's `boundsChange` handler, which assigns `lastBbox` on the
+			// line BEFORE it fetches; the `typeFilterChange` handler, itself wrapped in
+			// `if ( lastBbox )`; and this function's own conditional half. `lastBbox = null`
+			// happens in exactly ONE place — {@see start} — which empties the pool two lines
+			// later in the same synchronous run, and bumps the pool generation, so a listing
+			// still travelling across that reset is dropped on arrival rather than
+			// repopulating the pool behind the nulled bbox.
+			//
+			// The one route that reasoning does not close here is a provider — `Map_Provider`
+			// is a documented extension point — emitting `boundsChange` with a FALSY bbox,
+			// which would leave `lastBbox` null while a fetch went out anyway. That is closed
+			// one layer down instead: `pickup-datasource.js` OMITS a `bounds` that is not a
+			// 4-element array, so the query arrives with no addressing mode and
+			// `Point_Query::from_request()` refuses it — no points come back, the pool stays
+			// empty, the implication holds.
+			//
+			// So in the window the card describes the wipe is a no-op on an empty pool, and
+			// wherever the pool is NOT empty the refetch below always runs. Moving these two
+			// calls under the condition would change nothing observable and would cost the
+			// invariant "a cart change forgets everything the old cart was verdicted against,
+			// unconditionally" — the one thing #232/#238 exist to guarantee. Pinned by the
+			// `#248` block in `tests/js/pickup-mount.test.js`.
 			forgetPointDetails();
 			resetPointPool();
 


### PR DESCRIPTION
Closes #248.

Карточка требовала **замера, а не правки** — разбор в комментарии к ней это прямо говорил. Замер сделан: **дефекта в поведении нет**, и правка из карточки его бы не исправила, а сломала бы соседний инвариант.

## Инвариант

> **Непустой пул влечёт непустой `lastBbox`.**

Единственный писатель пула — приземлившийся листинг (`mergeIntoPool()`, только под `viewport`). Все фетчи, которые до него доходят, приходят из трёх мест:

| Источник фетча | Что с `lastBbox` |
|---|---|
| обработчик `boundsChange` | присваивает `lastBbox` строкой **перед** фетчем |
| обработчик `typeFilterChange` | сам обёрнут в `if ( lastBbox )` |
| условная половина `refresh()` | та самая, о которой карточка |

`lastBbox = null` происходит ровно в одном месте — `start()`, — который двумя строками ниже чистит пул в том же синхронном прогоне **и** двигает поколение пула, поэтому листинг, летящий через этот сброс, отбрасывается на приземлении, а не наполняет пул за спиной обнулённого bbox.

Значит: в окне, которое описывает карточка, безусловная чистка — **no-op на пустом пуле**, а везде, где пул не пуст, условный перезапрос **всегда** отрабатывает.

## Почему правку из карточки делать нельзя

Перенос сброса под условие не изменил бы ничего наблюдаемого и стоил бы инварианта «смена корзины забывает всё, что было отвердиктовано против старой корзины, **безусловно**» — ровно того, ради чего существуют #232/#238.

## Что мой s63-разбор НЕ покрывал

`Map_Provider` — документированная точка расширения, значит сторонний провайдер может отдать `boundsChange` с **ложным** bbox: `lastBbox` остался бы `null`, а фетч бы ушёл. Этот путь закрыт слоем ниже, а не здесь: datasource **опускает** `bounds`, который не является 4-элементным массивом, поэтому запрос приходит на сервер без режима адресации, и `Point_Query::from_request()` его отвергает. Обе половины цепочки теперь закреплены — новый тест datasource на опускание, существующий `PointQueryTest` на отказ.

## Что в PR

- 3 характеризующих теста на достижимое пространство состояний (описанное окно; непустой пул всегда перезапрашивает; листинг в полёте через retry не наполняет пул). Пул читается **пустым листингом** — под viewport пустой листинг рисует ровно содержимое пула.
- 1 тест datasource на опускание некорректного `bounds`.
- Инвариант записан комментарием прямо в `refresh()`, чтобы карточку не завели в третий раз.

## Проверка

Тест про листинг в полёте **проверен мутацией**: с отключённым гейтом поколений он падает (`× a listing in flight across a retry cannot repopulate the pool behind the nulled bbox`), вместе с двумя существующими тестами #234.

Jest: **869 passed / 869** (+4). PHP не тронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx85cZaYUGb8Zxv836PxD8