### PR TITLE
feat(location): режимы поля и арбитраж уровня «регион» — серверная половина (задача 13, #294)

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/class-test-list-location-provider.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-list-location-provider.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Woodev_Test_List_Location_Provider — the rig's `list`-capable fixture Location_Provider.
+ *
+ * Location Provider layer, Task 13 (docs-internal/plans/2026-08-12-location-provider-plan.md,
+ * spec D7): the bundled {@see \Woodev\Framework\Shipping\Location\Providers\Dadata_Provider}
+ * has NO {@see \Woodev\Framework\Shipping\Location\Location_Provider::CAPABILITY_LIST}
+ * capability — DaData is a query-driven API, it cannot enumerate — so `related-list` and
+ * `ajax-select2` field modes are never offered on a DaData-only store and both the unit suite
+ * and the rig need a fake provider that CAN enumerate to exercise those modes at all.
+ *
+ * Deliberately tiny, static, fixture-shaped data — this is not a real dictionary, it exists to
+ * make {@see self::list_localities()} observably work: two RU regions, with a couple of
+ * settlements enumerable within each once a region is chosen. `suggest()` is implemented too
+ * (required of every provider) as a trivial case-insensitive substring match over the SAME
+ * static data, so this provider is usable as the active provider outright, not merely as a
+ * `list`-only add-on.
+ *
+ * Registered via the {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::FILTER_PROVIDERS}
+ * filter — see `woodev_test_shipping_method_plugin_init()`'s own wiring — NOT made active by
+ * default: the store's `active_provider` setting still defaults to `dadata`
+ * ({@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::DEFAULT_PROVIDER_ID}),
+ * so an operator opts into it explicitly on the "Локация" settings page to see `related-list`/
+ * `ajax-select2` on the rig.
+ *
+ * Required/declared HERE (inside the plugin's own init callback), not at file top level — same
+ * reasoning as `class-test-location-adapter.php`'s own docblock (gotcha
+ * `fixture-classes-must-live-inside-plugin-init`): `Abstract_Location_Provider` is only
+ * autoloadable once `Woodev_Plugin_Bootstrap` has selected the highest-version framework copy
+ * and registered its autoloader.
+ *
+ * @package Woodev_Test_Shipping_Method
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Woodev_Test_List_Location_Provider' ) ) {
+
+	/**
+	 * Class Woodev_Test_List_Location_Provider
+	 */
+	class Woodev_Test_List_Location_Provider extends \Woodev\Framework\Shipping\Location\Abstract_Location_Provider {
+
+		/**
+		 * Provider id — the {@see \Woodev\Framework\Shipping\Location\Locality_Key}
+		 * namespace prefix every record this fixture produces carries.
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const PROVIDER_ID = 'test-list';
+
+		/**
+		 * Static region data: `native_id => name`. Fixture-shaped, not a real
+		 * dictionary.
+		 *
+		 * @since 2.0.2
+		 * @var array<string, string>
+		 */
+		private const REGIONS = [
+			'mo' => 'Московская область',
+			'lo' => 'Ленинградская область',
+		];
+
+		/**
+		 * Static settlement data per region: `region_native_id => [ native_id => name ]`.
+		 *
+		 * @since 2.0.2
+		 * @var array<string, array<string, string>>
+		 */
+		private const SETTLEMENTS = [
+			'mo' => [
+				'moscow'     => 'Москва',
+				'zelenograd' => 'Зеленоград',
+			],
+			'lo' => [
+				'spb'    => 'Санкт-Петербург',
+				'pushkin' => 'Пушкин',
+			],
+		];
+
+		/**
+		 * @inheritDoc
+		 *
+		 * @since 2.0.2
+		 */
+		public function get_id(): string {
+			return self::PROVIDER_ID;
+		}
+
+		/**
+		 * @inheritDoc
+		 *
+		 * @since 2.0.2
+		 */
+		public function get_name(): string {
+			return __( 'Тестовый список (Task 13, только для рига)', 'woodev-plugin-framework' );
+		}
+
+		/**
+		 * @inheritDoc
+		 *
+		 * @since 2.0.2
+		 */
+		public function get_countries(): array {
+			return [ 'RU' ];
+		}
+
+		/**
+		 * @inheritDoc
+		 *
+		 * @since 2.0.2
+		 */
+		protected function declare_suggest_levels(): array {
+			return [
+				\Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION,
+				\Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT,
+			];
+		}
+
+		/**
+		 * @inheritDoc
+		 *
+		 * Trivial case-insensitive substring match over the same static data
+		 * {@see self::list_localities()} enumerates — a real provider would call
+		 * out to its own API; this fixture never does any I/O.
+		 *
+		 * @since 2.0.2
+		 */
+		public function suggest( string $query, \Woodev\Framework\Shipping\Location\Location_Scope $scope ): array {
+			$needle = mb_strtolower( trim( $query ) );
+
+			if ( '' === $needle ) {
+				return [];
+			}
+
+			$matches = [];
+
+			foreach ( $this->list_localities( $scope ) as $record ) {
+				$name = \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION === $record->level()
+					? ( $record->region()['name'] ?? '' )
+					: ( $record->settlement()['name'] ?? '' );
+
+				if ( false !== mb_strpos( mb_strtolower( $name ), $needle ) ) {
+					$matches[] = $record;
+				}
+			}
+
+			return $matches;
+		}
+
+		/**
+		 * @inheritDoc
+		 *
+		 * Region-level scope (no parent — `region` is never given one, spec
+		 * {@see \Woodev\Framework\Shipping\Location\Location_Scope::within()}):
+		 * every fixture region. Settlement-level scope: the settlements under the
+		 * parent region named by {@see \Woodev\Framework\Shipping\Location\Location_Scope::parent_record()}
+		 * (falling back to {@see \Woodev\Framework\Shipping\Location\Location_Scope::parent_components()}'s
+		 * `region.name`-derived native id when the caller supplied raw components
+		 * instead of a record) — or nothing when no parent constraint narrows to a
+		 * known region. `address` level: this fixture has no street data, matching
+		 * the "list is region/settlement only" shape the plan's Task 13 description
+		 * uses CDEK's own dictionary as a reference for.
+		 *
+		 * @since 2.0.2
+		 */
+		public function list_localities( \Woodev\Framework\Shipping\Location\Location_Scope $scope ): array {
+			if ( \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION === $scope->level() ) {
+				return $this->region_records();
+			}
+
+			if ( \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT === $scope->level() ) {
+				return $this->settlement_records_for( $scope );
+			}
+
+			return [];
+		}
+
+		/**
+		 * Builds every fixture region as a {@see \Woodev\Framework\Shipping\Location\Location_Record}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return \Woodev\Framework\Shipping\Location\Location_Record[]
+		 */
+		private function region_records(): array {
+			$records = [];
+
+			foreach ( self::REGIONS as $native_id => $name ) {
+				$records[] = \Woodev\Framework\Shipping\Location\Location_Record::from_array(
+					[
+						'key'         => self::PROVIDER_ID . ':' . $native_id,
+						'provider_id' => self::PROVIDER_ID,
+						'level'       => \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION,
+						'country'     => 'RU',
+						'region'      => [ 'name' => $name, 'type' => 'область' ],
+						'label'       => $name,
+					]
+				);
+			}
+
+			return $records;
+		}
+
+		/**
+		 * Builds the settlement records for the region `$scope` is narrowed to, or
+		 * `[]` when the scope names no region this fixture recognizes.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param \Woodev\Framework\Shipping\Location\Location_Scope $scope Settlement-level scope.
+		 *
+		 * @return \Woodev\Framework\Shipping\Location\Location_Record[]
+		 */
+		private function settlement_records_for( \Woodev\Framework\Shipping\Location\Location_Scope $scope ): array {
+			$region_native_id = $this->region_native_id_from_scope( $scope );
+
+			if ( null === $region_native_id || ! isset( self::SETTLEMENTS[ $region_native_id ] ) ) {
+				return [];
+			}
+
+			$region_name = self::REGIONS[ $region_native_id ];
+			$records     = [];
+
+			foreach ( self::SETTLEMENTS[ $region_native_id ] as $native_id => $name ) {
+				$records[] = \Woodev\Framework\Shipping\Location\Location_Record::from_array(
+					[
+						'key'         => self::PROVIDER_ID . ':' . $native_id,
+						'provider_id' => self::PROVIDER_ID,
+						'level'       => \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT,
+						'country'     => 'RU',
+						'region'      => [ 'name' => $region_name, 'type' => 'область' ],
+						'settlement'  => [ 'name' => $name, 'type' => 'г' ],
+						'label'       => $name,
+					]
+				);
+			}
+
+			return $records;
+		}
+
+		/**
+		 * Resolves the region native id a scope's parent constraint names, in
+		 * either shape {@see \Woodev\Framework\Shipping\Location\Location_Scope}
+		 * carries a parent (a full record's own key, or raw `region.name`
+		 * components) — `null` when the scope has no parent, or the parent does
+		 * not match a fixture region this provider knows about.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param \Woodev\Framework\Shipping\Location\Location_Scope $scope Settlement-level scope.
+		 *
+		 * @return string|null
+		 */
+		private function region_native_id_from_scope( \Woodev\Framework\Shipping\Location\Location_Scope $scope ): ?string {
+			$parent_record = $scope->parent_record();
+
+			if ( null !== $parent_record ) {
+				[ $provider_id, $native_id ] = \Woodev\Framework\Shipping\Location\Locality_Key::parse( $parent_record->key() );
+
+				return self::PROVIDER_ID === $provider_id && isset( self::REGIONS[ $native_id ] ) ? $native_id : null;
+			}
+
+			$components = $scope->parent_components();
+			$region     = $components['region']['name'] ?? null;
+
+			if ( null === $region ) {
+				return null;
+			}
+
+			$match = array_search( $region, self::REGIONS, true );
+
+			return false !== $match ? (string) $match : null;
+		}
+	}
+}

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -310,6 +310,28 @@ function woodev_test_shipping_method_plugin_init(): void {
 	require_once __DIR__ . '/class-test-location-adapter.php';
 	require_once __DIR__ . '/class-test-credential-seeder.php';
 
+	// Task 13: the `list`-capable fixture provider — the bundled DaData provider has no
+	// `list` capability at all, so tests and the rig need a fake that DOES enumerate to
+	// exercise `related-list`/`ajax-select2` field modes. Required unconditionally, same
+	// reasoning as the two requires just above.
+	require_once __DIR__ . '/class-test-list-location-provider.php';
+
+	// Registers the fixture provider alongside the bundled DaData one — NOT made active
+	// by default (the store's `active_provider` setting still defaults to `dadata`), an
+	// operator opts in explicitly on the "Локация" settings page to see `related-list`/
+	// `ajax-select2` on the rig. Safe to register the closure here regardless of the
+	// bootstrap's own loading stage (see the `woodev_shipping_pickup_point_selection`
+	// filter registration further down in this file for the identical reasoning:
+	// registering a callback does not INVOKE it).
+	add_filter(
+		\Woodev\Framework\Shipping\Location\Location_Provider_Registry::FILTER_PROVIDERS,
+		static function ( array $providers ): array {
+			$providers[] = new Woodev_Test_List_Location_Provider();
+
+			return $providers;
+		}
+	);
+
 	if ( ! class_exists( 'Woodev_Test_Viewport_Point_Source' ) ) {
 
 		/**

--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -138,7 +138,7 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 		return $this->mode;
 	}
 
-	public function owns_region_states( string $country ): bool {
+	public function owns_region_states( string $country, array $final_states ): bool {
 		return in_array( $country, $this->owned_region_countries, true );
 	}
 
@@ -839,5 +839,69 @@ class CheckoutConfigTest extends TestCase {
 			->build( Checkout_Fields::from_array( [] ) );
 
 		$this->assertTrue( $config['location']['levels']['RU']['region'] );
+	}
+
+	/**
+	 * PR #304 review finding 1 (CRITICAL): `WC_Countries::get_states( $cc )`
+	 * returns `false` — not `[]` — when the country key is absent
+	 * (`includes/class-wc-countries.php`), and `(array) false === [ 0 => false ]`,
+	 * which is NON-empty. Every other test in this file exercises `wc_states()`
+	 * either through the `config_with_states()` Probe subclass's OVERRIDE
+	 * (never running the real method body at all) or through the
+	 * `function_exists( 'WC' ) === false` degradation branch above (never
+	 * reaching the `WC()->countries->get_states()` call either) — neither one
+	 * runs the real cast/filter logic this test pins.
+	 *
+	 * Isolated in its own process (`@runInSeparateProcess`, same idiom as
+	 * `FrameworkResolverTest`/`BootstrapRegistrationTest` elsewhere in this
+	 * suite): Brain Monkey must actually DECLARE a global `WC()` function to
+	 * stub it, and PHP cannot un-declare a function once declared — stubbing
+	 * `WC()` here would otherwise permanently poison every other test in the
+	 * suite relying on `function_exists( 'WC' ) === false` (measured directly,
+	 * see `wc_states()`'s own docblock: a first version of that method calling
+	 * `WC()` inline broke 21 unrelated tests the moment `composer test:unit`
+	 * ran the whole suite in one process).
+	 *
+	 * The mutant this pins: reverting `wc_states()`'s
+	 * `array_filter( (array) WC()->countries->get_states( $country ) )` back to
+	 * the bare `(array) WC()->countries->get_states( $country )` cast turns
+	 * `false` into `[ 0 => false ]` — non-empty — so `states_present` would be
+	 * `true` and this assertion would flip to `false`.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_wc_states_degrades_a_false_get_states_result_to_states_present_false(): void {
+		$countries = new class() {
+			/**
+			 * @param string $country ISO-3166 alpha-2 country code.
+			 *
+			 * @return false Mirrors `WC_Countries::get_states()`'s own contract
+			 *               for a country nothing is registered under.
+			 */
+			public function get_states( string $country ) {
+				return false;
+			}
+		};
+		$wc = new class( $countries ) {
+			public $countries;
+
+			public function __construct( $countries ) {
+				$this->countries = $countries;
+			}
+		};
+
+		Functions\when( 'WC' )->justReturn( $wc );
+
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'region' => true, 'settlement' => true, 'address' => true ], null, [ 'RU' ] );
+		// The REAL Checkout_Config — not the config_with_states() Probe — so
+		// wc_states()'s real body (the array_filter/(array) cast) actually runs.
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertTrue(
+			$config['location']['levels']['RU']['region'],
+			'a WC states read of `false` must degrade to states_present=false, not a false-positive conflict'
+		);
 	}
 }

--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -79,23 +79,43 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 	/** @var string[] */
 	private array $countries;
 
+	/** @var string Task 13: get_field_mode() return value. */
+	private string $mode;
+
+	/** @var string[] Task 13/issue #294: countries owns_region_states() reports true for. */
+	private array $owned_region_countries;
+
 	/**
-	 * @param bool                                                             $active           is_active() return value.
-	 * @param array<string, bool>                                              $supported_levels level => whether SOME configured provider serves it,
-	 *                                                                                             for EVERY country in $countries (this fake does not
-	 *                                                                                             model per-country level variance — LocationServiceTest
-	 *                                                                                             covers that against the real Dadata_Provider).
-	 * @param array{record: Location_Record, implicit: bool, saved_at: int}|null $customer        get_customer_record() return value.
-	 * @param string[]                                                          $countries        the layer's own supported-country set — what
-	 *                                                                                             get_supported_countries() (D15 gate fix, block
-	 *                                                                                             PR-B: the UNION across the chain, no longer a
-	 *                                                                                             single active-provider list) reports.
+	 * @param bool                                                             $active                 is_active() return value.
+	 * @param array<string, bool>                                              $supported_levels       level => whether SOME configured provider serves it,
+	 *                                                                                                   for EVERY country in $countries (this fake does not
+	 *                                                                                                   model per-country level variance — LocationServiceTest
+	 *                                                                                                   covers that against the real Dadata_Provider).
+	 * @param array{record: Location_Record, implicit: bool, saved_at: int}|null $customer              get_customer_record() return value.
+	 * @param string[]                                                          $countries              the layer's own supported-country set — what
+	 *                                                                                                   get_supported_countries() (D15 gate fix, block
+	 *                                                                                                   PR-B: the UNION across the chain, no longer a
+	 *                                                                                                   single active-provider list) reports.
+	 * @param string                                                            $mode                   Task 13: get_field_mode() return value; defaults to
+	 *                                                                                                   the pre-Task-13 hardcoded constant so every existing
+	 *                                                                                                   call site is unaffected.
+	 * @param string[]                                                          $owned_region_countries Task 13/issue #294: countries owns_region_states()
+	 *                                                                                                   reports `true` for.
 	 */
-	public function __construct( bool $active, array $supported_levels, ?array $customer, array $countries ) {
-		$this->active           = $active;
-		$this->supported_levels = $supported_levels;
-		$this->customer         = $customer;
-		$this->countries        = $countries;
+	public function __construct(
+		bool $active,
+		array $supported_levels,
+		?array $customer,
+		array $countries,
+		string $mode = Location_Provider_Registry::MODE_TYPEAHEAD,
+		array $owned_region_countries = []
+	) {
+		$this->active                 = $active;
+		$this->supported_levels       = $supported_levels;
+		$this->customer                = $customer;
+		$this->countries               = $countries;
+		$this->mode                    = $mode;
+		$this->owned_region_countries = $owned_region_countries;
 	}
 
 	public function is_active(): bool {
@@ -112,6 +132,14 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 
 	public function get_supported_countries(): array {
 		return $this->countries;
+	}
+
+	public function get_field_mode(): string {
+		return $this->mode;
+	}
+
+	public function owns_region_states( string $country ): bool {
+		return in_array( $country, $this->owned_region_countries, true );
 	}
 
 	public function get_levels_for_country( string $country ): array {
@@ -631,5 +659,185 @@ class CheckoutConfigTest extends TestCase {
 
 		$this->assertStringNotContainsStringIgnoringCase( 'token', $serialized );
 		$this->assertStringNotContainsStringIgnoringCase( 'secret', $serialized );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 13 — the `list` REST endpoint always rides along
+	// -------------------------------------------------------------------------
+
+	public function test_location_block_exposes_the_list_endpoint(): void {
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'settlement' => true ], null, [ 'RU' ] );
+		$config  = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame( 'https://x/wp-json/woodev/v1/location/list', $config['location']['endpoints']['list'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 13 — `mode` reads the real store setting (via Location_Service),
+	// no longer the hardcoded 'typeahead' constant
+	// -------------------------------------------------------------------------
+
+	public function test_mode_reads_from_the_location_service(): void {
+		$service = new Checkout_Config_Fake_Location_Service(
+			true,
+			[ 'region' => true ],
+			null,
+			[ 'RU' ],
+			Location_Provider_Registry::MODE_RELATED_LIST
+		);
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame( Location_Provider_Registry::MODE_RELATED_LIST, $config['location']['mode'] );
+	}
+
+	public function test_mode_defaults_to_typeahead(): void {
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'region' => true ], null, [ 'RU' ] );
+		$config  = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame( Location_Provider_Registry::MODE_TYPEAHEAD, $config['location']['mode'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 13 / issue #294 — the region arbitration: WC()->countries->get_states()
+	// is the FINAL authority, read here, after every woocommerce_states filter.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Builds a {@see Checkout_Config} whose overridable `wc_states()` seam
+	 * (see that method's own docblock) answers from a fixed `country => states`
+	 * map, WITHOUT ever touching Brain Monkey's global `WC()` function table.
+	 *
+	 * Deliberately NOT `Functions\when( 'WC' )->justReturn( ... )`: Brain
+	 * Monkey/Patchwork instruments a mocked function for the REST OF THE PHP
+	 * PROCESS once any test stubs it — measured directly, a first version of
+	 * this fixture broke 21 unrelated tests elsewhere in the suite the moment
+	 * `composer test:unit` ran the full run in one process (every other test
+	 * relying on `function_exists( 'WC' ) === false` started seeing it
+	 * defined-but-unmocked). The protected-method-override seam
+	 * `Checkout_Config::wc_states()` exists specifically so this fixture never
+	 * needs to touch that global table at all.
+	 *
+	 * @param array<string, array<string, string>> $states_by_country Country code => WC states array.
+	 *
+	 * @return Checkout_Config
+	 */
+	private function config_with_states(
+		string $plugin_id,
+		string $rest_base,
+		string $nonce,
+		array $countries,
+		?Location_Service $service,
+		array $states_by_country
+	): Checkout_Config {
+		return new class( $plugin_id, $rest_base, $nonce, $countries, $service, $states_by_country ) extends Checkout_Config {
+			private array $states_by_country;
+
+			public function __construct(
+				string $plugin_id,
+				string $rest_base,
+				string $nonce,
+				array $countries,
+				?Location_Service $service,
+				array $states_by_country
+			) {
+				parent::__construct( $plugin_id, $rest_base, $nonce, $countries, $service );
+				$this->states_by_country = $states_by_country;
+			}
+
+			protected function wc_states( string $country ): array {
+				return $this->states_by_country[ $country ] ?? [];
+			}
+		};
+	}
+
+	/**
+	 * The honest baseline: a country with NO registered WC states at all keeps
+	 * `region` exactly as the D15 chain answered (true) — this is what every
+	 * one of the nine location-layer countries measures as, on the rig, today
+	 * (issue #294 decision comment's own measurement).
+	 */
+	public function test_region_stays_ours_when_wc_has_no_states_for_the_country(): void {
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'region' => true, 'settlement' => true, 'address' => true ], null, [ 'RU' ] );
+		$config  = $this->config_with_states( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service, [] )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertTrue( $config['location']['levels']['RU']['region'] );
+	}
+
+	/**
+	 * The #294 rule's load-bearing case: a NON-EMPTY WC state list for a
+	 * country the D15 chain wanted "region" for, that this layer did NOT
+	 * inject itself (owns_region_states() false) — `region` must be reported
+	 * as NOT ours, and the conflict must be reported via `_doing_it_wrong()`
+	 * exactly once.
+	 */
+	public function test_region_reported_not_ours_when_wc_has_foreign_states_and_doing_it_wrong_fires_once(): void {
+		Functions\expect( '_doing_it_wrong' )->once();
+
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'region' => true, 'settlement' => true, 'address' => true ], null, [ 'BY' ] );
+		$config  = $this->config_with_states( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'BY' ], $service, [ 'BY' => [ 'MIN' => 'Минск' ] ] )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertFalse( $config['location']['levels']['BY']['region'], 'a country WC already has native/foreign states for is never ours' );
+	}
+
+	/**
+	 * The layer's OWN related-list injection is never treated as a conflict
+	 * with itself: `owns_region_states()` true means the SAME non-empty state
+	 * list this method reads is the layer's own doing, so `_doing_it_wrong()`
+	 * must NOT fire, even though the raw states-present check alone would
+	 * look identical to the foreign-conflict case above.
+	 */
+	public function test_doing_it_wrong_does_not_fire_for_the_layers_own_related_list_injection(): void {
+		Functions\expect( '_doing_it_wrong' )->never();
+
+		$service = new Checkout_Config_Fake_Location_Service(
+			true,
+			[ 'region' => true, 'settlement' => true, 'address' => true ],
+			null,
+			[ 'RU' ],
+			Location_Provider_Registry::MODE_RELATED_LIST,
+			[ 'RU' ] // owns_region_states( 'RU' ) === true.
+		);
+		$config = $this->config_with_states( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service, [ 'RU' => [ 'test-list:mo' => 'Московская область' ] ] )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		// The state list is non-empty (our own injection), so the client must
+		// still be told "region" is not a typeahead target here — WC already
+		// renders a native <select> — but WITHOUT the conflict warning.
+		$this->assertFalse( $config['location']['levels']['RU']['region'] );
+	}
+
+	/**
+	 * A country the D15 chain does NOT want "region" for at all must never
+	 * trigger the conflict warning, regardless of what WC's states look like —
+	 * there is nothing for this layer to have wanted here.
+	 */
+	public function test_doing_it_wrong_does_not_fire_when_the_chain_never_wanted_region(): void {
+		Functions\expect( '_doing_it_wrong' )->never();
+
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'region' => false, 'settlement' => true ], null, [ 'US' ] );
+		$config  = $this->config_with_states( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'US' ], $service, [ 'US' => [ 'CA' => 'California' ] ] )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertFalse( $config['location']['levels']['US']['region'] );
+	}
+
+	/**
+	 * Degradation: when WC() is unavailable at all (a caller/test with no
+	 * WooCommerce loaded), the region arbitration must never fatal — it
+	 * degrades to "no states known", trusting the D15 chain's own answer
+	 * unchanged (the exact pre-Task-13 behavior every other test in this file
+	 * without a WC() stub already relies on).
+	 */
+	public function test_region_arbitration_never_fatals_when_wc_is_unavailable(): void {
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'region' => true ], null, [ 'RU' ] );
+		$config  = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertTrue( $config['location']['levels']['RU']['region'] );
 	}
 }

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
@@ -86,7 +86,7 @@ final class Checkout_Handler_Fake_Location_Service extends Location_Service {
 		return \Woodev\Framework\Shipping\Location\Location_Provider_Registry::MODE_TYPEAHEAD;
 	}
 
-	public function owns_region_states( string $country ): bool {
+	public function owns_region_states( string $country, array $final_states ): bool {
 		return false;
 	}
 }

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
@@ -81,6 +81,14 @@ final class Checkout_Handler_Fake_Location_Service extends Location_Service {
 	public function provider_for_level( string $level, ?string $country = null ): ?Location_Provider {
 		return null;
 	}
+
+	public function get_field_mode(): string {
+		return \Woodev\Framework\Shipping\Location\Location_Provider_Registry::MODE_TYPEAHEAD;
+	}
+
+	public function owns_region_states( string $country ): bool {
+		return false;
+	}
 }
 
 /**

--- a/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
+++ b/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
@@ -835,6 +835,60 @@ final class LocationProviderRegistryTest extends TestCase {
 		$this->assertSame( \Woodev_Control::TYPE_SELECT, $setting->get_control()->get_type() );
 	}
 
+	/**
+	 * PR #304 review finding 6: `register_settings()` used to resolve the
+	 * active provider by looking `$this->providers[ $id ]` up DIRECTLY,
+	 * entirely skipping {@see Location_Provider_Registry::FILTER_ACTIVE_PROVIDER}
+	 * — the same filter {@see Location_Provider_Registry::get_active_provider()}
+	 * (and therefore the runtime's {@see Location_Provider_Registry::get_offered_field_modes()})
+	 * always applies. The stored id here names `acme`, which has no `list`
+	 * capability; the filter swaps the RESOLVED provider to a list-capable one
+	 * regardless. Before the fix, the settings page — built once, at
+	 * collection time, straight from the unfiltered id — would offer ONLY
+	 * `typeahead`, while the runtime (which DOES apply the filter) would
+	 * accept `related-list`/`ajax-select2` too: an admin could never even see
+	 * the option the runtime would actually honour. The mutant this pins:
+	 * reverting `register_settings()` to a direct `$this->providers[ $id ]`
+	 * lookup makes this assertion fail (the settings page would offer only
+	 * `[ 'typeahead' ]`, diverging from `get_offered_field_modes()`).
+	 */
+	public function test_settings_page_field_mode_options_reflect_the_active_provider_filter_not_the_raw_stored_id(): void {
+		$acme          = new Fake_Location_Provider( 'acme', 'ACME' ); // no `list` capability.
+		$list_provider = new Fake_List_Location_Provider( 'list-fixture', 'List Fixture', [ 'RU' ] );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $tag, $default = null ) use ( $acme, $list_provider ) {
+				if ( Location_Provider_Registry::FILTER_PROVIDERS === $tag ) {
+					return [ $acme, $list_provider ];
+				}
+				if ( Location_Provider_Registry::FILTER_ACTIVE_PROVIDER === $tag ) {
+					return $list_provider; // swaps the resolved provider regardless of the stored id.
+				}
+
+				return $default;
+			}
+		);
+		Functions\when( 'get_option' )->justReturn( 'acme' );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$setting = $registry->get_settings_handler()->get_setting( Location_Provider_Registry::SETTING_FIELD_MODE );
+
+		$this->assertSame(
+			$registry->get_offered_field_modes(),
+			array_keys( $setting->get_options() ),
+			'the settings page must offer exactly what the runtime would accept — both go through the SAME resolution now'
+		);
+		$this->assertContains(
+			Location_Provider_Registry::MODE_RELATED_LIST,
+			array_keys( $setting->get_options() ),
+			'the filter-swapped list-capable provider must be reflected on the settings page, not the raw stored id alone'
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// Task 13 — get_field_mode(): default + clamp against the offered set
 	// -------------------------------------------------------------------------
@@ -927,6 +981,16 @@ final class LocationProviderRegistryTest extends TestCase {
 	 */
 	private function activate_related_list_mode( Fake_List_Location_Provider $provider ): Location_Provider_Registry {
 		Functions\when( 'add_action' )->justReturn( true );
+		// Real WC() is never loaded in unit tests — mirrors the real
+		// `wc_strtoupper()` (`mb_strtoupper()` when available, Cyrillic-aware,
+		// see `wc-formatting-functions.php`) so the label -> key transform
+		// `inject_related_list_states()` now applies (PR #304 review finding 2)
+		// exercises the same semantics the real function would.
+		Functions\when( 'wc_strtoupper' )->alias(
+			static function ( $string ) {
+				return mb_strtoupper( (string) $string );
+			}
+		);
 		$this->stub_providers_filter( [ $provider ] );
 		Functions\when( 'get_option' )->alias(
 			static function ( $name, $default = null ) use ( $provider ) {
@@ -954,8 +1018,14 @@ final class LocationProviderRegistryTest extends TestCase {
 	 * value is permanent order data, and a provider-namespaced key renders as
 	 * raw garbage in the customer's formatted address the instant this injector
 	 * is not present (rig measurement, see the method's own docblock).
+	 *
+	 * PR #304 review finding 2: the KEY is `wc_strtoupper( $label )`, never the
+	 * bare (possibly mixed-case) label — `WC_Checkout::validate_posted_data()`
+	 * uppercases whatever the customer posted before matching it against the
+	 * registered keys, so a mixed-case key used bare would never match its own
+	 * uppercased submission again on the next render.
 	 */
-	public function test_inject_injects_regions_keyed_by_their_own_label(): void {
+	public function test_inject_injects_regions_keyed_by_their_own_uppercased_label(): void {
 		$provider = new Fake_List_Location_Provider(
 			'list-fixture',
 			'List Fixture',
@@ -966,7 +1036,7 @@ final class LocationProviderRegistryTest extends TestCase {
 
 		$states = $registry->inject_related_list_states( [] );
 
-		$this->assertSame( [ 'Московская область' => 'Московская область' ], $states['RU'] );
+		$this->assertSame( [ 'МОСКОВСКАЯ ОБЛАСТЬ' => 'Московская область' ], $states['RU'] );
 	}
 
 	/**
@@ -995,7 +1065,32 @@ final class LocationProviderRegistryTest extends TestCase {
 
 		$states = $registry->inject_related_list_states( [] );
 
-		$this->assertSame( [ 'Московская область' => 'Московская область' ], $states['RU'], 'the first record wins; the duplicate is dropped, not merged or suffixed' );
+		$this->assertSame( [ 'МОСКОВСКАЯ ОБЛАСТЬ' => 'Московская область' ], $states['RU'], 'the first record wins; the duplicate is dropped, not merged or suffixed' );
+	}
+
+	/**
+	 * PR #304 review finding 2: two labels differing only in case now collide
+	 * too, since duplicate detection moved onto the uppercased key.
+	 */
+	public function test_inject_treats_labels_differing_only_in_case_as_a_duplicate(): void {
+		Functions\expect( '_doing_it_wrong' )->once();
+
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[
+				'RU' => [
+					$this->region_record( 'list-fixture', 'mo-1', 'RU', 'Московская область' ),
+					$this->region_record( 'list-fixture', 'mo-2', 'RU', 'МОСКОВСКАЯ ОБЛАСТЬ' ),
+				],
+			]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertSame( [ 'МОСКОВСКАЯ ОБЛАСТЬ' => 'Московская область' ], $states['RU'], 'the first record wins, case-insensitively' );
 	}
 
 	public function test_inject_records_ownership_for_every_country_it_wrote(): void {
@@ -1007,10 +1102,94 @@ final class LocationProviderRegistryTest extends TestCase {
 		);
 		$registry = $this->activate_related_list_mode( $provider );
 
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertTrue( $registry->owns_region_states( 'RU', $states['RU'] ) );
+		$this->assertFalse( $registry->owns_region_states( 'BY', [] ), 'a country never injected into must not be reported owned' );
+	}
+
+	/**
+	 * PR #304 review finding 3: ownership must be re-confirmed against the
+	 * FINAL registered states, not merely trusted from the recorded flag — a
+	 * later filter callback (e.g. a §8 carrier takeover hooked after this
+	 * injector, both at the default `woocommerce_states` priority) can
+	 * overwrite what this injector wrote. The mutant this pins: reverting
+	 * `owns_region_states()` to trust the recorded flag alone (ignoring
+	 * `$final_states`) makes this assert `true` for a country this injector no
+	 * longer actually owns.
+	 */
+	public function test_owns_region_states_is_false_once_a_later_filter_overwrites_the_injection(): void {
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[ 'RU' => [ $this->region_record( 'list-fixture', 'mo', 'RU', 'Московская область' ) ] ]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
 		$registry->inject_related_list_states( [] );
 
-		$this->assertTrue( $registry->owns_region_states( 'RU' ) );
-		$this->assertFalse( $registry->owns_region_states( 'BY' ), 'a country never injected into must not be reported owned' );
+		// Simulates a §8 carrier takeover (Checkout_Handler::inject_states())
+		// running AFTER this injector on the same `woocommerce_states` filter
+		// and unconditionally overwriting the country's states.
+		$overwritten_by_someone_else = [ 'MOW' => 'Москва (перехвачено §8)' ];
+
+		$this->assertFalse( $registry->owns_region_states( 'RU', $overwritten_by_someone_else ) );
+	}
+
+	/**
+	 * PR #304 review finding 4: a record whose label is `''` (documented as
+	 * possible, {@see Location_Record::label()}) must never become a
+	 * selectable option — WooCommerce would render it indistinguishably from
+	 * its own "select an option…" placeholder. The mutant this pins: dropping
+	 * the empty-label guard makes `$options['']` register, so `RU` would carry
+	 * a blank entry and this assertion would fail.
+	 */
+	public function test_inject_skips_a_record_with_an_empty_or_whitespace_only_label(): void {
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[
+				'RU' => [
+					$this->region_record( 'list-fixture', 'blank', 'RU', '' ),
+					$this->region_record( 'list-fixture', 'whitespace', 'RU', '   ' ),
+					$this->region_record( 'list-fixture', 'mo', 'RU', 'Московская область' ),
+				],
+			]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertSame( [ 'МОСКОВСКАЯ ОБЛАСТЬ' => 'Московская область' ], $states['RU'], 'the empty/whitespace-only labels must never become options' );
+	}
+
+	/**
+	 * PR #304 review finding 4: labels are untrimmed by the provider, so
+	 * `'Москва'` and `'Москва '` would otherwise register as two visually
+	 * identical options — trimming BEFORE using the label as key or value
+	 * collapses them into one, same as the real duplicate-label path.
+	 */
+	public function test_inject_trims_labels_before_using_them_as_key_or_value(): void {
+		Functions\expect( '_doing_it_wrong' )->once();
+
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[
+				'RU' => [
+					$this->region_record( 'list-fixture', 'mo-1', 'RU', 'Москва' ),
+					$this->region_record( 'list-fixture', 'mo-2', 'RU', 'Москва ' ),
+				],
+			]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertSame( [ 'МОСКВА' => 'Москва' ], $states['RU'], 'a trailing-whitespace label is the same option as its trimmed form' );
 	}
 
 	/**
@@ -1027,7 +1206,7 @@ final class LocationProviderRegistryTest extends TestCase {
 
 		// Untouched — WC's own pre-existing entry survives.
 		$this->assertSame( [ 'MOW' => 'Москва (native)' ], $states['RU'] );
-		$this->assertFalse( $registry->owns_region_states( 'RU' ), 'nothing was actually injected — must not be reported owned' );
+		$this->assertFalse( $registry->owns_region_states( 'RU', $states['RU'] ), 'nothing was actually injected — must not be reported owned' );
 	}
 
 	/**
@@ -1047,7 +1226,7 @@ final class LocationProviderRegistryTest extends TestCase {
 		$states = $registry->inject_related_list_states( [ 'RU' => [ '77' => 'Москва (карьер)' ] ] );
 
 		$this->assertSame( [ '77' => 'Москва (карьер)' ], $states['RU'], 'first-wins — the pre-existing entry is kept' );
-		$this->assertFalse( $registry->owns_region_states( 'RU' ), 'a country this injector skipped is never reported owned' );
+		$this->assertFalse( $registry->owns_region_states( 'RU', $states['RU'] ), 'a country this injector skipped is never reported owned' );
 	}
 
 	public function test_inject_is_a_no_op_outside_related_list_mode(): void {

--- a/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
+++ b/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
@@ -82,6 +82,84 @@ class Fake_Location_Provider extends Abstract_Location_Provider {
 }
 
 /**
+ * A `list`-capable fake provider (Task 13) — {@see Fake_Location_Provider} never
+ * overrides {@see \Woodev\Framework\Shipping\Location\Abstract_Location_Provider::list_localities()},
+ * so its reflection-derived capability set never contains `list`; this fixture
+ * exists specifically to exercise the `related-list`/`ajax-select2` mode gate and
+ * {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::inject_related_list_states()},
+ * neither of which the DaData-shaped fake above can ever reach.
+ */
+class Fake_List_Location_Provider extends Abstract_Location_Provider {
+
+	private string $id;
+	private string $name;
+
+	/** @var string[] */
+	private array $countries;
+
+	/** @var array<string, \Woodev\Framework\Shipping\Location\Location_Record[]> country => region-level records. */
+	private array $region_records_by_country;
+
+	private bool $configured;
+
+	/** @var int Spy: how many times list_localities() was actually called. */
+	public int $list_localities_calls = 0;
+
+	/**
+	 * @param array<string, \Woodev\Framework\Shipping\Location\Location_Record[]> $region_records_by_country country => region-level records
+	 *                                                                                                          {@see self::list_localities()} returns
+	 *                                                                                                          for a region-level scope.
+	 */
+	public function __construct(
+		string $id,
+		string $name,
+		array $countries,
+		array $region_records_by_country = [],
+		bool $configured = true
+	) {
+		$this->id                       = $id;
+		$this->name                     = $name;
+		$this->countries                = $countries;
+		$this->region_records_by_country = $region_records_by_country;
+		$this->configured                = $configured;
+	}
+
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	public function get_name(): string {
+		return $this->name;
+	}
+
+	public function get_countries(): array {
+		return $this->countries;
+	}
+
+	public function is_configured(): bool {
+		return $this->configured;
+	}
+
+	protected function declare_suggest_levels(): array {
+		return [ Location_Record::LEVEL_REGION ];
+	}
+
+	public function suggest( string $query, Location_Scope $scope ): array {
+		return [];
+	}
+
+	public function list_localities( Location_Scope $scope ): array {
+		++$this->list_localities_calls;
+
+		if ( Location_Record::LEVEL_REGION !== $scope->level() ) {
+			return [];
+		}
+
+		return $this->region_records_by_country[ $scope->country() ] ?? [];
+	}
+}
+
+/**
  * @covers \Woodev\Framework\Shipping\Location\Location_Provider_Registry
  * @covers \Woodev\Framework\Shipping\Location\Location_Settings
  */
@@ -686,5 +764,324 @@ final class LocationProviderRegistryTest extends TestCase {
 		$fresh = Location_Provider_Registry::instance();
 		$this->assertFalse( $fresh->is_needed() );
 		$this->assertSame( [], $fresh->get_providers() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 13 (spec D7) — offered field modes = f(active provider capabilities)
+	// -------------------------------------------------------------------------
+
+	public function test_offered_field_modes_typeahead_only_for_the_real_dadata_provider(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] ); // active provider falls back to the bundled DaData default.
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame( [ Location_Provider_Registry::MODE_TYPEAHEAD ], $registry->get_offered_field_modes() );
+	}
+
+	public function test_offered_field_modes_include_related_list_and_ajax_select2_for_a_list_capable_active_provider(): void {
+		$list_provider = new Fake_List_Location_Provider( 'list-fixture', 'List Fixture', [ 'RU' ] );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $list_provider ] );
+		$this->stub_active_provider_option( 'list-fixture' );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame(
+			[ Location_Provider_Registry::MODE_TYPEAHEAD, Location_Provider_Registry::MODE_RELATED_LIST, Location_Provider_Registry::MODE_AJAX_SELECT2 ],
+			$registry->get_offered_field_modes()
+		);
+	}
+
+	public function test_offered_field_modes_typeahead_only_when_no_active_provider_resolves(): void {
+		// Gate open, but nothing collected yet — get_active_provider() is null.
+		Functions\when( 'add_action' )->justReturn( true );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+
+		$this->assertSame( [ Location_Provider_Registry::MODE_TYPEAHEAD ], $registry->get_offered_field_modes() );
+	}
+
+	/**
+	 * The settings surface's own `field_mode` select must offer EXACTLY the
+	 * same options {@see Location_Provider_Registry::get_offered_field_modes()}
+	 * computes — proving the registration-time computation (which cannot call
+	 * `get_active_provider()` — the settings handler does not exist yet, see
+	 * that private helper's own docblock) agrees with the read-time one.
+	 */
+	public function test_field_mode_setting_options_match_the_list_capable_active_providers_offered_modes(): void {
+		$list_provider = new Fake_List_Location_Provider( 'list-fixture', 'List Fixture', [ 'RU' ] );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $list_provider ] );
+		$this->stub_active_provider_option( 'list-fixture' );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$setting = $registry->get_settings_handler()->get_setting( Location_Provider_Registry::SETTING_FIELD_MODE );
+
+		$this->assertSame(
+			array_keys( $setting->get_options() ),
+			$registry->get_offered_field_modes()
+		);
+		$this->assertSame( \Woodev_Control::TYPE_SELECT, $setting->get_control()->get_type() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 13 — get_field_mode(): default + clamp against the offered set
+	// -------------------------------------------------------------------------
+
+	public function test_field_mode_defaults_to_typeahead(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->justReturn( null );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame( Location_Provider_Registry::MODE_TYPEAHEAD, $registry->get_field_mode() );
+	}
+
+	public function test_field_mode_returns_the_stored_value_when_it_is_offered(): void {
+		$list_provider = new Fake_List_Location_Provider( 'list-fixture', 'List Fixture', [ 'RU' ] );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $list_provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'list-fixture';
+				}
+				if ( 'woodev_location_field_mode' === $name ) {
+					return Location_Provider_Registry::MODE_RELATED_LIST;
+				}
+
+				return $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame( Location_Provider_Registry::MODE_RELATED_LIST, $registry->get_field_mode() );
+	}
+
+	/**
+	 * A stored `related-list` value from BEFORE a provider switch to a
+	 * non-`list` provider (e.g. back to DaData) must never be served as-is —
+	 * clamps to typeahead, the one mode every provider can always back.
+	 */
+	public function test_field_mode_clamps_a_stored_value_the_current_active_provider_no_longer_supports(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] ); // active provider falls back to DaData (no `list`).
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				return 'woodev_location_field_mode' === $name ? Location_Provider_Registry::MODE_RELATED_LIST : $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame( Location_Provider_Registry::MODE_TYPEAHEAD, $registry->get_field_mode() );
+	}
+
+	public function test_field_mode_is_typeahead_while_the_gate_is_closed(): void {
+		$registry = Location_Provider_Registry::instance();
+
+		$this->assertSame( Location_Provider_Registry::MODE_TYPEAHEAD, $registry->get_field_mode() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 13 — inject_related_list_states(): the related-list region renderer
+	// -------------------------------------------------------------------------
+
+	private function region_record( string $provider_id, string $native_id, string $country, string $name ): Location_Record {
+		return Location_Record::from_array(
+			[
+				'key'         => $provider_id . ':' . $native_id,
+				'provider_id' => $provider_id,
+				'level'       => Location_Record::LEVEL_REGION,
+				'country'     => $country,
+				'region'      => [ 'name' => $name, 'type' => 'область' ],
+				'label'       => $name,
+			]
+		);
+	}
+
+	/**
+	 * Activates a `list`-capable fixture provider as ACTIVE, with `field_mode`
+	 * stored as `related-list`, and collects the registry — the common setup
+	 * every `inject_related_list_states()` test below needs.
+	 */
+	private function activate_related_list_mode( Fake_List_Location_Provider $provider ): Location_Provider_Registry {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) use ( $provider ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return $provider->get_id();
+				}
+				if ( 'woodev_location_field_mode' === $name ) {
+					return Location_Provider_Registry::MODE_RELATED_LIST;
+				}
+
+				return $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		return $registry;
+	}
+
+	public function test_inject_injects_regions_keyed_by_the_records_own_locality_key(): void {
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[ 'RU' => [ $this->region_record( 'list-fixture', 'mo', 'RU', 'Московская область' ) ] ]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertSame( [ 'list-fixture:mo' => 'Московская область' ], $states['RU'] );
+	}
+
+	public function test_inject_records_ownership_for_every_country_it_wrote(): void {
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[ 'RU' => [ $this->region_record( 'list-fixture', 'mo', 'RU', 'Московская область' ) ] ]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$registry->inject_related_list_states( [] );
+
+		$this->assertTrue( $registry->owns_region_states( 'RU' ) );
+		$this->assertFalse( $registry->owns_region_states( 'BY' ), 'a country never injected into must not be reported owned' );
+	}
+
+	/**
+	 * The gotcha `checkout-field-takeover-woocommerce-states` discipline:
+	 * writing an empty array for a country tells WooCommerce it has NO states
+	 * at all and HIDES the field — a country the provider claims to cover but
+	 * has nothing to enumerate for must be left untouched instead.
+	 */
+	public function test_inject_never_writes_an_empty_array_for_a_country_with_nothing_to_enumerate(): void {
+		$provider = new Fake_List_Location_Provider( 'list-fixture', 'List Fixture', [ 'RU' ], [] ); // no region data at all.
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [ 'RU' => [ 'MOW' => 'Москва (native)' ] ] );
+
+		// Untouched — WC's own pre-existing entry survives.
+		$this->assertSame( [ 'MOW' => 'Москва (native)' ], $states['RU'] );
+		$this->assertFalse( $registry->owns_region_states( 'RU' ), 'nothing was actually injected — must not be reported owned' );
+	}
+
+	/**
+	 * First-wins: a country ALREADY carrying non-empty states (from an earlier
+	 * `woocommerce_states` callback — WC native, or a plugin's §8 carrier
+	 * takeover) is never clobbered by this injector.
+	 */
+	public function test_inject_never_overwrites_an_already_non_empty_country(): void {
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[ 'RU' => [ $this->region_record( 'list-fixture', 'mo', 'RU', 'Московская область' ) ] ]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [ 'RU' => [ '77' => 'Москва (карьер)' ] ] );
+
+		$this->assertSame( [ '77' => 'Москва (карьер)' ], $states['RU'], 'first-wins — the pre-existing entry is kept' );
+		$this->assertFalse( $registry->owns_region_states( 'RU' ), 'a country this injector skipped is never reported owned' );
+	}
+
+	public function test_inject_is_a_no_op_outside_related_list_mode(): void {
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[ 'RU' => [ $this->region_record( 'list-fixture', 'mo', 'RU', 'Московская область' ) ] ]
+		);
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		// active_provider = list-fixture, but field_mode left at its default (typeahead).
+		$this->stub_active_provider_option( 'list-fixture' );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertArrayNotHasKey( 'RU', $states );
+		$this->assertSame( 0, $provider->list_localities_calls, 'the provider must never even be asked outside related-list mode' );
+	}
+
+	public function test_inject_is_a_no_op_when_the_active_provider_lacks_the_list_capability(): void {
+		// The real bundled DaData provider is active (no fixture override) — it
+		// has no `list` capability at all, so even if field_mode somehow held
+		// 'related-list' (a value get_field_mode() itself would clamp away —
+		// this test calls the injector directly to prove the injector's OWN
+		// gate is independently defensive, not merely relying on that clamp).
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				return 'woodev_location_field_mode' === $name ? Location_Provider_Registry::MODE_RELATED_LIST : $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertSame( [], $states );
+	}
+
+	public function test_inject_is_a_no_op_when_the_active_provider_is_not_configured(): void {
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[ 'RU' => [ $this->region_record( 'list-fixture', 'mo', 'RU', 'Московская область' ) ] ],
+			false // not configured.
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertArrayNotHasKey( 'RU', $states );
+		$this->assertSame( 0, $provider->list_localities_calls );
+	}
+
+	public function test_inject_tolerates_a_non_array_input(): void {
+		$provider = new Fake_List_Location_Provider( 'list-fixture', 'List Fixture', [ 'RU' ], [] );
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( 'not-an-array' );
+
+		$this->assertIsArray( $states );
 	}
 }

--- a/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
+++ b/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
@@ -948,7 +948,14 @@ final class LocationProviderRegistryTest extends TestCase {
 		return $registry;
 	}
 
-	public function test_inject_injects_regions_keyed_by_the_records_own_locality_key(): void {
+	/**
+	 * s71 correction: the injected VALUE is the record's human-readable LABEL,
+	 * never its `provider_id:native_id` key — a `billing_state`/`shipping_state`
+	 * value is permanent order data, and a provider-namespaced key renders as
+	 * raw garbage in the customer's formatted address the instant this injector
+	 * is not present (rig measurement, see the method's own docblock).
+	 */
+	public function test_inject_injects_regions_keyed_by_their_own_label(): void {
 		$provider = new Fake_List_Location_Provider(
 			'list-fixture',
 			'List Fixture',
@@ -959,7 +966,36 @@ final class LocationProviderRegistryTest extends TestCase {
 
 		$states = $registry->inject_related_list_states( [] );
 
-		$this->assertSame( [ 'list-fixture:mo' => 'Московская область' ], $states['RU'] );
+		$this->assertSame( [ 'Московская область' => 'Московская область' ], $states['RU'] );
+	}
+
+	/**
+	 * Two records legitimately colliding on the same label within one country is
+	 * a real ambiguity — WooCommerce's state array is keyed by value, so only
+	 * ONE option could ever be selected under that text. The first (provider's
+	 * own enumeration order) wins; the collision is reported exactly once, never
+	 * silently dropped and never disambiguated with a synthetic suffix that
+	 * would itself leak into `billing_state`.
+	 */
+	public function test_inject_keeps_the_first_of_a_duplicate_label_and_warns_once(): void {
+		Functions\expect( '_doing_it_wrong' )->once();
+
+		$provider = new Fake_List_Location_Provider(
+			'list-fixture',
+			'List Fixture',
+			[ 'RU' ],
+			[
+				'RU' => [
+					$this->region_record( 'list-fixture', 'mo-1', 'RU', 'Московская область' ),
+					$this->region_record( 'list-fixture', 'mo-2', 'RU', 'Московская область' ),
+				],
+			]
+		);
+		$registry = $this->activate_related_list_mode( $provider );
+
+		$states = $registry->inject_related_list_states( [] );
+
+		$this->assertSame( [ 'Московская область' => 'Московская область' ], $states['RU'], 'the first record wins; the duplicate is dropped, not merged or suffixed' );
 	}
 
 	public function test_inject_records_ownership_for_every_country_it_wrote(): void {

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -1054,7 +1054,7 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$this->assertNull( $service->provider_for_list() );
 			$this->assertSame( [ Location_Provider_Registry::MODE_TYPEAHEAD ], $service->get_offered_field_modes() );
 			$this->assertSame( Location_Provider_Registry::MODE_TYPEAHEAD, $service->get_field_mode() );
-			$this->assertFalse( $service->owns_region_states( 'RU' ) );
+			$this->assertFalse( $service->owns_region_states( 'RU', [] ) );
 		}
 
 		// -------------------------------------------------------------------
@@ -1170,8 +1170,8 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$registry = Location_Provider_Registry::instance();
 			$service  = new Location_Service( $registry );
 
-			$this->assertSame( $registry->owns_region_states( 'RU' ), $service->owns_region_states( 'RU' ) );
-			$this->assertFalse( $service->owns_region_states( 'RU' ) );
+			$this->assertSame( $registry->owns_region_states( 'RU', [] ), $service->owns_region_states( 'RU', [] ) );
+			$this->assertFalse( $service->owns_region_states( 'RU', [] ) );
 		}
 	}
 }

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -245,6 +245,56 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 	}
 
 	/**
+	 * A `list`-capable fake provider (Task 13) — {@see Location_Service_Fake_Provider}
+	 * never overrides `list_localities()`, so it can never resolve through
+	 * {@see Location_Service::provider_for_list()}; this fixture exists
+	 * specifically to exercise that chain.
+	 */
+	class Location_Service_Fake_List_Provider extends Abstract_Location_Provider {
+
+		private string $id;
+
+		/** @var string[] */
+		private array $countries;
+
+		private bool $configured;
+
+		public function __construct( string $id, array $countries = [ 'RU' ], bool $configured = true ) {
+			$this->id        = $id;
+			$this->countries = $countries;
+			$this->configured = $configured;
+		}
+
+		public function get_id(): string {
+			return $this->id;
+		}
+
+		public function get_name(): string {
+			return $this->id;
+		}
+
+		public function get_countries(): array {
+			return $this->countries;
+		}
+
+		public function is_configured(): bool {
+			return $this->configured;
+		}
+
+		protected function declare_suggest_levels(): array {
+			return [ Location_Record::LEVEL_REGION ];
+		}
+
+		public function suggest( string $query, Location_Scope $scope ): array {
+			return [];
+		}
+
+		public function list_localities( Location_Scope $scope ): array {
+			return [];
+		}
+	}
+
+	/**
 	 * @covers \Woodev\Framework\Shipping\Location\Location_Service
 	 */
 	final class LocationServiceTest extends TestCase {
@@ -1001,6 +1051,127 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$this->assertFalse( $service->is_country_supported( 'RU' ) );
 			$this->assertNull( $service->provider_for_level( Location_Record::LEVEL_REGION ) );
 			$this->assertNull( $service->resolve_for( $plugin ) );
+			$this->assertNull( $service->provider_for_list() );
+			$this->assertSame( [ Location_Provider_Registry::MODE_TYPEAHEAD ], $service->get_offered_field_modes() );
+			$this->assertSame( Location_Provider_Registry::MODE_TYPEAHEAD, $service->get_field_mode() );
+			$this->assertFalse( $service->owns_region_states( 'RU' ) );
+		}
+
+		// -------------------------------------------------------------------
+		// provider_for_list(): Task 13's own D15-adjacent chain — chosen
+		// provider (if it declares `list`) -> bundled fallback (never, DaData
+		// has no `list` capability) -> null.
+		// -------------------------------------------------------------------
+
+		public function test_provider_for_list_resolves_the_active_provider_when_it_declares_list(): void {
+			$provider = new Location_Service_Fake_List_Provider( 'list-fixture', [ 'RU' ] );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $provider ] );
+			Functions\when( 'get_option' )->justReturn( 'list-fixture' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			$this->assertSame( $provider, $service->provider_for_list() );
+		}
+
+		public function test_provider_for_list_null_when_the_active_provider_does_not_cover_the_country(): void {
+			$provider = new Location_Service_Fake_List_Provider( 'list-fixture', [ 'RU' ] );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $provider ] );
+			Functions\when( 'get_option' )->justReturn( 'list-fixture' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			$this->assertNull( $service->provider_for_list( 'US' ) );
+		}
+
+		/**
+		 * The real bundled DaData provider has NO `list` capability at all — the
+		 * fallback slot is always occupied by it (Task 7), so this proves the
+		 * chain correctly resolves `null` rather than wrongly falling back to a
+		 * provider that cannot answer.
+		 */
+		public function test_provider_for_list_null_when_neither_chosen_nor_fallback_declares_list(): void {
+			$chosen = new Location_Service_Fake_Provider( 'city-dict', [ Location_Record::LEVEL_REGION ], true );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $chosen ] );
+			$this->stub_dadata_token( 'tok' ); // configured fallback — but still no `list` capability.
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			$this->assertNull( $service->provider_for_list() );
+		}
+
+		public function test_provider_for_list_null_when_the_list_capable_provider_is_not_configured(): void {
+			$provider = new Location_Service_Fake_List_Provider( 'list-fixture', [ 'RU' ], false );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $provider ] );
+			Functions\when( 'get_option' )->justReturn( 'list-fixture' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			$this->assertNull( $service->provider_for_list() );
+		}
+
+		// -------------------------------------------------------------------
+		// get_offered_field_modes() / get_field_mode() / owns_region_states():
+		// thin pass-throughs to the registry — LocationProviderRegistryTest
+		// covers the actual gating logic exhaustively; these spot-check that
+		// the façade genuinely delegates rather than reimplementing anything.
+		// -------------------------------------------------------------------
+
+		public function test_get_offered_field_modes_delegates_to_the_registry(): void {
+			$provider = new Location_Service_Fake_List_Provider( 'list-fixture', [ 'RU' ] );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $provider ] );
+			Functions\when( 'get_option' )->justReturn( 'list-fixture' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			$this->assertSame( $registry->get_offered_field_modes(), $service->get_offered_field_modes() );
+			$this->assertContains( Location_Provider_Registry::MODE_RELATED_LIST, $service->get_offered_field_modes() );
+		}
+
+		public function test_get_field_mode_delegates_to_the_registry(): void {
+			$this->activate_with_providers( [] );
+			$registry = Location_Provider_Registry::instance();
+			$service  = new Location_Service( $registry );
+
+			$this->assertSame( $registry->get_field_mode(), $service->get_field_mode() );
+		}
+
+		public function test_owns_region_states_delegates_to_the_registry(): void {
+			$this->activate_with_providers( [] );
+			$registry = Location_Provider_Registry::instance();
+			$service  = new Location_Service( $registry );
+
+			$this->assertSame( $registry->owns_region_states( 'RU' ), $service->owns_region_states( 'RU' ) );
+			$this->assertFalse( $service->owns_region_states( 'RU' ) );
 		}
 	}
 }

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -102,6 +102,21 @@ final class Location_Controller_Fake_Service extends Location_Service {
 	private bool $country_supported;
 
 	/**
+	 * Task 13: {@see self::provider_for_list()}'s own return value — a
+	 * SEPARATE fake from {@see self::$provider} (the `/suggest`/`/select`
+	 * seam's own resolution), since `/list` resolves through
+	 * {@see Location_Service::provider_for_list()}, a genuinely different
+	 * D15-adjacent chain. Defaults to `null` — every pre-existing test in this
+	 * file never touches `/list` and is unaffected.
+	 *
+	 * @var Location_Provider|null
+	 */
+	private ?Location_Provider $list_provider;
+
+	/** @var array<int, string|null> */
+	public array $provider_for_list_calls = [];
+
+	/**
 	 * Optional level => provider map (D15 gate fix, block PR-B test seam).
 	 * When set, {@see self::provider_for_level()} resolves THROUGH this map
 	 * instead of always returning the single {@see self::$provider} — lets a
@@ -139,6 +154,7 @@ final class Location_Controller_Fake_Service extends Location_Service {
 	/**
 	 * @param array<string, Location_Provider>|null $providers_by_level                    Optional level => provider map — see {@see self::$providers_by_level}.
 	 * @param Location_Provider|null                 $active_provider_for_level_blind_check See {@see self::$active_provider_for_level_blind_check}.
+	 * @param Location_Provider|null                 $list_provider                         Task 13: {@see self::provider_for_list()}'s return value.
 	 */
 	public function __construct(
 		bool $active = true,
@@ -147,7 +163,8 @@ final class Location_Controller_Fake_Service extends Location_Service {
 		bool $persist_result = true,
 		bool $country_supported = true,
 		?array $providers_by_level = null,
-		?Location_Provider $active_provider_for_level_blind_check = null
+		?Location_Provider $active_provider_for_level_blind_check = null,
+		?Location_Provider $list_provider = null
 	) {
 		$this->active                                = $active;
 		$this->provider                               = $provider;
@@ -156,6 +173,13 @@ final class Location_Controller_Fake_Service extends Location_Service {
 		$this->country_supported                      = $country_supported;
 		$this->providers_by_level                     = $providers_by_level;
 		$this->active_provider_for_level_blind_check = $active_provider_for_level_blind_check;
+		$this->list_provider                          = $list_provider;
+	}
+
+	public function provider_for_list( ?string $country = null ): ?Location_Provider {
+		$this->provider_for_list_calls[] = $country;
+
+		return $this->list_provider;
 	}
 
 	public function is_active(): bool {
@@ -262,6 +286,59 @@ final class Location_Controller_Fake_Provider extends Abstract_Location_Provider
 		$this->suggest_calls[] = [ $query, $scope ];
 
 		return ( $this->suggest_callback )( $query, $scope );
+	}
+}
+
+/**
+ * Task 13: a {@see Location_Controller_Fake_Provider} sibling that DOES
+ * override `list_localities()` — kept as a SEPARATE class rather than a
+ * conditional branch inside the one above, so reflection-derived capability
+ * discovery ({@see Abstract_Location_Provider::get_capabilities()}) correctly
+ * reports `list` present only for instances that genuinely need it; a
+ * conditionally-no-op override on the shared class would report the
+ * capability for every pre-existing test too, which is not what any of them
+ * intend to exercise.
+ */
+final class Location_Controller_Fake_List_Provider extends Abstract_Location_Provider {
+
+	/** @var callable */
+	private $list_callback;
+
+	/** @var string[] */
+	private array $countries;
+
+	/** @var array<int, Location_Scope> */
+	public array $list_calls = [];
+
+	public function __construct( callable $list_callback, array $countries = [ 'RU' ] ) {
+		$this->list_callback = $list_callback;
+		$this->countries     = $countries;
+	}
+
+	public function get_id(): string {
+		return 'fake-list';
+	}
+
+	public function get_name(): string {
+		return 'Fake List';
+	}
+
+	public function get_countries(): array {
+		return $this->countries;
+	}
+
+	protected function declare_suggest_levels(): array {
+		return Location_Record::LEVELS;
+	}
+
+	public function suggest( string $query, Location_Scope $scope ): array {
+		return [];
+	}
+
+	public function list_localities( Location_Scope $scope ): array {
+		$this->list_calls[] = $scope;
+
+		return ( $this->list_callback )( $scope );
 	}
 }
 
@@ -912,5 +989,135 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->check_select_permission( $request );
 
 		$this->assertTrue( $result );
+	}
+
+	// -------------------------------------------------------------------
+	// /list (Task 13; spec D7) — level enum, malformed country 400, no
+	// provider -> 404 (NOT /suggest's 200+empty), happy path, provider
+	// exception -> 502, `provider` param never read.
+	// -------------------------------------------------------------------
+
+	public function test_list_rejects_an_unknown_level(): void {
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => 'galaxy', 'country' => 'RU' ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_list_a_malformed_country_returns_400(): void {
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'not-a-code' ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertCount( 0, $service->provider_for_list_calls, 'a malformed country must never even reach provider_for_list()' );
+	}
+
+	/**
+	 * The deliberate asymmetry with `/suggest`: no provider anywhere in the
+	 * D15-adjacent `list` chain resolves for this (well-formed) country ->
+	 * 404, never `/suggest`'s 200+empty (see handle_list_request()'s own
+	 * docblock for why).
+	 */
+	public function test_list_no_provider_resolves_returns_404_not_200_empty(): void {
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null ); // list_provider = null
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+
+	public function test_list_happy_path_returns_shaped_localities(): void {
+		$record = Location_Record::from_array(
+			[
+				'key'         => 'fake-list:mo',
+				'provider_id' => 'fake-list',
+				'level'       => Location_Record::LEVEL_SETTLEMENT,
+				'country'     => 'RU',
+				'label'       => '<b>Москва</b>',
+			]
+		);
+		$provider = new Location_Controller_Fake_List_Provider( static fn() => [ $record ] );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertCount( 1, $result['localities'] );
+
+		$locality = $result['localities'][0];
+		$this->assertSame( 'fake-list:mo', $locality['key'] );
+		$this->assertSame( Location_Record::LEVEL_SETTLEMENT, $locality['level'] );
+		$this->assertStringContainsString( '&lt;b&gt;', $locality['label'], 'label must be escaped, same as /suggest' );
+
+		// The record must round-trip UNTOUCHED, same D12/D5 contract as /suggest.
+		$round_tripped = Location_Record::from_array( $locality['record'] );
+		$this->assertSame( $record->key(), $round_tripped->key() );
+
+		$this->assertCount( 1, $provider->list_calls );
+	}
+
+	public function test_list_never_reads_a_client_supplied_provider_param(): void {
+		$provider = new Location_Controller_Fake_List_Provider( static fn() => [] );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request(
+			[ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'provider' => 'cdek' ]
+		);
+		$ctrl->handle_list_request( $request );
+
+		$this->assertCount( 1, $service->provider_for_list_calls );
+	}
+
+	public function test_list_provider_exception_returns_502(): void {
+		$provider = new Location_Controller_Fake_List_Provider(
+			static function () {
+				throw new \RuntimeException( 'upstream boom' );
+			}
+		);
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 502, $result->get_error_data()['status'] );
+	}
+
+	public function test_list_within_matching_current_record_narrows_the_scope(): void {
+		$parent   = $this->region_record( 'dadata:region-1' );
+		$captured = null;
+		$provider = new Location_Controller_Fake_List_Provider(
+			static function ( Location_Scope $scope ) use ( &$captured ) {
+				$captured = $scope;
+
+				return [];
+			}
+		);
+		$service = new Location_Controller_Fake_Service( true, null, [ 'record' => $parent, 'implicit' => false, 'saved_at' => 0 ], true, true, null, null, $provider );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request(
+			[ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'within' => 'dadata:region-1' ]
+		);
+		$ctrl->handle_list_request( $request );
+
+		$this->assertNotNull( $captured );
+		$this->assertTrue( $captured->has_parent() );
+		$this->assertSame( $parent, $captured->parent_record() );
 	}
 }

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -1056,6 +1056,7 @@ final class LocationControllerTest extends TestCase {
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
 		$this->assertCount( 1, $result['localities'] );
+		$this->assertFalse( $result['truncated'] );
 
 		$locality = $result['localities'][0];
 		$this->assertSame( 'fake-list:mo', $locality['key'] );
@@ -1067,6 +1068,153 @@ final class LocationControllerTest extends TestCase {
 		$this->assertSame( $record->key(), $round_tripped->key() );
 
 		$this->assertCount( 1, $provider->list_calls );
+	}
+
+	// -------------------------------------------------------------------
+	// /list — PR #304 review finding 5: an unbounded enumeration is capped,
+	// an optional `limit` narrows it further (clamped), and the response is
+	// honest about truncation rather than silently cutting.
+	// -------------------------------------------------------------------
+
+	/**
+	 * @param int $count how many fake records the fixture provider returns.
+	 *
+	 * @return Location_Record[]
+	 */
+	private function many_records( int $count ): array {
+		$records = [];
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$records[] = Location_Record::from_array(
+				[
+					'key'         => 'fake-list:' . $i,
+					'provider_id' => 'fake-list',
+					'level'       => Location_Record::LEVEL_SETTLEMENT,
+					'country'     => 'RU',
+					'label'       => 'City ' . $i,
+				]
+			);
+		}
+
+		return $records;
+	}
+
+	public function test_list_caps_the_response_at_the_hard_limit_and_reports_truncation(): void {
+		// One MORE than the hard cap — the exact neighbouring value a mutant
+		// removing/loosening the cap would fail against.
+		$provider = new Location_Controller_Fake_List_Provider( fn() => $this->many_records( 501 ) );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertCount( 500, $result['localities'], 'the response must never exceed LIST_HARD_CAP' );
+		$this->assertTrue( $result['truncated'] );
+	}
+
+	public function test_list_exactly_at_the_hard_cap_is_not_reported_truncated(): void {
+		$provider = new Location_Controller_Fake_List_Provider( fn() => $this->many_records( 500 ) );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertCount( 500, $result['localities'] );
+		$this->assertFalse( $result['truncated'], 'the provider handed back exactly the cap, nothing was actually cut' );
+	}
+
+	public function test_list_limit_arg_narrows_the_response_below_the_hard_cap(): void {
+		$provider = new Location_Controller_Fake_List_Provider( fn() => $this->many_records( 20 ) );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'limit' => 5 ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertCount( 5, $result['localities'] );
+		$this->assertTrue( $result['truncated'] );
+	}
+
+	/**
+	 * A client cannot use `limit` to ask for MORE than the hard cap — the
+	 * mutant this pins: `min( $limit, self::LIST_HARD_CAP )` reverted to a
+	 * bare `$limit` would let this request through at 100000 records.
+	 */
+	public function test_list_limit_arg_above_the_hard_cap_is_clamped_to_it(): void {
+		$provider = new Location_Controller_Fake_List_Provider( fn() => $this->many_records( 501 ) );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'limit' => 100000 ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertCount( 500, $result['localities'] );
+		$this->assertTrue( $result['truncated'] );
+	}
+
+	public function test_list_limit_arg_zero_or_negative_falls_back_to_the_hard_cap(): void {
+		$provider = new Location_Controller_Fake_List_Provider( fn() => $this->many_records( 10 ) );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'limit' => -5 ] );
+		$result  = $ctrl->handle_list_request( $request );
+
+		$this->assertCount( 10, $result['localities'], 'a non-positive limit is not a valid narrowing — falls back to the hard cap' );
+		$this->assertFalse( $result['truncated'] );
+	}
+
+	/**
+	 * PR #304 review's own test-gap finding: nothing previously pinned
+	 * `LIST_RATE_LIMIT_MAX` itself, or even proved the limiter is wired into
+	 * `/list` at all — every other `/list` test in this file goes through
+	 * {@see Location_Controller_Probe}, which BYPASSES the limiter entirely.
+	 * This test uses the REAL {@see Location_Controller} (no probe) with the
+	 * real rate-limit storage stubbed (mirrors `RestRateLimitTraitTest`'s own
+	 * fixture setup), so it fails both against a mutant that unhooks the
+	 * limiter from `/list` and against a mutant that changes the budget away
+	 * from 60 (the 61st call is the neighbouring value that pins the exact
+	 * number, not merely "some limit exists").
+	 */
+	public function test_list_rate_limit_is_pinned_at_the_real_budget(): void {
+		$store = [];
+
+		Functions\when( 'get_transient' )->alias(
+			static function ( $key ) use ( &$store ) {
+				return $store[ $key ] ?? false;
+			}
+		);
+		Functions\when( 'set_transient' )->alias(
+			static function ( $key, $value, $ttl ) use ( &$store ) {
+				$store[ $key ] = $value;
+
+				return true;
+			}
+		);
+		Functions\when( 'wp_using_ext_object_cache' )->justReturn( false );
+
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.9';
+
+		$provider = new Location_Controller_Fake_List_Provider( static fn() => [] );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller( $service ); // the REAL controller — rate limiting genuinely runs.
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+
+		for ( $i = 0; $i < 60; $i++ ) {
+			$result = $ctrl->handle_list_request( $request );
+			$this->assertNotInstanceOf( \WP_Error::class, $result, "request {$i} (1-based " . ( $i + 1 ) . ') must still be within the 60/min budget' );
+		}
+
+		$result = $ctrl->handle_list_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result, 'the 61st request must be the one that trips the limiter' );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+
+		unset( $_SERVER['REMOTE_ADDR'] );
 	}
 
 	public function test_list_never_reads_a_client_supplied_provider_param(): void {

--- a/woodev/shipping-method/checkout/class-checkout-config.php
+++ b/woodev/shipping-method/checkout/class-checkout-config.php
@@ -321,18 +321,46 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *   meaningful attached to an actual record.
 		 *
 		 * **`related-list` region seam (Task 13; client-facing contract for the
-		 * next agent):** when `mode === 'related-list'`, the region `<select>`
-		 * WooCommerce renders is populated by
+		 * next agent — CORRECTED after the s71 rig measurement, see below):**
+		 * when `mode === 'related-list'`, the region `<select>` WooCommerce
+		 * renders is populated by
 		 * {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::inject_related_list_states()}
-		 * with `value => label` pairs where **the WC state VALUE is the record's
-		 * own {@see \Woodev\Framework\Shipping\Location\Location_Record::key()}**
-		 * (the full `provider_id:native_id` locality key), never an arbitrary
-		 * carrier code. A client-side related-list handler therefore reconstructs
-		 * a minimal, valid `Location_Record` straight from the selected
-		 * `<option>`'s `value` (the key) and `text` (the label) — no second
-		 * lookup, matching the backwards-fill discipline Task 11 already
-		 * established elsewhere in this layer — before POSTing it to the SAME
-		 * `/location/select` endpoint every other level already uses.
+		 * with `label => label` pairs — **the WC state VALUE is the record's own
+		 * {@see \Woodev\Framework\Shipping\Location\Location_Record::label()}**
+		 * (a human-readable region name), NEVER the record's `key()`
+		 * (`provider_id:native_id`). That value is what the customer's browser
+		 * submits as `billing_state`/`shipping_state` and it persists PERMANENTLY
+		 * into order data (a release-blocking installed-site data contract, per
+		 * this project's backward-compatibility policy); a provider-namespaced
+		 * key stored there renders as raw, meaningless text the instant this
+		 * injector stops running — after a provider switch (the key's namespace
+		 * changes), after the store mode is set back to `typeahead`, or after the
+		 * plugin is deactivated. Measured on the rig (s71): WITHOUT the injector
+		 * attached, a stored `dadata:0c089b04-…` key rendered verbatim inside
+		 * `WC_Countries::get_formatted_address()`'s output instead of the region
+		 * name.
+		 *
+		 * A client-side related-list handler does NOT reconstruct a
+		 * `Location_Record` from the selected `<option>` alone — a label is not a
+		 * full record. Instead it takes the option's selected TEXT (identical to
+		 * its `value`, since both are the label) and looks it up in the SAME
+		 * country's response from the `list` endpoint above (`GET
+		 * .../location/list?level=region&country={code}`, already fetched or
+		 * fetchable via this block's `endpoints.list`): each entry there carries
+		 * `{ key, label, level, record }` where `record` is the UNTOUCHED
+		 * {@see \Woodev\Framework\Shipping\Location\Location_Record::to_array()}
+		 * payload — match the selected label against that entry's `record.label`
+		 * (the raw, exact label, not the top-level `label` field, which is
+		 * `esc_html()`-escaped for direct display and must not be used for
+		 * equality matching), then POST the matched entry's `record` verbatim to
+		 * the SAME `/location/select` endpoint every other level already uses —
+		 * no second lookup beyond that one `/location/list` call, matching the
+		 * backwards-fill discipline Task 11 already established elsewhere in this
+		 * layer. Two records that legitimately share one label within a country
+		 * are pre-resolved server-side: `inject_related_list_states()` keeps only
+		 * the first and reports the rest via `_doing_it_wrong()`, so the label
+		 * the client sees is already unique — `record.label` uniquely identifies
+		 * one entry in that same country's `/location/list` response.
 		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 `levels` changed from a single flat per-level map to a
@@ -341,6 +369,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *              constant, `levels[country]['region']` is additionally
 		 *              gated against WooCommerce's own registered states, and
 		 *              `endpoints` gained `list` (Task 13; issue #294).
+		 * @since 2.0.2 `related-list` region seam corrected: the injected WC
+		 *              state VALUE is the record's `label()`, not its `key()` —
+		 *              a `billing_state`/`shipping_state` value is permanent
+		 *              order data (rig measurement, s71).
 		 *
 		 * @param \Woodev\Framework\Shipping\Location\Location_Service $service The active, already-confirmed façade.
 		 *

--- a/woodev/shipping-method/checkout/class-checkout-config.php
+++ b/woodev/shipping-method/checkout/class-checkout-config.php
@@ -321,30 +321,39 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *   meaningful attached to an actual record.
 		 *
 		 * **`related-list` region seam (Task 13; client-facing contract for the
-		 * next agent — CORRECTED after the s71 rig measurement, see below):**
-		 * when `mode === 'related-list'`, the region `<select>` WooCommerce
-		 * renders is populated by
+		 * next agent — CORRECTED after the s71 rig measurement AND the PR #304
+		 * review, see below):** when `mode === 'related-list'`, the region
+		 * `<select>` WooCommerce renders is populated by
 		 * {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::inject_related_list_states()}
-		 * with `label => label` pairs — **the WC state VALUE is the record's own
-		 * {@see \Woodev\Framework\Shipping\Location\Location_Record::label()}**
-		 * (a human-readable region name), NEVER the record's `key()`
-		 * (`provider_id:native_id`). That value is what the customer's browser
-		 * submits as `billing_state`/`shipping_state` and it persists PERMANENTLY
-		 * into order data (a release-blocking installed-site data contract, per
-		 * this project's backward-compatibility policy); a provider-namespaced
-		 * key stored there renders as raw, meaningless text the instant this
-		 * injector stops running — after a provider switch (the key's namespace
-		 * changes), after the store mode is set back to `typeahead`, or after the
-		 * plugin is deactivated. Measured on the rig (s71): WITHOUT the injector
-		 * attached, a stored `dadata:0c089b04-…` key rendered verbatim inside
+		 * with `wc_strtoupper( label ) => label` pairs — the `<option>` VALUE is
+		 * the record's own {@see \Woodev\Framework\Shipping\Location\Location_Record::label()}
+		 * UPPERCASED (via WooCommerce's own `wc_strtoupper()`, Cyrillic-aware),
+		 * the `<option>` TEXT is the human-readable label unchanged, and NEITHER
+		 * is ever the record's `key()` (`provider_id:native_id`). The VALUE is
+		 * what the customer's browser submits as `billing_state`/`shipping_state`
+		 * and it persists PERMANENTLY into order data (a release-blocking
+		 * installed-site data contract, per this project's backward-compatibility
+		 * policy); a provider-namespaced key stored there renders as raw,
+		 * meaningless text the instant this injector stops running — after a
+		 * provider switch (the key's namespace changes), after the store mode is
+		 * set back to `typeahead`, or after the plugin is deactivated. Measured
+		 * on the rig (s71): WITHOUT the injector attached, a stored
+		 * `dadata:0c089b04-…` key rendered verbatim inside
 		 * `WC_Countries::get_formatted_address()`'s output instead of the region
-		 * name.
+		 * name. The VALUE is uppercased — not the bare label — because
+		 * `WC_Checkout::validate_posted_data()` uppercases whatever the customer
+		 * posted before matching it against the registered keys; a mixed-case
+		 * key used bare would get shouted into an uppercase STORED value that no
+		 * longer equals its own option's key, so the field would silently revert
+		 * to the placeholder on the next render (PR #304 review finding 2,
+		 * measured on the rig: posting `Московская область` stored `МОСКОВСКАЯ
+		 * ОБЛАСТЬ`, which the mixed-case key could never match again).
 		 *
 		 * A client-side related-list handler does NOT reconstruct a
 		 * `Location_Record` from the selected `<option>` alone — a label is not a
-		 * full record. Instead it takes the option's selected TEXT (identical to
-		 * its `value`, since both are the label) and looks it up in the SAME
-		 * country's response from the `list` endpoint above (`GET
+		 * full record. Instead it takes the option's selected TEXT (the human
+		 * label — NOT its `value`, which is uppercased) and looks it up in the
+		 * SAME country's response from the `list` endpoint above (`GET
 		 * .../location/list?level=region&country={code}`, already fetched or
 		 * fetchable via this block's `endpoints.list`): each entry there carries
 		 * `{ key, label, level, record }` where `record` is the UNTOUCHED
@@ -373,6 +382,14 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *              state VALUE is the record's `label()`, not its `key()` —
 		 *              a `billing_state`/`shipping_state` value is permanent
 		 *              order data (rig measurement, s71).
+		 * @since 2.0.2 `related-list` region seam corrected again: the injected
+		 *              WC state KEY is now `wc_strtoupper( trim( label ) )`
+		 *              rather than the bare label, the ownership check
+		 *              ({@see \Woodev\Framework\Shipping\Location\Location_Service::owns_region_states()})
+		 *              now re-confirms against the FINAL registered states, and
+		 *              `wc_states()`'s cast no longer turns a `false`
+		 *              `get_states()` result into a non-empty array (PR #304
+		 *              review findings 1-4).
 		 *
 		 * @param \Woodev\Framework\Shipping\Location\Location_Service $service The active, already-confirmed façade.
 		 *
@@ -409,9 +426,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 				// method's own docblock for the full rule, and {@see self::wc_states()}
 				// for why that read goes through an overridable seam rather than a bare
 				// WC() call inline here.
-				$states_present = [] !== $this->wc_states( $code );
+				$final_states   = $this->wc_states( $code );
+				$states_present = [] !== $final_states;
 
-				if ( $country_levels['region'] && $states_present && ! $service->owns_region_states( $code ) ) {
+				if ( $country_levels['region'] && $states_present && ! $service->owns_region_states( $code, $final_states ) ) {
 					$region_conflict_countries[] = $code;
 				}
 
@@ -521,9 +539,14 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *
 		 * Degrades to `[]` (never fatals) when `WC()`/`WC()->countries` is
 		 * unavailable — the same "no states known, trust the D15 chain's own
-		 * answer unchanged" degradation the pre-Task-13 code implicitly had.
+		 * answer unchanged" degradation the pre-Task-13 code implicitly had. Also
+		 * degrades to `[]` (via `array_filter()`) when `get_states()` itself
+		 * answers `false` for an absent country key — see this method's own body
+		 * comment (PR #304 review finding 1).
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Wrapped the cast in `array_filter()` — a bare `(array) false`
+		 *              is `[ 0 => false ]`, non-empty (PR #304 review finding 1).
 		 *
 		 * @param string $country ISO-3166 alpha-2 country code.
 		 *
@@ -536,7 +559,19 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 				return [];
 			}
 
-			return (array) WC()->countries->get_states( $country );
+			// `WC_Countries::get_states()` returns `false` — not `[]` — when the
+			// country key is absent (`includes/class-wc-countries.php`), and
+			// `(array) false === [ 0 => false ]`, which is NON-empty: a bare cast
+			// here made `$states_present` true for every country with no states at
+			// all, which in the DEFAULT configuration (typeahead mode, no §8
+			// takeover) meant the region typeahead never attached anywhere and
+			// `_doing_it_wrong()` fired on every checkout render (PR #304 review
+			// finding 1, measured on the rig: `get_states( 'RU' )` -> `false`,
+			// `(array) false` -> `[ 0 => false ]`). `array_filter()` drops that
+			// falsy entry, mirroring WooCommerce's own precedent for this exact
+			// trap: `StoreApi\Utilities\ValidationUtils::format_state()` reads
+			// `array_filter( (array) wc()->countries->get_states( $country ) )`.
+			return array_filter( (array) WC()->countries->get_states( $country ) );
 		}
 	}
 

--- a/woodev/shipping-method/checkout/class-checkout-config.php
+++ b/woodev/shipping-method/checkout/class-checkout-config.php
@@ -43,16 +43,28 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 	 *   'takeover' => [ field_id => [ country_code => bool ] ],
 	 *   // Present only when a Location_Service was injected AND is_active() (Task 9):
 	 *   'location' => [
-	 *     'endpoints' => [ 'suggest' => string, 'select' => string ],
+	 *     'endpoints' => [ 'suggest' => string, 'select' => string, 'list' => string ], // 'list' added Task 13
 	 *     'nonce'     => string, // same wp_rest nonce as the top-level 'nonce' above
 	 *     'countries' => string[],
-	 *     'mode'      => string,
+	 *     'mode'      => string, // 'typeahead' | 'related-list' | 'ajax-select2' (Task 13; spec D7)
 	 *     'levels'    => [ country_code => [ 'region' => bool, 'settlement' => bool, 'address' => bool ] ],
 	 *     'current'   => [ 'key' => string, 'level' => string ]|null,
 	 *     'implicit'  => bool,
 	 *   ],
 	 * ]
 	 * ```
+	 *
+	 * Task 13 (issue #294) note on `location.levels[country].region`: `true` means
+	 * this layer wants AND is free to serve that country's region field with a
+	 * typeahead — free because WooCommerce has no registered `woocommerce_states`
+	 * entry for it. `false` covers two different reasons the client must NOT try to
+	 * tell apart from this flag alone (it does not need to): either no configured
+	 * provider supports the level there, OR WooCommerce already renders a native
+	 * `<select>` for it (its own list, a plugin's §8 carrier takeover, or THIS
+	 * layer's own `related-list` mode injection) — in every `false` case the client
+	 * must leave the field exactly as WooCommerce rendered it and never attach a
+	 * typeahead. See {@see self::build_location_block()}'s own docblock for the full
+	 * arbitration rule and the `related-list` region seam's exact value shape.
 	 *
 	 * @since 2.0.2
 	 */
@@ -239,12 +251,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *   not just what the ACTIVE provider alone lists. A country the store does
 		 *   not even sell to is not useful information for the client-side D2
 		 *   arbitration this list feeds, hence the intersection with the WC list.
-		 * - `mode` — the store's field-presentation setting (spec D7). Nothing
-		 *   declares that setting yet (Tasks 13/14), so the only HONEST value today
-		 *   is the one mode D7 says is unconditionally available regardless of
-		 *   provider capability: free-text typeahead. This constant is the one
-		 *   TODO-shaped line in this method — Task 13/14 replaces it with a real
-		 *   read from the settings surface.
+		 * - `mode` — the store's field-presentation setting (spec D7; Task 13),
+		 *   read from {@see \Woodev\Framework\Shipping\Location\Location_Service::get_field_mode()}
+		 *   — one of `typeahead` / `related-list` / `ajax-select2`, already
+		 *   clamped against the active provider's own capabilities (a mode the
+		 *   provider cannot serve is never returned, regardless of what the
+		 *   store option literally holds).
 		 * - `levels` — a MAP, `{ [country]: { region, settlement, address } }`, one
 		 *   entry per country in `countries` above (D15 amendment follow-up:
 		 *   per-country suggest levels — DaData genuinely serves `address` in
@@ -263,6 +275,41 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *   learns only this — NEVER which provider serves a level (spec D15) —
 		 *   because neither this method nor `get_levels_for_country()` ever reads
 		 *   {@see \Woodev\Framework\Shipping\Location\Location_Provider::get_id()}.
+		 *
+		 *   **`levels[country]['region']` — issue #294 arbitration (Task 13).**
+		 *   The D15 chain's own opinion ("some provider could suggest a region")
+		 *   is NOT the final answer for `region` the way it is for `settlement`/
+		 *   `address`: WooCommerce owns the region concept as soon as ANY
+		 *   `woocommerce_states` entry exists for that country. This method reads
+		 *   `WC()->countries->get_states( $code )` (through {@see self::wc_states()},
+		 *   a thin overridable seam — see that method's own docblock for why it
+		 *   is not an inline `WC()` call) — deliberately HERE, AFTER every
+		 *   `woocommerce_states` filter has already run (WooCommerce's own
+		 *   native list, a plugin's §8 carrier takeover via
+		 *   {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::inject_states()},
+		 *   and this layer's OWN `related-list` mode injector,
+		 *   {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::inject_related_list_states()}
+		 *   — one place, one source of truth, per the decided rule) — and reports
+		 *   `region` as OURS (`true`) only when the chain wants it AND the country
+		 *   has NO registered states at all. A non-empty state list means
+		 *   WooCommerce renders a native `<select>` there regardless of what this
+		 *   layer wants, so pretending a typeahead still belongs on that field is
+		 *   exactly the drift the card that decided this found (never write an
+		 *   empty array into `woocommerce_states` either — gotcha
+		 *   `checkout-field-takeover-woocommerce-states` — this method only READS
+		 *   the filter's result, it never writes to it).
+		 *
+		 *   A non-empty state list the D15 chain wanted `region` for, that this
+		 *   layer did NOT inject itself
+		 *   ({@see \Woodev\Framework\Shipping\Location\Location_Service::owns_region_states()}
+		 *   false), is a genuine conflict — some OTHER source (native WC, or a
+		 *   plugin's own §8 takeover) already owns that country's regions. This
+		 *   is reported via `_doing_it_wrong()`, ONCE per config build (not once
+		 *   per conflicting country), mirroring `inject_states()`'s own
+		 *   conflict-observability mechanism. A `related-list`-mode injection is
+		 *   never a conflict with itself: `owns_region_states()` distinguishes
+		 *   "we put these states there" from "someone else did", so the warning
+		 *   never fires for the layer's own intended rendering.
 		 * - `current`/`implicit` — from
 		 *   {@see \Woodev\Framework\Shipping\Location\Location_Service::get_customer_record()}.
 		 *   `current`'s shape (`{ key, level }`) is deliberately byte-for-byte the
@@ -273,14 +320,32 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *   `false` when there is no record at all — an implicit flag is only
 		 *   meaningful attached to an actual record.
 		 *
+		 * **`related-list` region seam (Task 13; client-facing contract for the
+		 * next agent):** when `mode === 'related-list'`, the region `<select>`
+		 * WooCommerce renders is populated by
+		 * {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::inject_related_list_states()}
+		 * with `value => label` pairs where **the WC state VALUE is the record's
+		 * own {@see \Woodev\Framework\Shipping\Location\Location_Record::key()}**
+		 * (the full `provider_id:native_id` locality key), never an arbitrary
+		 * carrier code. A client-side related-list handler therefore reconstructs
+		 * a minimal, valid `Location_Record` straight from the selected
+		 * `<option>`'s `value` (the key) and `text` (the label) — no second
+		 * lookup, matching the backwards-fill discipline Task 11 already
+		 * established elsewhere in this layer — before POSTing it to the SAME
+		 * `/location/select` endpoint every other level already uses.
+		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 `levels` changed from a single flat per-level map to a
 		 *              per-country map (D15 amendment follow-up).
+		 * @since 2.0.2 `mode` reads the real store setting instead of a hardcoded
+		 *              constant, `levels[country]['region']` is additionally
+		 *              gated against WooCommerce's own registered states, and
+		 *              `endpoints` gained `list` (Task 13; issue #294).
 		 *
 		 * @param \Woodev\Framework\Shipping\Location\Location_Service $service The active, already-confirmed façade.
 		 *
 		 * @return array{
-		 *     endpoints: array{suggest: string, select: string},
+		 *     endpoints: array{suggest: string, select: string, list: string},
 		 *     nonce: string,
 		 *     countries: string[],
 		 *     mode: string,
@@ -300,9 +365,38 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 				}
 			}
 
-			$levels = [];
+			$levels                    = [];
+			$region_conflict_countries = [];
+
 			foreach ( $countries as $code ) {
-				$levels[ $code ] = $service->get_levels_for_country( $code );
+				$country_levels = $service->get_levels_for_country( $code );
+
+				// #294 arbitration: the authority is the FINAL woocommerce_states
+				// result, read AFTER every filter (native WC, §8 carrier takeover,
+				// this layer's own related-list injector) has already run — see this
+				// method's own docblock for the full rule, and {@see self::wc_states()}
+				// for why that read goes through an overridable seam rather than a bare
+				// WC() call inline here.
+				$states_present = [] !== $this->wc_states( $code );
+
+				if ( $country_levels['region'] && $states_present && ! $service->owns_region_states( $code ) ) {
+					$region_conflict_countries[] = $code;
+				}
+
+				$country_levels['region'] = $country_levels['region'] && ! $states_present;
+
+				$levels[ $code ] = $country_levels;
+			}
+
+			if ( [] !== $region_conflict_countries ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						'the location layer wanted to serve the "region" level via typeahead for %s, but WooCommerce already has native/injected states registered for those countries (see the woocommerce_states filter — issue #294); the layer stands down and reports "region" as not its own for them.',
+						implode( ', ', $region_conflict_countries )
+					),
+					'2.0.2'
+				);
 			}
 
 			$customer = $service->get_customer_record();
@@ -358,15 +452,59 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 				'endpoints' => [
 					'suggest' => $this->rest_base . '/location/suggest',
 					'select'  => $this->rest_base . '/location/select',
+					'list'    => $this->rest_base . '/location/list',
 				],
 				'nonce'     => $this->nonce,
 				'countries' => array_values( $countries ),
-				'mode'      => 'typeahead',
+				'mode'      => $service->get_field_mode(),
 				'levels'    => $levels,
 				'current'   => $current,
 				'implicit'  => $implicit,
 				'i18n'      => array_map( 'strval', (array) $strings ),
 			];
+		}
+
+		/**
+		 * Reads WooCommerce's FINAL registered states for one country — the
+		 * issue #294 arbitration's own single source of truth (see
+		 * {@see self::build_location_block()}'s own docblock for the full rule).
+		 *
+		 * A `protected`, overridable seam rather than an inline `WC()` call for
+		 * a specific, measured reason: Brain Monkey (`Functions\when( 'WC' )`)
+		 * instruments the global `WC()` function for the REST OF THE PHP
+		 * PROCESS once any single test stubs it — every OTHER unit test in the
+		 * suite that relies on `function_exists( 'WC' ) === false` (the
+		 * established "no WooCommerce loaded in unit tests" idiom this
+		 * codebase's other classes already use, e.g.
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::wc_country_codes()})
+		 * would start seeing `WC()` DEFINED-BUT-UNMOCKED and fail with Brain
+		 * Monkey's own `MissingFunctionExpectations` — measured directly: a
+		 * first version of this method called `WC()` inline and a single
+		 * stubbing test in `CheckoutConfigTest` broke 21 unrelated tests
+		 * elsewhere in the full suite the moment `composer test:unit` ran all
+		 * files in one process. A protected method a TEST SUBCLASS overrides
+		 * (the same "Probe subclass" discipline `Checkout_Handler::current_country()`
+		 * already establishes for this exact class of problem) sidesteps Brain
+		 * Monkey's global function table entirely.
+		 *
+		 * Degrades to `[]` (never fatals) when `WC()`/`WC()->countries` is
+		 * unavailable — the same "no states known, trust the D15 chain's own
+		 * answer unchanged" degradation the pre-Task-13 code implicitly had.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $country ISO-3166 alpha-2 country code.
+		 *
+		 * @return array<string, string> WC state code => label, or `[]` when
+		 *                                WooCommerce has none registered (or is
+		 *                                unavailable).
+		 */
+		protected function wc_states( string $country ): array {
+			if ( ! function_exists( 'WC' ) || ! WC() || ! isset( WC()->countries ) ) {
+				return [];
+			}
+
+			return (array) WC()->countries->get_states( $country );
 		}
 	}
 

--- a/woodev/shipping-method/location/class-location-provider-registry.php
+++ b/woodev/shipping-method/location/class-location-provider-registry.php
@@ -233,9 +233,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		private ?Location_Settings $settings_handler = null;
 
 		/**
-		 * Countries {@see self::inject_related_list_states()} itself successfully
-		 * wrote non-empty `woocommerce_states` options for, THIS request — the
-		 * ownership record {@see self::owns_region_states()} answers from.
+		 * The exact `woocommerce_states` OPTIONS {@see self::inject_related_list_states()}
+		 * itself successfully wrote for a country, THIS request — the ownership
+		 * record {@see self::owns_region_states()} compares against the FINAL
+		 * registered states to answer from.
 		 *
 		 * Recorded rather than inferred from the field-mode setting alone
 		 * (`mode === 'related-list'`) because that alone cannot distinguish "we
@@ -247,8 +248,16 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 * `_doing_it_wrong()` (issue #294) must fire in the second case, not the
 		 * first.
 		 *
+		 * Storing the OPTIONS themselves (not merely a `true` flag) is what lets
+		 * {@see self::owns_region_states()} detect a LATER filter callback
+		 * (e.g. a §8 carrier takeover hooked after this injector) clobbering this
+		 * country's states after this method already ran — see that method's own
+		 * docblock, PR #304 review finding 3.
+		 *
 		 * @since 2.0.2
-		 * @var array<string, true>
+		 * @since 2.0.2 Stores the injected OPTIONS rather than a bare `true` flag
+		 *              (PR #304 review finding 3).
+		 * @var array<string, array<string, string>>
 		 */
 		private array $related_list_states_countries = [];
 
@@ -683,7 +692,21 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 * Returns `null` outright while the gate is closed — no settings handler
 		 * exists to read a value from, and there is nothing to be "active" about.
 		 *
+		 * Delegates the id -> instance resolution (+ {@see self::FILTER_ACTIVE_PROVIDER})
+		 * to {@see self::resolve_active_provider_for_id()} — the SAME resolution
+		 * {@see self::register_settings()} now goes through, so the settings page
+		 * (built once, at collection time) and every runtime caller of this method
+		 * can never disagree about which provider is active (PR #304 review
+		 * finding 6: `register_settings()` used to look the id up directly against
+		 * `$this->providers`, skipping the filter entirely, so a plugin using
+		 * {@see self::FILTER_ACTIVE_PROVIDER} to swap the resolved provider could
+		 * make the admin settings page offer a narrower set of field modes than
+		 * the runtime would actually accept).
+		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Delegates to {@see self::resolve_active_provider_for_id()},
+		 *              shared with {@see self::register_settings()} (PR #304
+		 *              review finding 6).
 		 *
 		 * @return Location_Provider|null
 		 */
@@ -693,24 +716,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 			}
 
 			$active_id = (string) $this->settings_handler->get_value( self::SETTING_ACTIVE_PROVIDER );
-			$provider  = $this->providers[ $active_id ] ?? $this->providers[ self::DEFAULT_PROVIDER_ID ] ?? null;
 
-			/**
-			 * Filters the resolved active location provider instance.
-			 *
-			 * Left in place even though nothing in this codebase consumes it yet
-			 * (project preference: extension hooks are not gated on a consumer).
-			 *
-			 * @since 2.0.2
-			 *
-			 * @param Location_Provider|null $provider  The resolved provider, or null
-			 *                                           when the (possibly-fallen-back-to)
-			 *                                           id has nothing registered.
-			 * @param string                 $active_id The store setting's raw value
-			 *                                           (before the default-id fallback
-			 *                                           above was applied).
-			 */
-			return apply_filters( self::FILTER_ACTIVE_PROVIDER, $provider, $active_id );
+			return $this->resolve_active_provider_for_id( $active_id );
 		}
 
 		/**
@@ -844,20 +851,49 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 
 		/**
 		 * Whether {@see self::inject_related_list_states()} itself successfully
-		 * injected `$country`'s `woocommerce_states` options THIS request — the
+		 * injected `$country`'s `woocommerce_states` options THIS request AND
+		 * those options are still what WooCommerce is serving right now — the
 		 * precise "is this non-empty state list ours" answer
 		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}
 		 * needs for the issue #294 arbitration (see {@see self::inject_related_list_states()}'s
 		 * own docblock for why the field-mode setting alone cannot answer this).
 		 *
-		 * @since 2.0.2
+		 * `$final_states` is the country's FINAL `woocommerce_states` read —
+		 * after every filter callback that ran this request, including any §8
+		 * carrier takeover ({@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::inject_states()})
+		 * that runs AFTER this injector (both are hooked at the default
+		 * priority; this injector merely runs first) and clobbers its result
+		 * unconditionally. Recording "we wrote it" alone (the pre-PR-304
+		 * behaviour) answered a question that had already gone stale by the
+		 * time it mattered: a later §8 takeover silently overwrote this
+		 * layer's own injection while the recorded flag stayed `true`, so the
+		 * #294 conflict this rule exists to surface never fired for the exact
+		 * collision it was written for (PR #304 review finding 3) — the client
+		 * was then offered carrier option TEXTS that appear in no `/location/list`
+		 * response, so the label -> record lookup found nothing and nothing
+		 * ever reached `/location/select`. Comparing against the FINAL read
+		 * closes that gap, and covers any third party filtering
+		 * `woocommerce_states` directly the same way.
 		 *
-		 * @param string $country ISO-3166 alpha-2 country code, any case/whitespace.
+		 * @since 2.0.2
+		 * @since 2.0.2 Takes the caller's own FINAL `woocommerce_states` read
+		 *              and compares it against what was actually injected,
+		 *              rather than trusting the recorded flag alone (PR #304
+		 *              review finding 3).
+		 *
+		 * @param string                $country      ISO-3166 alpha-2 country code, any case/whitespace.
+		 * @param array<string, string> $final_states The country's FINAL registered WC states
+		 *                                             (e.g. {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::wc_states()}'s
+		 *                                             own read), compared against what this
+		 *                                             injector itself wrote.
 		 *
 		 * @return bool
 		 */
-		public function owns_region_states( string $country ): bool {
-			return isset( $this->related_list_states_countries[ strtoupper( trim( $country ) ) ] );
+		public function owns_region_states( string $country, array $final_states ): bool {
+			$country = strtoupper( trim( $country ) );
+
+			return isset( $this->related_list_states_countries[ $country ] )
+				&& $this->related_list_states_countries[ $country ] === $final_states;
 		}
 
 		/**
@@ -902,35 +938,56 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 *   own catch-and-degrade discipline for the equivalent REST path).
 		 *
 		 * The WC state array's VALUE is the record's own {@see Location_Record::label()}
-		 * — a human-readable region name, THE SAME STRING used as the key — never
-		 * the record's {@see Location_Record::key()} (`provider_id:native_id`).
-		 * That value is what the customer's browser submits as `billing_state` /
-		 * `shipping_state`, and it persists PERMANENTLY into order data — a
-		 * provider-namespaced key stored there renders as raw, meaningless text in
-		 * {@see \WC_Countries::get_formatted_address()} the instant this injector
-		 * is not present to translate it back (a provider switch renamespaces the
-		 * keys, a mode switch back to `typeahead` stops injecting entirely, and a
-		 * deactivated plugin obviously never runs at all) — order history must
-		 * stay meaningful without this plugin (measured on the rig, s71: an
-		 * uninjected `dadata:0c089b04-…` key rendered verbatim in a formatted
-		 * address). Identity already lives where it belongs — in our own customer
-		 * location record, persisted through `/location/select` — so a second copy
-		 * of identity inside a WooCommerce field this layer does not own would be
-		 * both redundant and permanent. See `Checkout_Config`'s own class docblock
-		 * for how the client-side related-list renderer (a later agent's task)
-		 * maps the selected label back to a full record via `/location/list`
-		 * instead.
+		 * (trimmed) — a human-readable region name — never the record's
+		 * {@see Location_Record::key()} (`provider_id:native_id`). That value is
+		 * what {@see \WC_Countries::get_formatted_address()} resolves through the
+		 * KEY to render on the order, and it persists PERMANENTLY into order
+		 * data — a provider-namespaced key stored there renders as raw,
+		 * meaningless text the instant this injector is not present to translate
+		 * it back (a provider switch renamespaces the keys, a mode switch back to
+		 * `typeahead` stops injecting entirely, and a deactivated plugin obviously
+		 * never runs at all) — order history must stay meaningful without this
+		 * plugin (measured on the rig, s71: an uninjected `dadata:0c089b04-…` key
+		 * rendered verbatim in a formatted address). Identity already lives where
+		 * it belongs — in our own customer location record, persisted through
+		 * `/location/select` — so a second copy of identity inside a WooCommerce
+		 * field this layer does not own would be both redundant and permanent.
+		 * See `Checkout_Config`'s own class docblock for how the client-side
+		 * related-list renderer maps the selected label back to a full record via
+		 * `/location/list` instead.
 		 *
-		 * Two records legitimately colliding on the same label within one country
-		 * ARE possible (a provider's own data, not a coding mistake) and are a
-		 * real ambiguity: WooCommerce's state array is keyed by value, so only one
-		 * of them could ever be selected. The first one (provider's own
-		 * enumeration order) wins; every later collision is dropped and reported
-		 * via `_doing_it_wrong()` — the label-identity discipline this layer
-		 * enforces makes a synthetic disambiguating suffix (e.g. appending the
-		 * key) the wrong fix, since that suffix would itself leak into
-		 * `billing_state` and recreate the exact opaque-value problem this method
-		 * exists to remove.
+		 * The KEY is the label UPPERCASED via WooCommerce's own `wc_strtoupper()`
+		 * — never the bare (possibly mixed-case) label — because
+		 * `WC_Checkout::validate_posted_data()` uppercases whatever the customer
+		 * posted before matching it against the registered state keys
+		 * (`includes/class-wc-checkout.php`); for WC's own native states this is a
+		 * no-op (their keys are already uppercase codes), but a mixed-case human
+		 * label used bare AS the key gets shouted into an UPPERCASE value that no
+		 * longer equals the option's own key, so the next render's `selected()`
+		 * check never matches and the field silently reverts to the placeholder
+		 * (PR #304 review finding 2, measured on the rig: posting `Московская
+		 * область` stored `МОСКОВСКАЯ ОБЛАСТЬ`, which the mixed-case key could
+		 * never match again). Pre-uppercasing the key makes the round trip a
+		 * no-op: the posted value already equals the key, WC's own uppercase
+		 * normalization maps it straight back to itself, and
+		 * `get_formatted_address()` still resolves the pretty (human-case) LABEL
+		 * through that key.
+		 *
+		 * A record whose (trimmed) label is empty is skipped outright — an empty
+		 * string is indistinguishable from WooCommerce's own "select an option…"
+		 * placeholder and must never become a selectable option (PR #304 review
+		 * finding 4).
+		 *
+		 * Two records legitimately colliding on the same UPPERCASED label within
+		 * one country ARE possible (a provider's own data, not a coding mistake,
+		 * and now also two labels differing only in case) and are a real
+		 * ambiguity: WooCommerce's state array is keyed by value, so only one of
+		 * them could ever be selected. The first one (provider's own enumeration
+		 * order) wins; every later collision is dropped and reported via
+		 * `_doing_it_wrong()` — the label-identity discipline this layer enforces
+		 * makes a synthetic disambiguating suffix (e.g. appending the key) the
+		 * wrong fix, since that suffix would itself leak into `billing_state` and
+		 * recreate the exact opaque-value problem this method exists to remove.
 		 *
 		 * @internal Hooked to `woocommerce_states`; not part of the public
 		 *           consumption surface.
@@ -942,6 +999,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 *              meaning once this injector stops running (rig measurement,
 		 *              s71). Duplicate labels within one country are now detected
 		 *              and reported instead of silently colliding.
+		 * @since 2.0.2 The KEY is now `wc_strtoupper( trim( $label ) )` rather than
+		 *              the bare label, and an empty/whitespace-only label is
+		 *              skipped rather than registered — PR #304 review findings 2
+		 *              and 4.
 		 *
 		 * @param mixed $states WC states keyed by country code, as received from
 		 *                      whichever `woocommerce_states` callback ran before
@@ -952,6 +1013,20 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		public function inject_related_list_states( $states ): array {
 			$states = is_array( $states ) ? $states : [];
 
+			// KNOWN LATENT CONSTRAINT (PR #304 review finding 7, not fixed — see
+			// that review's own "not in scope" note): this method is hooked at
+			// `plugins_loaded` ({@see self::add_hooks()}), but {@see self::get_field_mode()}
+			// answers `self::MODE_TYPEAHEAD` until `$this->settings_handler` exists,
+			// which {@see self::register_settings()} only builds at `init` priority
+			// 20 ({@see self::collect()}). So ANY `woocommerce_states` read that
+			// happens between `plugins_loaded` and `init:20` — even with the store
+			// option genuinely set to `related-list` — sees this gate closed and
+			// gets the un-injected list; because WordPress does not "replay" a
+			// filter for a caller that already consumed its result, that caller's
+			// copy of the list stays un-injected for the rest of the request. No
+			// WooCommerce-core caller was found running that early (WC's own
+			// checkout/order code all runs well after `init`), so this is latent,
+			// not observed — left as a comment rather than restructured.
 			if ( self::MODE_RELATED_LIST !== $this->get_field_mode() ) {
 				return $states;
 			}
@@ -983,9 +1058,15 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 						continue;
 					}
 
-					$label = $record->label();
+					$label = trim( $record->label() );
 
-					if ( isset( $options[ $label ] ) ) {
+					if ( '' === $label ) {
+						continue; // Finding 4: never a selectable-but-blank option.
+					}
+
+					$key = wc_strtoupper( $label );
+
+					if ( isset( $options[ $key ] ) ) {
 						_doing_it_wrong(
 							__METHOD__,
 							sprintf(
@@ -1000,7 +1081,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 						continue;
 					}
 
-					$options[ $label ] = $label;
+					$options[ $key ] = $label;
 				}
 
 				if ( [] === $options ) {
@@ -1009,7 +1090,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 
 				$states[ $country ] = $options;
 
-				$this->related_list_states_countries[ $country ] = true;
+				$this->related_list_states_countries[ $country ] = $options;
 			}
 
 			return $states;
@@ -1024,15 +1105,29 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 * through the handler this method is about to build — the handler does not
 		 * exist yet at this point (constructing it is literally what this method
 		 * does), so there is nothing to read the value from otherwise. Both paths
-		 * read the exact same option name, so they can never disagree.
+		 * read the exact same option name, so they can never disagree on WHICH ID
+		 * is stored.
+		 *
+		 * The id -> instance resolution itself now goes through
+		 * {@see self::resolve_active_provider_for_id()} — the SAME resolution
+		 * {@see self::get_active_provider()} uses, {@see self::FILTER_ACTIVE_PROVIDER}
+		 * included. Previously this method looked the id up directly against
+		 * `$this->providers`, entirely skipping that filter — so a site using it to
+		 * swap the resolved provider could make this settings page offer a
+		 * NARROWER set of field modes than the runtime would actually accept for
+		 * the very same store setting (PR #304 review finding 6).
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Resolves the active provider through
+		 *              {@see self::resolve_active_provider_for_id()} instead of a
+		 *              direct `$this->providers[ $id ]` lookup (PR #304 review
+		 *              finding 6).
 		 *
 		 * @return void
 		 */
 		private function register_settings(): void {
 			$active_id       = $this->resolve_stored_active_provider_id();
-			$active_provider = $this->providers[ $active_id ] ?? null;
+			$active_provider = $this->resolve_active_provider_for_id( $active_id );
 			$provider_fields = null !== $active_provider ? $active_provider->get_settings_fields() : [];
 
 			$provider_options = [];
@@ -1082,6 +1177,45 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 			}
 
 			return self::DEFAULT_PROVIDER_ID;
+		}
+
+
+		/**
+		 * Resolves a provider id to its registered instance, falling back to
+		 * {@see self::DEFAULT_PROVIDER_ID} and applying {@see self::FILTER_ACTIVE_PROVIDER}
+		 * — the single resolution both {@see self::get_active_provider()} and
+		 * {@see self::register_settings()} now go through (PR #304 review finding
+		 * 6), so the admin settings surface and the runtime can never disagree
+		 * about which provider is active.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $active_id A provider id — typically the store setting's
+		 *                          raw value, already resolved to a KNOWN id by
+		 *                          the caller where possible (not required: an
+		 *                          unknown id here still falls back safely).
+		 *
+		 * @return Location_Provider|null
+		 */
+		private function resolve_active_provider_for_id( string $active_id ): ?Location_Provider {
+			$provider = $this->providers[ $active_id ] ?? $this->providers[ self::DEFAULT_PROVIDER_ID ] ?? null;
+
+			/**
+			 * Filters the resolved active location provider instance.
+			 *
+			 * Left in place even though nothing in this codebase consumes it yet
+			 * (project preference: extension hooks are not gated on a consumer).
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param Location_Provider|null $provider  The resolved provider, or null
+			 *                                           when the (possibly-fallen-back-to)
+			 *                                           id has nothing registered.
+			 * @param string                 $active_id The id being resolved (before
+			 *                                           the default-id fallback above
+			 *                                           was applied).
+			 */
+			return apply_filters( self::FILTER_ACTIVE_PROVIDER, $provider, $active_id );
 		}
 	}
 

--- a/woodev/shipping-method/location/class-location-provider-registry.php
+++ b/woodev/shipping-method/location/class-location-provider-registry.php
@@ -102,6 +102,65 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		public const SETTING_ACTIVE_PROVIDER = 'active_provider';
 
 		/**
+		 * The store setting id holding the field-presentation mode (Task 13;
+		 * spec D7). See {@see self::get_offered_field_modes()} for how the
+		 * OFFERED options are gated by the active provider's capabilities, and
+		 * {@see self::get_field_mode()} for the read-side clamp that keeps a
+		 * previously-saved value honest across a provider switch.
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const SETTING_FIELD_MODE = 'field_mode';
+
+		/**
+		 * Field mode: always-available free-text typeahead (spec D7 baseline —
+		 * every provider can serve this, `suggest()` is REQUIRED of all of them).
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const MODE_TYPEAHEAD = 'typeahead';
+
+		/**
+		 * Field mode: the region level is rendered THROUGH WooCommerce's own
+		 * `woocommerce_states` filter (native `<select>`), with the active
+		 * provider's own enumerated regions injected into it — see
+		 * {@see self::inject_related_list_states()}. Descendant levels (e.g.
+		 * settlement within a chosen region) are populated via `select2` fed by
+		 * `GET woodev/v1/location/list` (Task 13). Only offered when the active
+		 * provider declares {@see Location_Provider::CAPABILITY_LIST} — DaData
+		 * cannot enumerate (query-driven API only).
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const MODE_RELATED_LIST = 'related-list';
+
+		/**
+		 * Field mode: `select2` with remote data through the existing
+		 * `GET woodev/v1/location/suggest` seam — same underlying data source as
+		 * typeahead, a different client renderer (spec D7: "three renderers over
+		 * one data source"). Only offered when the active provider declares
+		 * {@see Location_Provider::CAPABILITY_LIST} — matching D7's own gate for
+		 * `related-list`, since a provider that can enumerate can always also be
+		 * queried, but the reverse is not true (DaData: query-only).
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const MODE_AJAX_SELECT2 = 'ajax-select2';
+
+		/**
+		 * Every field mode this layer knows about, in the fixed offering order
+		 * {@see self::get_offered_field_modes()} always returns them in.
+		 *
+		 * @since 2.0.2
+		 * @var string[]
+		 */
+		public const FIELD_MODES = [ self::MODE_TYPEAHEAD, self::MODE_RELATED_LIST, self::MODE_AJAX_SELECT2 ];
+
+		/**
 		 * Filter tag: lets a plugin register its own {@see Location_Provider}
 		 * instances alongside the bundled ones. Receives (and must return) a plain
 		 * list — any entry not implementing {@see Location_Provider} is rejected
@@ -174,6 +233,26 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		private ?Location_Settings $settings_handler = null;
 
 		/**
+		 * Countries {@see self::inject_related_list_states()} itself successfully
+		 * wrote non-empty `woocommerce_states` options for, THIS request — the
+		 * ownership record {@see self::owns_region_states()} answers from.
+		 *
+		 * Recorded rather than inferred from the field-mode setting alone
+		 * (`mode === 'related-list'`) because that alone cannot distinguish "we
+		 * injected this country's regions" from "related-list mode is on, but a
+		 * plugin's own §8 carrier takeover reached this country's states first,
+		 * or this specific country had nothing to enumerate" — both leave the
+		 * mode flag identical but the OWNERSHIP genuinely differs, and
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}'s
+		 * `_doing_it_wrong()` (issue #294) must fire in the second case, not the
+		 * first.
+		 *
+		 * @since 2.0.2
+		 * @var array<string, true>
+		 */
+		private array $related_list_states_countries = [];
+
+		/**
 		 * Use {@see self::instance()}.
 		 *
 		 * @since 2.0.2
@@ -238,6 +317,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 			self::remove_hooked_instances( 'init', self::class, 'collect' );
 			self::remove_hooked_instances( 'rest_api_init', self::class, 'register_rest' );
 			self::remove_hooked_instances( 'wp_login', Customer_Location_Store::class, 'handle_wp_login' );
+			self::remove_hooked_instances( 'woocommerce_states', self::class, 'inject_related_list_states' );
 
 			self::$instance = null;
 		}
@@ -358,7 +438,26 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 * on `wp-login.php` (plugins load there like on any other request), always
 		 * before `wp_login` fires on that same request.
 		 *
+		 * `woocommerce_states` (Task 13, issue #294): {@see self::inject_related_list_states()}
+		 * is hooked here too, unconditionally and unfiltered by mode/capability —
+		 * the same "hook is cheap, the callback itself gates on the live setting"
+		 * discipline {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::inject_states()}
+		 * already follows. Registering it here (once, fleet-wide) rather than from
+		 * a per-plugin `Location_Service` instance avoids the exact multi-instance
+		 * dedup trap the `wp_login` paragraph above already solved for
+		 * `Customer_Location_Store` — `add_action()`/`add_filter()` dedup by object
+		 * identity, not by class, so N shipping plugins each building their own
+		 * `Location_Service` would double-inject. No explicit priority: the #294
+		 * decision's own measured ordering fact (this file's class docblock does
+		 * not repeat it — see `Checkout_Config::build_location_block()`'s own
+		 * docblock) only requires this filter to be attached before ANYTHING calls
+		 * `WC_Countries::get_states()`, which `add_hooks()` — called synchronously
+		 * from `Shipping_Plugin::add_hooks()` at `plugins_loaded` — always
+		 * satisfies regardless of priority.
+		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Also hooks {@see self::inject_related_list_states()} onto
+		 *              `woocommerce_states` (Task 13, issue #294).
 		 *
 		 * @return void
 		 */
@@ -371,6 +470,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 			add_action( 'init', [ $this, 'collect' ], 20 );
 			add_action( 'wp_login', [ new Customer_Location_Store(), 'handle_wp_login' ], 10, 2 );
 			add_action( 'rest_api_init', [ $this, 'register_rest' ] );
+			add_filter( 'woocommerce_states', [ $this, 'inject_related_list_states' ] );
 		}
 
 		/**
@@ -614,6 +714,260 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		}
 
 		/**
+		 * Gets the field-presentation modes the STORE SETTING is allowed to offer
+		 * right now (Task 13; spec D7), gated by the ACTIVE provider's OWN
+		 * capabilities — never the whole D15 chain: `related-list`/`ajax-select2`
+		 * feed `list_localities()`, which is not a D15 fallback-chained capability
+		 * the way `suggest()` is (spec D15 is about per-LEVEL suggest support; a
+		 * provider either can or cannot enumerate at all).
+		 *
+		 * `typeahead` is unconditional — every provider implements `suggest()`
+		 * (spec D7 baseline: it is REQUIRED, not a capability). The other two are
+		 * offered together, both gated on the SAME {@see Location_Provider::CAPABILITY_LIST}
+		 * flag — a provider that can enumerate a scope can always also be asked
+		 * for it via the existing `/suggest` seam, so nothing further
+		 * distinguishes them for gating purposes; they differ only in which
+		 * client renderer consumes the data (spec D7: "three renderers over one
+		 * data source").
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string[] Subset of {@see self::FIELD_MODES}, always containing
+		 *                  {@see self::MODE_TYPEAHEAD}.
+		 */
+		public function get_offered_field_modes(): array {
+			return self::offered_field_modes_for( $this->get_active_provider() );
+		}
+
+		/**
+		 * The actual gate {@see self::get_offered_field_modes()} answers from —
+		 * factored out as a static, provider-in/modes-out pure function so
+		 * {@see self::register_settings()} can compute the SAME answer for the
+		 * `field_mode` select's options at construction time, when
+		 * {@see self::$settings_handler} does not exist yet and
+		 * {@see self::get_active_provider()} would therefore short-circuit to
+		 * `null` regardless of which provider is actually about to become active
+		 * (that method's own early return: "no settings handler exists to read a
+		 * value from"). `register_settings()` instead passes the `$active_provider`
+		 * it already resolved via {@see self::resolve_stored_active_provider_id()}
+		 * moments earlier, sidestepping the chicken-and-egg order entirely rather
+		 * than duplicating this gate's logic a second time.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Provider|null $provider The provider to gate against, or
+		 *                                          `null` (no provider active).
+		 *
+		 * @return string[] Subset of {@see self::FIELD_MODES}, always containing
+		 *                  {@see self::MODE_TYPEAHEAD}.
+		 */
+		private static function offered_field_modes_for( ?Location_Provider $provider ): array {
+			$modes = [ self::MODE_TYPEAHEAD ];
+
+			if ( null !== $provider && in_array( Location_Provider::CAPABILITY_LIST, $provider->get_capabilities(), true ) ) {
+				$modes[] = self::MODE_RELATED_LIST;
+				$modes[] = self::MODE_AJAX_SELECT2;
+			}
+
+			return $modes;
+		}
+
+		/**
+		 * User-facing labels for every mode in {@see self::FIELD_MODES} — the
+		 * single place both the OFFERED-options builder below and (if a future
+		 * task needs it) any other mode-labeling call site reads from, so the
+		 * Russian copy exists exactly once.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, string> mode => label.
+		 */
+		private static function field_mode_labels(): array {
+			return [
+				self::MODE_TYPEAHEAD    => __( 'Текстовый поиск с подсказками', 'woodev-plugin-framework' ),
+				self::MODE_RELATED_LIST => __( 'Список (нативный выпадающий список)', 'woodev-plugin-framework' ),
+				self::MODE_AJAX_SELECT2 => __( 'Список с поиском (выпадающий список с запросом)', 'woodev-plugin-framework' ),
+			];
+		}
+
+		/**
+		 * Builds the `field_mode` select's `id => label` options map, gated
+		 * against `$provider` via {@see self::offered_field_modes_for()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Provider|null $provider The provider to gate against.
+		 *
+		 * @return array<string, string>
+		 */
+		private static function offered_field_mode_options( ?Location_Provider $provider ): array {
+			$labels = self::field_mode_labels();
+
+			$options = [];
+
+			foreach ( self::offered_field_modes_for( $provider ) as $mode ) {
+				$options[ $mode ] = $labels[ $mode ];
+			}
+
+			return $options;
+		}
+
+		/**
+		 * Gets the store's field-presentation mode (Task 13; spec D7), clamped
+		 * against {@see self::get_offered_field_modes()} so a previously-saved
+		 * value that the CURRENT active provider no longer supports (e.g. the
+		 * store switched from a `list`-capable provider back to DaData) never
+		 * silently serves a mode the provider cannot back — falls back to
+		 * {@see self::MODE_TYPEAHEAD}, the one mode every provider can always
+		 * serve, exactly like {@see self::get_active_provider()} falls back to
+		 * {@see self::DEFAULT_PROVIDER_ID} for the analogous "stored value now
+		 * names something unavailable" case.
+		 *
+		 * Returns {@see self::MODE_TYPEAHEAD} outright while the gate is closed —
+		 * mirrors {@see self::get_active_provider()}'s own "nothing to read from
+		 * yet" early return.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		public function get_field_mode(): string {
+			if ( null === $this->settings_handler ) {
+				return self::MODE_TYPEAHEAD;
+			}
+
+			$stored  = (string) $this->settings_handler->get_value( self::SETTING_FIELD_MODE );
+			$offered = $this->get_offered_field_modes();
+
+			return in_array( $stored, $offered, true ) ? $stored : self::MODE_TYPEAHEAD;
+		}
+
+		/**
+		 * Whether {@see self::inject_related_list_states()} itself successfully
+		 * injected `$country`'s `woocommerce_states` options THIS request — the
+		 * precise "is this non-empty state list ours" answer
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}
+		 * needs for the issue #294 arbitration (see {@see self::inject_related_list_states()}'s
+		 * own docblock for why the field-mode setting alone cannot answer this).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $country ISO-3166 alpha-2 country code, any case/whitespace.
+		 *
+		 * @return bool
+		 */
+		public function owns_region_states( string $country ): bool {
+			return isset( $this->related_list_states_countries[ strtoupper( trim( $country ) ) ] );
+		}
+
+		/**
+		 * Injects the active provider's enumerated regions as WooCommerce native
+		 * states — the `related-list` mode's region renderer (Task 13; spec D7,
+		 * issue #294 decision comment point 4: "related-list ... is the region
+		 * level rendered THROUGH `woocommerce_states`, not a competitor to that
+		 * filter").
+		 *
+		 * Hooked unconditionally (see {@see self::add_hooks()}); this callback
+		 * itself is what actually gates on the live field-mode setting and the
+		 * active provider's `list` capability + configuration, so a mode/provider
+		 * switch takes effect on the very next `woocommerce_states` read with no
+		 * re-hooking needed.
+		 *
+		 * Iterates the active provider's OWN static {@see Location_Provider::get_countries()}
+		 * list (not the D15 chain-wide union {@see \Woodev\Framework\Shipping\Location\Location_Service::get_supported_countries()}
+		 * computes — `list_localities()` is not D15 fallback-chained, see
+		 * {@see self::get_offered_field_modes()}'s own docblock) and, for each
+		 * country:
+		 *
+		 * - Skips it when `$states[$country]` is ALREADY non-empty — first-wins,
+		 *   the same discipline {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::inject_states()}
+		 *   already applies for two conflicting §8 carrier takeovers; whichever
+		 *   filter callback runs first (bootstrap/plugin-construction order) owns
+		 *   the country, and this injector never clobbers it.
+		 * - NEVER writes an empty array when {@see Location_Provider::list_localities()}
+		 *   returns nothing for a country the provider otherwise claims to cover —
+		 *   an empty array tells WooCommerce "this country has no states at all"
+		 *   and HIDES the region field entirely (gotcha
+		 *   `checkout-field-takeover-woocommerce-states`); the country is simply
+		 *   left untouched, falling back to whatever `woocommerce_states` already
+		 *   held (native WC list, or nothing — WC then renders the region as a
+		 *   plain text input, which the ALWAYS-AVAILABLE typeahead baseline can
+		 *   still enhance).
+		 * - Records every country it DID successfully inject into
+		 *   {@see self::$related_list_states_countries}, so {@see self::owns_region_states()}
+		 *   can answer precisely.
+		 * - A provider's own `list_localities()` throwing is swallowed — a
+		 *   misbehaving provider must never break checkout page rendering
+		 *   (mirrors {@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller::handle_suggest_request()}'s
+		 *   own catch-and-degrade discipline for the equivalent REST path).
+		 *
+		 * The WC state array's VALUE keys are the record's own {@see Location_Record::key()}
+		 * (the full `provider_id:native_id` locality key), not an arbitrary
+		 * carrier code — see `Checkout_Config`'s own class docblock for why this
+		 * is the exact seam the client-side related-list renderer (a later
+		 * agent's task) reconstructs a full record from without a second lookup.
+		 *
+		 * @internal Hooked to `woocommerce_states`; not part of the public
+		 *           consumption surface.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param mixed $states WC states keyed by country code, as received from
+		 *                      whichever `woocommerce_states` callback ran before
+		 *                      this one (or WooCommerce's own native list).
+		 *
+		 * @return array<string, array<string, string>>
+		 */
+		public function inject_related_list_states( $states ): array {
+			$states = is_array( $states ) ? $states : [];
+
+			if ( self::MODE_RELATED_LIST !== $this->get_field_mode() ) {
+				return $states;
+			}
+
+			$provider = $this->get_active_provider();
+
+			if ( null === $provider || ! $provider->is_configured()
+				|| ! in_array( Location_Provider::CAPABILITY_LIST, $provider->get_capabilities(), true ) ) {
+				return $states;
+			}
+
+			foreach ( $provider->get_countries() as $country ) {
+				$country = strtoupper( trim( (string) $country ) );
+
+				if ( isset( $states[ $country ] ) && [] !== $states[ $country ] ) {
+					continue;
+				}
+
+				try {
+					$records = $provider->list_localities( Location_Scope::for_country( $country, Location_Record::LEVEL_REGION ) );
+				} catch ( \Throwable $exception ) {
+					continue;
+				}
+
+				$options = [];
+
+				foreach ( $records as $record ) {
+					if ( ! $record instanceof Location_Record ) {
+						continue;
+					}
+
+					$options[ $record->key() ] = $record->label();
+				}
+
+				if ( [] === $options ) {
+					continue;
+				}
+
+				$states[ $country ] = $options;
+
+				$this->related_list_states_countries[ $country ] = true;
+			}
+
+			return $states;
+		}
+
+		/**
 		 * Builds the settings handler and registers it as a framework service on
 		 * the SP-1 surface.
 		 *
@@ -638,7 +992,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 				$provider_options[ $id ] = $provider->get_name();
 			}
 
-			$this->settings_handler = new Location_Settings( self::SETTINGS_SERVICE_ID, $provider_options, $provider_fields );
+			$field_mode_options = self::offered_field_mode_options( $active_provider );
+
+			$this->settings_handler = new Location_Settings( self::SETTINGS_SERVICE_ID, $provider_options, $provider_fields, $field_mode_options );
 
 			\Woodev\Framework\Settings\Settings_Page_Registry::instance()->register_service(
 				\Woodev\Framework\Settings\Settings_Provider::create(

--- a/woodev/shipping-method/location/class-location-provider-registry.php
+++ b/woodev/shipping-method/location/class-location-provider-registry.php
@@ -901,16 +901,47 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 *   (mirrors {@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller::handle_suggest_request()}'s
 		 *   own catch-and-degrade discipline for the equivalent REST path).
 		 *
-		 * The WC state array's VALUE keys are the record's own {@see Location_Record::key()}
-		 * (the full `provider_id:native_id` locality key), not an arbitrary
-		 * carrier code — see `Checkout_Config`'s own class docblock for why this
-		 * is the exact seam the client-side related-list renderer (a later
-		 * agent's task) reconstructs a full record from without a second lookup.
+		 * The WC state array's VALUE is the record's own {@see Location_Record::label()}
+		 * — a human-readable region name, THE SAME STRING used as the key — never
+		 * the record's {@see Location_Record::key()} (`provider_id:native_id`).
+		 * That value is what the customer's browser submits as `billing_state` /
+		 * `shipping_state`, and it persists PERMANENTLY into order data — a
+		 * provider-namespaced key stored there renders as raw, meaningless text in
+		 * {@see \WC_Countries::get_formatted_address()} the instant this injector
+		 * is not present to translate it back (a provider switch renamespaces the
+		 * keys, a mode switch back to `typeahead` stops injecting entirely, and a
+		 * deactivated plugin obviously never runs at all) — order history must
+		 * stay meaningful without this plugin (measured on the rig, s71: an
+		 * uninjected `dadata:0c089b04-…` key rendered verbatim in a formatted
+		 * address). Identity already lives where it belongs — in our own customer
+		 * location record, persisted through `/location/select` — so a second copy
+		 * of identity inside a WooCommerce field this layer does not own would be
+		 * both redundant and permanent. See `Checkout_Config`'s own class docblock
+		 * for how the client-side related-list renderer (a later agent's task)
+		 * maps the selected label back to a full record via `/location/list`
+		 * instead.
+		 *
+		 * Two records legitimately colliding on the same label within one country
+		 * ARE possible (a provider's own data, not a coding mistake) and are a
+		 * real ambiguity: WooCommerce's state array is keyed by value, so only one
+		 * of them could ever be selected. The first one (provider's own
+		 * enumeration order) wins; every later collision is dropped and reported
+		 * via `_doing_it_wrong()` — the label-identity discipline this layer
+		 * enforces makes a synthetic disambiguating suffix (e.g. appending the
+		 * key) the wrong fix, since that suffix would itself leak into
+		 * `billing_state` and recreate the exact opaque-value problem this method
+		 * exists to remove.
 		 *
 		 * @internal Hooked to `woocommerce_states`; not part of the public
 		 *           consumption surface.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 The injected VALUE changed from the record's `key()` to its
+		 *              `label()` — a `billing_state`/`shipping_state` value is
+		 *              permanent order data, and a provider-namespaced key has no
+		 *              meaning once this injector stops running (rig measurement,
+		 *              s71). Duplicate labels within one country are now detected
+		 *              and reported instead of silently colliding.
 		 *
 		 * @param mixed $states WC states keyed by country code, as received from
 		 *                      whichever `woocommerce_states` callback ran before
@@ -952,7 +983,24 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 						continue;
 					}
 
-					$options[ $record->key() ] = $record->label();
+					$label = $record->label();
+
+					if ( isset( $options[ $label ] ) ) {
+						_doing_it_wrong(
+							__METHOD__,
+							sprintf(
+								"provider '%s' returned two regions labeled '%s' for country '%s'; only the first is offered in the related-list select, since the label is the value the customer submits and a second option under the same text would be indistinguishable to them",
+								$provider->get_id(),
+								$label,
+								$country
+							),
+							'2.0.2'
+						);
+
+						continue;
+					}
+
+					$options[ $label ] = $label;
 				}
 
 				if ( [] === $options ) {

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -575,23 +575,30 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		/**
 		 * Whether the `related-list` mode's own region injector
 		 * ({@see Location_Provider_Registry::inject_related_list_states()})
-		 * itself wrote `$country`'s `woocommerce_states` options THIS request —
-		 * thin pass-through to {@see Location_Provider_Registry::owns_region_states()}.
+		 * itself wrote `$country`'s `woocommerce_states` options THIS request AND
+		 * those options are still what WooCommerce is serving right now — thin
+		 * pass-through to {@see Location_Provider_Registry::owns_region_states()}.
 		 *
 		 * This is the precision {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}
 		 * needs for the issue #294 arbitration: a non-empty state list for a
 		 * country can come from WooCommerce's own native list, a plugin's §8
 		 * carrier takeover, OR this layer's own related-list injection — only
-		 * the last one is NOT a conflict.
+		 * the last one is NOT a conflict, and only when nothing ran AFTER this
+		 * layer's injector to clobber it (PR #304 review finding 3).
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Takes the caller's own FINAL `woocommerce_states` read
+		 *              (PR #304 review finding 3) — see
+		 *              {@see Location_Provider_Registry::owns_region_states()}'s
+		 *              own docblock for why.
 		 *
-		 * @param string $country ISO-3166 alpha-2 country code, any case/whitespace.
+		 * @param string                $country      ISO-3166 alpha-2 country code, any case/whitespace.
+		 * @param array<string, string> $final_states The country's FINAL registered WC states.
 		 *
 		 * @return bool
 		 */
-		public function owns_region_states( string $country ): bool {
-			return $this->registry->owns_region_states( $country );
+		public function owns_region_states( string $country, array $final_states ): bool {
+			return $this->registry->owns_region_states( $country, $final_states );
 		}
 	}
 

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -473,6 +473,126 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 
 			return in_array( $level, $provider->get_suggest_levels( $normalized ), true );
 		}
+
+		/**
+		 * Walks the D15 chain (chosen → bundled fallback → null) for the
+		 * {@see Location_Provider::CAPABILITY_LIST} capability (Task 13) — the
+		 * `GET woodev/v1/location/list` route's own provider resolution, mirroring
+		 * {@see self::provider_for_level()}'s shape exactly but gating on the
+		 * `list` capability instead of a suggest level. `list_localities()` is
+		 * NOT itself a per-level D15 fallback concept the way `suggest()` is
+		 * (spec D15 is specifically about per-LEVEL suggest support); this chain
+		 * exists so `/location/list` degrades the same forgiving way `/suggest`
+		 * does when the CHOSEN provider cannot enumerate but the bundled fallback
+		 * theoretically could (today: never — DaData has no `list` capability at
+		 * all — but the chain costs nothing to keep consistent with every other
+		 * D15-shaped resolution in this façade, and a future `list`-capable
+		 * bundled provider would be served correctly with zero caller changes).
+		 *
+		 * `$country` (optional): when given, a candidate is eligible only when it
+		 * ALSO covers it ({@see Location_Provider::get_countries()}) — mirrors
+		 * {@see self::provider_serves_level()}'s own country check. Omitted: no
+		 * country check, only the capability itself decides (used by
+		 * {@see Location_Provider_Registry::get_offered_field_modes()}'s own
+		 * gate, which is intentionally country-blind — mode OFFERING is a
+		 * store-wide decision, not a per-country one).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string|null $country ISO-3166 alpha-2 country code, or `null`
+		 *                             for the country-blind chain walk.
+		 *
+		 * @return Location_Provider|null
+		 */
+		public function provider_for_list( ?string $country = null ): ?Location_Provider {
+			$chosen = $this->registry->get_active_provider();
+
+			if ( null !== $chosen && $chosen->is_configured() && $this->provider_serves_list( $chosen, $country ) ) {
+				return $chosen;
+			}
+
+			$fallback = $this->registry->get_providers()[ Location_Provider_Registry::DEFAULT_PROVIDER_ID ] ?? null;
+
+			if ( null !== $fallback && $fallback->is_configured() && $this->provider_serves_list( $fallback, $country ) ) {
+				return $fallback;
+			}
+
+			return null;
+		}
+
+		/**
+		 * Whether `$provider` is an eligible {@see self::provider_for_list()}
+		 * candidate: declares {@see Location_Provider::CAPABILITY_LIST} and,
+		 * when `$country` is given, also covers it.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Provider $provider Candidate provider.
+		 * @param string|null       $country  ISO-3166 alpha-2 country code, or `null`.
+		 *
+		 * @return bool
+		 */
+		private function provider_serves_list( Location_Provider $provider, ?string $country ): bool {
+			if ( ! in_array( Location_Provider::CAPABILITY_LIST, $provider->get_capabilities(), true ) ) {
+				return false;
+			}
+
+			if ( null === $country ) {
+				return true;
+			}
+
+			return in_array( strtoupper( trim( $country ) ), $provider->get_countries(), true );
+		}
+
+		/**
+		 * Gets the field-presentation modes the store setting is currently
+		 * allowed to offer (Task 13; spec D7) — thin pass-through to
+		 * {@see Location_Provider_Registry::get_offered_field_modes()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string[]
+		 */
+		public function get_offered_field_modes(): array {
+			return $this->registry->get_offered_field_modes();
+		}
+
+		/**
+		 * Gets the store's field-presentation mode (Task 13; spec D7) — thin
+		 * pass-through to {@see Location_Provider_Registry::get_field_mode()},
+		 * clamped against {@see self::get_offered_field_modes()} so a stale
+		 * saved value can never name a mode the current active provider does
+		 * not back.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		public function get_field_mode(): string {
+			return $this->registry->get_field_mode();
+		}
+
+		/**
+		 * Whether the `related-list` mode's own region injector
+		 * ({@see Location_Provider_Registry::inject_related_list_states()})
+		 * itself wrote `$country`'s `woocommerce_states` options THIS request —
+		 * thin pass-through to {@see Location_Provider_Registry::owns_region_states()}.
+		 *
+		 * This is the precision {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}
+		 * needs for the issue #294 arbitration: a non-empty state list for a
+		 * country can come from WooCommerce's own native list, a plugin's §8
+		 * carrier takeover, OR this layer's own related-list injection — only
+		 * the last one is NOT a conflict.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $country ISO-3166 alpha-2 country code, any case/whitespace.
+		 *
+		 * @return bool
+		 */
+		public function owns_region_states( string $country ): bool {
+			return $this->registry->owns_region_states( $country );
+		}
 	}
 
 endif;

--- a/woodev/shipping-method/location/class-location-settings.php
+++ b/woodev/shipping-method/location/class-location-settings.php
@@ -4,11 +4,17 @@
  *
  * The store-level settings handler for the Location Provider layer (Task 3;
  * spec D4: "provider tokens/keys are store settings, held server-side"). Owns
- * exactly two kinds of fields:
+ * exactly three kinds of fields:
  *
  * 1. `active_provider` — a select whose options are every registered provider's
  *    id => name, defaulting to {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::DEFAULT_PROVIDER_ID}.
- * 2. Whatever the currently ACTIVE provider declares via
+ * 2. `field_mode` (Task 13; spec D7) — a select whose OPTIONS are gated by the
+ *    active provider's capabilities (typeahead always; related-list/ajax-select2
+ *    only when it declares `list`) — computed by
+ *    {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry}, this
+ *    handler only ever renders whatever option set it was handed, exactly like
+ *    `active_provider`'s own options.
+ * 3. Whatever the currently ACTIVE provider declares via
  *    {@see \Woodev\Framework\Shipping\Location\Location_Provider::get_settings_fields()} —
  *    merged in verbatim, keyed by the provider's own field ids. A registered but
  *    NOT-active provider's fields are never merged in (spec §4.1: rendered on the
@@ -47,6 +53,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 		private array $provider_options;
 
 		/**
+		 * Offered `field_mode` select options, `id => label` (Task 13; spec D7),
+		 * already gated by the active provider's capabilities — resolved by the
+		 * caller ({@see Location_Provider_Registry::offered_field_mode_options()}),
+		 * exactly like {@see self::$provider_options} is.
+		 *
+		 * @since 2.0.2
+		 * @var array<string, string>
+		 */
+		private array $field_mode_options;
+
+		/**
 		 * The active provider's declared settings fields (Location_Provider::get_settings_fields()
 		 * shape), or `[]` when no provider is active. Set BEFORE the parent
 		 * constructor runs, since `register_settings()` (called from it) reads it.
@@ -60,32 +77,41 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 		 * Constructor.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Added the `$field_mode_options` parameter (Task 13; spec D7).
 		 *
-		 * @param string                              $id               settings id (the option-name namespace).
-		 * @param array<string, string>               $provider_options registered provider `id => name` pairs.
-		 * @param array<string, array<string, mixed>> $provider_fields  the active provider's declared
-		 *                                                               settings fields, already resolved
-		 *                                                               by the caller.
+		 * @param string                              $id                  settings id (the option-name namespace).
+		 * @param array<string, string>               $provider_options    registered provider `id => name` pairs.
+		 * @param array<string, array<string, mixed>> $provider_fields     the active provider's declared
+		 *                                                                  settings fields, already resolved
+		 *                                                                  by the caller.
+		 * @param array<string, string>               $field_mode_options  offered `field_mode` select options
+		 *                                                                  (`id => label`), already gated by the
+		 *                                                                  active provider's capabilities.
 		 */
-		public function __construct( string $id, array $provider_options, array $provider_fields = [] ) {
-			$this->provider_options = $provider_options;
-			$this->provider_fields  = $provider_fields;
+		public function __construct( string $id, array $provider_options, array $provider_fields = [], array $field_mode_options = [] ) {
+			$this->provider_options   = $provider_options;
+			$this->provider_fields    = $provider_fields;
+			$this->field_mode_options = $field_mode_options;
 
 			parent::__construct( $id );
 		}
 
 		/**
 		 * Gets the settings ids this handler owns, in registration order — the
-		 * active-provider select first, then the active provider's own fields.
-		 * Used by {@see Location_Provider_Registry} to build the `Settings_Section`
-		 * without duplicating this handler's own field list.
+		 * active-provider select first, then the field-mode select, then the
+		 * active provider's own fields. Used by {@see Location_Provider_Registry}
+		 * to build the `Settings_Section` without duplicating this handler's own
+		 * field list.
 		 *
 		 * @since 2.0.2
 		 *
 		 * @return string[]
 		 */
 		public function get_owned_setting_ids(): array {
-			return array_merge( [ Location_Provider_Registry::SETTING_ACTIVE_PROVIDER ], array_keys( $this->provider_fields ) );
+			return array_merge(
+				[ Location_Provider_Registry::SETTING_ACTIVE_PROVIDER, Location_Provider_Registry::SETTING_FIELD_MODE ],
+				array_keys( $this->provider_fields )
+			);
 		}
 
 		/**
@@ -105,6 +131,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 				]
 			);
 			$this->register_control( Location_Provider_Registry::SETTING_ACTIVE_PROVIDER, \Woodev_Control::TYPE_SELECT );
+
+			$this->register_setting(
+				Location_Provider_Registry::SETTING_FIELD_MODE,
+				\Woodev_Setting::TYPE_STRING,
+				[
+					'name'    => __( 'Режим отображения полей локации', 'woodev-plugin-framework' ),
+					'options' => $this->field_mode_options,
+					'default' => Location_Provider_Registry::MODE_TYPEAHEAD,
+				]
+			);
+			$this->register_control( Location_Provider_Registry::SETTING_FIELD_MODE, \Woodev_Control::TYPE_SELECT );
 
 			foreach ( $this->provider_fields as $field_id => $field ) {
 				$this->register_provider_field( (string) $field_id, (array) $field );

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -139,6 +139,35 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		protected const LIST_RATE_LIMIT_MAX = 60;
 
 		/**
+		 * Hard cap on the number of localities `/list` ever returns in one
+		 * response, and the default when no (or an out-of-range) `limit` request
+		 * arg is given (PR #304 review finding 5).
+		 *
+		 * The provider contract itself is unbounded (`list_localities()`: "every
+		 * locality within scope") and `within` cannot narrow it for a GUEST
+		 * customer either (it only resolves against an already-persisted
+		 * customer record, see {@see self::build_scope()}), so a country-wide
+		 * `settlement`/`address` enumeration can legitimately be a dictionary
+		 * provider's ENTIRE city table — with every record's full `raw` payload —
+		 * per request. 500 is chosen deliberately: comfortably above the largest
+		 * real `region` list (Russia: 85 federal subjects, the top of what this
+		 * layer's own supported countries ever enumerate at that level), while
+		 * still bounding a `settlement`/`address` dictionary dump — which can run
+		 * into the tens of thousands of rows — to a JSON payload and DOM size a
+		 * single request/render can comfortably handle.
+		 *
+		 * The response is honest about a cap actually having been hit
+		 * ({@see self::handle_list_request()}'s own `truncated` field) rather
+		 * than silently returning a partial list that reads as "this is all
+		 * there is".
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var int
+		 */
+		protected const LIST_HARD_CAP = 500;
+
+		/**
 		 * The façade this controller dispatches through. Defaults to a fresh
 		 * {@see Location_Service} (which itself defaults to the shared
 		 * {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry}
@@ -295,6 +324,16 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 							'within'  => [
 								'type'              => 'string',
 								'validate_callback' => 'rest_validate_request_arg',
+							],
+							'limit'   => [
+								'type'              => 'integer',
+								'validate_callback' => 'rest_validate_request_arg',
+
+								// Clamped server-side to [1, LIST_HARD_CAP] by the
+								// callback — see handle_list_request()'s own docblock
+								// (PR #304 review finding 5). A client value <= 0,
+								// missing, or malformed simply falls back to the hard
+								// cap; there is no error path for this arg.
 							],
 
 							// Deliberately no `q` (this is enumeration, not a query-driven
@@ -485,13 +524,31 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 * true" signal, not the routine "nothing typed yet" a `/suggest` empty
 		 * read represents.
 		 *
+		 * The response is capped at {@see self::LIST_HARD_CAP} records (PR #304
+		 * review finding 5): the provider contract itself promises "every
+		 * locality within scope" with no size bound, and a guest customer has no
+		 * way to narrow an unscoped `settlement`/`address` enumeration via
+		 * `within` either (it only resolves against an already-persisted
+		 * customer record, {@see self::build_scope()}), so an unbounded request
+		 * could ask a dictionary provider for its entire city table, full `raw`
+		 * payloads included, in one response. The optional `limit` request arg
+		 * narrows the cap further (clamped to `[1, LIST_HARD_CAP]`; a missing or
+		 * out-of-range value falls back to the hard cap outright, never an
+		 * error). The response is honest about truncation — a `truncated: true`
+		 * flag when the provider returned more than what was actually sent, so
+		 * a client can tell "this is everything" from "there is more, refine
+		 * `within`" instead of a silently-cut list reading as the former.
+		 *
 		 * @internal
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Capped at {@see self::LIST_HARD_CAP} records, with an
+		 *              optional clamped `limit` arg and a `truncated` response
+		 *              flag (PR #304 review finding 5).
 		 *
 		 * @param \WP_REST_Request $request request object.
 		 *
-		 * @return \WP_REST_Response|\WP_Error|array{localities: array<int, array<string, mixed>>}
+		 * @return \WP_REST_Response|\WP_Error|array{localities: array<int, array<string, mixed>>, truncated: bool}
 		 */
 		public function handle_list_request( $request ) {
 
@@ -511,6 +568,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 
 			$country = $this->normalize_param( $request->get_param( 'country' ) );
 			$within  = $this->cap_length( $this->normalize_param( $request->get_param( 'within' ) ), self::MAX_PARAM_LENGTH );
+
+			$raw_limit = $request->get_param( 'limit' );
+			$limit     = null === $raw_limit ? self::LIST_HARD_CAP : (int) $raw_limit;
+			$limit     = $limit > 0 ? min( $limit, self::LIST_HARD_CAP ) : self::LIST_HARD_CAP;
 
 			try {
 				$scope = $this->build_scope( $country, $level, $within );
@@ -543,7 +604,15 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 				return $this->upstream_error();
 			}
 
-			return rest_ensure_response( [ 'localities' => $this->to_response_records( $records ) ] );
+			$truncated = count( $records ) > $limit;
+			$records   = array_slice( $records, 0, $limit );
+
+			return rest_ensure_response(
+				[
+					'localities' => $this->to_response_records( $records ),
+					'truncated'  => $truncated,
+				]
+			);
 		}
 
 		/**

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -3,8 +3,10 @@
  * Woodev Location REST Controller
  *
  * Serves the store-level Location Provider layer's client seam (Task 8; spec D1,
- * D4, D8, D15): `GET woodev/v1/location/suggest` (query-driven suggestions) and
- * `POST woodev/v1/location/select` (persist a chosen record). Unlike the sibling
+ * D4, D8, D15): `GET woodev/v1/location/suggest` (query-driven suggestions),
+ * `POST woodev/v1/location/select` (persist a chosen record), and
+ * `GET woodev/v1/location/list` (full enumeration within a scope — Task 13,
+ * feeding the `related-list`/`ajax-select2` field modes, spec D7). Unlike the sibling
  * shipping controllers ({@see Field_Source_Controller}, {@see Pickup_Controller}),
  * this one is FLEET-WIDE, not per-plugin: there is exactly one active location
  * provider per store (spec §4.1), so the route carries no `plugin_id` path
@@ -24,7 +26,7 @@
  *
  * SECURITY (D4: tokens are store settings, held server-side; the client talks
  * only to this REST seam):
- * - `/suggest` is a PUBLIC guest-checkout read, mirroring
+ * - `/suggest` and `/list` are both PUBLIC guest-checkout reads, mirroring
  *   {@see Field_Source_Controller} and {@see Pickup_Controller} exactly: every
  *   param is normalized/capped before use, every response field is either the
  *   provider's OWN {@see Location_Record} shape (never provider settings/
@@ -32,7 +34,9 @@
  *   {@see Location_Provider::get_settings_fields()}/`is_configured()`'s
  *   underlying option reads) or explicitly escaped (`label`), and a best-effort
  *   per-IP rate limit ({@see Rest_Rate_Limit_Trait}) raises the bar against
- *   abuse.
+ *   abuse. `/list` degrades to 404 rather than `/suggest`'s 200+empty when
+ *   nothing can answer it — see {@see self::handle_list_request()}'s own
+ *   docblock for why that asymmetry is intentional.
  * - `/select` is NOT public-read: it is the customer's write into the
  *   server-side customer-location store, so it is nonce-gated exactly like
  *   {@see Pickup_Controller::check_select_permission()} — a capability check is
@@ -120,6 +124,19 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 * @var int
 		 */
 		protected const SELECT_RATE_LIMIT_MAX = 30;
+
+		/**
+		 * Rate-limit budget for `/list` (Task 13) — a discrete lookup fired on a
+		 * parent-region change under `related-list`/`ajax-select2` modes, not a
+		 * per-keystroke stream the way `/suggest` is; sits at the same budget as
+		 * `/suggest` regardless, since a related-list select2's own remote-data
+		 * mode (spec D7) can re-query as the customer scrolls/searches within it.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var int
+		 */
+		protected const LIST_RATE_LIMIT_MAX = 60;
 
 		/**
 		 * The façade this controller dispatches through. Defaults to a fresh
@@ -246,6 +263,45 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 								'type'     => 'object',
 								'required' => true,
 							],
+						],
+					],
+				]
+			);
+
+			register_rest_route(
+				'woodev/v1',
+				'/location/list',
+				[
+					[
+						'methods'  => 'GET',
+						'callback' => [ $this, 'handle_list_request' ],
+
+						// Intentionally public read — same reasoning as `/suggest` above
+						// (see the class docblock's SECURITY paragraph): every returned
+						// field is a neutral Location_Record component or the
+						// explicitly-escaped `label`, never a provider credential.
+						'permission_callback' => '__return_true',
+						'args'                => [
+							'level'   => [
+								'type'              => 'string',
+								'required'          => true,
+								'validate_callback' => 'rest_validate_request_arg',
+							],
+							'country' => [
+								'type'              => 'string',
+								'required'          => true,
+								'validate_callback' => 'rest_validate_request_arg',
+							],
+							'within'  => [
+								'type'              => 'string',
+								'validate_callback' => 'rest_validate_request_arg',
+							],
+
+							// Deliberately no `q` (this is enumeration, not a query-driven
+							// search — spec D7/Location_Provider::list_localities()) and no
+							// `provider` (same reasoning as `/suggest`'s own args block: the
+							// D15-adjacent chain — Location_Service::provider_for_list() —
+							// resolves it server-side, never the client).
 						],
 					],
 				]
@@ -407,7 +463,87 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 				return $this->upstream_error();
 			}
 
-			return rest_ensure_response( [ 'suggestions' => $this->to_response_suggestions( $records ) ] );
+			return rest_ensure_response( [ 'suggestions' => $this->to_response_records( $records ) ] );
+		}
+
+		/**
+		 * Handles a list (enumeration) request (Task 13; spec D7).
+		 *
+		 * Degradation deliberately differs from `/suggest` above (see that
+		 * method's own docblock for why the read/write distinction there does
+		 * NOT apply the same way here): a well-formed country the resolved
+		 * `list`-capable provider does not cover, or no provider anywhere in the
+		 * D15-adjacent chain ({@see Location_Service::provider_for_list()})
+		 * declaring `list` at all, is a 404 — mirroring `/select`'s
+		 * inactive-layer 404 ({@see self::handle_select_request()}), not
+		 * `/suggest`'s 200+empty. This is deliberate: `related-list`/
+		 * `ajax-select2` modes are only ever OFFERED to the store setting when
+		 * the active provider already declares `list`
+		 * ({@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::get_offered_field_modes()}),
+		 * so a client legitimately reaching this route at all already believes
+		 * the capability exists — a 404 here is a genuine "this stopped being
+		 * true" signal, not the routine "nothing typed yet" a `/suggest` empty
+		 * read represents.
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param \WP_REST_Request $request request object.
+		 *
+		 * @return \WP_REST_Response|\WP_Error|array{localities: array<int, array<string, mixed>>}
+		 */
+		public function handle_list_request( $request ) {
+
+			if ( $this->is_rate_limited( 'woodev_location_list_rl_', self::LIST_RATE_LIMIT_MAX ) ) {
+				return $this->rate_limited_error();
+			}
+
+			$level = $this->normalize_param( $request->get_param( 'level' ) );
+
+			if ( ! in_array( $level, Location_Record::LEVELS, true ) ) {
+				return new \WP_Error(
+					'woodev_location_invalid_level',
+					__( 'Некорректный уровень поиска.', 'woodev-plugin-framework' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$country = $this->normalize_param( $request->get_param( 'country' ) );
+			$within  = $this->cap_length( $this->normalize_param( $request->get_param( 'within' ) ), self::MAX_PARAM_LENGTH );
+
+			try {
+				$scope = $this->build_scope( $country, $level, $within );
+			} catch ( \InvalidArgumentException $exception ) {
+				return new \WP_Error(
+					'woodev_location_invalid_country',
+					__( 'Некорректный код страны.', 'woodev-plugin-framework' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			// Deliberately never reads `$request->get_param( 'provider' )` — same
+			// reasoning as `/suggest` above (see the class docblock and
+			// register_routes()'s own comment on this route).
+			$provider = $this->service->provider_for_list( $country );
+
+			if ( null === $provider ) {
+				return new \WP_Error(
+					'woodev_location_list_unavailable',
+					__( 'Список населённых пунктов сейчас недоступен.', 'woodev-plugin-framework' ),
+					[ 'status' => 404 ]
+				);
+			}
+
+			try {
+				$records = $provider->list_localities( $scope );
+			} catch ( \Throwable $exception ) {
+				$this->log_failure( 'list', $exception );
+
+				return $this->upstream_error();
+			}
+
+			return rest_ensure_response( [ 'localities' => $this->to_response_records( $records ) ] );
 		}
 
 		/**
@@ -540,20 +676,24 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		}
 
 		/**
-		 * Maps raw provider records into the wire shape (spec Task 8):
-		 * `{ key, label, level, record }`. `label` is explicitly escaped for
-		 * direct display; `record` is the record's OWN `to_array()`, UNTOUCHED,
-		 * so the client can round-trip it back to `/select` verbatim (D12/D5).
+		 * Maps raw provider records into the wire shape (spec Task 8): shared by
+		 * `/suggest` (its own `suggestions` array) and `/list` (its own
+		 * `localities` array, Task 13) — same shape either way, `{ key, label,
+		 * level, record }`. `label` is explicitly escaped for direct display;
+		 * `record` is the record's OWN `to_array()`, UNTOUCHED, so the client can
+		 * round-trip it back to `/select` verbatim (D12/D5).
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Renamed from `to_response_suggestions()` — shared by
+		 *              `/list` too now (Task 13).
 		 *
-		 * @param Location_Record[] $records Provider suggestions.
+		 * @param Location_Record[] $records Provider records (suggest matches or a full enumeration).
 		 *
 		 * @return array<int, array{key: string, label: string, level: string, record: array<string, mixed>}>
 		 */
-		private function to_response_suggestions( array $records ): array {
+		private function to_response_records( array $records ): array {
 
-			$suggestions = [];
+			$mapped = [];
 
 			foreach ( $records as $record ) {
 
@@ -561,7 +701,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 					continue; // Defensive: a misbehaving provider must not break the field.
 				}
 
-				$suggestions[] = [
+				$mapped[] = [
 					'key'    => $record->key(),
 					'label'  => esc_html( $record->label() ),
 					'level'  => $record->level(),
@@ -569,7 +709,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 				];
 			}
 
-			return array_values( $suggestions );
+			return array_values( $mapped );
 		}
 
 		/**
@@ -643,7 +783,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 *
 		 * @since 2.0.2
 		 *
-		 * @param string     $operation One of `suggest`.
+		 * @param string     $operation One of `suggest`, `list`.
 		 * @param \Throwable $exception The caught failure.
 		 *
 		 * @return void


### PR DESCRIPTION
Серверная половина задачи 13 плана location-провайдера плюс правило арбитража, решённое по #294. Клиентские рендереры — следующим PR.

## Арбитраж #294 (главное здесь)

Замер: **ни у одной из девяти поддерживаемых стран** (RU BY KZ UZ AM AZ KG TJ TM) у WooCommerce нет собственных регионов; контроль US/IT/CN/MD даёт 54/107/32/35. Значит конфликт «уровень регион против states» сегодня целиком наш против нашего же — его создаёт takeover §8.

Правило: авторитет — **итоговый** список states, прочитанный в `Checkout_Config::build_location_block()` после всех фильтров `woocommerce_states`. Есть непустой список → `levels[country].region` приезжает клиенту как `false`, и текстовый виджет не цепляется к полю, которое WooCommerce всё равно отрисует селектом.

**Ловушка замерена, а не выведена.** `WC_Countries::get_states()` наполняется лениво один раз за запрос, поэтому важен порядок. Проверено временным mu-plugin-зондом на риге через рефлексию `geo_cache`: фильтр §8 висит на `woocommerce_states` уже к `plugins_loaded`, а первый реальный вызов `get_states()` случается между `template_redirect` и `wp_enqueue_scripts` — всегда после. 

## Режимы (D7)

`mode` больше не захардкожен: читается из настройки, а список предлагаемых режимов — функция capability активного провайдера (рефлексия в `Abstract_Location_Provider`). DaData умеет только `suggest` → только `typeahead`; фикстурный провайдер с `list` → плюс `related-list` и `ajax-select2`. Добавлен `GET woodev/v1/location/list` с той же защитой, что у соседей, и 404 когда `list` никем не обслуживается.

`related-list` реализован **через** `woocommerce_states`, а не рядом с ним — ровно как требует готча `checkout-field-takeover-woocommerce-states`. Пустой массив в фильтр не пишется никогда (это спрятало бы поле).

## Клиентский шов (для следующего PR)

- `config.location.mode` — `typeahead | related-list | ajax-select2`, уже усечён по capability
- `config.location.endpoints.list` — новый URL
- `config.location.levels[country].region` — `true` только если цепочка D15 хочет регион И у страны нет зарегистрированных states
- в режиме `related-list` значением `<option>` служит ключ записи (`provider_id:native_id`)

## Проверка

unit 1974 → **2012** (4979 → 5045 ассертов), jest 999 без изменений, phpcs и phpstan чисто.

## Отход от плана, сознательный

Вызов `WC()` спрятан за защищённый шов `wc_states()`, а не сделан инлайном: первая версия уронила 21 посторонний тест — Brain Monkey/Patchwork инструментирует замоканную функцию на весь процесс, и тесты, ветвящиеся на `function_exists('WC') === false`, начали видеть её определённой. Использован тот же приём, что уже применён в `Checkout_Handler::current_country()`.

Refs #294