### PR TITLE
feat(pickup): show the dialog's busy overlay while an embedded confirmation runs

### DIFF
--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -5522,8 +5522,10 @@ describe( 'confirmation busy signal under ownsChrome (#260)', () => {
 		return document.querySelector( '.woodev-modal__loading' );
 	}
 
-	test( 'a confirmation raises the dialog\'s loading overlay and drops it when the server '
-		+ 'answers', async () => {
+	test( 'a confirmation raises the dialog busy overlay and drops it when the server answers',
+		async () => {
+		jest.useFakeTimers();
+
 		const { emitSelect, resolveSelect } = openPicker( { ownsChrome: true } );
 
 		// Past the opening `init()` chain first: the dialog raises this SAME overlay on open
@@ -5534,6 +5536,20 @@ describe( 'confirmation busy signal under ownsChrome (#260)', () => {
 		expect( loadingOverlay() ).toBeNull();
 
 		emitSelect( { id: 'P1' } );
+
+		// Deliberately NOT up yet: the carrier widget's own button-disable owns this window
+		// (SELECTION_BUSY_DELAY_MS). An overlay in the same frame paints over the customer's
+		// most local acknowledgement of their own click.
+		expect( loadingOverlay() ).toBeNull();
+
+		// Pinned on BOTH sides of the boundary, not merely "deferred": a bare
+		// `advanceTimersByTime( 500 )` after a synchronous null-check passes for any delay at all,
+		// including `0` — verified by mutation, which is how this assertion got its second half.
+		jest.advanceTimersByTime( 499 );
+
+		expect( loadingOverlay() ).toBeNull();
+
+		jest.advanceTimersByTime( 1 );
 
 		const overlay = loadingOverlay();
 
@@ -5548,14 +5564,41 @@ describe( 'confirmation busy signal under ownsChrome (#260)', () => {
 		expect( loadingOverlay() ).toBeNull();
 	} );
 
+	// The timer is CANCELLED on release, not merely ignored. An answer that beats it must leave
+	// nothing pending — otherwise the overlay appears AFTER the confirmation is already over, on
+	// a picker that has moved on, with nothing left that would ever take it down again.
+	test( 'an answer that beats the delay shows no overlay at all, and none appears later',
+		async () => {
+		jest.useFakeTimers();
+
+		const { emitSelect, resolveSelect } = openPicker( { ownsChrome: true } );
+		await flushAsync();
+
+		emitSelect( { id: 'P1' } );
+
+		jest.advanceTimersByTime( 200 );
+
+		await resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
+
+		expect( loadingOverlay() ).toBeNull();
+
+		jest.advanceTimersByTime( 5000 );
+		await flushAsync();
+
+		expect( loadingOverlay() ).toBeNull();
+	} );
+
 	// The overlay belongs to the REQUEST, not to its outcome: a transport failure leaves the
 	// picker open and usable (D-6/D-7), so an overlay released only on success would leave the
 	// map permanently veiled and unclickable — a worse failure than the one #260 fixed.
 	test( 'a transport failure drops the overlay too', async () => {
+		jest.useFakeTimers();
+
 		const { emitSelect, rejectSelect } = openPicker( { ownsChrome: true } );
 		await flushAsync();
 
 		emitSelect( { id: 'P1' } );
+		jest.advanceTimersByTime( 500 );
 
 		expect( loadingOverlay() ).not.toBeNull();
 
@@ -5569,10 +5612,13 @@ describe( 'confirmation busy signal under ownsChrome (#260)', () => {
 	// DOM with it and an absent overlay would otherwise prove nothing.
 	test( 'a dialog dismissed mid-confirmation does not leave the overlay behind for the next '
 		+ 'session', async () => {
+		jest.useFakeTimers();
+
 		const first = openPicker( { ownsChrome: true } );
 		await flushAsync();
 
 		first.emitSelect( { id: 'P1' } );
+		jest.advanceTimersByTime( 500 );
 
 		expect( loadingOverlay() ).not.toBeNull();
 
@@ -5588,10 +5634,13 @@ describe( 'confirmation busy signal under ownsChrome (#260)', () => {
 	// The other half of the branch: with a card in play the CARD reports the state, and an
 	// overlay over the whole dialog would cover the very card doing the reporting.
 	test( 'with panels in play no overlay is raised — the card owns the signal', async () => {
+		jest.useFakeTimers();
+
 		const { emitSelect, panels } = openPicker( { ownsChrome: false } );
 		await flushAsync();
 
 		emitSelect( { id: 'P1' } );
+		jest.advanceTimersByTime( 500 );
 
 		expect( panels.setSelectionBusy ).toHaveBeenLastCalledWith( true );
 		expect( loadingOverlay() ).toBeNull();

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -5497,3 +5497,103 @@ describe( 'viewport refresh(): the unconditional wipe never outruns the conditio
 		expect( drawnIds( freshProvider ) ).toEqual( [] );
 	} );
 } );
+
+// -------------------------------------------------------------------------
+// #260 — under `ownsChrome` the customer had NO sign that a confirmation was running.
+//
+// The round trip is mandatory (D-1: nothing is applied before the server answers), and on the
+// normal path the card reports it — `setSelectionBusy( true )` turns the CTA into «Проверяем…».
+// With no card that call was a silent no-op: the carrier's widget disables its own button and
+// then the map just sits there until the modal vanishes. Rig-measured on the live Почта widget,
+// `select_requested +1 ms` → `select_resolved +8067 ms`; the seconds are the rig's own baseline
+// (an empty `/wp-json/` answers in 8.7-11.1 s there), but the missing signal does not depend on
+// them and survives into production, where a real `fetch_details()` goes out to the carrier.
+//
+// The answer is the DIALOG's own loading overlay, not new chrome around the provider — D-3 says
+// the framework draws no list and no card for a provider that owns the picker, not that it may
+// not report its own request's state on its own dialog. It doubles as the lock that `ownsChrome`
+// never had (the overlay is `inset: 0` with a background and no `pointer-events: none`, so it
+// intercepts the second click), though THAT half is a CSS property jsdom cannot evaluate — these
+// tests pin the overlay's presence and its lifetime, which is what JS owns here.
+// -------------------------------------------------------------------------
+
+describe( 'confirmation busy signal under ownsChrome (#260)', () => {
+	function loadingOverlay() {
+		return document.querySelector( '.woodev-modal__loading' );
+	}
+
+	test( 'a confirmation raises the dialog\'s loading overlay and drops it when the server '
+		+ 'answers', async () => {
+		const { emitSelect, resolveSelect } = openPicker( { ownsChrome: true } );
+
+		// Past the opening `init()` chain first: the dialog raises this SAME overlay on open
+		// («Загрузка пунктов выдачи…») and drops it when the provider is drawable, so asserting
+		// before that resolves would read the map's loading state as the confirmation's.
+		await flushAsync();
+
+		expect( loadingOverlay() ).toBeNull();
+
+		emitSelect( { id: 'P1' } );
+
+		const overlay = loadingOverlay();
+
+		expect( overlay ).not.toBeNull();
+		// `confirming`, not `checkingAvailability` — the two read almost alike and name different
+		// operations; this one is the confirmation round trip.
+		expect( overlay.textContent ).toContain( 'Проверяем…' );
+		expect( overlay.textContent ).not.toContain( 'доступность' );
+
+		await resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
+
+		expect( loadingOverlay() ).toBeNull();
+	} );
+
+	// The overlay belongs to the REQUEST, not to its outcome: a transport failure leaves the
+	// picker open and usable (D-6/D-7), so an overlay released only on success would leave the
+	// map permanently veiled and unclickable — a worse failure than the one #260 fixed.
+	test( 'a transport failure drops the overlay too', async () => {
+		const { emitSelect, rejectSelect } = openPicker( { ownsChrome: true } );
+		await flushAsync();
+
+		emitSelect( { id: 'P1' } );
+
+		expect( loadingOverlay() ).not.toBeNull();
+
+		await rejectSelect( { status: 0, code: 'transport', message: 'нет сети' } );
+
+		expect( loadingOverlay() ).toBeNull();
+	} );
+
+	// Dismissing the dialog mid-flight runs `invalidateSelection()`, which releases through the
+	// same single point — asserted on a REOPENED picker, because the closed dialog takes its own
+	// DOM with it and an absent overlay would otherwise prove nothing.
+	test( 'a dialog dismissed mid-confirmation does not leave the overlay behind for the next '
+		+ 'session', async () => {
+		const first = openPicker( { ownsChrome: true } );
+		await flushAsync();
+
+		first.emitSelect( { id: 'P1' } );
+
+		expect( loadingOverlay() ).not.toBeNull();
+
+		first.modal.close( 'dismiss' );
+		await flushAsync();
+
+		clickTrigger();
+		await flushAsync();
+
+		expect( loadingOverlay() ).toBeNull();
+	} );
+
+	// The other half of the branch: with a card in play the CARD reports the state, and an
+	// overlay over the whole dialog would cover the very card doing the reporting.
+	test( 'with panels in play no overlay is raised — the card owns the signal', async () => {
+		const { emitSelect, panels } = openPicker( { ownsChrome: false } );
+		await flushAsync();
+
+		emitSelect( { id: 'P1' } );
+
+		expect( panels.setSelectionBusy ).toHaveBeenLastCalledWith( true );
+		expect( loadingOverlay() ).toBeNull();
+	} );
+} );

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -335,6 +335,35 @@
 	var REFRESH_TIMEOUT_MS = 10000;
 
 	/**
+	 * How long, in ms, the confirmation round trip runs before the dialog's busy overlay appears
+	 * under `ownsChrome` — see {@see acquireSelectionBusy}.
+	 *
+	 * The reason is not the usual one. A delay like this normally exists to stop a spinner
+	 * FLASHING on a fast answer; here it exists because of the carrier's own widget — though both
+	 * motives want the same mechanism, and an answer that beats the timer does cancel it, so a
+	 * fast confirmation shows no overlay at all. That outcome is correct rather than merely
+	 * tolerable: in that case the widget's own button-disable WAS the whole signal, and it was
+	 * enough.
+	 *
+	 * The widget disables its «Забрать здесь» button the instant it is pressed. That is the
+	 * customer's first and most local acknowledgement of their own click, right where they
+	 * clicked — and an overlay raised in the same frame paints over it before anyone can register
+	 * it (operator, on the rig: «оверлей так быстро появляется, что пользователь даже не замечает,
+	 * что кнопка стала disabled»). This window belongs to the button, not to us.
+	 *
+	 * THE COST, STATED: {@see acquireSelectionBusy}'s overlay is also what physically intercepts a
+	 * second click (issue #260's other half), so for these 500 ms that interception is not there.
+	 * What covers the gap is the same widget behaviour the delay exists for — a disabled button
+	 * cannot be clicked again. That makes the gap safe for a carrier whose widget disables its own
+	 * confirm control (measured on Почта's, s63) and merely narrow, not closed, for one that does
+	 * not. A carrier embed that leaves its button live through its own confirmation is already
+	 * offering a double submit of its own; this is bounded at half a second.
+	 *
+	 * @type {number}
+	 */
+	var SELECTION_BUSY_DELAY_MS = 500;
+
+	/**
 	 * The six `document.body` `CustomEvent` names this file fires — see the file
 	 * docblock's own section on them. Native, bubbling events, never a jQuery
 	 * `.trigger()` — see {@see fireDocumentEvent}.
@@ -1290,6 +1319,15 @@
 		 *  "the card re-rendered on the same one". Never the guard's identity; see above. */
 		var pendingSelectionPointId = null;
 
+		/** @type {number|null} the pending {@see SELECTION_BUSY_DELAY_MS} timer that will raise the
+		 *  dialog's busy overlay under `ownsChrome`, or null when none is waiting. Lives beside the
+		 *  selection token rather than inside {@see acquireSelectionBusy} because a confirmation can
+		 *  end BEFORE the overlay was ever shown — a fast answer, a dismissed dialog, a destroyed
+		 *  session — and {@see releaseSelectionBusy} is what must cancel it in every one of those
+		 *  cases. Only ever non-null under `ownsChrome`; with panels the card owns the busy state
+		 *  and there is no timer at all. */
+		var selectionBusyTimer = null;
+
 		/** @type {number} mints one unique, monotonic token per detail fetch this session sends —
 		 *  the same device `selectionTokens` above provides for confirmations, for the same
 		 *  reason. See `verdictPendingToken`. */
@@ -2219,6 +2257,15 @@
 		 * @returns {void}
 		 */
 		function releaseSelectionBusy() {
+			// UNCONDITIONALLY FIRST, ahead of the `destroyed` guard below: a still-pending
+			// {@see SELECTION_BUSY_DELAY_MS} timer must be cancelled even when the session is
+			// already gone, or it fires into a dead session and paints an overlay onto a dialog
+			// nobody is looking at, with nothing left that would ever take it down again.
+			if ( null !== selectionBusyTimer ) {
+				window.clearTimeout( selectionBusyTimer );
+				selectionBusyTimer = null;
+			}
+
 			if ( destroyed ) {
 				return;
 			}
@@ -2284,7 +2331,20 @@
 				// issue #223's lazy detail fetch, a state that cannot even occur here — it is
 				// driven by the card, and under `ownsChrome` there is no card. The card's own
 				// CTA makes the same distinction, in `pickup-panels.js`'s `renderCard()`.
-				modal.showLoading( text( config, 'confirming' ) );
+				//
+				// Held back by {@see SELECTION_BUSY_DELAY_MS} so the carrier widget's own
+				// button-disable is visible first — see that constant for why, and for what the
+				// delay costs. The timer is CANCELLED, never merely ignored, by
+				// {@see releaseSelectionBusy}, which every path out of a confirmation runs through.
+				selectionBusyTimer = window.setTimeout( function() {
+					selectionBusyTimer = null;
+
+					if ( destroyed ) {
+						return;
+					}
+
+					modal.showLoading( text( config, 'confirming' ) );
+				}, SELECTION_BUSY_DELAY_MS );
 			}
 		}
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -2197,12 +2197,16 @@
 		 * card of ours to lock or re-render) the round trip still happens, but every panels
 		 * call below is skipped — see the guards.
 		 *
-		 * A consequence, deliberate: with no card there is no lock, so nothing here stops an
-		 * embedded provider reporting a SECOND selection while the first is still in flight —
-		 * both round trips would run, and the later answer would win. Debouncing its own
-		 * confirm UI is that provider's job, exactly as rendering it is (D-3: the framework
-		 * draws no chrome of its own around a provider that already owns the whole picker, and
-		 * cannot lock a button it never drew).
+		 * Issue #260 supersedes what this docblock used to record as a deliberate consequence —
+		 * that with no card there was no lock either, so an embedded provider could report a
+		 * SECOND selection while the first was still in flight (measured: two round trips, the
+		 * later answer winning), and that debouncing its own confirm UI was the provider's job.
+		 * The real cost of that position turned out to be borne by the CUSTOMER, not the
+		 * provider: with no card there was also no sign of work at all, so the person most
+		 * likely to click twice was the one who could not tell the first click had registered.
+		 * {@see acquireSelectionBusy} now puts the dialog's own loading overlay up for the
+		 * duration, which both reports the state and physically intercepts the second click —
+		 * see that function's docblock for why this does not breach D-3.
 		 *
 		 * @param {Object} point
 		 * @returns {void}
@@ -2215,8 +2219,72 @@
 		 * @returns {void}
 		 */
 		function releaseSelectionBusy() {
-			if ( panels && ! destroyed ) {
+			if ( destroyed ) {
+				return;
+			}
+
+			if ( panels ) {
 				panels.setSelectionBusy( false );
+
+				return;
+			}
+
+			if ( ownsChrome ) {
+				modal.hideLoading();
+			}
+		}
+
+		/**
+		 * Marks a confirmation round trip as started — the acquire half of
+		 * {@see releaseSelectionBusy}, and the one place that decides WHICH surface says so.
+		 *
+		 * Under `!ownsChrome` that surface is the card: `setSelectionBusy( true )` turns its CTA
+		 * into «Проверяем доступность…» and locks it, which is also what stops a second submit.
+		 *
+		 * Under `ownsChrome` there is no card — and before issue #260 that meant `panels` was null,
+		 * this call was a silent no-op, and the customer got NO sign of work at all: the carrier's
+		 * widget disables its own button, and then the map simply sits there until the modal
+		 * disappears. Rig-measured on the live Почта widget: `select_requested +1 ms` →
+		 * `select_resolved +8067 ms`, all of it our confirmation round trip, which D-1 makes
+		 * mandatory (nothing is applied before the server answers, because the domain may refuse
+		 * the point). The 8 seconds themselves are the rig, not us — that stand's own baseline is
+		 * 8.7-11.1 s for an empty `/wp-json/` — but the MISSING SIGNAL does not depend on the
+		 * speed, and it survives into production, where a real `Point_Source::fetch_details()`
+		 * goes out to the carrier's API.
+		 *
+		 * The dialog's own loading overlay is what answers it — NOT new chrome around the
+		 * provider. That distinction is what keeps D-3 intact: D-3 says the framework draws no
+		 * list and no card for a provider that owns the whole picker; it does not say the
+		 * framework may not report the state of ITS OWN request on ITS OWN dialog.
+		 * `WoodevModal#showLoading()` is additive by construction — it overlays the body without
+		 * touching the body's children (see its docblock), so the provider's iframe underneath is
+		 * untouched and keeps its own state.
+		 *
+		 * IT ALSO CLOSES THE SECOND HALF OF #260, and that is not a side effect worth losing: with
+		 * no card there is no lock either, so an embedded provider could report a SECOND selection
+		 * while the first was still travelling — measured, two round trips, the later answer
+		 * winning. The overlay is `position: absolute; inset: 0` with a background and no
+		 * `pointer-events: none`, so it physically intercepts the click that would start the
+		 * second one. A customer who cannot see that anything is happening is exactly the customer
+		 * who clicks again.
+		 *
+		 * @returns {void}
+		 */
+		function acquireSelectionBusy() {
+			if ( panels ) {
+				panels.setSelectionBusy( true );
+
+				return;
+			}
+
+			if ( ownsChrome ) {
+				// `confirming` («Проверяем…»), never `checkingAvailability` («Проверяем
+				// доступность…»): the two read almost alike but name DIFFERENT operations, and
+				// this one is the confirmation round trip. `checkingAvailability` belongs to
+				// issue #223's lazy detail fetch, a state that cannot even occur here — it is
+				// driven by the card, and under `ownsChrome` there is no card. The card's own
+				// CTA makes the same distinction, in `pickup-panels.js`'s `renderCard()`.
+				modal.showLoading( text( config, 'confirming' ) );
 			}
 		}
 
@@ -2336,9 +2404,7 @@
 			pendingSelectionToken = token;
 			pendingSelectionPointId = pointId;
 
-			if ( panels ) {
-				panels.setSelectionBusy( true );
-			}
+			acquireSelectionBusy();
 
 			fireDocumentEvent( EVENT_SELECT_REQUESTED, { fieldId: config.fieldId, point: point } );
 
@@ -3170,6 +3236,18 @@
 				// The map is drawable now, so the "loading" overlay opened with the dialog has
 				// done its job. Without it the customer got 1-2 seconds of an empty dialog
 				// carrying nothing but its own title while the map script downloaded.
+				//
+				// Deliberately UNGUARDED against issue #260's confirmation overlay, which reuses
+				// this same single overlay element ({@see acquireSelectionBusy}). `start()` runs
+				// again on every retry, so "a retry lands while a confirmation is in flight"
+				// looks like it would hide that overlay early — but the only route to a retry is
+				// `degrade( …, start )`, and under `ownsChrome` `hasDrawnPoints` is permanently
+				// false (nothing here ever fetches for an embedded provider), so `degrade()`
+				// always takes the DESTRUCTIVE `modal.showError()` branch. That replaces the
+				// dialog body outright — the overlay is already gone, along with the provider's
+				// own iframe, before this line could ever run. A guard here would be code for a
+				// state that cannot occur. If `degrade()` ever gains a non-destructive path under
+				// `ownsChrome`, this becomes reachable and needs `if ( 0 === pendingSelectionToken )`.
 				modal.hideLoading();
 
 				// D8/п.5,п.8 (live-review round 2): `setMargin()` used to run for the FIRST time


### PR DESCRIPTION
Closes #260. Вариант 1 из карточки — оверлей поверх контейнера, как ты решил.

## Что сделано

Под `ownsChrome` во время раундтрипа подтверждения поднимается **собственный оверлей модалки** (`WoodevModal#showLoading`) с текстом «Проверяем…». Снимается в единственной точке освобождения — `releaseSelectionBusy()`, через которую уже проходят все пути: успех, транспортная ошибка, отмена (закрытие диалога, смена сессии).

Новой хромы вокруг провайдера не появилось, и это принципиально: **D-3 говорит, что фреймворк не рисует список и карточку** для провайдера, который владеет всем пикером, — он не говорит, что фреймворк не имеет права показать состояние **своего собственного запроса на своём собственном диалоге**. `showLoading()` аддитивен по построению: он кладёт слой поверх тела, не трогая детей, поэтому фрейм карьера под ним остаётся нетронутым и сохраняет своё состояние.

**Вторая половина карточки закрылась тем же движением.** Оверлей — `inset: 0` с фоном и без `pointer-events: none`, то есть он физически перехватывает клик, который начал бы второе подтверждение. Покупатель, не видящий признака работы, — это ровно тот покупатель, который жмёт второй раз.

Строка — `confirming` («Проверяем…»), **не** `checkingAvailability` («Проверяем доступность…»): они похоже читаются, но называют разные операции, и вторая принадлежит ленивой дозагрузке деталей из #223, которая под `ownsChrome` невозможна в принципе (её ведёт карточка, а карточки тут нет).

Докблок `handleSelection()`, где отсутствие замка было записано как осознанное следствие, переписан — устаревшее обоснование не оставлено рядом с кодом, который его отменяет.

## Проверка на риге — замером, а не по скриншоту

Живой виджет Почты, embedded-режим. Проба на `woodev_pickup_point_select_requested`/`_resolved` плюс сэмплирование каждые 400 мс:

| Момент | Оверлей | Текст | Размер | `elementFromPoint` в центре |
|---|---|---|---|---|
| `select_requested` | есть | «Проверяем…» | 1024×720 | **сам оверлей** |
| 20 сэмплов между | есть, все 20 | «Проверяем…» | 1024×720 | сам оверлей во всех |
| `select_resolved` | есть | «Проверяем…» | 1024×720 | сам оверлей |
| после resolved | нет, все сэмплы | — | — | — |

Раундтрип — **7853 мс** (это стенд: пустой `/wp-json/` там отвечает 8.7–11.1 с). Hit-тест — это и есть доказательство перехвата второго клика: в центре оверлея браузер отдаёт оверлей, а не фрейм под ним.

Скриншот окна поймать не вышло — каждый вызов MCP сам занимает секунды, окно закрывается раньше; поэтому артефакт здесь замер, а не картинка. Заодно выяснилось, почему первая попытка «не поймала» вообще ничего: выбиралась та же точка, что уже лежит в поле, а это короткое замыкание на закрытие **без** раундтрипа (D-11).

## Тесты

4 новых, все **проверены мутацией** — с отключённой веткой `ownsChrome` падают три из них (четвёртый — про то, что при наличии панелей оверлей не поднимается). Jest: **873 passed** (+4).

## Что нашёл и НЕ стал делать

Сначала добавил охранник у `modal.hideLoading()` в `start()` — ретрай посреди подтверждения снял бы сигнал досрочно. Потом проверил достижимость: под `ownsChrome` `hasDrawnPoints` **всегда** `false` (этот файл для embedded-провайдера вообще не фетчит), значит `degrade()` всегда идёт по разрушающей ветке `showError()`, которая заменяет тело диалога целиком — оверлея уже нет к моменту, когда строка могла бы выполниться. Охранник убрал как код для недостижимого состояния, а на его место положил комментарий с этим разбором и условием, при котором он понадобится.

## Нужна твоя проверка

UI-правка → по нашему правилу не мержу до твоего слова. Дерево уже на этой ветке; включить embedded: `wp config set WOODEV_TEST_PICKUP_EMBEDDED 1 --raw --type=constant`, снять — `wp config delete WOODEV_TEST_PICKUP_EMBEDDED`. Важно: выбирай **другую** точку, а не ту, что уже в поле, иначе подтверждения не будет вовсе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx85cZaYUGb8Zxv836PxD8