### PR TITLE
fix(api): маскировать креденшл-заголовок по имени, а не по истинности значения (#288)

### DIFF
--- a/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
+++ b/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
@@ -163,6 +163,43 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 	}
 
 	/**
+	 * Membership is decided by header NAME, never by the value being truthy.
+	 *
+	 * The first version of this fix guarded the mask with `! empty( $value )`, and
+	 * `empty()` is true for the string `'0'` — so a credential whose value happens
+	 * to be `0` (a perfectly valid opaque token) was handed to the request logger
+	 * in clear text. Found by the Codex critic pass on #288.
+	 *
+	 * @return void
+	 */
+	public function test_a_falsey_but_valid_credential_value_is_still_masked(): void {
+		$api = new Testable_Api_Base();
+		$api->set_headers_for_test( [ 'X-Secret' => '0' ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertSame( '*', $headers['X-Secret'], "a credential of '0' must be masked, not passed through" );
+	}
+
+	/**
+	 * Masking a genuinely empty value is harmless: the mask is as long as the
+	 * value, so the header still logs as empty rather than as a row of stars.
+	 *
+	 * Pinned so a future "optimisation" that skips empty values cannot quietly
+	 * reintroduce the `'0'` hole above.
+	 *
+	 * @return void
+	 */
+	public function test_an_empty_credential_value_stays_empty(): void {
+		$api = new Testable_Api_Base();
+		$api->set_headers_for_test( [ 'Authorization' => '' ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertSame( '', $headers['Authorization'] );
+	}
+
+	/**
 	 * A header that carries no credential passes through unmasked.
 	 *
 	 * @return void

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -315,9 +315,16 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 
 			$secret_names = array_map( 'strtolower', $this->get_secret_request_header_names() );
 
+			/*
+			 * Membership is decided by header NAME alone, never by the value being
+			 * truthy: `empty()` is true for the string `'0'`, so a credential whose
+			 * value happens to be `0` would have reached the logger in clear text.
+			 * Masking a genuinely empty value costs nothing — the mask is as long as
+			 * the value, so an empty header still logs as empty.
+			 */
 			foreach ( $headers as $name => $value ) {
-				if ( ! empty( $value ) && in_array( strtolower( (string) $name ), $secret_names, true ) ) {
-					$headers[ $name ] = str_repeat( '*', strlen( $value ) );
+				if ( in_array( strtolower( (string) $name ), $secret_names, true ) ) {
+					$headers[ $name ] = str_repeat( '*', strlen( (string) $value ) );
 				}
 			}
 


### PR DESCRIPTION
Догон к #288. Находка критика Codex по тому PR — единственная за прогон, и настоящая.

## Дефект

`get_sanitized_request_headers()` охранял маску условием `! empty( $value )`, а `empty()` истинно для строки `'0'`. То есть креденшл со значением `0` — вполне допустимый непрозрачный токен — уезжал открытым текстом всем слушателям `woodev_{api_id}_api_request_performed`, ровно в тот лог, ради чистоты которого карточка и заведена.

Дыра при этом **новая для каждого** не-`Authorization` заголовка, который #288 только что взял под опеку: раньше маскировался один `Authorization`, теперь восемь имён, и у каждого своё значение.

## Правка

Членство решается по ИМЕНИ заголовка. Маскировать по-настоящему пустое значение ничего не стоит: маска длиной в значение, поэтому пустой заголовок так и логируется пустым, а не рядом звёздочек.

Обе стороны закреплены тестами (`'0'` маскируется; `''` остаётся пустым), чтобы будущая «оптимизация — не трогать пустые» не вернула дыру молча.

## Проверка

unit 1979 → **1981**, phpcs чисто.

Refs #288