### PR TITLE
feat(checkout): убрать «Заполните обязательное поле» под полем и под кнопкой ПВЗ (#274, пункт 1)

### DIFF
--- a/tests/js/checkout-field-classic.test.js
+++ b/tests/js/checkout-field-classic.test.js
@@ -84,7 +84,10 @@ function buildConfig() {
 	return {
 		endpoint: ENDPOINT,
 		nonce:    'test-nonce',
-		i18n:     { placeholder: 'Выберите…', required: 'Заполните обязательное поле.' },
+		// No `required` key: #274 removed the inline «Заполните обязательное поле.» caption
+		// and, with it, the only consumer of that string — a fixture carrying it would be
+		// richer than production in exactly the direction that hides a regression.
+		i18n:     { placeholder: 'Выберите…' },
 		fields:   {
 			billing_state: { source_kind: 'options', required: true },
 			billing_city:  { source_kind: 'suggest', depends_on: 'billing_state', required: true },

--- a/woodev/shipping-method/assets/js/frontend/checkout-field-classic.js
+++ b/woodev/shipping-method/assets/js/frontend/checkout-field-classic.js
@@ -659,46 +659,18 @@
 	// ---------------------------------------------------------------------
 
 	/**
-	 * Показывает/убирает inline-ошибку рядом с полем (или его pickup-якорем).
-	 *
-	 * @param {Object}  entry   Запись { store, config }.
-	 * @param {string}  fieldId Id поля.
-	 * @param {boolean} invalid Требуется ли показать ошибку.
-	 * @returns {void}
-	 */
-	function toggleFieldError( entry, fieldId, invalid ) {
-		var field    = entry.store.getField( fieldId )
-		var errorId  = 'woodev-checkout-field-error-' + fieldId
-		var $error   = $( '#' + errorId )
-		var $anchor  = field && field.is_pickup_slot
-			? $( '[data-woodev-pickup-slot="' + fieldId + '"]' ).first()
-			: $( '#' + fieldId ).first()
-
-		if( ! invalid ) {
-			$error.remove()
-			return
-		}
-
-		if( ! $anchor.length ) {
-			return
-		}
-
-		if( ! $error.length ) {
-			$error = $( '<span id="' + errorId + '" class="woodev-checkout-field-error" role="alert"></span>' )
-			$anchor.after( $error )
-		}
-
-		var i18nRequired = ( entry.config && entry.config.i18n && entry.config.i18n.required )
-			? entry.config.i18n.required
-			: 'Заполните обязательное поле.'
-		$error.text( i18nRequired )
-	}
-
-	/**
 	 * Пересчитывает A2-гейт по ВСЕМ сторам: если хоть одно требуемое поле пусто —
-	 * блокирует «Оформить заказ» и показывает inline-ошибку; иначе разблокирует.
+	 * блокирует «Оформить заказ»; иначе разблокирует.
 	 *
 	 * Сервер остаётся авторитетом — это только UX.
+	 *
+	 * НИКАКОГО inline-текста под полем (#274). Раньше здесь рисовалась подпись
+	 * «Заполните обязательное поле.» под «Населённым пунктом» и под кнопкой выбора
+	 * ПВЗ; ни СДЭК, ни Яндекс, ни Почта так не делают, и правило оператора то же:
+	 * заблокированный контрол не поясняем — заблокирован и всё. Отключённая кнопка
+	 * «Оформить заказ» и есть сигнал, а WooCommerce всё равно скажет своё при
+	 * отправке формы. Вместе с текстом ушла и строка `i18n.required` из
+	 * `Checkout_Handler::enqueue_*` — у неё не осталось потребителя.
 	 *
 	 * @returns {void}
 	 */
@@ -712,8 +684,6 @@
 				var required = entry.store.evaluateRequired( fieldId )
 				var value    = entry.store.getValue( fieldId )
 				var invalid  = required && ( value === undefined || value === null || String( value ) === '' )
-
-				toggleFieldError( entry, fieldId, invalid )
 
 				if( invalid ) {
 					blocked = true

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -542,8 +542,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 				$this->wc_country_codes(),
 				$this->location_service()
 			) )->build( $this->fields );
+			// No `required` string here any more (#274): the client no longer renders an
+			// inline «Заполните обязательное поле.» under the field or under the pickup
+			// trigger — none of СДЭК/Яндекс/Почта does, and a blocked control needs no
+			// caption. The disabled «Оформить заказ» button is the signal; WooCommerce
+			// still says its own piece on submit.
 			$config['i18n']  = [
-				'required'    => __( 'Заполните обязательное поле.', 'woodev-plugin-framework' ),
 				'placeholder' => $this->placeholder_label(),
 			];
 


### PR DESCRIPTION
> **Только пункт 1 из трёх. Визуальное — не мержу, нужна твоя проверка.** Пункты 2 и 3 расписаны в карточке #274 с поправкой к постановке, которую дал замер.

## Что сделано

A2-гейт рисовал «Заполните обязательное поле.» под takeover-полем и под кнопкой выбора ПВЗ. Ни СДЭК, ни Яндекс, ни Почта так не делают, и твоё же правило то же: заблокированный контрол не поясняем — заблокирован и всё. Сигнал — отключённая «Оформить заказ», а на отправке формы WooCommerce всё равно скажет своё.

`toggleFieldError()` удалён, а не заглушён, и вместе с ним ушёл единственный потребитель строки `i18n.required` — поэтому строка убрана и из локализованного конфига `Checkout_Handler`. `refreshGate()` считает `blocked` в точности как раньше: вердикт гейта не менялся.

Из jest-фикстуры ключ `required` тоже убран — иначе фикстура осталась бы богаче продакшена ровно в той оси, где это скрывает регрессию.

Тесты: 895 jest, 1595 unit / 4259 ассертов, phpcs чисто — всё без изменений, потому что убрана подпись, а не логика.

Refs #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DztXR7YdJEGkeZVjSaqCzd