### PR TITLE
test(integration): маршрутные тесты сами устанавливают свои предусловия (#293)

### DIFF
--- a/tests/integration/Shipping/LocationRouteTest.php
+++ b/tests/integration/Shipping/LocationRouteTest.php
@@ -23,6 +23,26 @@ use WP_REST_Request;
 
 class LocationRouteTest extends TestCase {
 
+	/**
+	 * The DaData provider's own store-level token option — the ONLY thing
+	 * {@see \Woodev\Framework\Shipping\Location\Providers\Dadata_Provider::is_configured()}
+	 * (and therefore {@see \Woodev\Framework\Shipping\Location\Location_Service::is_active()})
+	 * checks once the registry gate is open (this file always opens it via
+	 * {@see self::activate_and_boot_rest()}).
+	 *
+	 * @var string
+	 */
+	private const OPTION_DADATA_TOKEN = 'woodev_location_token';
+
+	/**
+	 * The option's value as found at the start of THIS test, captured in
+	 * {@see self::setUp()} and restored in {@see self::tearDown()}. `false`
+	 * means the option did not exist at all.
+	 *
+	 * @var string|false
+	 */
+	private $original_dadata_token;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -30,11 +50,49 @@ class LocationRouteTest extends TestCase {
 		// and a prior test (or another declaring plugin loaded in wp-env) may
 		// already have opened it; reset so this test controls the gate itself.
 		Location_Provider_Registry::instance()->reset_for_tests();
+
+		// The rig environment may carry `woodev_location_token` already seeded
+		// by `Woodev_Test_Credential_Seeder` (tests/_fixtures/woodev-test-shipping-method/
+		// class-test-credential-seeder.php) from the rig's own WOODEV_TEST_DADATA_TOKEN
+		// wp-config constant — that seeding happens once, at fixture-plugin bootstrap,
+		// long before this test runs, and is idempotent (never re-seeds over a
+		// non-empty option), so it is never "reset" between tests by the environment
+		// itself. A test asserting INACTIVE-layer behaviour that merely relies on the
+		// CI container happening to have no token defined is fragile in ANY
+		// environment, CI included — the option is DB state, not something an env
+		// constant check can stand in for. Every test in this file therefore starts
+		// from a known, explicitly-neutralised baseline; a test that needs the ACTIVE
+		// path opts back in via self::make_location_layer_active().
+		$this->original_dadata_token = get_option( self::OPTION_DADATA_TOKEN, false );
+		delete_option( self::OPTION_DADATA_TOKEN );
 	}
 
 	protected function tearDown(): void {
+		if ( false === $this->original_dadata_token ) {
+			delete_option( self::OPTION_DADATA_TOKEN );
+		} else {
+			update_option( self::OPTION_DADATA_TOKEN, $this->original_dadata_token );
+		}
+
 		Location_Provider_Registry::instance()->reset_for_tests();
 		parent::tearDown();
+	}
+
+	/**
+	 * Opts a test back into the ACTIVE path: seeds a fake (never network-reaching)
+	 * token into the same option `Dadata_Provider::is_configured()` reads, making
+	 * `Location_Service::is_active()` true for the rest of this test. Safe on any
+	 * environment — nothing this file exercises with the layer active ever calls
+	 * the provider's own HTTP client, see
+	 * {@see self::test_select_with_a_valid_nonce_and_active_layer_persists_and_returns_200()}'s
+	 * own docblock for why `/select` in particular never does.
+	 *
+	 * @param string $token the fake token to seed.
+	 *
+	 * @return void
+	 */
+	private function make_location_layer_active( string $token = 'test-integration-token' ): void {
+		update_option( self::OPTION_DADATA_TOKEN, $token );
 	}
 
 	/**
@@ -114,8 +172,9 @@ class LocationRouteTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// 2. Guest access to /suggest (public read) — layer inactive (no provider
-	//    configured in this test env) degrades to 200 + empty, never a fatal.
+	// 2. Guest access to /suggest (public read) — layer inactive (own
+	//    precondition: setUp() neutralises OPTION_DADATA_TOKEN regardless of
+	//    what the environment seeded) degrades to 200 + empty, never a fatal.
 	// -------------------------------------------------------------------------
 
 	public function test_a_guest_can_call_suggest_and_it_never_fatals_with_no_provider_configured(): void {
@@ -148,8 +207,10 @@ class LocationRouteTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// 3. /select without a valid nonce is refused; the layer being inactive in
-	//    this test env means a well-nonced request still 404s rather than 500s.
+	// 3. /select without a valid nonce is refused; the layer being inactive
+	//    (own precondition, see setUp()) means a well-nonced request still
+	//    404s rather than 500s. The next section (4) proves the OTHER half —
+	//    a well-nonced request against an ACTIVE layer persists and 200s.
 	// -------------------------------------------------------------------------
 
 	public function test_select_without_a_nonce_is_refused(): void {
@@ -192,9 +253,59 @@ class LocationRouteTest extends TestCase {
 
 		$response = rest_get_server()->dispatch( $request );
 
-		// No DaData token is configured in this test environment, so
-		// Location_Service::is_active() is false — the write correctly 404s
-		// rather than persisting against an inactive layer or fataling.
+		// setUp() neutralised OPTION_DADATA_TOKEN, so Location_Service::is_active()
+		// is false regardless of what the environment seeded — the write correctly
+		// 404s rather than persisting against an inactive layer or fataling.
 		$this->assertSame( 404, $response->get_status() );
+	}
+
+	// -------------------------------------------------------------------------
+	// 4. /select with a valid nonce AND an active layer actually persists —
+	//    the ACTIVE-path counterpart to section 3, own precondition via
+	//    make_location_layer_active(), never dependent on what the rig/CI
+	//    environment happens to seed.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * `handle_select_request()` never calls the provider's own HTTP client —
+	 * {@see \Woodev\Framework\Shipping\Location\Location_Service::set_customer_record()}
+	 * is a thin pass-through to
+	 * {@see \Woodev\Framework\Shipping\Location\Customer_Location_Store::set()}, a
+	 * local WC session/customer-meta write — so seeding a FAKE token via
+	 * make_location_layer_active() is enough to prove the active path end to
+	 * end without ever reaching a third-party API (unlike `/suggest`, which
+	 * calls `$provider->suggest()` and is therefore intentionally NOT exercised
+	 * here in the active state).
+	 *
+	 * @return void
+	 */
+	public function test_select_with_a_valid_nonce_and_active_layer_persists_and_returns_200(): void {
+		$this->activate_and_boot_rest();
+		$this->make_location_layer_active();
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', '/woodev/v1/location/select' );
+		$request->set_param(
+			'record',
+			[
+				'key'         => 'dadata:fias-1',
+				'provider_id' => 'dadata',
+				'level'       => 'settlement',
+				'country'     => 'RU',
+			]
+		);
+		$request->add_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			[
+				'key'   => 'dadata:fias-1',
+				'level' => 'settlement',
+			],
+			$response->get_data()['current']
+		);
 	}
 }

--- a/tests/integration/Shipping/PickupRouteTest.php
+++ b/tests/integration/Shipping/PickupRouteTest.php
@@ -20,7 +20,9 @@
 
 namespace Woodev\Tests\Integration\Shipping;
 
+use ReflectionProperty;
 use Woodev\Framework\Shipping\Pickup\Point_Query;
+use Woodev\Framework\Shipping\Pickup\Point_Source;
 use Woodev\Framework\Shipping\Rest_Api\Pickup_Controller;
 use Woodev\Tests\Integration\TestCase;
 use WP_REST_Request;
@@ -37,7 +39,42 @@ class PickupRouteTest extends TestCase {
 	private const VIEWPORT_BBOX = '55.70,37.60,55.85,37.70';
 
 	/**
-	 * Set up — resolve the fixture plugin and assert it's loaded.
+	 * The ambient fixture plugin's `Pickup_Handler::$source` as found at the
+	 * start of THIS test, captured in {@see self::setUp()} and restored in
+	 * {@see self::tearDown()}.
+	 *
+	 * @var Point_Source
+	 */
+	private $original_ambient_point_source;
+
+	/**
+	 * Set up — resolve the fixture plugin, assert it's loaded, and pin the
+	 * ambient `/woodev/v1/shipping/pickup/woodev-test-shipping-method/points`
+	 * route onto a known, network-free `Point_Source`.
+	 *
+	 * The rig's `WOODEV_TEST_PICKUP_LIVE_YANDEX` / `WOODEV_TEST_PICKUP_LIVE_POCHTA` /
+	 * `WOODEV_TEST_PICKUP_STRATEGY` wp-config constants (precedence: LIVE_YANDEX >
+	 * LIVE_POCHTA > STRATEGY — see woodev-test-shipping-method.php's own
+	 * point-source-selection block) pick the fixture's `Point_Source` ONCE, at the
+	 * plugin's construction (bootstrap time, long before any test runs) — they are
+	 * plain PHP constants and cannot be flipped per test. Every test below that
+	 * talks to the ambient route (`test_a_guest_can_read_points()`,
+	 * `test_a_foreign_locality_returns_no_points()`,
+	 * `test_each_returned_point_carries_a_selectable_verdict()`,
+	 * `test_point_details_route_returns_a_known_point_and_404s_for_an_unknown_one()`)
+	 * assumes the STOCK bulk-fixture data (locality "Москва", point id
+	 * "FIX-BULK-1", …) — an assumption that silently depends on which constants
+	 * happen to be defined this run, and breaks (live-API 502s, or a live provider
+	 * that has simply never heard of "FIX-BULK-1") the moment the rig is pointed at
+	 * a live source. A test must never depend on a live third-party API, so this
+	 * establishes its own precondition instead: swap the handler's private
+	 * `$source` property (no public setter exists — production code has no reason
+	 * to swap it at runtime) to a fresh `Woodev_Test_Bulk_Point_Source`, then
+	 * rebuild the REST server so `Pickup_Handler::register_rest()` (hooked on
+	 * `rest_api_init`) re-registers `Pickup_Controller` bound to it — the exact
+	 * "null $wp_rest_server, then rest_get_server()" idiom
+	 * `LocationRouteTest::activate_and_boot_rest()` already uses to force a fresh
+	 * `rest_api_init` pass.
 	 *
 	 * @return void
 	 */
@@ -48,17 +85,59 @@ class PickupRouteTest extends TestCase {
 			function_exists( 'woodev_test_shipping_method_plugin' ),
 			'woodev_test_shipping_method_plugin() must exist — the shipping fixture plugin must be active in wp-env.'
 		);
+
+		$this->original_ambient_point_source = $this->ambient_point_source();
+		$this->force_ambient_point_source( new \Woodev_Test_Bulk_Point_Source() );
 	}
 
 	/**
 	 * Removes any $_POST leftovers from a payment-method test so it cannot leak
-	 * into a later test in the same process.
+	 * into a later test in the same process, and restores the ambient fixture
+	 * plugin's original `Point_Source` (see {@see self::setUp()}).
 	 *
 	 * @return void
 	 */
 	protected function tearDown(): void {
 		unset( $_POST['payment_method'] );
+
+		$this->force_ambient_point_source( $this->original_ambient_point_source );
+
 		parent::tearDown();
+	}
+
+	/**
+	 * Reads the ambient fixture plugin's current `Pickup_Handler::$source` via
+	 * reflection — see {@see self::setUp()} for why no public accessor exists.
+	 *
+	 * @return Point_Source
+	 */
+	private function ambient_point_source(): Point_Source {
+		$handler  = woodev_test_shipping_method_plugin()->get_pickup_handler();
+		$property = new ReflectionProperty( $handler, 'source' );
+		$property->setAccessible( true );
+
+		return $property->getValue( $handler );
+	}
+
+	/**
+	 * Swaps the ambient fixture plugin's `Pickup_Handler::$source` and rebuilds
+	 * the REST server so the swap takes effect — see {@see self::setUp()} for the
+	 * full reasoning.
+	 *
+	 * @param Point_Source $source the source the ambient route should serve.
+	 *
+	 * @return void
+	 */
+	private function force_ambient_point_source( Point_Source $source ): void {
+		$handler  = woodev_test_shipping_method_plugin()->get_pickup_handler();
+		$property = new ReflectionProperty( $handler, 'source' );
+		$property->setAccessible( true );
+		$property->setValue( $handler, $source );
+
+		do_action( 'rest_api_init' );
+
+		$GLOBALS['wp_rest_server'] = null;
+		rest_get_server();
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Карточка #293: локальный `Integration` красный на машине оператора и зелёный на CI, потому что контейнер `tests` (`:8974`) нёс те же риг-константы, что и `dev`.

## Две половины

**Окружение (сделано вне этого PR, файл gitignored).** Константы `WOODEV_TEST_*` удалены из tests-контейнера через `wp config delete`; `dev` не тронут — риг по-прежнему на живом Яндексе с токеном DaData. Попутный замер: `.wp-env.override.json` оказался лишь **зеркалом**, а авторитет — `wp config set` в самом контейнере, поэтому разнесение по секциям `env.development` в файле само по себе ничего не изменило.

**Тесты (этот PR).** Тест не должен наследовать состояние окружения ни в каком контейнере:

- `LocationRouteTest` — `Location_Service::is_active()` сводится к `Dadata_Provider::is_configured()`, то есть к опции `woodev_location_token` (состояние БД, засеваемое фикстурным `Woodev_Test_Credential_Seeder`). `setUp()`/`tearDown()` теперь снимают и восстанавливают эту опцию вокруг каждого теста, так что оба теста НЕАКТИВНОГО слоя держатся детерминированно. Активный путь получил собственный явный засев и новый тест на персист `/select`, чтобы покрытие не потерялось.
- `PickupRouteTest` — источник точек выбирается один раз при конструировании плагина из констант, то есть переключить его на тест штатно нечем. Тесты подменяют `Pickup_Handler::$source` рефлексией на фикстурный `Woodev_Test_Bulk_Point_Source` и пересобирают REST-сервер тем же идиомом, который уже используется в `LocationRouteTest::activate_and_boot_rest()`. **Тест больше не ходит в живой сторонний API** — это не подавление шума, а настоящая починка покрытия.

## Что проверено, а что нет — честно

- phpcs 211/211 чисто, phpstan без ошибок, unit 1974 зелёных.
- **Живой интеграционный прогон не выполнен исполнителем**: контейнеры wp-env привязаны к главному дереву, которое было занято другой веткой. Проверю отдельным прогоном перед мерджем и допишу результат сюда.

Closes #293