### PR TITLE
fix(api): маскировать любой известный креденшл-заголовок в логе запроса (#288)

### DIFF
--- a/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
+++ b/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Unit tests for Woodev_API_Base::get_sanitized_request_headers() /
+ * get_secret_request_header_names() — issue #288.
+ *
+ * Woodev_API_Base::broadcast_request() hands the sanitized request headers to the
+ * documented `woodev_{api_id}_api_request_performed` action, i.e. to any attached
+ * request logger. Before this fix, the sanitizer masked ONLY the `Authorization`
+ * header by exact key match; any other credential header (e.g. a vendor-specific
+ * `X-Secret`) rode the broadcast in plaintext. This file pins:
+ *
+ * - `Authorization` stays masked (regression guard — the payment-gateway tree
+ *   shares this base class);
+ * - every other header name in the default {@see \Woodev_API_Base::get_secret_request_header_names()}
+ *   list is masked too;
+ * - the match is case-insensitive, while the returned array preserves the
+ *   ORIGINAL key casing the request actually sent;
+ * - a subclass can extend the list with its own header name;
+ * - a non-secret header passes through untouched.
+ *
+ * @package Woodev\Tests\Unit\Api
+ */
+
+namespace Woodev\Tests\Unit\Api;
+
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/woodev/api/class-api-base.php';
+
+/**
+ * Minimal concrete Woodev_API_Base double exposing the protected header
+ * sanitizer surface for direct assertions, without pulling in the HTTP/broadcast
+ * machinery this fix does not touch.
+ */
+class Testable_Api_Base extends \Woodev_API_Base {
+
+	/**
+	 * Seeds the request headers under test.
+	 *
+	 * @param array<string, string> $headers Header name/value pairs, casing as sent.
+	 * @return void
+	 */
+	public function set_headers_for_test( array $headers ): void {
+		$this->set_request_headers( $headers );
+	}
+
+	/**
+	 * Exposes the protected sanitizer under test.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_sanitized_headers_for_test(): array {
+		return $this->get_sanitized_request_headers();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_new_request( $args = [] ) {
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_plugin() {
+		return null;
+	}
+}
+
+/**
+ * A subclass extending the default credential-header list with a header the
+ * base class does not know about — proves the extension seam works.
+ */
+class Testable_Api_Base_With_Custom_Secret extends Testable_Api_Base {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<int, string>
+	 */
+	protected function get_secret_request_header_names(): array {
+		return array_merge( parent::get_secret_request_header_names(), [ 'X-Custom-Secret' ] );
+	}
+}
+
+/**
+ * Class ApiBaseSanitizedHeadersTest.
+ */
+final class ApiBaseSanitizedHeadersTest extends TestCase {
+
+	/**
+	 * Regression guard: Authorization must stay masked exactly as before.
+	 *
+	 * @return void
+	 */
+	public function test_authorization_header_is_masked(): void {
+		$value = 'token-value-that-must-never-reach-the-log';
+
+		$api = new Testable_Api_Base();
+		$api->set_headers_for_test( [ 'Authorization' => $value ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $value ) ), $headers['Authorization'] );
+	}
+
+	/**
+	 * A non-Authorization credential header from the default list is masked too.
+	 *
+	 * @return void
+	 */
+	public function test_default_list_masks_a_non_authorization_credential_header(): void {
+		$secret = 'secret-value-that-must-never-reach-the-log';
+
+		$api = new Testable_Api_Base();
+		$api->set_headers_for_test( [ 'X-Secret' => $secret ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['X-Secret'] );
+		$this->assertStringNotContainsString( $secret, print_r( $headers, true ), 'the secret leaked into the sanitized headers' );
+	}
+
+	/**
+	 * HTTP header names are case-insensitive: a lowercase `x-secret` must be
+	 * masked, and the returned array must keep the ORIGINAL key casing.
+	 *
+	 * @return void
+	 */
+	public function test_match_is_case_insensitive_but_preserves_original_key_casing(): void {
+		$secret = 'secret-value-that-must-never-reach-the-log';
+
+		$api = new Testable_Api_Base();
+		$api->set_headers_for_test( [ 'x-secret' => $secret ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertArrayHasKey( 'x-secret', $headers );
+		$this->assertArrayNotHasKey( 'X-Secret', $headers );
+		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['x-secret'] );
+	}
+
+	/**
+	 * A subclass extending get_secret_request_header_names() gets its custom
+	 * header masked through the same shared logic — no divergent sanitizer needed.
+	 *
+	 * @return void
+	 */
+	public function test_subclass_can_extend_the_secret_header_name_list(): void {
+		$secret = 'secret-value-that-must-never-reach-the-log';
+
+		$api = new Testable_Api_Base_With_Custom_Secret();
+		$api->set_headers_for_test( [ 'X-Custom-Secret' => $secret ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['X-Custom-Secret'] );
+	}
+
+	/**
+	 * A header that carries no credential passes through unmasked.
+	 *
+	 * @return void
+	 */
+	public function test_non_secret_header_passes_through_untouched(): void {
+		$api = new Testable_Api_Base();
+		$api->set_headers_for_test( [ 'Content-Type' => 'application/json' ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertSame( 'application/json', $headers['Content-Type'] );
+	}
+}

--- a/tests/unit/Shipping/Location/DadataApiClientTest.php
+++ b/tests/unit/Shipping/Location/DadataApiClientTest.php
@@ -94,8 +94,11 @@ final class DadataApiClientTest extends TestCase {
 
 	// -------------------------------------------------------------------------
 	// Broadcast — the woodev_location_dadata_api_request_performed action must
-	// never carry the Clean secret in plaintext (P1 review finding: the base
-	// class's get_sanitized_request_headers() masks only Authorization).
+	// never carry the Clean secret in plaintext. Masking is now the base class's
+	// job (issue #288: Woodev_API_Base::get_sanitized_request_headers() masks
+	// every header named in get_secret_request_header_names(), which already
+	// includes X-Secret by default) — this client no longer needs its own
+	// override; these tests pin that the shared default still covers it.
 	// -------------------------------------------------------------------------
 
 	/**

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -294,15 +294,70 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			return $this->request_headers;
 		}
 
+		/**
+		 * Gets the sanitized request headers, for logging.
+		 *
+		 * Masks the VALUE of every header whose name (matched case-insensitively —
+		 * HTTP header names are case-insensitive) appears in
+		 * {@see self::get_secret_request_header_names()}, using the same convention
+		 * as before (`*` repeated to the value's original length). The original key
+		 * casing sent on the wire is preserved in the returned array; only the
+		 * comparison is case-insensitive.
+		 *
+		 * @since 2.0.2 masks every header from {@see self::get_secret_request_header_names()},
+		 *              not only `Authorization`.
+		 *
+		 * @return array<string, string>
+		 */
 		protected function get_sanitized_request_headers() {
 
 			$headers = $this->get_request_headers();
 
-			if ( ! empty( $headers['Authorization'] ) ) {
-				$headers['Authorization'] = str_repeat( '*', strlen( $headers['Authorization'] ) );
+			$secret_names = array_map( 'strtolower', $this->get_secret_request_header_names() );
+
+			foreach ( $headers as $name => $value ) {
+				if ( ! empty( $value ) && in_array( strtolower( (string) $name ), $secret_names, true ) ) {
+					$headers[ $name ] = str_repeat( '*', strlen( $value ) );
+				}
 			}
 
 			return $headers;
+		}
+
+		/**
+		 * Names of the request headers whose values carry a credential and must be
+		 * masked before {@see self::get_sanitized_request_headers()} hands the
+		 * request off to `woodev_{api_id}_api_request_performed` — the documented
+		 * action any attached request logger listens on.
+		 *
+		 * This is the extension point for an API client that authenticates with a
+		 * header other than `Authorization` (e.g. a vendor-specific API-secret
+		 * header): override this method in the subclass and return
+		 * `array_merge( parent::get_secret_request_header_names(), [ 'X-My-Header' ] )`
+		 * rather than overriding {@see self::get_sanitized_request_headers()} itself —
+		 * one extra name here is masked exactly like every other credential header,
+		 * with no risk of drifting from the shared masking logic.
+		 *
+		 * The default list covers `Authorization` (never regress this — the
+		 * payment-gateway tree shares this base class and its production request
+		 * logs depend on it staying masked) plus the header names real third-party
+		 * APIs are commonly seen using for a second credential.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<int, string>
+		 */
+		protected function get_secret_request_header_names(): array {
+			return [
+				'Authorization',
+				'Proxy-Authorization',
+				'Api-Key',
+				'X-Api-Key',
+				'X-Api-Secret',
+				'X-Auth-Token',
+				'X-Access-Token',
+				'X-Secret',
+			];
 		}
 
 		protected function get_request_user_agent() {

--- a/woodev/shipping-method/location/providers/class-dadata-api-client.php
+++ b/woodev/shipping-method/location/providers/class-dadata-api-client.php
@@ -147,40 +147,6 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Providers\\Dadata
 		}
 
 		/**
-		 * {@inheritDoc}
-		 *
-		 * The base class ({@see \Woodev_API_Base::get_sanitized_request_headers()})
-		 * masks only `Authorization` — it has no way to know this client also
-		 * sends the DaData "Clean" secret as a SEPARATE `X-Secret` header (see the
-		 * constructor). Left to the base implementation, that secret would ride
-		 * `woodev_{api_id}_api_request_performed`'s broadcast
-		 * ({@see \Woodev_API_Base::broadcast_request()}) in plaintext, reaching
-		 * every request logger attached to it. Masked here with the SAME
-		 * convention the base class uses for `Authorization` — same character
-		 * (`*`), same length (not a fixed-width placeholder) — rather than a
-		 * second, divergent masking style.
-		 *
-		 * This is a per-client patch, not a base-class fix: `Woodev_API_Base`
-		 * masks exactly one hard-coded header name, so any OTHER credential a
-		 * different client puts in a non-`Authorization` header has the same
-		 * hole. That base class is shared with the payment-gateway tree and is
-		 * out of this change's scope.
-		 *
-		 * @since 2.0.2
-		 *
-		 * @return array<string, string>
-		 */
-		protected function get_sanitized_request_headers() {
-			$headers = parent::get_sanitized_request_headers();
-
-			if ( ! empty( $headers['X-Secret'] ) ) {
-				$headers['X-Secret'] = str_repeat( '*', strlen( $headers['X-Secret'] ) );
-			}
-
-			return $headers;
-		}
-
-		/**
 		 * Address/locality suggestion lookup — `POST suggest/address`.
 		 *
 		 * @since 2.0.2


### PR DESCRIPTION
Решение оператора по карточке #288: варианты (1) + (2) вместе — инвертировать умолчание списком известных креденшл-заголовков И дать наследнику явную точку расширения для нестандартных.

## Что было

`Woodev_API_Base::broadcast_request()` отдаёт заголовки запроса в документированный экшен `woodev_{api_id}_api_request_performed`, то есть в любой подключённый логгер (обычно БД или файл). Санитайзер маскировал ровно один захардкоженный заголовок — `Authorization`. Любой креденшл, который карьер требует передавать иначе, уезжал в лог открытым текстом. Это не гипотеза: так и произошло с секретом DaData Clean-API в `X-Secret`.

## Что стало

Новый шов `get_secret_request_header_names(): array` с умолчанием из восьми имён (`Authorization`, `Proxy-Authorization`, `Api-Key`, `X-Api-Key`, `X-Api-Secret`, `X-Auth-Token`, `X-Access-Token`, `X-Secret`). `get_sanitized_request_headers()` сравнивает имена **регистронезависимо** (имена HTTP-заголовков регистронезависимы), но возвращает исходный регистр ключа и прежний стиль маски `str_repeat('*', strlen($value))` — формат лога не меняется, платёжное дерево не задето.

Локальное переопределение санитайзера в DaData-клиенте **удалено**: умолчание теперь покрывает его заголовок целиком, а дубль правки в наследнике — ровно тот дрейф, ради устранения которого карточка и заведена.

## Проверка

- unit: 1974 → **1979** тестов, 4963 → 4971 ассертов, зелено; phpcs и phpstan чисто
- Codex-ревью по ветке: находок нет

## Побочно заведено

**#300** — заголовки и тело ОТВЕТА уезжают в тот же экшен вообще без санитайзера (`get_response_data_for_broadcast()`); это другой вектор (секрет, который вернули нам), поэтому отдельной карточкой, а не расширением этой.

Closes #288