### PR TITLE
fix(pickup): не обещать повтор действия, которым управляет карьер (#297)

### DIFF
--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -610,6 +610,9 @@ function phpI18n( overrides ) {
 			continueCheckout: 'Продолжить оформление заказа',
 			confirming: 'Проверяем…',
 			selectFailed: 'Не удалось подтвердить выбор. Попробуйте ещё раз.',
+			// #297: the `ownsChrome` counterpart of `selectFailed` above — never promises a
+			// repeat of the carrier's own (possibly now-disabled) confirm press.
+			selectFailedEmbedded: 'Не удалось подтвердить выбор. Выберите пункт ещё раз.',
 		},
 		overrides
 	);
@@ -5921,7 +5924,10 @@ describe( 'refusal is announced under ownsChrome (#265)', () => {
 
 		await rejectSelect( { status: 0, code: 'transport', message: 'нет сети' } );
 
-		expect( noticeText() ).toContain( phpI18n().selectFailed );
+		// #297: under `ownsChrome` this is `selectFailedEmbedded`, NOT the framework-panels
+		// `selectFailed` — see the dedicated describe block below for the full audit.
+		expect( noticeText() ).toContain( phpI18n().selectFailedEmbedded );
+		expect( noticeText() ).not.toContain( phpI18n().selectFailed );
 	} );
 
 	it( 'announces a domain refusal in the domain’s own words when it supplied any', async () => {
@@ -5979,6 +5985,7 @@ describe( 'refusal is announced under ownsChrome (#265)', () => {
 		// different instruction to the customer than "try again".
 		expect( noticeText() ).toContain( phpI18n().stalePage );
 		expect( noticeText() ).not.toContain( phpI18n().selectFailed );
+		expect( noticeText() ).not.toContain( phpI18n().selectFailedEmbedded );
 	} );
 
 	it( 'does NOT double-report when panels exist — that path is unchanged', async () => {
@@ -5990,5 +5997,46 @@ describe( 'refusal is announced under ownsChrome (#265)', () => {
 
 		expect( panels.setPointVerdict ).toHaveBeenCalled();
 		expect( notice() ).toBeNull();
+	} );
+} );
+
+/**
+ * #297 — under `ownsChrome`, `selectFailed`'s "Попробуйте ещё раз" invited the customer to
+ * repeat a press the carrier's own widget had already made impossible: Почта's confirm control
+ * (measured on the rig, s70) disables itself the instant it is pressed and never re-enables, so
+ * the customer who read the message and pressed again got nothing — same shape of promise as
+ * #260/#265, one layer further in.
+ *
+ * The fix is `selectionErrorKey()` reading `ownsChrome` (never controlling the carrier's own
+ * button, per D-3 — see that function's own docblock): `selectFailedEmbedded` under `ownsChrome`,
+ * the unchanged `selectFailed` everywhere else. Both directions are asserted here — a fix that
+ * only checked the `ownsChrome` branch could pass against a gate reading the flag backwards.
+ */
+describe( 'transport-failure copy never promises a retry the carrier controls (#297)', () => {
+	function noticeText() {
+		const el = document.querySelector( '.woodev-modal__notice' );
+
+		return el ? el.textContent : '';
+	}
+
+	it( 'shows the no-retry copy under ownsChrome, where the confirm control is the carrier’s own', async () => {
+		const { emitSelect, rejectSelect } = openPicker( { ownsChrome: true } );
+		await flushAsync();
+
+		emitSelect( { id: 'P1' } );
+		await rejectSelect( { status: 500, code: 'woodev_pickup_upstream_error', message: 'boom' } );
+
+		expect( noticeText() ).toContain( phpI18n().selectFailedEmbedded );
+		expect( noticeText() ).not.toContain( phpI18n().selectFailed );
+	} );
+
+	it( 'keeps the original retry copy under the framework’s own panels, where the CTA is ours', async () => {
+		const { emitSelect, rejectSelect, panels } = openPicker();
+		await flushAsync();
+
+		emitSelect( { id: 'P1' } );
+		await rejectSelect( { status: 500, code: 'woodev_pickup_upstream_error', message: 'boom' } );
+
+		expect( panels.showSelectionError ).toHaveBeenCalledWith( phpI18n().selectFailed );
 	} );
 } );

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1319,18 +1319,18 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 		}
 
 		/**
-		 * The three confirmation strings (Task 4) the CTA's busy/failure states read by name.
-		 * A missing key here renders BLANK under a button the customer just pressed, so
-		 * presence AND non-emptiness are both asserted — the same contract the panel keys
-		 * carry.
+		 * The confirmation strings (Task 4, plus #297's `selectFailedEmbedded`) the CTA's
+		 * busy/failure states read by name. A missing key here renders BLANK under a button
+		 * the customer just pressed, so presence AND non-emptiness are both asserted — the
+		 * same contract the panel keys carry.
 		 */
-		public function test_config_i18n_carries_the_three_confirmation_strings(): void {
+		public function test_config_i18n_carries_the_confirmation_strings(): void {
 			Functions\when( 'apply_filters' )->returnArg( 2 );
 			$this->stub_config_dependencies_except_filters();
 
 			$i18n = $this->make_handler()->get_js_config()['i18n'];
 
-			foreach ( [ 'confirming', 'selectFailed', 'stalePage' ] as $key ) {
+			foreach ( [ 'confirming', 'selectFailed', 'selectFailedEmbedded', 'stalePage' ] as $key ) {
 				$this->assertArrayHasKey( $key, $i18n, "i18n is missing the \"{$key}\" confirmation key" );
 				$this->assertNotSame( '', $i18n[ $key ], "i18n[\"{$key}\"] must not be empty" );
 			}
@@ -1338,6 +1338,16 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			// `selectFailed` is deliberately NOT the generic `error` string: that one is
 			// written for a failed points FETCH and would be misleading under a confirm button.
 			$this->assertNotSame( $i18n['error'], $i18n['selectFailed'] );
+
+			// #297: `selectFailedEmbedded` is the `ownsChrome` counterpart of `selectFailed` and
+			// must actually say something different -- the whole point is that it stops
+			// promising a repeat of the carrier's own confirm press.
+			$this->assertNotSame( $i18n['selectFailed'], $i18n['selectFailedEmbedded'] );
+			$this->assertStringNotContainsString(
+				'Попробуйте ещё раз',
+				$i18n['selectFailedEmbedded'],
+				'selectFailedEmbedded must not promise a retry the ownsChrome customer cannot make'
+			);
 		}
 
 		public function test_config_rest_root_uses_the_sanitized_plugin_segment(): void {
@@ -2442,6 +2452,9 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 				// questions, two independently released locks -- see `setVerdictPending()`.
 				'checkingAvailability' => 'Проверяем доступность…',
 				'selectFailed'     => 'Не удалось подтвердить выбор. Попробуйте ещё раз.',
+				// #297: the `ownsChrome` counterpart — never promises a repeat of an action the
+				// carrier's own widget (not the framework) controls. See class-pickup-handler.php.
+				'selectFailedEmbedded' => 'Не удалось подтвердить выбор. Выберите пункт ещё раз.',
 				'stalePage'        => 'Страница устарела. Обновите её и выберите пункт выдачи заново.',
 			];
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -623,12 +623,28 @@
 	 * string, which is written for a failed points FETCH ("не удалось загрузить пункты") and
 	 * would be actively misleading under a button the customer just pressed to confirm one.
 	 *
+	 * `ownsChrome` picks between `selectFailed` ("Попробуйте ещё раз") and its embedded
+	 * counterpart `selectFailedEmbedded` (#297) — NOT between two spellings of the same idea.
+	 * Under the framework's own panels the confirm CTA is the framework's OWN button, alive
+	 * again the moment {@see releaseSelectionBusy} runs, so "try again" describes a real,
+	 * available action. Under `ownsChrome` the confirm control belongs to the carrier's own
+	 * widget — measured on Почта's, s70: it disables itself the instant it is pressed and
+	 * never re-enables — so the SAME words would invite the customer to repeat a press they no
+	 * longer have. `stalePage` is exempt from this split on purpose: reloading the page is
+	 * available in both modes alike, so it never needed a second spelling.
+	 *
 	 * @param {Object}      config
-	 * @param {Object|null} reason `{ status, code, message }`.
+	 * @param {Object|null} reason     `{ status, code, message }`.
+	 * @param {boolean}     ownsChrome whether the framework draws no chrome of its own for
+	 *                                 this session (see {@see openSession}'s own `ownsChrome`).
 	 * @returns {string}
 	 */
-	function selectionErrorKey( config, reason ) {
-		return 'stalePage' === errorMessageKey( config, reason ) ? 'stalePage' : 'selectFailed';
+	function selectionErrorKey( config, reason, ownsChrome ) {
+		if ( 'stalePage' === errorMessageKey( config, reason ) ) {
+			return 'stalePage';
+		}
+
+		return ownsChrome ? 'selectFailedEmbedded' : 'selectFailed';
 	}
 
 	/**
@@ -2691,12 +2707,17 @@
 				// Transport failure: nothing about the point was refused, so nothing is
 				// remembered and the CTA stays alive (spec D-6/D-7).
 				if ( panels ) {
-					panels.showSelectionError( text( config, selectionErrorKey( config, reason ) ) );
+					panels.showSelectionError( text( config, selectionErrorKey( config, reason, false ) ) );
 				} else {
 					// #265: with no panels (`ownsChrome`) this branch used to be entirely
 					// silent — the customer pressed «Забрать здесь», waited out the round
 					// trip, watched #260's overlay clear, and got nothing at all.
-					announceWithoutPanels( text( config, selectionErrorKey( config, reason ) ) );
+					//
+					// `ownsChrome: true` here (#297) is what picks `selectFailedEmbedded` over
+					// `selectFailed` — see {@see selectionErrorKey}'s own docblock for why the
+					// same "Попробуйте ещё раз" wording is wrong under a carrier widget whose
+					// confirm control does not come back.
+					announceWithoutPanels( text( config, selectionErrorKey( config, reason, true ) ) );
 				}
 
 				return;

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -1219,6 +1219,21 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 					'Не удалось подтвердить выбор. Попробуйте ещё раз.',
 					'woodev-plugin-framework'
 				),
+				// #297: the `ownsChrome` counterpart of `selectFailed` above. Under an embedded
+				// provider the confirm control belongs to the carrier's own widget — Почта's, the
+				// case that surfaced this, disables it the instant it is pressed and never
+				// re-enables it — so "Попробуйте ещё раз" invites the customer to repeat an action
+				// they no longer have. The RULE this encodes is general, not a Почта workaround:
+				// under `ownsChrome` the framework must never promise a repeat of an action it does
+				// not control. This string points at what stays available instead — the carrier's
+				// list/map is still live, only that one confirm press failed — never at retrying
+				// the confirm itself. `finishSelection()`'s no-panels branch is the only caller
+				// (see {@see selectionErrorKey()} on the JS side, which picks this key over
+				// `selectFailed` precisely when `panels` is null).
+				'selectFailedEmbedded' => __(
+					'Не удалось подтвердить выбор. Выберите пункт ещё раз.',
+					'woodev-plugin-framework'
+				),
 				// A 403 on the select route is not the customer's fault and not retryable in
 				// place — the page's nonce has outlived the session it was minted for.
 				'stalePage'        => __(


### PR DESCRIPTION
Карточка #297, вариант 1 (решение оператора): под `ownsChrome` текст должен звать к действию, которое покупателю доступно.

## Наблюдение (риг, живой виджет Почты, s70)

Виджет Почты сам блокирует свою кнопку «Забрать здесь» сразу после нажатия и не разблокирует её на этой карточке. А транспортная ветка показывала: «Не удалось подтвердить выбор. **Попробуйте ещё раз.**» — то есть фреймворк предлагал повторить действие, которого у покупателя больше нет.

Это не дефект #277: до него обе ветки отказа под `ownsChrome` молчали вовсе. Сообщение строго лучше молчания, и следующий слой стал виден только потому, что оно появилось.

## Аудит, а не одна строка

Проверены ВСЕ строки, достижимые под `ownsChrome`:

| Строка | Достижима под `ownsChrome` | Обещает недоступный повтор | Изменена |
|---|---|---|---|
| `selectFailed` | да | **да** | **да** → новый ключ `selectFailedEmbedded` |
| `stalePage` | да | нет — обещает перезагрузку страницы, она доступна всегда | нет |
| `blocked` | да | нет — чисто описательная | нет |
| `result.reason` | да | не наша — приходит с сервера | нет |
| `error` / `upstreamError` / `rateLimited` / `notFound` (путь fetch) | **нет** — под `ownsChrome` панелей и запроса листинга не бывает | — | нет |
| те же по событию `error` провайдера | да | нет — кнопка повтора здесь **наша собственная** (`start()`), не карьера | нет |
| `detailsError` | нет — ключ PHP без потребителя в JS | — | нет |

То есть менять понадобилось ровно одну строку, но узнать это можно было только аудитом: три из семи путей ведут к НАШЕЙ работающей кнопке повтора, и заменить там текст было бы регрессией.

## Правило, а не обход Почты

В комментарии PHP и докблоке JS зафиксировано: **под `ownsChrome` не обещать повтор действия, которым мы не управляем.** Блокировка кнопки — свойство Почты, а не контракт embedded-режима; другой карьер может вести себя иначе. Управлять чужим UI по-прежнему нельзя (D-3).

Формулировка: «Не удалось подтвердить выбор. Выберите пункт ещё раз.»

## Проверка

- unit 1974 / 4972 ассертов, jest **1001**, phpcs и phpstan чисто
- jest пинует обе стороны: под `ownsChrome` новый текст, под нашими панелями прежний
- **Не проверено на риге**: нужен embedded-режим и искусственный отказ живого карьера — ровно та причина, по которой и #277 не проверялся. Текст твой собственный из карточки, но глянуть стоит.

Closes #297