### PR TITLE
fix(checkout): каскад стирал значение, отданное сервером (#272)

### DIFF
--- a/docs-internal/GOTCHAS.md
+++ b/docs-internal/GOTCHAS.md
@@ -1,6 +1,19 @@
 # Gotchas — Woodev Plugin Framework
-> **125 atomic gotchas, 22 namespaces (28 index sections)** — update when adding/removing.
-> Last updated: 2026-08-11 (session 65, pickup-selection persistence #176: **+5 files, no new
+> **126 atomic gotchas, 22 namespaces (28 index sections)** — update when adding/removing.
+> Last updated: 2026-08-11 (session 66, #272: **+1 file, existing namespace `[shipping/checkout]`** —
+> `a-programmatic-parent-change-must-not-run-a-destructive-cascade` (WooCommerce fires PROGRAMMATIC
+> `change` events on address fields while initialising the checkout, carrying the value the field
+> already has; they pass the adapter's `meaningful` gate legitimately, so a destructive dependent-
+> select cascade ran on EVERY load and wiped the server-rendered city in store and DOM. The harm is
+> not the wipe but the window: WooCommerce's own init `update_checkout` serialised the form ~50 ms
+> later and ~2.9 s BEFORE the source answered, writing `billing_city=''` into `WC()->customer`, so
+> the page erased its own value permanently. The card blamed the takeover conversion — it is
+> downstream and faithfully converts an already-empty field — and proposed suppressing a `change`
+> that never fires (`changes: []`). Gate destruction on a REMEMBERED previous parent value, keep
+> `resolved` (value consistency) separate from `fetched` (option set), and re-resolve the node in
+> `.done()`: the takeover replaces it mid-flight, so the late restore was landing on a DETACHED
+> element)).
+> Prior: 2026-08-11 (session 65, pickup-selection persistence #176: **+5 files, no new
 > namespace**. `custom-checkout-field-is-empty-on-reload-by-construction` (a field added through
 > `woocommerce_checkout_fields` is empty after a reload BY CONSTRUCTION — `WC_Checkout::get_value()`
 > resolves `$_POST` → `woocommerce_checkout_get_value` → a `WC_Customer` getter/meta →
@@ -299,6 +312,8 @@
 - [box-packer/virtual-box-null-best-inf-overflow] `$best=null; $best_volume=PHP_FLOAT_MAX` → if all candidate volumes overflow to INF, `INF < PHP_FLOAT_MAX = false` → `$best` never set → null dereference. Fix: initialize `$best = $candidates[0]` → [gotchas/virtual-box-null-best-inf-overflow.md](gotchas/virtual-box-null-best-inf-overflow.md) (2026-06-09)
 
 ### [shipping/checkout] — Checkout field layer (§8)
+- [shipping/checkout] A dependent-select cascade is DESTRUCTIVE, and WooCommerce fires PROGRAMMATIC `change` events on address fields while initialising the checkout — carrying the value the field already has, which passes the adapter's own `meaningful` gate legitimately (`'77'` is neither the `'*'` wildcard nor an empty-without-`originalEvent`). So a no-op cascade ran on EVERY page load and cleared the server-rendered city in both the store and the DOM. The damage is not the clearing but the WINDOW it opens: WooCommerce's own initialisation `update_checkout` serialises the form ~50 ms after the wipe and ~2.9 s BEFORE the source answers, so `billing_city=''` reaches `update_order_review()` and is written into `WC()->customer` — after which the server renders an empty field forever and the loss is self-sustaining. Two decoys: #272 blamed the takeover conversion (`options: [""]`), which is DOWNSTREAM and faithfully converts a field the cascade already emptied (`fromVal: ""`); and it proposed not firing `change` until the value is transferred, but no `change` fires on the child at all (`changes: []`), so that fix would have changed nothing. Gate destruction on a REMEMBERED previous parent value (seeded at `prefill()` from the rendered parent — the server rendered the pair together), keep `resolved` (value consistency, gates clearing) separate from `fetched` (option set, gates the request — `applyTakeover()` cannot supply options, it sends `parent: ''`), and re-resolve `$child` in `.done()`: the takeover replaces the node mid-flight, so the late restore was landing on a DETACHED element, invisible to customer and form serialization alike → [gotchas/a-programmatic-parent-change-must-not-run-a-destructive-cascade.md](gotchas/a-programmatic-parent-change-must-not-run-a-destructive-cascade.md) (s66)
+
 - [shipping/checkout] Takeover for a WC-states field (region) must use the `woocommerce_states` filter (WC renders + persists natively), NOT client DOM conversion — WC's `update_checkout` re-render fires programmatic `change('' / '*')` that wipes an external store, re-inits select2 (clearing values), etc. City (non-WC concept) stays client select2 with defensive guards (no re-init, safety-net restore, re-add value as option) → [gotchas/checkout-field-takeover-woocommerce-states.md](gotchas/checkout-field-takeover-woocommerce-states.md) (s42)
 
 - [shipping/checkout] A field added through `woocommerce_checkout_fields` is empty after a reload **by construction**, and it is not a broken restore. WooCommerce renders every field with `$checkout->get_value( $key )` (`form-shipping.php:63` for the `order` section), and that method resolves `$_POST` → the `woocommerce_checkout_get_value` filter → a `WC_Customer` getter or meta → `default_checkout_{key}`; for a key that is neither `billing_*` nor `shipping_*` and that nobody wrote to customer meta, every step yields nothing on a GET. The sanctioned restore seam is that filter, and it sits AFTER `$_POST` — so a failed submit still re-renders what the customer posted. Answer only for your own field id and return the incoming `$value` untouched for every other, or it short-circuits the whole checkout. The half-fixed state is the dangerous one: SP-5 also writes the point's address into the NATIVE address fields, which WooCommerce does persist, so the customer saw the address intact while the id was gone and the order stayed blocked. To tell this case from a broken restore, read the rendered `value` ATTRIBUTE on load, not the DOM after scripts run → [gotchas/custom-checkout-field-is-empty-on-reload-by-construction.md](gotchas/custom-checkout-field-is-empty-on-reload-by-construction.md) (s65)

--- a/docs-internal/gotchas/a-programmatic-parent-change-must-not-run-a-destructive-cascade.md
+++ b/docs-internal/gotchas/a-programmatic-parent-change-must-not-run-a-destructive-cascade.md
@@ -1,0 +1,111 @@
+# A programmatic parent `change` must not run a destructive cascade
+
+**Namespace:** `[shipping/checkout]` · **Discovered:** s66 (2026-08-11), rig measurement on `:8973/classic-checkout/` (#272)
+
+## The trap
+
+A dependent-select cascade is **destructive by design**: when the region changes, the city chosen
+for the old region is stale, so `cascadeChild()` clears the child's value in the store and in the
+DOM before asking the source for the new option set.
+
+WooCommerce fires **programmatic `change` events on address fields while initialising the
+checkout**, carrying the value the field already has. The adapter's `meaningful` gate lets those
+through legitimately — it only filters the `'*'` wildcard and empties-without-`originalEvent`, and
+a non-empty `'77'` is neither. So on **every page load** a cascade ran against a parent that had
+not changed, and destroyed the value the server had just rendered.
+
+The damage does not come from the clearing itself but from the **window it opens**. Measured, in
+order:
+
+```
+DCL      t=0      <input name="billing_city" value="Москва">   server rendered it correctly
+t=7002   cascadeChild  $child.val( '' )                        synchronous wipe: DOM + store
+t=7003   GET  …/field-source/billing_city?parent=77&country=RU  source asked
+t=7054   POST /?wc-ajax=update_order_review   billing_city=''   WC's OWN init update_checkout
+t=9957   fillSelect → 'Москва'                                 answer lands 2.9 s later
+```
+
+WooCommerce's own initialisation `update_checkout` serialises the form ~50 ms after the wipe and
+~2.9 s **before** the source answers, so the empty value reaches `update_order_review()` and is
+written into `WC()->customer`. From then on the server renders an empty field on every load and
+the loss is self-sustaining — the page erases its own value, permanently, with no user action.
+
+**Two things make this hard to read from the code.** First, `#272` was filed against the *takeover
+conversion* (`ensureSelect()` building a `<select>` with no options), because the measured symptom
+is `options: [""]`; the conversion is downstream — it faithfully converts a field the cascade has
+*already* emptied (`fromVal: ""` at the `replaceWith` call). Second, **no `change` event fires on
+the child at all** (`changes: []`), so "stop the conversion from firing `change` before it
+transfers the value" — the obvious fix, and the one the card proposed — would have changed nothing.
+
+A third, independent defect hid in the same function: `cascadeChild()` captured `$child` **before**
+the request and wrote the response into that captured reference. The takeover replaces the node
+mid-flight, so the late restore landed on a **detached element** — invisible to the customer and to
+form serialization alike, which is why even the 2.9 s-late recovery never showed up on screen.
+
+## The fix
+
+Track, per child, the parent value the child is already consistent with, and gate the destruction
+on a real change. Two records, not one, because they answer different questions:
+
+- `entry.resolved[ childId ]` — the parent value the child's **value** is consistent with. Seeded
+  in `prefill()` from the parent's rendered value, because the server rendered the pair
+  *together*. Gates the clearing.
+- `entry.fetched[ childId ]` — the parent value the child's **option set** was fetched against.
+  Gates the request. It must be separate: at load the value is already consistent (nothing to
+  clear) while the options have never been fetched, and a dependent select still needs them —
+  `applyTakeover()` cannot supply them, it sends `parent: ''`.
+
+Released on `.fail()` (`fetched` only), or a repeat of the same change never retries.
+
+```js
+// ❌ every cascade destroys, including the no-op one WooCommerce fires at init
+store.setValue( childId, '' )
+$child.val( '' )
+
+// ✅ destroy only when the parent actually changed
+var changed = entry.resolved[ childId ] !== parentValue
+
+if ( changed ) {
+    store.setValue( childId, '' )
+    $child.val( '' )
+    entry.resolved[ childId ] = parentValue
+}
+```
+
+Re-resolve the node in `.done()` (`$child = $( '#' + childId )`) instead of trusting the captured
+reference, and when the source omits the current value, branch on the same verdict: parent changed
+→ the value is genuinely stale, clear it; parent unchanged → the value is legitimate and the source
+merely did not return it (a truncated or query-scoped set), so **re-add it as a selected option**
+rather than dropping it.
+
+Compare parent values through a normaliser: `.val()` yields `undefined` for a missing element and
+`null` for an option-less `<select>`, while the same value arrives from the server as a string, so
+an un-normalised comparison declares a change where there is none.
+
+## Rule of thumb
+
+**A destructive reaction needs a real transition, not an event.** An event says "something fired",
+not "the value differs" — and any framework that re-renders will fire plenty of the former. Key the
+destruction on a remembered previous value.
+
+And when a value is destroyed in a window that some *other* actor closes, the harm is set by that
+actor's schedule, not yours: here a 3-second async gap was crossed by WooCommerce's own 50 ms form
+serialization, which converted a transient UI blip into permanent session damage. Ask what else
+reads this state before the answer lands.
+
+## Related
+
+- [[checkout-field-takeover-woocommerce-states]] — the takeover's own value-preservation guards
+  (`re-add value as option`, the `updated_checkout` safety net). They were never reached here: the
+  cascade had already emptied both the DOM and the store before the takeover ran.
+- [[custom-checkout-field-is-empty-on-reload-by-construction]] — the *other* reason a checkout
+  field is empty after a reload. That one is by construction and has no bug to find; this one is a
+  real defect, and the two look identical from the browser. Distinguish them by reading the
+  rendered `value` **attribute**: present means the server knows the value and the client is
+  losing it.
+- [[wc-does-not-save-the-address-until-every-required-text-field-is-filled]] — the same
+  `update_checkout` path from the other side: when the client gate is *closed* nothing persists at
+  all. Both must be understood to reason about what the checkout actually stores.
+- [[built-on-both-sides-with-no-caller-in-the-middle]] — the class of defect that only a real page
+  reveals; this adapter had **no** jest coverage at all until #272, which is why a load-time
+  regression could live in it indefinitely.

--- a/tests/js/checkout-field-classic.test.js
+++ b/tests/js/checkout-field-classic.test.js
@@ -1,0 +1,326 @@
+/**
+ * Tests for checkout-field-classic.js — the classic-checkout adapter of the §8 field layer.
+ *
+ * FIRST test coverage this file has ever had. That absence is why #272 survived: the cascade
+ * destroyed a server-rendered value on every page load, and nothing but a browser could say so.
+ *
+ * The contract under test here is the CASCADE's destructiveness gate. A cascade drops the child's
+ * value by design ("the region changed, so the city is stale"), but WooCommerce fires PROGRAMMATIC
+ * `change` events on address fields while initialising the checkout, carrying the value the field
+ * already had. Those pass the adapter's own `meaningful` gate legitimately (non-empty value), so
+ * before #272 they ran a full destructive cascade against a parent that had not changed:
+ *
+ *   DCL                <input value="Москва">      server rendered it
+ *   cascadeChild       $child.val( '' )            synchronous wipe of DOM + store
+ *   +50ms              WC's own update_order_review posts billing_city=''  → WC()->customer
+ *   +2900ms            the source answers, value restored — into a DETACHED node, too late
+ *
+ * Hence the two assertions every test here makes: the value must survive SYNCHRONOUSLY (the POST
+ * window is ~50 ms, long before any response), and the late write must land on the node that is
+ * actually IN the document (the takeover converts `<input>` → `<select>` mid-flight).
+ *
+ * Real jQuery is loaded (it IS a devDependency — `package.json` `devDependencies.jquery`; the
+ * claim to the contrary in `pickup-mount.test.js`'s docblock is stale). `$.ajax` is stubbed so
+ * each test drives the response timing by hand. select2 is deliberately absent, so
+ * `select2Method()` returns '' and `initSuggest()` no-ops — exactly the "no select2 on the page"
+ * branch, which keeps the DOM assertions about plain `<option>` elements honest.
+ *
+ * @see woodev/shipping-method/assets/js/frontend/checkout-field-classic.js
+ */
+
+'use strict';
+
+jest.useFakeTimers();
+
+const CONFIG_GLOBAL = 'woodev_checkout_field_config_test';
+const ENDPOINT      = 'https://example.test/wp-json/woodev/v1/test/field-source';
+
+let ajaxCalls;
+
+/**
+ * Installs the WooCommerce classic-checkout markup the adapter reaches for.
+ *
+ * `billing_city` is rendered as a text `<input>` carrying a value, which is what the server
+ * really emits for a field WooCommerce has no concept of (measured on the rig, s66).
+ *
+ * @param {string} city  Server-rendered city value.
+ * @param {string} state Server-rendered region value.
+ * @returns {void}
+ */
+function installMarkup( city, state ) {
+	document.body.innerHTML = `
+		<form class="checkout woocommerce-checkout">
+			<div class="woocommerce-billing-fields__field-wrapper">
+				<p id="billing_country_field" class="form-row">
+					<select id="billing_country" name="billing_country">
+						<option value="RU" selected>Россия</option>
+						<option value="US">США</option>
+					</select>
+				</p>
+				<p id="billing_state_field" class="form-row">
+					<select id="billing_state" name="billing_state">
+						<option value="77">Москва</option>
+						<option value="78">Санкт-Петербург</option>
+					</select>
+				</p>
+				<p id="billing_city_field" class="form-row">
+					<input type="text" id="billing_city" name="billing_city" value="${ city }" />
+				</p>
+			</div>
+			<div id="shipping_method"></div>
+			<button type="submit" id="place_order"></button>
+		</form>
+	`;
+
+	document.getElementById( 'billing_state' ).value = state;
+}
+
+/**
+ * Builds the localized config global the adapter discovers by prefix.
+ *
+ * @returns {Object}
+ */
+function buildConfig() {
+	return {
+		endpoint: ENDPOINT,
+		nonce:    'test-nonce',
+		i18n:     { placeholder: 'Выберите…', required: 'Заполните обязательное поле.' },
+		fields:   {
+			billing_state: { source_kind: 'options', required: true },
+			billing_city:  { source_kind: 'suggest', depends_on: 'billing_state', required: true },
+		},
+		takeover: {
+			billing_state: { RU: true },
+			billing_city:  { RU: true },
+		},
+	};
+}
+
+/**
+ * Replaces `$.ajax` with a stub whose responses each test resolves by hand.
+ *
+ * Returns the recorded calls; every entry exposes `resolve()`/`reject()` so a test can decide
+ * WHEN the source answers — the whole defect lives in the window before it does.
+ *
+ * @returns {Array<Object>}
+ */
+function stubAjax() {
+	const calls = [];
+
+	global.jQuery.ajax = jest.fn( function( opts ) {
+		const handlers = { done: [], fail: [] };
+		const chain    = {
+			done( cb ) { handlers.done.push( cb ); return chain; },
+			fail( cb ) { handlers.fail.push( cb ); return chain; },
+		};
+
+		calls.push( {
+			opts,
+			resolve( response ) { handlers.done.forEach( ( cb ) => cb( response ) ); },
+			reject( error ) { handlers.fail.forEach( ( cb ) => cb( {}, 'error', error ) ); },
+		} );
+
+		return chain;
+	} );
+
+	return calls;
+}
+
+/**
+ * Loads the adapter fresh and runs its boot (jQuery ready + the deferred takeover tick).
+ *
+ * @param {string} city  Server-rendered city value.
+ * @param {string} state Server-rendered region value.
+ * @returns {void}
+ */
+function boot( city = 'Москва', state = '77' ) {
+	installMarkup( city, state );
+
+	global.jQuery = require( 'jquery' );
+	global.$      = global.jQuery;
+	window.jQuery = global.jQuery;
+
+	window.WoodevCheckoutFieldStore = require(
+		'../../woodev/shipping-method/assets/js/frontend/checkout-field-store.js'
+	);
+	window[ CONFIG_GLOBAL ] = buildConfig();
+
+	ajaxCalls = stubAjax();
+
+	require( '../../woodev/shipping-method/assets/js/frontend/checkout-field-classic.js' );
+
+	// Three timer generations have to drain here, which is why this is `runAllTimers`
+	// rather than a counted number of `runOnlyPendingTimers()` passes: jQuery schedules
+	// `jQuery.ready` on a timer when the document is already complete, jQuery 3+ then
+	// fires `readyList.then( … )` — i.e. our ready callback — ASYNCHRONOUSLY on a second
+	// timer, and that callback finally registers the takeover's own `setTimeout( …, 0 )`.
+	// Two passes left the takeover un-run, so `#billing_city` stayed a text `<input>` and
+	// every option assertion silently compared against an empty list.
+	jest.runAllTimers();
+}
+
+/**
+ * Returns the `#billing_city` element currently IN the document.
+ *
+ * Deliberately re-queried on every call: the takeover replaces the node, so a reference held
+ * across a cascade is exactly the stale-reference bug this file pins.
+ *
+ * @returns {HTMLElement}
+ */
+function city() {
+	return document.getElementById( 'billing_city' );
+}
+
+/**
+ * Lists the option values of the live `#billing_city` element.
+ *
+ * @returns {Array<string>}
+ */
+function cityOptions() {
+	const el = city();
+
+	return el && el.options ? Array.prototype.map.call( el.options, ( o ) => o.value ) : [];
+}
+
+/**
+ * Fires a jQuery `change` on the region select — programmatic, so no `originalEvent`,
+ * which is precisely how WooCommerce's own churn arrives.
+ *
+ * @param {string} value Region value to report.
+ * @returns {void}
+ */
+function changeState( value ) {
+	global.jQuery( '#billing_state' ).val( value ).trigger( 'change' );
+}
+
+/**
+ * The cascade request issued for `billing_city`, if any.
+ *
+ * @returns {Object|undefined}
+ */
+function cityRequest() {
+	return ajaxCalls.filter( ( c ) => String( c.opts.url ).indexOf( 'billing_city' ) !== -1 ).pop();
+}
+
+beforeEach( () => {
+	jest.resetModules();
+	delete window[ CONFIG_GLOBAL ];
+	delete window.WoodevCheckoutFieldStore;
+	document.body.innerHTML = '';
+} );
+
+describe( 'cascade destructiveness gate (#272)', () => {
+
+	it( 'keeps the server-rendered child value when the parent reports the SAME value', () => {
+		boot( 'Москва', '77' );
+
+		expect( city().value ).toBe( 'Москва' );
+
+		// WooCommerce's init-time programmatic change: same region, no user action.
+		changeState( '77' );
+
+		// The POST window. Nothing may have cleared the field by now.
+		expect( city().value ).toBe( 'Москва' );
+		expect( cityOptions() ).toContain( 'Москва' );
+	} );
+
+	it( 'DOES clear the child when the parent value genuinely changed', () => {
+		boot( 'Москва', '77' );
+
+		changeState( '78' );
+
+		expect( city().value ).toBe( '' );
+	} );
+
+	it( 'restores the value as a selected option when the source omits it and the parent is unchanged', () => {
+		boot( 'Москва', '77' );
+
+		changeState( '77' );
+
+		const request = cityRequest();
+		expect( request ).toBeDefined();
+		expect( request.opts.data.parent ).toBe( '77' );
+
+		// A truncated / query-scoped set that does not carry the current value.
+		request.resolve( { options: [ { value: 'Зеленоград', label: 'Зеленоград' } ] } );
+
+		expect( cityOptions() ).toContain( 'Москва' );
+		expect( city().value ).toBe( 'Москва' );
+	} );
+
+	it( 'drops the value when the source omits it AFTER a genuine parent change', () => {
+		boot( 'Москва', '77' );
+
+		changeState( '78' );
+
+		const request = cityRequest();
+		request.resolve( { options: [ { value: 'Кронштадт', label: 'Кронштадт' } ] } );
+
+		expect( cityOptions() ).not.toContain( 'Москва' );
+		expect( city().value ).toBe( '' );
+	} );
+
+	it( 'writes the late response into the node that is IN the document, not the captured one', () => {
+		boot( 'Москва', '77' );
+
+		changeState( '78' );
+
+		const request  = cityRequest();
+		const captured = city();
+
+		// Mimic the takeover swapping the element while the request is in flight
+		// (ensureSelect() does exactly this, measured at ~6 ms after the cascade starts).
+		const fresh = document.createElement( 'select' );
+		fresh.id    = 'billing_city';
+		fresh.name  = 'billing_city';
+		captured.parentNode.replaceChild( fresh, captured );
+
+		request.resolve( { options: [ { value: 'Санкт-Петербург', label: 'Санкт-Петербург' } ] } );
+
+		expect( city() ).toBe( fresh );
+		expect( cityOptions() ).toContain( 'Санкт-Петербург' );
+
+		// The detached node must NOT be where the answer landed. It legitimately still
+		// carries the options the boot takeover gave it — what must be absent is the
+		// RESPONSE, which is the whole point: a write there is invisible to the customer
+		// and to the form serialization alike.
+		const strandedOptions = captured.options
+			? Array.prototype.map.call( captured.options, ( o ) => o.value )
+			: [];
+		expect( strandedOptions ).not.toContain( 'Санкт-Петербург' );
+	} );
+
+	it( 'retries after a failed source request instead of considering the parent resolved', () => {
+		boot( 'Москва', '77' );
+
+		changeState( '78' );
+		const first = cityRequest();
+		expect( first ).toBeDefined();
+		first.reject( 'boom' );
+
+		const before = global.jQuery.ajax.mock.calls.length;
+
+		// The very same region value again: a released `fetched` entry must let it through.
+		changeState( '78' );
+
+		expect( global.jQuery.ajax.mock.calls.length ).toBeGreaterThan( before );
+		// The adapter logs the transport failure through logError(); assert it so
+		// @wordpress/jest-console does not fail the suite on an unexpected console.error.
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'does not re-issue a cascade for a repeated no-op change once resolved', () => {
+		boot( 'Москва', '77' );
+
+		changeState( '77' );
+		const first = cityRequest();
+		first.resolve( { options: [ { value: 'Москва', label: 'Москва' } ] } );
+
+		const after = global.jQuery.ajax.mock.calls.length;
+
+		changeState( '77' );
+
+		expect( global.jQuery.ajax.mock.calls.length ).toBe( after );
+		expect( city().value ).toBe( 'Москва' );
+	} );
+} );

--- a/woodev/shipping-method/assets/js/frontend/checkout-field-classic.js
+++ b/woodev/shipping-method/assets/js/frontend/checkout-field-classic.js
@@ -40,7 +40,16 @@
 
 		return {
 			store:  factory.createStore( config ),
-			config: config || {}
+			config: config || {},
+			// Per-child record of the PARENT value the child's own value is CONSISTENT
+			// with. A cascade is destructive (it drops the child's value), so the drop
+			// only happens when the parent actually CHANGED — see cascadeChild().
+			resolved: {},
+			// Per-child record of the PARENT value the child's OPTION SET was fetched
+			// against. Separate from `resolved` on purpose: at page load the value is
+			// already consistent with the rendered parent (nothing to drop) while the
+			// options have never been fetched (a dependent select still needs them).
+			fetched: {}
 		}
 	} ).filter( function( entry ) {
 		return entry.config && entry.config.fields
@@ -193,24 +202,56 @@
 	// ---------------------------------------------------------------------
 
 	/**
-	 * Запускает каскад для одного потомка: чистит значение, запрашивает
-	 * источник, перезаполняет `<select>` из данных, восстанавливает значение.
+	 * Нормализует значение родителя к строке для сравнения «сменился ли он».
 	 *
-	 * @param {Object} entry    Запись { store, config }.
-	 * @param {string} childId  Id поля-потомка.
-	 * @param {string} parentId Id поля-родителя.
+	 * `.val()` отдаёт `undefined` для отсутствующего элемента и `null` для
+	 * `<select>` без опций, а с сервера то же значение приходит строкой —
+	 * сравнение без нормализации объявляло бы смену там, где её нет.
+	 *
+	 * @param {*} value
+	 * @returns {string}
+	 */
+	function cascadeKey( value ) {
+		return value === undefined || value === null ? '' : String( value )
+	}
+
+	/**
+	 * Запускает каскад для одного потомка: запрашивает источник, перезаполняет
+	 * `<select>` из данных, восстанавливает значение.
+	 *
+	 * Каскад ДЕСТРУКТИВЕН — он роняет значение потомка, — поэтому чистка идёт
+	 * только когда родитель РЕАЛЬНО сменился. WooCommerce на инициализации
+	 * чекаута сам стреляет программным `change` по адресным полям (см. гейт
+	 * `meaningful` ниже: непустое значение проходит его законно), и такой
+	 * «холостой» каскад раньше синхронно обнулял и DOM, и стор. Стартовый
+	 * `update_checkout` самого WooCommerce сериализовал форму спустя ~50 мс —
+	 * то есть ЗАДОЛГО до ответа источника — и уносил пустое значение в
+	 * `WC()->customer`, после чего сервер отдавал пустое поле уже на всех
+	 * последующих загрузках. Ни одного `change` по самому потомку при этом не
+	 * происходит: значение убивает не событие, а окно между чисткой и ответом.
+	 *
+	 * @param {Object} entry       Запись { store, config, resolved }.
+	 * @param {string} childId     Id поля-потомка.
+	 * @param {string} parentId    Id поля-родителя.
+	 * @param {string} parentValue Текущее значение родителя.
 	 * @returns {void}
 	 */
-	function cascadeChild( entry, childId, parentId ) {
+	function cascadeChild( entry, childId, parentId, parentValue ) {
 		var store    = entry.store
 		var $child   = $( '#' + childId )
 		var previous = store.getValue( childId )
+		var changed  = entry.resolved[ childId ] !== parentValue
 
-		// Значение потомка теперь неактуально: чистим в сторе и в DOM.
-		store.setValue( childId, '' )
+		if( changed ) {
+			// Родитель сменился → значение потомка неактуально: чистим в сторе и в DOM.
+			store.setValue( childId, '' )
 
-		if( $child.length ) {
-			$child.val( '' )
+			if( $child.length ) {
+				$child.val( '' )
+			}
+
+			// После чистки состояние потомка согласовано с новым родителем.
+			entry.resolved[ childId ] = parentValue
 		}
 
 		var url = sourceUrl( entry.config, childId )
@@ -220,12 +261,21 @@
 			return
 		}
 
+		// Набор опций для этого значения родителя уже загружен — повторный
+		// «холостой» change не должен слать запрос ещё раз.
+		if( entry.fetched[ childId ] === parentValue ) {
+			refreshGate()
+			return
+		}
+
+		entry.fetched[ childId ] = parentValue
+
 		$.ajax( {
 			url:      url,
 			method:   'GET',
 			dataType: 'json',
 			data:     {
-				parent:  store.getValue( parentId ) !== undefined ? store.getValue( parentId ) : '',
+				parent:  parentValue !== undefined && parentValue !== null ? parentValue : '',
 				country: currentCountry()
 			},
 			beforeSend: function( xhr ) {
@@ -234,6 +284,17 @@
 				}
 			}
 		} ).done( function( response ) {
+			// Перечитываем узел: takeover мог заменить <input> на <select>
+			// (ensureSelect) пока запрос был в полёте, и захваченная ссылка
+			// указывала бы на открепленный от документа элемент — запись в него
+			// не видна ни покупателю, ни сериализации формы.
+			$child = $( '#' + childId )
+
+			if( ! $child.length ) {
+				refreshGate()
+				return
+			}
+
 			var options  = response && response.options ? response.options : []
 			var restored = fillSelect( $child, options, previous, placeholderText( entry.config ) )
 
@@ -241,14 +302,26 @@
 			// независимо от того, вернулась ли опция (спека: не «ронять» значение).
 			store.setValue( childId, previous )
 
-			if( ! restored ) {
-				// В DOM опции нет — очищаем видимый выбор, но храним в сторе.
-				$child.val( '' )
+			if( ! restored && previous !== undefined && previous !== null && previous !== '' ) {
+				if( changed ) {
+					// Родитель сменился, и в новом наборе значения нет — оно
+					// действительно устарело: убираем видимый выбор.
+					$child.val( '' )
+				} else {
+					// Родитель ТОТ ЖЕ, значит значение законно. Источник мог просто
+					// не вернуть его (усечённый/поисковый набор) — возвращаем как
+					// выбранную опцию, а не выбрасываем.
+					$child.append( new Option( previous, previous, true, true ) )
+					$child.val( previous )
+				}
 			}
 
 			maybeInitSelect2( entry, childId )
 			refreshGate()
 		} ).fail( function( xhr, status, error ) {
+			// Набор опций не получен — значение родителя НЕ считается загруженным,
+			// иначе повтор того же change больше никогда не догрузит потомка.
+			delete entry.fetched[ childId ]
 			logError( error || status || 'field-source request failed' )
 			refreshGate()
 		} )
@@ -257,13 +330,14 @@
 	/**
 	 * Прогоняет каскад для всех потомков родителя.
 	 *
-	 * @param {Object} entry    Запись { store, config }.
-	 * @param {string} parentId Id изменившегося родителя.
+	 * @param {Object} entry       Запись { store, config, resolved }.
+	 * @param {string} parentId    Id изменившегося родителя.
+	 * @param {string} parentValue Текущее значение родителя.
 	 * @returns {void}
 	 */
-	function runCascade( entry, parentId ) {
+	function runCascade( entry, parentId, parentValue ) {
 		entry.store.childrenOf( parentId ).forEach( function( childId ) {
-			cascadeChild( entry, childId, parentId )
+			cascadeChild( entry, childId, parentId, parentValue )
 		} )
 	}
 
@@ -676,6 +750,26 @@
 			}
 		} )
 
+		// Фиксируем, против какого значения родителя КАЖДЫЙ потомок уже разрешён на
+		// момент загрузки: сервер отрендерил их согласованной парой. Без этого
+		// стартовый программный `change` от WooCommerce читается как смена родителя
+		// и «холостой» каскад роняет только что отданное сервером значение.
+		Object.keys( fields ).forEach( function( fieldId ) {
+			var parentId = fields[ fieldId ] && fields[ fieldId ].depends_on
+				? fields[ fieldId ].depends_on
+				: ''
+
+			if( ! parentId ) {
+				return
+			}
+
+			var $parent = $( '#' + parentId )
+
+			if( $parent.length ) {
+				entry.resolved[ fieldId ] = cascadeKey( $parent.val() )
+			}
+		} )
+
 		store.setChosenMethod( selectedShippingMethod() )
 		store.setCountry( currentCountry() )
 	}
@@ -705,10 +799,10 @@
 	 * @param {string} parentId
 	 * @returns {void}
 	 */
-	function cascadeFromParent( parentId ) {
+	function cascadeFromParent( parentId, parentValue ) {
 		stores.forEach( function( entry ) {
 			if( entry.store.childrenOf( parentId ).length ) {
-				runCascade( entry, parentId )
+				runCascade( entry, parentId, cascadeKey( parentValue ) )
 			}
 		} )
 	}
@@ -764,7 +858,7 @@
 
 			// Изменение поля-родителя (в т.ч. нативного) → каскад потомков.
 			if( id && meaningful ) {
-				cascadeFromParent( id )
+				cascadeFromParent( id, value )
 			}
 		} )
 


### PR DESCRIPTION
Замерено на риге `:8973/classic-checkout/`, и **механизм из карточки оказался неверным** — правка идёт по фактическому.

## Что происходит на самом деле

Каскад зависимого селекта деструктивен намеренно: сменился регион — город устарел. Но WooCommerce на инициализации чекаута сам стреляет **программными `change`** по адресным полям, донося значение, которое у поля уже есть. Гейт `meaningful` в адаптере пропускает их законно (`'77'` — не `'*'` и не пустое-без-`originalEvent`). Значит холостой каскад шёл на **каждой загрузке страницы**.

Ущерб даёт не сама чистка, а окно, которое она открывает:

```
DCL      t=0      <input name="billing_city" value="Москва">   сервер отдал верно
t=7002   cascadeChild  $child.val( '' )                        синхронное обнуление DOM + стора
t=7003   GET  …/field-source/billing_city?parent=77&country=RU
t=7054   POST update_order_review  billing_city=''             стартовый update_checkout WooCommerce
t=9957   fillSelect → 'Москва'                                 ответ источника, на 2.9 с позже
```

Стартовый `update_checkout` самого WooCommerce сериализует форму через ~50 мс после чистки и за ~2.9 с **до** ответа источника, поэтому пустое значение уезжает в `WC()->customer`. Дальше сервер отдаёт пустое поле на всех загрузках — страница стирает своё значение сама, без участия покупателя.

## Поправки к карточке

1. **Виновата не конвертация takeover'а.** `ensureSelect()` стоит ниже по потоку и честно конвертирует поле, которое каскад уже опустошил — на момент `replaceWith` замерено `fromVal: ""`. Симптом `options: [""]` — следствие, не причина.
2. **Никакого `change` по потомку не летит вовсе** (`changes: []`). Предложенная в карточке правка «не отправлять `change`, пока значение не перенесено» не изменила бы ничего.

## Правка

Деструктивность гейтится запомненным прежним значением родителя, двумя раздельными записями:

- `resolved[ childId ]` — значение родителя, с которым согласовано **значение** потомка. Засевается в `prefill()` из отрендеренного родителя: сервер отдал пару согласованной. Гейтит чистку.
- `fetched[ childId ]` — значение родителя, под которое загружен **набор опций**. Раздельно намеренно: на загрузке значение уже согласовано (чистить нечего), а опции не запрашивались ни разу, и `applyTakeover()` их дать не может — он посылает `parent: ''`. Освобождается на `.fail()`, иначе повтор того же change никогда не догрузит потомка.

Попутно в той же функции исправлены два самостоятельных дефекта:

- `.done()` писал в `$child`, захваченный **до** запроса, а takeover подменяет узел в полёте — позднее восстановление уходило в открепленный от документа элемент (невидимо ни покупателю, ни сериализации формы);
- отсутствие значения в ответе роняло его даже когда родитель не менялся. Теперь при неизменившемся родителе значение возвращается выбранной опцией: усечённый или поисковый набор — не доказательство, что значение невалидно.

## Проверка на риге, после правки

Три перезагрузки подряд: обнулений значения нет ни одного (`sets: []`), POST WooCommerce несёт `city='Москва'`, сервер держит `value="Москва"`, поле в итоге — `<select>` с полным набором источника (`["", Москва, Зеленоград, Троицк]`) и выбранным городом. Каскад по-прежнему грузит опции с `parent=77` — регрессии нет.

## Тесты

Первое покрытие этого адаптера в jest за всю его историю — 7 кейсов, 880 → **887**. PHP без изменений: 1595 / 4259.

**Мутационная проверка — убиты все 7:** гейт принудительно always-true и always-false, снятие перечитывания узла в `.done()`, снятие возврата значения опцией, снятие `delete fetched` на `.fail()`, снятие короткого замыкания по `fetched`, снятие засева в `prefill()`.

Готча: `a-programmatic-parent-change-must-not-run-a-destructive-cascade`.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DztXR7YdJEGkeZVjSaqCzd