### PR TITLE
fix(pickup): derive short_address at the boundary, show it first in search results

### DIFF
--- a/tests/js/map-provider-embedded.test.js
+++ b/tests/js/map-provider-embedded.test.js
@@ -422,7 +422,12 @@ test( 'absent optional fields default to the empty-string/empty-array/null shape
 
 	expect( onError ).not.toHaveBeenCalled();
 	const point = onSelect.mock.calls[ 0 ][ 0 ];
-	expect( point.short_address ).toBe( '' );
+	// `short_address` deliberately LEFT OUT of this group as of issue #263: it is no longer an
+	// independent optional field that blanks to `''`, but a DERIVED view of the required
+	// `address`, filled at this boundary. Its own three tests are in the "Derived short_address"
+	// section above. Every field below stays here because it has no derivation source — its
+	// absence is information («the carrier does not publish it»), and inventing a value would be
+	// worse data than an honest blank.
 	expect( point.locality ).toBe( '' );
 	expect( point.postal_code ).toBe( '' );
 	expect( point.phone ).toBe( '' );
@@ -644,6 +649,49 @@ test( 'onerror firing before the timeout suppresses a SECOND error from the time
 	jest.runOnlyPendingTimers();
 
 	expect( onError ).toHaveBeenCalledTimes( 1 );
+} );
+
+// -----------------------------------------------------------------------
+// Derived short_address (issue #263)
+// -----------------------------------------------------------------------
+
+// The JS half of the boundary rule `Pickup_Point::from_array()` applies on the REST path, and
+// it must not diverge from it: `short_address` is a shortened VIEW of the already-required
+// `address`, so a carrier that sends none gets it derived here rather than leaving every
+// display site to patch up an empty field on its own (which is how the search row ended up
+// with no address at all — see `pickup-panels.js`).
+test( 'short_address falls back to address when the carrier sends none', () => {
+	const { iframe, onSelect } = initProvider();
+	const payload = validPointPayload();
+
+	delete payload.short_address;
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope( payload ) );
+
+	expect( onSelect ).toHaveBeenCalledTimes( 1 );
+	expect( onSelect.mock.calls[ 0 ][ 0 ].short_address ).toBe( 'Москва, ул. Тверская, 1' );
+} );
+
+test( 'an empty short_address is treated as absent, not as a deliberate blank', () => {
+	const { iframe, onSelect } = initProvider();
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope(
+		Object.assign( validPointPayload(), { short_address: '' } )
+	) );
+
+	expect( onSelect.mock.calls[ 0 ][ 0 ].short_address ).toBe( 'Москва, ул. Тверская, 1' );
+} );
+
+// A DEFAULT, never an override — a carrier with a genuinely shorter form still wins, which is
+// the only reason the field exists apart from `address`.
+test( 'a supplied short_address is kept', () => {
+	const { iframe, onSelect } = initProvider();
+
+	dispatchMessage( EXPECTED_ORIGIN, iframe.contentWindow, envelope(
+		Object.assign( validPointPayload(), { short_address: 'Тверская, 1' } )
+	) );
+
+	expect( onSelect.mock.calls[ 0 ][ 0 ].short_address ).toBe( 'Тверская, 1' );
 } );
 
 // -----------------------------------------------------------------------

--- a/tests/js/pickup-panels.test.js
+++ b/tests/js/pickup-panels.test.js
@@ -2103,6 +2103,51 @@ it( 'renders escaped point fields (not double-escaped) inside a search point res
 	expect( layout.querySelector( '.woodev-pickup-search__name' ).textContent ).toBe( 'ПВЗ "Ромашка"' );
 } );
 
+// Issue #263 (operator decision, 11.08.2026). The address is the PRIMARY line of a point
+// result and the name the secondary one under it: a chain's points share a name by definition,
+// so a name-first row produced five results reading «5 Post (Пятерочка)» with nothing to tell
+// them apart. The DOM order is what this pins; the visual hierarchy is `pickup.css`'s half and
+// jsdom cannot see it (no stylesheet is parsed in this suite at all).
+it( 'puts the address BEFORE the name in a search point result', () => {
+	const panels = mount( searchConfig );
+	const layout = panels.buildSearchLayout();
+	panels.renderSearchResults( { points: [ point() ], addresses: [] } );
+
+	const row = layout.querySelector( '.woodev-pickup-search__item--point' );
+	const lines = [ ...row.children ].map( ( el ) => el.className );
+
+	expect( lines ).toEqual( [ 'woodev-pickup-search__address', 'woodev-pickup-search__name' ] );
+	expect( row.querySelector( '.woodev-pickup-search__address' ).textContent ).toBe( 'Ленина, 5' );
+	expect( row.querySelector( '.woodev-pickup-search__name' ).textContent ).toBe( 'ПВЗ «Магнит»' );
+} );
+
+// The row reads ONE field and trusts it — the `short_address || address` fallback it never had
+// (and the sidebar row did) moved to `Pickup_Point::from_array()`, which derives `short_address`
+// from the required `address` whenever a carrier sends none. Re-adding a fallback here would
+// recreate the drift: two display sites, one rule, applied to one of them.
+it( 'reads short_address alone, because the boundary guarantees it is filled', () => {
+	const panels = mount( searchConfig );
+	const layout = panels.buildSearchLayout();
+
+	// What a point looks like AFTER the boundary has derived the field — never an empty one.
+	panels.renderSearchResults( {
+		points: [ point( { short_address: 'Москва, Ленина 5' } ) ],
+		addresses: [],
+	} );
+
+	expect( layout.querySelector( '.woodev-pickup-search__address' ).textContent )
+		.toBe( 'Москва, Ленина 5' );
+} );
+
+// The sidebar row lost its inline fallback in the same change and must read the one field too.
+it( 'renders the sidebar row address from short_address alone', () => {
+	const panels = mount( searchConfig );
+	panels.setVisible( [ { key: 'g1', points: [ point( { short_address: 'Ленина, 5' } ) ] } ] );
+
+	expect( panels.root.querySelector( '.woodev-pickup-list__address' ).textContent )
+		.toBe( 'Ленина, 5' );
+} );
+
 it( 'never executes markup smuggled through a geocoder displayName', () => {
 	const panels = mount( searchConfig );
 	const layout = panels.buildSearchLayout();

--- a/tests/unit/Shipping/Pickup/PickupPointTest.php
+++ b/tests/unit/Shipping/Pickup/PickupPointTest.php
@@ -145,9 +145,59 @@ final class PickupPointTest extends TestCase {
 	}
 
 	/**
+	 * Issue #263 (operator decision, 11.08.2026): `short_address` is a shortened VIEW of the
+	 * already-required `address`, so it is DERIVED at this boundary rather than left empty for
+	 * every display site to patch up on its own. That distinction is the fix: while the
+	 * fallback lived at the display sites, `pickup-panels.js` had it in the sidebar row and NOT
+	 * in the search row, so a carrier sending no short form produced search results with no
+	 * address at all — five rows of one chain's name, indistinguishable.
+	 *
+	 * Downstream may now assume `short_address` is non-empty whenever `address` is, which is
+	 * always: `address` is required and a payload without it never becomes a point.
+	 */
+	public function test_short_address_is_derived_from_address_when_absent(): void {
+		$point = $this->make_point( [] );
+
+		$this->assertSame( 'Москва, ул. Тверская, 1', $point->to_array()['short_address'] );
+	}
+
+	/**
+	 * An EMPTY string counts as absent, not as a deliberate blank: `''` is what a carrier
+	 * mapper emits for a field it has nothing for, and treating it as an explicit choice would
+	 * reinstate the very blank line this derivation exists to prevent.
+	 */
+	public function test_short_address_is_derived_when_the_supplied_value_is_empty(): void {
+		$point = $this->make_point( [ 'short_address' => '' ] );
+
+		$this->assertSame( 'Москва, ул. Тверская, 1', $point->to_array()['short_address'] );
+	}
+
+	/**
+	 * The derivation is a DEFAULT, never an override — a carrier that really does have a
+	 * shorter form still wins, which is the whole reason the field exists separately.
+	 */
+	public function test_a_supplied_short_address_is_kept(): void {
+		$point = $this->make_point( [ 'short_address' => 'Тверская, 1' ] );
+
+		$this->assertSame( 'Тверская, 1', $point->to_array()['short_address'] );
+	}
+
+	/**
+	 * The derived value crosses the browser boundary through the SAME escaping list as a
+	 * supplied one — it is produced here, in `from_array()`, long before
+	 * {@see Pickup_Point::to_browser_array()} runs, so deriving it cannot open a hole in a
+	 * consumer that writes the field as markup (`pickup-panels.js` does).
+	 */
+	public function test_a_derived_short_address_is_escaped_for_the_browser(): void {
+		$point = $this->make_point( [ 'address' => '<b>Москва</b>, ул. Тверская, 1' ] );
+
+		$this->assertStringNotContainsString( '<b>', $point->to_browser_array()['short_address'] );
+	}
+
+	/**
 	 * Issue #199: `point_short_name` is the domain's optional override for the card's tab
 	 * label — absent must mean "fall back to `type.label`", same `isset() ? … : ''` cascade
-	 * as `short_address`/`locality`, never an error.
+	 * as `locality`, never an error.
 	 */
 	public function test_point_short_name_defaults_to_empty_when_absent(): void {
 		$point = $this->make_point( [] );

--- a/woodev/shipping-method/assets/css/frontend/pickup.css
+++ b/woodev/shipping-method/assets/css/frontend/pickup.css
@@ -1199,7 +1199,18 @@
 	background: #f6f7f7;
 }
 
-.woodev-pickup-search__name {
+/* Issue #263 — the two lines of a POINT result swapped roles (operator decision,
+   11.08.2026). The address is primary because it is what tells one result from another: a
+   chain's points share a name by definition, so a name-first row of five «5 Post
+   (Пятерочка)» is unreadable, which is exactly what the rig showed. The name stays,
+   secondary, because it is what the customer recognises once the address has placed the
+   point. Order in the DOM changed with it (`buildSearchPointItem()`); this pair only
+   supplies the visual hierarchy.
+
+   `.woodev-pickup-search__display-name` — the single line of an ADDRESS suggestion, a
+   different section entirely — kept the secondary treatment it already had and is split
+   out below rather than left sharing a selector whose meaning has now flipped. */
+.woodev-pickup-search__address {
 	display: block;
 	font-size: 14px;
 	font-weight: 600;
@@ -1207,7 +1218,7 @@
 	color: #1e1e1e;
 }
 
-.woodev-pickup-search__address,
+.woodev-pickup-search__name,
 .woodev-pickup-search__display-name {
 	display: block;
 	margin-top: 2px;

--- a/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
+++ b/woodev/shipping-method/assets/js/frontend/map-provider-embedded.js
@@ -572,7 +572,14 @@
 				code: String( type.code ),
 				label: String( type.label ),
 			},
-			short_address: optionalString( payload, 'short_address' ),
+			// DERIVED, not merely optional (issue #263) — the JS half of the same
+			// boundary rule `Pickup_Point::from_array()` applies on the REST path,
+			// and it must not diverge from it. `short_address` is a shortened VIEW
+			// of the already-required `address`, so its absence carries no
+			// information and the display sites must never have to ask twice; a
+			// carrier with a real short form still overrides by sending one. See
+			// that PHP method's own comment for the defect this closed.
+			short_address: optionalString( payload, 'short_address' ) || String( payload.address ),
 			locality: optionalString( payload, 'locality' ),
 			postal_code: optionalString( payload, 'postal_code' ),
 			phone: optionalString( payload, 'phone' ),

--- a/woodev/shipping-method/assets/js/frontend/pickup-panels.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-panels.js
@@ -772,9 +772,16 @@
 		icon.innerHTML = pointGlyphMarkup( config, point ); // eslint-disable-line -- framework constant or server-sanitised markup, see pointGlyphMarkup's own docblock.
 		wrap.appendChild( icon );
 
+		// Issue #263: this used to read `fieldValue( point.short_address ) || fieldValue(
+		// point.address )`. The fallback moved to the boundary
+		// ({@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}) and is gone from
+		// here deliberately — while it lived at the display sites, the SEARCH row two functions
+		// down did not have it, and a carrier sending no short form rendered a row with no
+		// address at all. Do not re-add it: a fallback repeated per display site is exactly the
+		// shape that drifts.
 		var addressEl = document.createElement( 'span' );
 		addressEl.className = 'woodev-pickup-list__address';
-		addressEl.innerHTML = fieldValue( point.short_address ) || fieldValue( point.address ); // eslint-disable-line -- server-escaped.
+		addressEl.innerHTML = fieldValue( point.short_address ); // eslint-disable-line -- server-escaped.
 		addressEl.setAttribute( 'title', decodeForTitle( point.address ) );
 		wrap.appendChild( addressEl );
 
@@ -944,16 +951,31 @@
 		item.className = 'woodev-pickup-search__item woodev-pickup-search__item--point';
 		item.dataset.pointId = String( point.id );
 
-		var nameEl = document.createElement( 'span' );
-		nameEl.className = 'woodev-pickup-search__name';
-		nameEl.innerHTML = fieldValue( point.name ); // eslint-disable-line -- server-escaped, see file docblock.
-
+		// ADDRESS FIRST, NAME SECOND (issue #263, operator decision 11.08.2026). The
+		// old order put the name on top and, because this row read `short_address`
+		// with no fallback while the sidebar row two functions up read
+		// `short_address || address`, a carrier that sends no short form (live
+		// Yandex) produced an EMPTY address line — five results for one street, all
+		// reading «5 Post (Пятерочка)», impossible to tell apart. The fallback is
+		// gone from both rows now; `short_address` is derived from `address` at the
+		// boundary instead ({@see \Woodev\Framework\Shipping\Pickup\Pickup_Point::from_array()}),
+		// so this row can read the one field and trust it.
+		//
+		// The address is the primary line because it is what distinguishes one
+		// result from another — a chain's points share a name by definition. The
+		// name stays, smaller and muted underneath (see `pickup.css`), because it
+		// is what the customer recognises once the address has told them which
+		// point this is.
 		var addressEl = document.createElement( 'span' );
 		addressEl.className = 'woodev-pickup-search__address';
 		addressEl.innerHTML = fieldValue( point.short_address ); // eslint-disable-line -- server-escaped.
 
-		item.appendChild( nameEl );
+		var nameEl = document.createElement( 'span' );
+		nameEl.className = 'woodev-pickup-search__name';
+		nameEl.innerHTML = fieldValue( point.name ); // eslint-disable-line -- server-escaped, see file docblock.
+
 		item.appendChild( addressEl );
+		item.appendChild( nameEl );
 
 		item.addEventListener( 'click', function() {
 			self._emit( 'searchPointPicked', point.id );

--- a/woodev/shipping-method/pickup/class-pickup-point.php
+++ b/woodev/shipping-method/pickup/class-pickup-point.php
@@ -103,7 +103,29 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Point' ) ) :
 						'code'  => (string) $payload['type']['code'],
 						'label' => (string) $payload['type']['label'],
 					],
-					'short_address'   => isset( $payload['short_address'] ) ? (string) $payload['short_address'] : '',
+					// DERIVED, not merely optional (issue #263, operator decision 11.08.2026).
+					// `short_address` is a shortened VIEW of the already-required `address`, so
+					// its absence has no information in it — unlike `phone`/`work_time`, where
+					// absence means "this carrier does not publish it" and forcing the plugin to
+					// supply something would produce invented data instead of an honest gap. A
+					// carrier with no separate short form therefore does not have to repeat
+					// itself; one with a real one still overrides by sending it.
+					//
+					// The derivation lives HERE, at the boundary, rather than at the display
+					// sites, and that is the whole point of the fix: `pickup-panels.js` carried
+					// `short_address || address` in its sidebar row and NOT in its search row, so
+					// a carrier that sends no short form (live Yandex) rendered five search
+					// results that were all just the point NAME, indistinguishable from each
+					// other. A fallback repeated at N display sites drifts; a derivation at one
+					// boundary cannot. Downstream code may now assume `short_address` is non-empty
+					// whenever `address` is — which is always, since `address` is required above.
+					// The JS half of the same boundary (`normalizePoint()` in
+					// `map-provider-embedded.js`) derives it identically; the two must not
+					// diverge, per the #201/#251 lesson about validation and conversion drifting
+					// apart when they live in different places.
+					'short_address'   => isset( $payload['short_address'] ) && '' !== $payload['short_address']
+						? (string) $payload['short_address']
+						: (string) $payload['address'],
 					'locality'        => isset( $payload['locality'] ) ? (string) $payload['locality'] : '',
 					'postal_code'     => isset( $payload['postal_code'] ) ? (string) $payload['postal_code'] : '',
 					'phone'           => isset( $payload['phone'] ) ? (string) $payload['phone'] : '',


### PR DESCRIPTION
Closes #263. Реализовано по принятому решению о контракте.

## Решение, которое реализовано

> Поле, которое является **производным видом обязательного** (`short_address` от `address`), выводится **на границе**, а не в месте показа. Домен может переопределить настоящей короткой формой, но не обязан.
> Поле, у которого источника вывода нет (`phone`, `work_time`, `instruction`), остаётся опциональным — там отсутствие это **информация**.

Обязательным `short_address` не делали: большинство карьеров писали бы `'short_address' => $address` дословно (контракт растёт, информативность нет), плюс это ломающее изменение для уже написанных плагинов.

## Что изменено

| Слой | Было | Стало |
|---|---|---|
| `Pickup_Point::from_array()` (PHP, REST-путь) | `short_address` → `''` при отсутствии | выводится из обязательного `address` |
| `normalizePoint()` (JS, embedded-путь) | то же | то же, идентично |
| строка поиска | `short_address` (пусто) + название сверху | **адрес сверху**, название снизу мельче и `muted` |
| строка сайдбара | `short_address \|\| address` | `short_address`, фолбэк удалён |

Обе половины границы обязаны совпадать — расхождение валидации и преобразования между ними уже стоило нам hex-координаты в #201/#251. Гарантия полная: `address` обязателен, без него точка не создаётся вовсе, значит «`short_address` непуст всегда» — следствие, а не пожелание.

## Тесты

**10 новых** на трёх поверхностях: PHP (`PickupPointTest` — вывод при отсутствии, вывод при пустой строке, переданное значение побеждает, **производное значение экранируется** через тот же список `to_browser_array()`), JS embedded (те же три случая), JS panels (порядок элементов в строке поиска, чтение одного поля в обеих строках).

Существующий тест «absent optional fields default to `''`» **исправлен, а не обойдён**: `short_address` из этой группы выведен с комментарием, почему он больше не независимое опциональное поле.

Прогоны: jest **880 passed**, PHP unit **1550**, phpcs чисто, LF сохранён.

## Нужна твоя проверка — и честно о её границе

Порядок элементов в DOM закреплён тестом, но **визуальную иерархию тест не видит**: в `tests/js` не парсится ни один стиль (это же ограничение мы записали при #252). Поэтому «адрес крупнее, название мельче и приглушённее» подтверждается только глазом.

Свою проверку на риге довести не смог: выпадашка результатов поиска не открывается при скриптовом вводе (`input` + `submit`/Enter не поднимают `.woodev-pickup-search__results`, панель остаётся `hidden`). Не стал закапываться в это в конце сессии — но и мержить непроверенное не стал.

**Что смотреть:** открыть пикер на живом Яндексе (город задать руками: State → Москва, City → Москва), ввести в поиск улицу, совпадающую с реальной точкой. В секции «ПУНКТЫ ВЫДАЧИ» должно быть две строки на результат — адрес сверху обычным весом, название под ним мельче и серым.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qx85cZaYUGb8Zxv836PxD8