### PR TITLE
feat(location): режимы related-list и ajax-select2 — клиентская половина + потребитель persisted:false (#295)

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -30,6 +30,7 @@
 const CONFIG_GLOBAL = 'woodev_checkout_field_config_location_cascade_test';
 const SUGGEST_URL = 'https://example.test/wp-json/woodev/v1/location/suggest';
 const SELECT_URL = 'https://example.test/wp-json/woodev/v1/location/select';
+const LIST_URL = 'https://example.test/wp-json/woodev/v1/location/list';
 
 let attachCalls;
 let fetchCalls;
@@ -169,17 +170,22 @@ function buildConfig( opts ) {
 		nonce: 'test-nonce',
 		takeover: {},
 		location: {
-			endpoints: { suggest: SUGGEST_URL, select: SELECT_URL },
+			endpoints: { suggest: SUGGEST_URL, select: SELECT_URL, list: LIST_URL },
 			nonce: 'test-nonce',
 			countries: o.countries || [ 'RU' ],
-			mode: 'typeahead',
+			// Task 13 (spec D7): 'typeahead' | 'related-list' | 'ajax-select2'.
+			mode: o.mode || 'typeahead',
 			// Keyed BY COUNTRY, mirroring Checkout_Config::build_location_block(): DaData's
 			// coverage is per country (street data for RU/BY/KZ/UZ, city-only elsewhere), so
 			// a flat per-level map cannot describe it without lying.
 			levels: o.levels || { RU: { region: true, settlement: true, address: true } },
 			current: o.current !== undefined ? o.current : null,
 			implicit: false,
-			i18n: o.i18n !== undefined ? o.i18n : { noResults: 'Поиск не дал результатов. Попробуйте изменить запрос.', noResultsAddress: 'Адрес не найден — введите вручную.' },
+			i18n: o.i18n !== undefined ? o.i18n : {
+				noResults: 'Поиск не дал результатов. Попробуйте изменить запрос.',
+				noResultsAddress: 'Адрес не найден — введите вручную.',
+				notPersisted: 'Не удалось сохранить выбор — попробуйте ещё раз.',
+			},
 		},
 	};
 }
@@ -297,6 +303,7 @@ beforeEach( () => {
 	delete window[ CONFIG_GLOBAL ];
 	delete window.WoodevCheckoutFieldStore;
 	delete window.WoodevLocationTypeahead;
+	delete window.WoodevLocationRenderers;
 	delete window.jQuery;
 	delete global.jQuery;
 	delete global.$;
@@ -486,6 +493,101 @@ describe( 'persist then trigger (D8)', () => {
 		expect( document.getElementById( 'billing_city' ).value ).toBe( 'г Москва' );
 
 		triggerSpy.mockRestore();
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// #295 finding 1 — the client now CONSUMES `persisted: false`, not just skips the trigger
+// -----------------------------------------------------------------------
+
+describe( '#295 finding 1 — the "not saved" notice consumes persisted: false', () => {
+	function notice() {
+		return document.querySelector( '.woodev-location-notice' );
+	}
+
+	it( 'shows the server-supplied notPersisted string right after the field, anchored past it in the DOM', async () => {
+		boot( { settlement: true } );
+
+		const settlementCall = callFor( 'billing_city' );
+		const item = {
+			key: 'dadata:city1', label: 'г Москва', level: 'settlement',
+			record: { key: 'dadata:city1', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Москва' },
+		};
+
+		selectViaFake( settlementCall, item );
+
+		const selectReq = fetchCalls[ fetchCalls.length - 1 ];
+		selectReq.resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: false } );
+		await flushMicrotasks();
+
+		expect( notice() ).not.toBeNull();
+		expect( notice().textContent ).toBe( 'Не удалось сохранить выбор — попробуйте ещё раз.' );
+		expect( notice().getAttribute( 'role' ) ).toBe( 'alert' );
+		expect( document.getElementById( 'billing_city' ).nextElementSibling ).toBe( notice() );
+	} );
+
+	it( 'does NOT show a notice for a network/transport failure — only an honest persisted: false is consumed', async () => {
+		const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		boot( { settlement: true } );
+
+		const settlementCall = callFor( 'billing_city' );
+		const item = {
+			key: 'dadata:city1', label: 'г Москва', level: 'settlement',
+			record: { key: 'dadata:city1', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Москва' },
+		};
+
+		selectViaFake( settlementCall, item );
+
+		fetchCalls[ fetchCalls.length - 1 ].reject( new Error( 'network down' ) );
+		await flushMicrotasks();
+
+		expect( notice() ).toBeNull();
+
+		consoleSpy.mockRestore();
+	} );
+
+	it( 'clears a previously-shown notice once a LATER selection persists successfully', async () => {
+		boot( { settlement: true } );
+
+		const settlementCall = callFor( 'billing_city' );
+		const first = {
+			key: 'dadata:city1', label: 'г Москва', level: 'settlement',
+			record: { key: 'dadata:city1', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Москва' },
+		};
+
+		selectViaFake( settlementCall, first );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: first.record.key, level: 'settlement' }, persisted: false } );
+		await flushMicrotasks();
+
+		expect( notice() ).not.toBeNull();
+
+		const second = {
+			key: 'dadata:city2', label: 'г Казань', level: 'settlement',
+			record: { key: 'dadata:city2', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Казань' },
+		};
+
+		selectViaFake( settlementCall, second );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: second.record.key, level: 'settlement' }, persisted: true } );
+		await flushMicrotasks();
+
+		expect( notice() ).toBeNull();
+	} );
+
+	it( 'degrades to silence when the server config carries no notPersisted string (older config)', async () => {
+		boot( { settlement: true, i18n: { noResults: 'x' } } );
+
+		const settlementCall = callFor( 'billing_city' );
+		const item = {
+			key: 'dadata:city1', label: 'г Москва', level: 'settlement',
+			record: { key: 'dadata:city1', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Москва' },
+		};
+
+		selectViaFake( settlementCall, item );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: false } );
+		await flushMicrotasks();
+
+		expect( notice() ).toBeNull();
 	} );
 } );
 
@@ -1153,6 +1255,167 @@ describe( 'D15 — a level no configured provider serves stays native', () => {
 		document.getElementById( 'billing_address_1' ).dispatchEvent( new Event( 'change', { bubbles: true } ) );
 
 		expect( document.getElementById( 'billing_postcode' ).value ).toBe( '' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// Task 13 renderer seam (spec D7) — the cascade must not know WHICH renderer a field uses,
+// only how to ask `window.WoodevLocationRenderers` for one, and it must fall back to the
+// baseline typeahead whenever nothing claims the node.
+// -----------------------------------------------------------------------
+
+describe( 'Task 13 renderer seam (spec D7)', () => {
+	it( 'falls back to the baseline typeahead when nothing is registered for the resolved mode', () => {
+		// `window.WoodevLocationRenderers` is left entirely undefined (as if
+		// location-select-modes.js never loaded) — the D7 floor ("text+typeahead always")
+		// must still hold.
+		boot( { settlement: true, mode: 'related-list' } );
+
+		expect( callFor( 'billing_city' ) ).not.toBeUndefined();
+	} );
+
+	it( 'attaches the {mode}:{level}-specific renderer INSTEAD of the baseline typeahead, and hands it the shared onSelect', async () => {
+		const specialCalls = [];
+		window.WoodevLocationRenderers = {
+			'custom-mode:settlement': ( el, options ) => {
+				specialCalls.push( { el, options } );
+
+				return { detach: jest.fn() };
+			},
+		};
+
+		boot( { settlement: true, mode: 'custom-mode' } );
+
+		expect( callFor( 'billing_city' ) ).toBeUndefined(); // the baseline typeahead was never asked.
+		expect( specialCalls ).toHaveLength( 1 );
+		expect( specialCalls[ 0 ].el.id ).toBe( 'billing_city' );
+
+		// The SAME persist route every other level uses (D8) — not a duplicated one.
+		const record = { key: 'dadata:city1', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Москва' };
+		specialCalls[ 0 ].options.onSelect( { record } );
+
+		const selectReq = fetchCalls[ fetchCalls.length - 1 ];
+		expect( selectReq.url ).toBe( SELECT_URL );
+		expect( JSON.parse( selectReq.init.body ) ).toEqual( { record } );
+
+		const triggerSpy = jest.spyOn( window.jQuery.fn, 'trigger' );
+		selectReq.resolve( { current: { key: record.key, level: 'settlement' }, persisted: true } );
+		await flushMicrotasks();
+
+		expect( triggerSpy.mock.calls.some( ( args ) => args[ 0 ] === 'update_checkout' ) ).toBe( true );
+		triggerSpy.mockRestore();
+	} );
+
+	it( 'prefers the {mode}:{level} key over the bare {mode} key when both are registered', () => {
+		const levelSpecific = jest.fn( () => ( { detach: jest.fn() } ) );
+		const bareMode = jest.fn( () => ( { detach: jest.fn() } ) );
+
+		window.WoodevLocationRenderers = {
+			'custom-mode:settlement': levelSpecific,
+			'custom-mode': bareMode,
+		};
+
+		boot( { settlement: true, mode: 'custom-mode' } );
+
+		expect( levelSpecific ).toHaveBeenCalledTimes( 1 );
+		expect( bareMode ).not.toHaveBeenCalled();
+	} );
+
+	it( 'the bare {mode} key serves every level uniformly when no level-specific one is registered', () => {
+		const bareMode = jest.fn( () => ( { detach: jest.fn() } ) );
+
+		window.WoodevLocationRenderers = { 'custom-mode': bareMode };
+
+		boot( { region: true, settlement: true, address: true, mode: 'custom-mode' } );
+
+		expect( bareMode ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'a renderer that DECLINES (returns a falsy value) falls back to the baseline typeahead', () => {
+		window.WoodevLocationRenderers = { 'custom-mode:settlement': () => null };
+
+		boot( { settlement: true, mode: 'custom-mode' } );
+
+		expect( callFor( 'billing_city' ) ).not.toBeUndefined();
+	} );
+
+	it( 'a DOM-replacing renderer\'s reported `api.el` is what gets stored as the node\'s live element', () => {
+		// Guards against reconcileAfterCheckoutUpdate() misreading a select2-style DOM swap
+		// (input replaced by a <select>) as a checkout re-render every single pass.
+		const replacement = document.createElement( 'select' );
+		replacement.id = 'billing_city';
+
+		window.WoodevLocationRenderers = {
+			'custom-mode:settlement': ( el ) => {
+				el.parentNode.replaceChild( replacement, el );
+
+				return { detach: jest.fn(), el: replacement };
+			},
+		};
+
+		boot( { settlement: true, mode: 'custom-mode' } );
+
+		// Trigger updated_checkout — if the WRONG element were stored, this would misfire a
+		// spurious detach/reattach; nothing here asserts on that directly, but a second pass
+		// re-deriving country arbitration must not throw or double-attach.
+		window.jQuery( document.body ).trigger( 'updated_checkout' );
+
+		expect( document.getElementById( 'billing_city' ) ).toBe( replacement );
+	} );
+
+	// -------------------------------------------------------------------
+	// isNodeActive()'s ONE necessary D15 exception — related-list region only
+	// -------------------------------------------------------------------
+
+	describe( 'the related-list region exception to the D15 level gate (issue #294)', () => {
+		it( 'attempts the related-list:region renderer even when levels[country].region is false', () => {
+			const regionRenderer = jest.fn( () => ( { detach: jest.fn() } ) );
+
+			window.WoodevLocationRenderers = { 'related-list:region': regionRenderer };
+
+			boot( {
+				region: true, mode: 'related-list',
+				// Mirrors class-checkout-config.php's own #294 arbitration: `region` reads
+				// `false` here REGARDLESS of whether this layer's own related-list injector
+				// populated the states or a genuine conflict did — see isRelatedListRegionNode()'s
+				// own docblock.
+				levels: { RU: { region: false, settlement: true, address: true } },
+			} );
+
+			expect( regionRenderer ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does NOT bypass the D15 gate for any OTHER mode — a plain typeahead mode still stays native', () => {
+			const regionRenderer = jest.fn( () => ( { detach: jest.fn() } ) );
+
+			// Registered under a DIFFERENT mode key — must never be consulted while
+			// `entry.location.mode` is `'typeahead'`.
+			window.WoodevLocationRenderers = { 'typeahead:region': regionRenderer };
+
+			boot( {
+				region: true, mode: 'typeahead',
+				levels: { RU: { region: false, settlement: true, address: true } },
+			} );
+
+			expect( regionRenderer ).not.toHaveBeenCalled();
+			expect( callFor( 'billing_state' ) ).toBeUndefined(); // D15: unsupported level stays fully native.
+		} );
+
+		it( 'does NOT bypass the D15 gate for a non-region level under related-list mode', () => {
+			const settlementRenderer = jest.fn( () => ( { detach: jest.fn() } ) );
+
+			window.WoodevLocationRenderers = { 'related-list:settlement': settlementRenderer };
+
+			boot( {
+				settlement: true, mode: 'related-list',
+				levels: { RU: { region: true, settlement: false, address: true } },
+			} );
+
+			// isNodeActive() is false for this node (settlement is D15-unsupported and this is
+			// NOT the region exception), so attachOne() — and therefore the registered
+			// renderer — is never even reached.
+			expect( settlementRenderer ).not.toHaveBeenCalled();
+		} );
 	} );
 } );
 

--- a/tests/js/location-select-modes.test.js
+++ b/tests/js/location-select-modes.test.js
@@ -1,0 +1,544 @@
+/**
+ * Tests for location-select-modes.js — Task 13 of the 2026-08-12 location-provider plan
+ * (spec D7: `related-list` region/settlement renderers, `ajax-select2`).
+ *
+ * Covers, per renderer: the decline contract (wrong element shape falls back to the baseline
+ * typeahead, per `location-cascade.js`'s own `attachOne()`), the DOM-replacement + restore
+ * lifecycle for the two select2-backed renderers (select2 can only enhance a real `<select>`),
+ * population from the SAME `/location/list`/`options.fetch` primitives the cascade hands over,
+ * the SHARED `onSelect` persist path (never a duplicated one), and the dual native+jQuery
+ * `change` event-world binding (gotcha `jquery-trigger-change-fires-no-native-event`) —
+ * including that a SINGLE real native event delivered to BOTH bound worlds calls `onSelect`
+ * only once (double delivery harmless by construction).
+ *
+ * Real jQuery is loaded throughout (a devDependency). `select2` itself is NOT a dependency of
+ * this repo (it ships with WordPress/WooCommerce as the `selectWoo` script handle) — every test
+ * either stubs `jQuery.fn.select2` to capture the config passed to it (proving the WIRING is
+ * correct without the real plugin) or leaves it absent entirely (proving the graceful
+ * degradation the file docblock describes).
+ *
+ * @see woodev/shipping-method/assets/js/frontend/location-select-modes.js
+ * @see docs-internal/plans/2026-08-12-location-provider-plan.md — Task 13
+ * @see docs-internal/specs/2026-08-12-location-provider-design.md — D7
+ */
+
+'use strict';
+
+const LIST_URL = 'https://example.test/wp-json/woodev/v1/location/list';
+
+let fetchJsonCalls;
+
+/**
+ * Mirrors location-cascade.js's own `buildUrl()` exactly — omits empty/absent params.
+ *
+ * @param {string} base
+ * @param {Object} params
+ * @returns {string}
+ */
+function buildUrl( base, params ) {
+	const parts = [];
+
+	Object.keys( params || {} ).forEach( ( key ) => {
+		const value = params[ key ];
+
+		if ( undefined !== value && null !== value && '' !== value ) {
+			parts.push( encodeURIComponent( key ) + '=' + encodeURIComponent( value ) );
+		}
+	} );
+
+	return parts.length ? base + '?' + parts.join( '&' ) : base;
+}
+
+/**
+ * A controllable `options.fetchJson` double — mirrors `location-cascade.test.js`'s own
+ * `mockFetch()` convention: each captured call exposes `resolve()`/`reject()`.
+ *
+ * @returns {Function}
+ */
+function fakeFetchJson() {
+	fetchJsonCalls = [];
+
+	return jest.fn( ( url, init ) => {
+		const entry = { url, init };
+
+		entry.promise = new Promise( ( resolve, reject ) => {
+			entry.resolve = ( body ) => resolve( body );
+			entry.reject = reject;
+		} );
+
+		fetchJsonCalls.push( entry );
+
+		return entry.promise;
+	} );
+}
+
+/**
+ * Builds a fresh `options` object matching the exact shape `location-cascade.js`'s
+ * `attachOne()` hands to every renderer.
+ *
+ * @param {Object} overrides
+ * @returns {Object}
+ */
+function buildOptions( overrides ) {
+	return Object.assign(
+		{
+			fetch: jest.fn( () => Promise.resolve( [] ) ),
+			onSelect: jest.fn(),
+			emptyText: '',
+			node: { level: 'settlement', fieldId: 'billing_city' },
+			location: { endpoints: { list: LIST_URL }, mode: 'related-list' },
+			country: jest.fn( () => 'RU' ),
+			parentKey: jest.fn( () => null ),
+			buildUrl,
+			fetchJson: fakeFetchJson(),
+			nonceHeader: jest.fn( () => ( { 'X-WP-Nonce': 'N' } ) ),
+		},
+		overrides
+	);
+}
+
+beforeEach( () => {
+	jest.resetModules();
+	// Fresh <body> per test — jest.resetModules() gives a fresh MODULE, not a fresh DOM; a
+	// module that bound a delegated/element-level listener on a surviving node keeps answering
+	// with stale closure state (gotcha `jest-resetmodules-leaves-listeners-on-the-surviving-body`).
+	document.body.replaceWith( document.createElement( 'body' ) );
+	document.body.innerHTML = '';
+	delete window.WoodevLocationRenderers;
+	delete window.jQuery;
+	delete global.jQuery;
+	delete global.$;
+
+	global.jQuery = require( 'jquery' );
+	global.$ = global.jQuery;
+	window.jQuery = global.jQuery;
+} );
+
+// -----------------------------------------------------------------------
+// Registration — the seam location-cascade.js reads from
+// -----------------------------------------------------------------------
+
+describe( 'registers onto window.WoodevLocationRenderers on load', () => {
+	it( 'registers related-list:region, related-list:settlement, and the bare ajax-select2 key', () => {
+		require( '../../woodev/shipping-method/assets/js/frontend/location-select-modes.js' );
+
+		expect( typeof window.WoodevLocationRenderers[ 'related-list:region' ] ).toBe( 'function' );
+		expect( typeof window.WoodevLocationRenderers[ 'related-list:settlement' ] ).toBe( 'function' );
+		expect( typeof window.WoodevLocationRenderers[ 'ajax-select2' ] ).toBe( 'function' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// related-list: region — native <select> watcher
+// -----------------------------------------------------------------------
+
+describe( 'related-list region renderer', () => {
+	let mod;
+
+	beforeEach( () => {
+		mod = require( '../../woodev/shipping-method/assets/js/frontend/location-select-modes.js' );
+	} );
+
+	function installSelect() {
+		document.body.innerHTML = `
+			<select id="billing_state" name="billing_state">
+				<option value="">-- выберите --</option>
+				<option value="МОСКВА">Москва</option>
+				<option value="КАЗАНЬ">Казань</option>
+			</select>
+		`;
+
+		return document.getElementById( 'billing_state' );
+	}
+
+	it( 'declines (returns null) when the field is a plain <input>, not a <select>', () => {
+		document.body.innerHTML = '<input id="billing_state" name="billing_state" value="" />';
+		const options = buildOptions( { node: { level: 'region', fieldId: 'billing_state' } } );
+
+		const api = mod.attachRelatedListRegion( document.getElementById( 'billing_state' ), options );
+
+		expect( api ).toBeNull();
+	} );
+
+	it( 'matches the selected OPTION TEXT against record.label from /location/list and calls the shared onSelect', async () => {
+		const el = installSelect();
+		const options = buildOptions( { node: { level: 'region', fieldId: 'billing_state' } } );
+
+		mod.attachRelatedListRegion( el, options );
+
+		el.value = 'МОСКВА';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( fetchJsonCalls ).toHaveLength( 1 );
+		expect( fetchJsonCalls[ 0 ].url ).toBe( LIST_URL + '?level=region&country=RU' );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [
+				{ key: 'dadata:kazan', label: 'Казань', level: 'region', record: { key: 'dadata:kazan', label: 'Казань' } },
+				{ key: 'dadata:msk', label: 'Москва', level: 'region', record: { key: 'dadata:msk', label: 'Москва' } },
+			],
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( options.onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( options.onSelect ).toHaveBeenCalledWith( { record: { key: 'dadata:msk', label: 'Москва' } } );
+	} );
+
+	it( 'never calls onSelect when nothing in the list matches the selected text', async () => {
+		const el = installSelect();
+		const options = buildOptions( { node: { level: 'region', fieldId: 'billing_state' } } );
+
+		mod.attachRelatedListRegion( el, options );
+
+		el.value = 'КАЗАНЬ';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		fetchJsonCalls[ 0 ].resolve( { localities: [] } );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		// toHaveLength(0), never toEqual([]) — a mock's own .mock.calls can hold an
+		// [undefined] entry that toEqual([]) would let through unnoticed (gotcha
+		// `jest-toequal-empty-array-ignores-undefined`).
+		expect( options.onSelect.mock.calls ).toHaveLength( 0 );
+	} );
+
+	it( 'a REAL jQuery .trigger("change") alone (no native event at all) still reaches onSelect', async () => {
+		// Pins gotcha `jquery-trigger-change-fires-no-native-event`: WooCommerce may enhance
+		// this very <select> with selectWoo independently of this layer, and a pick through
+		// THAT reports via exactly this call — no native DOM event at all.
+		const el = installSelect();
+		const options = buildOptions( { node: { level: 'region', fieldId: 'billing_state' } } );
+
+		mod.attachRelatedListRegion( el, options );
+
+		window.jQuery( el ).val( 'МОСКВА' ).trigger( 'change' );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [ { key: 'dadata:msk', label: 'Москва', level: 'region', record: { key: 'dadata:msk', label: 'Москва' } } ],
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( options.onSelect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'a single native event delivered to BOTH bound worlds calls onSelect exactly once — double delivery is harmless', async () => {
+		const el = installSelect();
+		const options = buildOptions( { node: { level: 'region', fieldId: 'billing_state' } } );
+
+		mod.attachRelatedListRegion( el, options );
+
+		// jQuery's own `.on()` binds a REAL native listener under the hood — a single genuine
+		// native dispatch is therefore seen by BOTH our own addEventListener AND jQuery's.
+		el.value = 'МОСКВА';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [ { key: 'dadata:msk', label: 'Москва', level: 'region', record: { key: 'dadata:msk', label: 'Москва' } } ],
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		// Pinned against the earlier "one dispatch, one match" test: still exactly 1, not 2 —
+		// distinguishes "de-duplicated" from "coincidentally called once".
+		expect( options.onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( fetchJsonCalls ).toHaveLength( 1 ); // the list itself is also fetched only once.
+	} );
+
+	it( 'caches the region list per country — a second selection in the SAME country issues no second fetch', async () => {
+		const el = installSelect();
+		const options = buildOptions( { node: { level: 'region', fieldId: 'billing_state' } } );
+
+		mod.attachRelatedListRegion( el, options );
+
+		el.value = 'МОСКВА';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [
+				{ key: 'dadata:msk', label: 'Москва', level: 'region', record: { key: 'dadata:msk', label: 'Москва' } },
+				{ key: 'dadata:kzn', label: 'Казань', level: 'region', record: { key: 'dadata:kzn', label: 'Казань' } },
+			],
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		el.value = 'КАЗАНЬ';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( fetchJsonCalls ).toHaveLength( 1 ); // cached — pinned against the 2-country case below.
+		expect( options.onSelect ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'a country change re-fetches the list', async () => {
+		const el = installSelect();
+		let country = 'RU';
+		const options = buildOptions( {
+			node: { level: 'region', fieldId: 'billing_state' },
+			country: jest.fn( () => country ),
+		} );
+
+		mod.attachRelatedListRegion( el, options );
+
+		el.value = 'МОСКВА';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		fetchJsonCalls[ 0 ].resolve( { localities: [] } );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		country = 'BY';
+		el.value = 'КАЗАНЬ';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		fetchJsonCalls[ 1 ].resolve( { localities: [] } );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( fetchJsonCalls ).toHaveLength( 2 ); // pinned against the same-country 1-call case above.
+	} );
+
+	it( 'detach() unbinds both worlds — a change afterwards never reaches onSelect', () => {
+		const el = installSelect();
+		const options = buildOptions( { node: { level: 'region', fieldId: 'billing_state' } } );
+
+		const api = mod.attachRelatedListRegion( el, options );
+
+		api.detach();
+
+		el.value = 'МОСКВА';
+		el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		window.jQuery( el ).trigger( 'change' );
+
+		expect( fetchJsonCalls ).toHaveLength( 0 );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// related-list: settlement — select2 fed by the full per-region /location/list
+// -----------------------------------------------------------------------
+
+describe( 'related-list settlement renderer', () => {
+	let mod;
+
+	beforeEach( () => {
+		mod = require( '../../woodev/shipping-method/assets/js/frontend/location-select-modes.js' );
+		document.body.innerHTML = '<form><input type="text" id="billing_city" name="billing_city" value="" /></form>';
+	} );
+
+	it( 'declines when the field is not a plain <input>', () => {
+		document.body.innerHTML = '<select id="billing_city" name="billing_city"></select>';
+		const options = buildOptions();
+
+		const api = mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), options );
+
+		expect( api ).toBeNull();
+	} );
+
+	it( 'replaces the <input> with a <select> carrying the SAME id, fetches the full region-scoped list, and populates <option>s', async () => {
+		const input = document.getElementById( 'billing_city' );
+		const options = buildOptions( {
+			node: { level: 'settlement', fieldId: 'billing_city' },
+			country: jest.fn( () => 'RU' ),
+			parentKey: jest.fn( () => 'dadata:region1' ),
+		} );
+
+		mod.attachRelatedListSettlement( input, options );
+
+		expect( document.getElementById( 'billing_city' ).tagName ).toBe( 'SELECT' );
+		expect( fetchJsonCalls[ 0 ].url ).toBe( LIST_URL + '?level=settlement&country=RU&within=' + encodeURIComponent( 'dadata:region1' ) );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [ { key: 'dadata:zh', label: 'Жуковский', level: 'settlement', record: { key: 'dadata:zh', label: 'Жуковский' } } ],
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		const select = document.getElementById( 'billing_city' );
+		expect( select.options.length ).toBe( 1 ); // pinned: exactly the one entry the fake response carried.
+		expect( select.options[ 0 ].value ).toBe( 'dadata:zh' );
+		expect( select.options[ 0 ].textContent ).toBe( 'Жуковский' );
+	} );
+
+	it( 'omits `within` when parentKey() is empty (no region selected yet — country-wide list)', () => {
+		const options = buildOptions( { parentKey: jest.fn( () => null ) } );
+
+		mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), options );
+
+		expect( fetchJsonCalls[ 0 ].url ).not.toContain( 'within=' );
+	} );
+
+	it( 'picking an option calls the shared onSelect with the matching record — the SAME persist path as every other level', async () => {
+		const options = buildOptions( { node: { level: 'settlement', fieldId: 'billing_city' } } );
+
+		mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), options );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [ { key: 'dadata:zh', label: 'Жуковский', level: 'settlement', record: { key: 'dadata:zh', label: 'Жуковский' } } ],
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		const select = document.getElementById( 'billing_city' );
+		select.value = 'dadata:zh';
+		select.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( options.onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( options.onSelect ).toHaveBeenCalledWith( { record: { key: 'dadata:zh', label: 'Жуковский' } } );
+	} );
+
+	it( 'initializes select2 in LOCAL mode (no `ajax` config) when the plugin is present', async () => {
+		const select2Calls = [];
+		window.jQuery.fn.select2 = jest.fn( function( config ) {
+			select2Calls.push( config );
+			return this;
+		} );
+
+		mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), buildOptions() );
+
+		fetchJsonCalls[ 0 ].resolve( { localities: [] } );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( select2Calls ).toHaveLength( 1 );
+		expect( select2Calls[ 0 ].ajax ).toBeUndefined();
+
+		delete window.jQuery.fn.select2;
+	} );
+
+	it( 'detach() restores the ORIGINAL <input> node in place, removing the <select>', async () => {
+		const input = document.getElementById( 'billing_city' );
+		const options = buildOptions();
+
+		const api = mod.attachRelatedListSettlement( input, options );
+
+		fetchJsonCalls[ 0 ].resolve( { localities: [] } );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		api.detach();
+
+		const restored = document.getElementById( 'billing_city' );
+		expect( restored ).toBe( input );
+		expect( restored.tagName ).toBe( 'INPUT' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// ajax-select2 — select2 remote data through the SAME options.fetch the typeahead uses
+// -----------------------------------------------------------------------
+
+describe( 'ajax-select2 renderer', () => {
+	let mod;
+
+	beforeEach( () => {
+		mod = require( '../../woodev/shipping-method/assets/js/frontend/location-select-modes.js' );
+		document.body.innerHTML = '<input type="text" id="billing_address_1" name="billing_address_1" value="" />';
+	} );
+
+	afterEach( () => {
+		delete window.jQuery.fn.select2;
+	} );
+
+	it( 'declines when the field is not a plain <input>', () => {
+		document.body.innerHTML = '<select id="billing_address_1"></select>';
+
+		const api = mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), buildOptions() );
+
+		expect( api ).toBeNull();
+	} );
+
+	it( 'does NOT call options.fetch upfront — only select2 ajax.transport drives population', () => {
+		const fetchSpy = jest.fn( () => Promise.resolve( [] ) );
+		const options = buildOptions( { fetch: fetchSpy } );
+
+		mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), options );
+
+		expect( fetchSpy.mock.calls ).toHaveLength( 0 );
+	} );
+
+	it( 'wires the SAME options.fetch as select2\'s own ajax.transport — shared code path, not a copy', async () => {
+		const fetchSpy = jest.fn( ( term ) => Promise.resolve( [
+			{ key: 'dadata:tv', label: 'ул Тверская', level: 'address', value: 'ул Тверская', record: { key: 'dadata:tv', label: 'ул Тверская' } },
+		] ) );
+		const options = buildOptions( { fetch: fetchSpy } );
+
+		const select2Calls = [];
+		window.jQuery.fn.select2 = jest.fn( function( config ) {
+			select2Calls.push( config );
+			return this;
+		} );
+
+		mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), options );
+
+		expect( select2Calls ).toHaveLength( 1 );
+		expect( typeof select2Calls[ 0 ].ajax.transport ).toBe( 'function' );
+
+		const success = jest.fn();
+		const failure = jest.fn();
+
+		select2Calls[ 0 ].ajax.transport( { data: { term: 'Твер' } }, success, failure );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( fetchSpy ).toHaveBeenCalledWith( 'Твер' );
+		expect( success ).toHaveBeenCalledTimes( 1 );
+		expect( success.mock.calls[ 0 ][ 0 ].results ).toEqual( [ { id: 'dadata:tv', text: 'ул Тверская' } ] );
+	} );
+
+	it( 'a selection AFTER an ajax.transport response calls the shared onSelect with the fetched record', async () => {
+		const fetchSpy = jest.fn( () => Promise.resolve( [
+			{ key: 'dadata:tv', label: 'ул Тверская', level: 'address', value: 'ул Тверская', record: { key: 'dadata:tv', label: 'ул Тверская' } },
+		] ) );
+		const options = buildOptions( { fetch: fetchSpy } );
+
+		const select2Calls = [];
+		window.jQuery.fn.select2 = jest.fn( function( config ) {
+			select2Calls.push( config );
+			return this;
+		} );
+
+		mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), options );
+
+		select2Calls[ 0 ].ajax.transport( { data: { term: 'Твер' } }, jest.fn(), jest.fn() );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		// select2 itself would insert the picked <option> into the underlying <select> before
+		// marking it selected (a bare `.value =` assignment is a no-op without a matching
+		// <option> present — both jQuery's and the native `<select>` value setter search the
+		// existing option list) — reproduced explicitly here, same as the next test.
+		const select = document.getElementById( 'billing_address_1' );
+		const option = document.createElement( 'option' );
+		option.value = 'dadata:tv';
+		select.appendChild( option );
+		select.value = 'dadata:tv';
+		select.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( options.onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( options.onSelect ).toHaveBeenCalledWith( { record: { key: 'dadata:tv', label: 'ул Тверская' } } );
+	} );
+
+	it( 'a jQuery-only .trigger("change") (select2\'s own reporting mechanism, no native event) still reaches onSelect', async () => {
+		// The core event-world pin: select2 reports a pick via EXACTLY this call — no native
+		// DOM event is ever dispatched (gotcha `jquery-trigger-change-fires-no-native-event`).
+		// A NATIVE-only `addEventListener('change')` would never see this at all.
+		const fetchSpy = jest.fn( () => Promise.resolve( [
+			{ key: 'dadata:tv', label: 'ул Тверская', level: 'address', value: 'ул Тверская', record: { key: 'dadata:tv', label: 'ул Тверская' } },
+		] ) );
+		const options = buildOptions( { fetch: fetchSpy } );
+
+		const select2Calls = [];
+		window.jQuery.fn.select2 = jest.fn( function( config ) {
+			select2Calls.push( config );
+			return this;
+		} );
+
+		mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), options );
+
+		// Prime the lookup map exactly the way a real ajax.transport response would.
+		select2Calls[ 0 ].ajax.transport( { data: { term: 'Твер' } }, jest.fn(), jest.fn() );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		const select = document.getElementById( 'billing_address_1' );
+
+		// A real select2 pick inserts the chosen result's own <option> into the underlying
+		// <select> before marking it selected — reproduced explicitly here since no real
+		// select2 runs under jest (see the file docblock's SELECT2 IS OPTIONAL section).
+		const option = document.createElement( 'option' );
+		option.value = 'dadata:tv';
+		select.appendChild( option );
+
+		window.jQuery( select ).val( 'dadata:tv' ).trigger( 'change' );
+
+		expect( options.onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( options.onSelect ).toHaveBeenCalledWith( { record: { key: 'dadata:tv', label: 'ул Тверская' } } );
+	} );
+} );

--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -650,6 +650,18 @@ class CheckoutConfigTest extends TestCase {
 		$this->assertSame( 'Ничего нет', $config['location']['i18n']['noResults'] );
 	}
 
+	public function test_location_block_carries_the_not_persisted_message(): void {
+		// #295 finding 1 (Task 13): the client-side consumer for an honest
+		// `persisted: false` /select response reads this string — see
+		// `location-cascade.js`'s own `showNotPersistedNotice()`.
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'settlement' => true ], null, [ 'RU' ] );
+		$config  = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertIsString( $config['location']['i18n']['notPersisted'] );
+		$this->assertNotSame( '', $config['location']['i18n']['notPersisted'] );
+	}
+
 	public function test_no_token_or_secret_leaks_into_the_i18n_block(): void {
 		$service = new Checkout_Config_Fake_Location_Service( true, [ 'settlement' => true ], null, [ 'RU' ] );
 		$config  = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
@@ -187,6 +187,7 @@ class CheckoutHandlerEnqueueTest extends TestCase {
 		$handler->enqueue_assets();
 
 		$this->assertArrayNotHasKey( 'woodev-location-typeahead', $scripts );
+		$this->assertArrayNotHasKey( 'woodev-location-select-modes', $scripts );
 		$this->assertArrayNotHasKey( 'woodev-location-cascade', $scripts );
 		$this->assertArrayNotHasKey( 'woodev-location-styles', $styles );
 
@@ -206,6 +207,7 @@ class CheckoutHandlerEnqueueTest extends TestCase {
 		$handler->enqueue_assets();
 
 		$this->assertArrayNotHasKey( 'woodev-location-typeahead', $scripts );
+		$this->assertArrayNotHasKey( 'woodev-location-select-modes', $scripts );
 		$this->assertArrayNotHasKey( 'woodev-location-cascade', $scripts );
 		$this->assertArrayNotHasKey( 'woodev-location-styles', $styles );
 		$this->assertArrayNotHasKey( 'location', $localized[0][2] );
@@ -231,6 +233,7 @@ class CheckoutHandlerEnqueueTest extends TestCase {
 
 		// Files forced to report as not-yet-built — must never be enqueued.
 		$this->assertArrayNotHasKey( 'woodev-location-typeahead', $scripts );
+		$this->assertArrayNotHasKey( 'woodev-location-select-modes', $scripts );
 		$this->assertArrayNotHasKey( 'woodev-location-cascade', $scripts );
 		$this->assertArrayNotHasKey( 'woodev-location-styles', $styles );
 
@@ -266,6 +269,15 @@ class CheckoutHandlerEnqueueTest extends TestCase {
 		$this->assertStringContainsString( 'location-cascade.js', $scripts['woodev-location-cascade']['src'] );
 		$this->assertContains( 'woodev-location-typeahead', $scripts['woodev-location-cascade']['deps'] );
 		$this->assertContains( 'woodev-checkout-field-store', $scripts['woodev-location-cascade']['deps'] );
+
+		// Task 13's renderer registry (spec D7) — enqueued with the SAME "selectWoo" dependency
+		// `woodev-checkout-field-classic` already requires (select2 can only enhance a real
+		// `<select>`), and declared as a dependency of the cascade itself so its own renderer
+		// registration has always already run by the time the cascade reads it.
+		$this->assertArrayHasKey( 'woodev-location-select-modes', $scripts );
+		$this->assertStringContainsString( 'location-select-modes.js', $scripts['woodev-location-select-modes']['src'] );
+		$this->assertContains( 'selectWoo', $scripts['woodev-location-select-modes']['deps'] );
+		$this->assertContains( 'woodev-location-select-modes', $scripts['woodev-location-cascade']['deps'] );
 
 		// The typeahead's own suggestion-listbox stylesheet — same "built" probe, same guard.
 		$this->assertArrayHasKey( 'woodev-location-styles', $styles );

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -1,6 +1,6 @@
 /**
  * Woodev Location Cascade — field-graph wiring for the location provider layer
- * (spec §4.4/D2, plan Tasks 11-12).
+ * (spec §4.4/D2/D7, plan Tasks 11-13).
  *
  * Builds ON TOP OF the §8 checkout-field store (`checkout-field-store.js`, Task 10 of the
  * 2026-07-06 plan) rather than a parallel state world: the store already owns canonical
@@ -8,6 +8,18 @@
  * persistence, backwards fill, per-country attach/detach, and (Task 12) a client-side wrap of
  * WC's OWN Address Autocomplete provider registry for mixed-country stores (see the
  * "WC Address Autocomplete suppression" section below).
+ *
+ * RENDERER SEAM (Task 13, spec D7 — "mode is presentation, provider is data"): this module
+ * owns exactly ONE renderer itself — the baseline typeahead ({@see attachOne}'s fallback path,
+ * gated by the D15 `isLevelServed()` chain) — and otherwise only knows how to ASK for one:
+ * {@see resolveModeRenderer} looks up `window.WoodevLocationRenderers[mode(+':'+level)]`,
+ * a registry `location-select-modes.js` populates with the `related-list` and `ajax-select2`
+ * renderers. This file never imports that module, never branches on its presence, and never
+ * inspects what a resolved renderer actually does with the `fetch`/`onSelect`/scoping
+ * primitives {@see attachOne} hands it — the cascade stays entirely ignorant of WHICH
+ * presentation a field gets, only of the fixed chain and persistence contract every
+ * presentation must honour identically (D8's persist-then-trigger route via the SAME
+ * `onSelectFor()`, never a duplicated one).
  *
  * STORE SHARING (discovered from `class-checkout-handler.php::enqueue_assets()`, not spelled
  * out in the plan — contradiction noted in the Task 11 report): this file is enqueued with a
@@ -269,13 +281,80 @@
 
 		var country = countryFor( node );
 
+		if ( ! isCountrySupported( entry, country ) ) {
+			return false;
+		}
+
+		// Task 13 / spec D7's ONE necessary exception to the D15 level gate below — see
+		// isRelatedListRegionNode()'s own docblock for why `isLevelServed()` cannot answer
+		// this case at all (by the SERVER's own design, not an oversight here).
+		if ( isRelatedListRegionNode( entry, node ) ) {
+			return true;
+		}
+
 		// The D15 level gate belongs HERE, not only inside attachOne(): the reconcile in
 		// applyCountryArbitration() decides detach-vs-attach purely from this predicate, so a
 		// gate that lives only on the attach path can never DETACH. Concretely — a customer
 		// on RU with an attached address widget who switches to AM (a country we serve, but
 		// with city-only data) would keep a widget that can never return anything, because
 		// the country itself is still supported and the section is still visible.
-		return isCountrySupported( entry, country ) && isLevelServed( entry, country, node.level );
+		return isLevelServed( entry, country, node.level );
+	}
+
+	/**
+	 * Whether `node` is the region level of an entry in `related-list` mode (spec D7; Task 13;
+	 * issue #294 arbitration) — the ONE case where {@see isLevelServed}'s "region" answer is
+	 * structurally unable to describe reality and must not be consulted at all.
+	 *
+	 * Per `class-checkout-config.php::build_location_block()`'s own docblock: `levels[country]
+	 * .region` reads `false` for EVERY country whose region `<select>` already has WooCommerce
+	 * states registered — REGARDLESS of whether those states came from a genuine conflict
+	 * (some other source already owns the field) or from THIS layer's OWN `related-list` mode
+	 * injecting them on purpose (`Location_Provider_Registry::inject_related_list_states()`).
+	 * The server's own docblock says the client "must NOT try to tell the two apart... it does
+	 * not need to" — and it does not, because the real gate for the region node under
+	 * `related-list` mode is not "does the D15 suggest chain want this level" at all, it is
+	 * "did WooCommerce actually render a `<select>` here", which {@see attachOne}'s own
+	 * `related-list:region` renderer checks directly against the live DOM (`el.tagName`) —
+	 * this predicate only decides whether that renderer gets a chance to run.
+	 *
+	 * @param {Object} entry
+	 * @param {{level: string}} node
+	 * @returns {boolean}
+	 */
+	function isRelatedListRegionNode( entry, node ) {
+		return 'related-list' === ( entry.location && entry.location.mode ) && 'region' === node.level;
+	}
+
+	/**
+	 * Resolves the mode-specific renderer for `node`, if Task 13's `location-select-modes.js`
+	 * registered one — spec D7's "mode is presentation, provider is data": this cascade must
+	 * not know WHICH renderer a field uses, only how to ask the registry for one. Lookup order:
+	 * `{mode}:{level}` (a renderer specific to one field kind under one mode — e.g.
+	 * `related-list`'s region native-`<select>` watcher, which shares nothing with its own
+	 * settlement renderer) first, then the bare `{mode}` (a renderer that serves every level
+	 * uniformly — `ajax-select2`'s select2 widget is the same shape for region, settlement, or
+	 * address). Returns `null` when nothing is registered for either key, or when
+	 * `location-select-modes.js` never loaded at all — {@see attachOne}'s baseline typeahead
+	 * path is the fallback either way, never a special case of this function.
+	 *
+	 * @param {Object} entry
+	 * @param {{level: string}} node
+	 * @returns {function(Element, Object): ({detach: Function}|null)|null}
+	 */
+	function resolveModeRenderer( entry, node ) {
+		var mode = ( entry.location && entry.location.mode ) || 'typeahead';
+		var registry = window.WoodevLocationRenderers || {};
+
+		if ( 'function' === typeof registry[ mode + ':' + node.level ] ) {
+			return registry[ mode + ':' + node.level ];
+		}
+
+		if ( 'function' === typeof registry[ mode ] ) {
+			return registry[ mode ];
+		}
+
+		return null;
 	}
 
 	/**
@@ -463,11 +542,18 @@
 			resolved: {},
 			// Per-LEVEL confirmed record (only chain levels; postcode never has one of its own).
 			records: {},
-			// fieldId -> { el, api } for every CURRENTLY attached typeahead widget.
+			// fieldId -> { el, api } for every CURRENTLY attached widget (typeahead OR one of
+			// Task 13's mode-specific renderers — see attachOne()/resolveModeRenderer()).
 			widgets: {},
 			// Single-flight /select queue state (Finding 2) — see enqueueSelect()/sendNextSelect().
 			pendingRecord: null,
 			selectInFlight: false,
+			// Task 13 / #295 finding 1: the fieldId the MOST RECENT selection came from (any
+			// level — the /select queue is per ENTRY, not per node) and the currently-shown
+			// "your choice was not saved" notice element, if any — see
+			// showNotPersistedNotice()/clearNotPersistedNotice().
+			lastSelectedFieldId: null,
+			notPersistedNotice: null,
 		};
 	}
 
@@ -696,11 +782,24 @@
 
 		fetchJson( url, { method: 'POST', headers: headers, body: JSON.stringify( { record: record } ) } ).then(
 			function( body ) {
-				settleSelect( entry, !! ( body && false !== body.persisted ) );
+				// `persisted` is always present on a successful response (Location_Controller::
+				// handle_select_request()'s own return type — never ambiguous), so `!shouldTrigger`
+				// here means exactly one thing: the server answered, honestly, that it could not
+				// write the record (#295 finding 1 — typically a guest whose session/cart cookie
+				// has not initialized yet, gotcha `guest-session-write-needs-the-cart-cookie`).
+				var persisted = !! ( body && false !== body.persisted );
+
+				settleSelect( entry, persisted, ! persisted );
 			},
 			function( error ) {
 				logError( error );
-				settleSelect( entry, false );
+				// A network/parse failure is a DIFFERENT failure mode from an honest
+				// `persisted: false` — the server never got to answer at all, so there is no
+				// signal to "consume" here (#295 finding 1 is specifically about the EXISTING
+				// `persisted` flag going unread, not about inventing a new one for transport
+				// errors). Stays silent to the customer, same as before this task; the visible
+				// field value still survives (the widget already wrote it before onSelect ran).
+				settleSelect( entry, false, false );
 			}
 		);
 	}
@@ -708,15 +807,25 @@
 	/**
 	 * Frees the single-flight slot for `entry` and either forwards to the next queued
 	 * selection (a newer one arrived while this request was in flight — this response is
-	 * stale by construction, so it never fires the trigger) or, when nothing newer is queued,
-	 * treats this response as FINAL: fires `update_checkout` iff `shouldTrigger`.
+	 * stale by construction, so it never fires the trigger NOR shows a notice for it) or,
+	 * when nothing newer is queued, treats this response as FINAL: fires `update_checkout`
+	 * iff `shouldTrigger`, or — Task 13 / #295 finding 1 — shows the "your choice was not
+	 * saved" notice iff `notPersisted` (an honest `persisted: false` from the server, as
+	 * opposed to a network failure, which stays silent — see {@see sendNextSelect}'s own
+	 * comment on that distinction). A successful FINAL persist always clears any notice a
+	 * PRIOR selection may have left behind ({@see clearNotPersistedNotice}), so a stale
+	 * warning never survives past the outcome it described.
 	 *
 	 * @param {Object}  entry
 	 * @param {boolean} shouldTrigger Whether THIS response, if final, should fire the trigger
 	 *                                (a successful persist with `persisted !== false`).
+	 * @param {boolean} notPersisted  Whether THIS response, if final, should surface the
+	 *                                not-saved notice (a successful response carrying an
+	 *                                explicit `persisted: false` — never true together with
+	 *                                `shouldTrigger`).
 	 * @returns {void}
 	 */
-	function settleSelect( entry, shouldTrigger ) {
+	function settleSelect( entry, shouldTrigger, notPersisted ) {
 		entry.selectInFlight = false;
 
 		if ( entry.pendingRecord ) {
@@ -724,9 +833,84 @@
 			return;
 		}
 
-		if ( shouldTrigger && window.jQuery ) {
-			window.jQuery( document.body ).trigger( 'update_checkout' );
+		if ( shouldTrigger ) {
+			clearNotPersistedNotice( entry );
+
+			if ( window.jQuery ) {
+				window.jQuery( document.body ).trigger( 'update_checkout' );
+			}
+
+			return;
 		}
+
+		if ( notPersisted ) {
+			showNotPersistedNotice( entry );
+		}
+	}
+
+	/**
+	 * Shows the "your choice was not saved" notice for `entry` — Task 13 / #295 finding 1: the
+	 * server has always answered `persisted: false` honestly, but until now nothing on the
+	 * client read it beyond skipping `update_checkout` (see this file's own D8 section above).
+	 * Anchored right after the field the customer's MOST RECENT selection came from
+	 * ({@see entry.lastSelectedFieldId}) — persistence is an ENTRY-level outcome (the
+	 * single-flight `/select` queue in {@see enqueueSelect} is per entry, not per node), so
+	 * there is no field this is MORE specifically about than "whichever one the customer just
+	 * used". A missing anchor (the field no longer in the document — a country switch tore
+	 * the section down between the select and this response landing) is a silent no-op: there
+	 * is nowhere left to put the message, and the field itself is gone anyway.
+	 *
+	 * Text comes from `entry.location.i18n.notPersisted` — server-supplied, translated,
+	 * filterable via `woodev_location_i18n` (`class-checkout-config.php::build_location_block()`),
+	 * same convention as `noResults`/`noResultsAddress`: this string reaches the customer, so
+	 * it is never a literal here. An older config without the key (or a filter that cleared
+	 * it) degrades to silence rather than inventing a string client-side.
+	 *
+	 * @param {Object} entry
+	 * @returns {void}
+	 */
+	function showNotPersistedNotice( entry ) {
+		clearNotPersistedNotice( entry );
+
+		var anchor = entry.lastSelectedFieldId && document.getElementById( entry.lastSelectedFieldId );
+
+		if ( ! anchor || ! anchor.parentNode ) {
+			return;
+		}
+
+		var i18n = entry.location.i18n || {};
+		var text = 'string' === typeof i18n.notPersisted ? i18n.notPersisted : '';
+
+		if ( '' === text ) {
+			return;
+		}
+
+		var notice = document.createElement( 'p' );
+
+		notice.className = 'woodev-location-notice';
+		notice.setAttribute( 'role', 'alert' );
+		notice.textContent = text;
+
+		anchor.parentNode.insertBefore( notice, anchor.nextSibling );
+
+		entry.notPersistedNotice = notice;
+	}
+
+	/**
+	 * Removes the notice {@see showNotPersistedNotice} inserted for `entry`, if any — a safe
+	 * no-op otherwise (nothing shown, or it was already removed).
+	 *
+	 * @param {Object} entry
+	 * @returns {void}
+	 */
+	function clearNotPersistedNotice( entry ) {
+		var notice = entry.notPersistedNotice;
+
+		if ( notice && notice.parentNode ) {
+			notice.parentNode.removeChild( notice );
+		}
+
+		entry.notPersistedNotice = null;
 	}
 
 	/**
@@ -745,6 +929,10 @@
 			}
 
 			entry.records[ node.level ] = record;
+			// Task 13 / #295 finding 1: remembers WHICH field to anchor a future "not saved"
+			// notice to — see showNotPersistedNotice()'s own docblock for why this is an
+			// entry-level, not node-level, concept.
+			entry.lastSelectedFieldId = node.fieldId;
 
 			backwardsFill( entry, node.level, record );
 			enqueueSelect( entry, record );
@@ -803,13 +991,9 @@
 	 * @returns {void}
 	 */
 	function attachOne( entry, node ) {
-		if ( ! isLevelServed( entry, countryFor( node ), node.level ) ) {
-			return;
-		}
-
 		var el = document.getElementById( node.fieldId );
 
-		if ( ! el || 'function' !== typeof window.WoodevLocationTypeahead ) {
+		if ( ! el ) {
 			return;
 		}
 
@@ -823,16 +1007,66 @@
 			? i18n.noResultsAddress
 			: i18n.noResults;
 
-		var api = window.WoodevLocationTypeahead( el, {
+		// Handed to WHICHEVER renderer attaches — a Task 13 mode-specific one or the baseline
+		// typeahead below get the EXACT SAME `fetch`/`onSelect` (spec: "assert the shared code
+		// path, not a copy" — a related-list/ajax-select2 pick persists through the identical
+		// `onSelectFor()` → backwardsFill()/enqueueSelect() route every other level already
+		// uses), plus this module's own generic request/scoping primitives, so a renderer never
+		// reimplements suggest/list URL building, JSON fetching, or live country/parent scoping
+		// — it only decides HOW to present them. Still fully mode-ignorant on THIS side: none of
+		// these primitives know or care which renderer, if any, ends up using them.
+		var options = {
 			fetch: fetchFor( entry, node ),
 			onSelect: onSelectFor( entry, node ),
 			// Server-supplied (translated, filterable via `woodev_location_i18n`) — never a
 			// literal here: this string reaches the customer, so it follows the same route
 			// every other user-facing string in this layer takes.
 			emptyText: 'string' === typeof emptyKey ? emptyKey : '',
-		} );
+			node: node,
+			location: entry.location,
+			country: function() {
+				return countryFor( node );
+			},
+			parentKey: function() {
+				return scopeKeyFor( entry, node.level );
+			},
+			buildUrl: buildUrl,
+			fetchJson: fetchJson,
+			nonceHeader: function() {
+				return nonceHeader( entry );
+			},
+		};
 
-		entry.widgets[ node.fieldId ] = { el: el, api: api };
+		var renderer = resolveModeRenderer( entry, node );
+
+		if ( renderer ) {
+			var api = renderer( el, options );
+
+			if ( api ) {
+				// A DOM-replacing renderer (Task 13's select2-backed ones swap the plain
+				// `<input>` for a real `<select>` — select2 cannot enhance anything else)
+				// reports the LIVE element back via `api.el`; a renderer that never touches
+				// the DOM shape (the related-list region watcher) simply omits it and `el`
+				// (captured above, before the renderer ran) is still correct. Storing the
+				// wrong one here would make reconcileAfterCheckoutUpdate()'s own "was this
+				// node replaced by a checkout re-render" check misfire on every single pass.
+				entry.widgets[ node.fieldId ] = { el: api.el || el, api: api };
+
+				return;
+			}
+			// A renderer declining (returns a falsy value — e.g. `related-list`'s region
+			// watcher finding this country's field is a plain `<input>`, not the `<select>`
+			// its own mode should have produced) falls through to the baseline below, exactly
+			// like a mode with nothing registered for this node at all.
+		}
+
+		// Baseline: text+typeahead, gated by the D15 per-country/level chain (spec D7: "text+
+		// typeahead always" is the FLOOR, never conditional on a special renderer existing).
+		if ( ! isLevelServed( entry, countryFor( node ), node.level ) || 'function' !== typeof window.WoodevLocationTypeahead ) {
+			return;
+		}
+
+		entry.widgets[ node.fieldId ] = { el: el, api: window.WoodevLocationTypeahead( el, options ) };
 	}
 
 	/**

--- a/woodev/shipping-method/assets/js/frontend/location-select-modes.js
+++ b/woodev/shipping-method/assets/js/frontend/location-select-modes.js
@@ -1,0 +1,498 @@
+/**
+ * Woodev Location Select Modes — the `related-list` and `ajax-select2` field renderers for the
+ * location provider layer (spec D7, plan Task 13).
+ *
+ * REGISTRY, NOT A CALLER: this file never calls into `location-cascade.js` and is never
+ * `require()`d by it. It only writes onto `window.WoodevLocationRenderers`, a plain object
+ * `location-cascade.js`'s own `resolveModeRenderer()` reads defensively (missing entirely,
+ * or missing this mode/level, both degrade to "use the baseline typeahead" — see that
+ * function's own docblock). Load order matters only in ONE direction: this file must have
+ * already run by the time `location-cascade.js`'s `boot()` calls `attachAll()` for the first
+ * time, which the PHP enqueue wiring guarantees by declaring this script a hard dependency of
+ * `location-cascade.js` (`class-checkout-handler.php::enqueue_assets()`).
+ *
+ * EVERY RENDERER SHARES THE SAME CONTRACT `location-cascade.js`'s baseline typeahead honours:
+ * `attach( el, options ) -> {detach, el?}|null`. `options.onSelect( { record } )` is THE SAME
+ * function every other level's typeahead already calls (`onSelectFor()` in the cascade file) —
+ * a selection made through ANY renderer here flows through the identical backwards-fill +
+ * single-flight `/select` persist route (D8) as Task 11's typeahead. Nothing in this file ever
+ * calls `fetch()`/`XMLHttpRequest` directly or re-derives a suggest/list URL by hand — it only
+ * ever uses `options.fetch` (suggest, already scoped by the cascade) and the generic
+ * `options.buildUrl`/`options.fetchJson`/`options.nonceHeader`/`options.country`/
+ * `options.parentKey` primitives the cascade hands over for exactly this purpose.
+ *
+ * THE EVENT-WORLD TRAP (gotcha `jquery-trigger-change-fires-no-native-event`): select2 (and
+ * WooCommerce's own selectWoo enhancement of a plain `<select>`, which MAY independently apply
+ * to the `related-list` region field WooCommerce itself renders) reports a pick via jQuery
+ * `.trigger('change')` — no native DOM event at all. Every renderer in this file therefore
+ * binds its `change` handler in BOTH worlds via {@see bindChangeBothWorlds}: a native
+ * `addEventListener` AND, when jQuery is present, a `.on()` binding too. A REAL user pick on a
+ * plain (non-enhanced) `<select>`/`<input>` still dispatches a genuine native event, which BOTH
+ * bindings then see — so every handler here is written to be a no-op on the SECOND, redundant
+ * delivery (tracked via a small "last handled value" remembered per instance), never merely
+ * lucky about it.
+ *
+ * SELECT2 IS OPTIONAL AT RUNTIME, NOT AT BUILD TIME: this repo has no `select2`/`selectWoo` npm
+ * package (it ships with WordPress/WooCommerce as the `selectWoo` script handle — declared as a
+ * hard dependency of this file in `class-checkout-handler.php::enqueue_assets()`, same as
+ * `checkout-field-classic.js` already requires it). `buildSelectField()` therefore checks
+ * `jQuery.fn.select2` defensively before calling it — real production always has it once
+ * `selectWoo` has loaded; a jsdom test harness (no such package) still gets a fully working,
+ * fully testable plain `<select>` with the same dual-world `change` wiring, exactly what a
+ * test needs to pin the event-world contract with REAL jQuery and no third-party plugin at
+ * all.
+ *
+ * @file
+ * @since 2.1.0
+ */
+
+( function() {
+	'use strict';
+
+	var LOG = '[woodev-location-select-modes]';
+
+	/**
+	 * Logs an error with this module's prefix, never throwing — mirrors
+	 * `location-cascade.js`'s own `logError()`.
+	 *
+	 * @param {*} error
+	 * @returns {void}
+	 */
+	function logError( error ) {
+		if ( window.console && 'function' === typeof console.error ) {
+			console.error( LOG, error );
+		}
+	}
+
+	/** @type {Object.<string, function>} the registry `location-cascade.js` reads from. */
+	var registry = window.WoodevLocationRenderers = window.WoodevLocationRenderers || {};
+
+	// -------------------------------------------------------------------------
+	// Shared dual-event-world `change` binder — see the file docblock's EVENT-WORLD TRAP.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Binds `handler` to `el`'s `change` event in both the native and jQuery worlds. Returns an
+	 * `unbind()` that reverses exactly what was bound (never more): a jQuery-less page (or a
+	 * jsdom test that never loaded it) only ever gets the native half bound/unbound.
+	 *
+	 * @param {Element}  el
+	 * @param {Function} handler
+	 * @returns {function(): void}
+	 */
+	function bindChangeBothWorlds( el, handler ) {
+		el.addEventListener( 'change', handler );
+
+		var jquery = false;
+
+		if ( window.jQuery ) {
+			var $el = window.jQuery( el );
+
+			if ( $el && 'function' === typeof $el.on ) {
+				$el.on( 'change', handler );
+				jquery = true;
+			}
+		}
+
+		return function unbind() {
+			el.removeEventListener( 'change', handler );
+
+			if ( jquery && window.jQuery ) {
+				window.jQuery( el ).off( 'change', handler );
+			}
+		};
+	}
+
+	// -------------------------------------------------------------------------
+	// related-list: region — a watcher on the NATIVE WooCommerce <select>
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Attaches the `related-list` region renderer — spec D7, Task 13 (issue #294 arbitration).
+	 *
+	 * Does NOT create any widget: under `related-list` mode WooCommerce itself renders the
+	 * region `<select>`, populated server-side by `Location_Provider_Registry::
+	 * inject_related_list_states()` through the EXISTING §8 `woocommerce_states` filter — the
+	 * `<option>` VALUE is `wc_strtoupper(trim(record.label))` (uppercased so WooCommerce's own
+	 * `validate_posted_data()` uppercasing of the posted value still matches the registered
+	 * key — see `class-checkout-config.php::build_location_block()`'s own docblock for the
+	 * measured rig failure this fixed), the `<option>` TEXT is the human label unchanged. This
+	 * function only WATCHES that select: it looks the selected TEXT up against the SAME
+	 * country's `GET /location/list?level=region` response (`entry.record.label`, the RAW
+	 * label — never the top-level `label` field, which is `esc_html()`-escaped for display and
+	 * would never equality-match) and, on a match, hands the matched record to
+	 * `options.onSelect()` — the exact same persist route every other level already uses.
+	 *
+	 * Declines (`null`) when `el` is not a `<select>` — the country's region field is a plain
+	 * `<input>` because the D15 chain did not want it enumerated there, or a genuine conflict
+	 * left WooCommerce's own/another source's states in place (`class-checkout-config.php`'s
+	 * own docblock: the client cannot and need not tell these apart from the config alone).
+	 * `location-cascade.js`'s `attachOne()` falls back to the baseline typeahead in that case,
+	 * gated by the ordinary D15 `levels[country].region` flag.
+	 *
+	 * @param {Element} el
+	 * @param {Object}  options See the file docblock's shared contract.
+	 * @returns {{detach: function(): void, el: Element}|null}
+	 */
+	function attachRelatedListRegion( el, options ) {
+		if ( ! el || 'SELECT' !== el.tagName ) {
+			return null;
+		}
+
+		/** @type {Promise<Array>|null} cached per country — see fetchRegionList(). */
+		var listPromise = null;
+		var listCountry = null;
+		var lastHandledText = null;
+
+		/**
+		 * Fetches (and caches, per country) the region-level `/location/list` entries.
+		 *
+		 * @returns {Promise<Array>}
+		 */
+		function fetchRegionList() {
+			var country = options.country();
+
+			if ( listPromise && listCountry === country ) {
+				return listPromise;
+			}
+
+			listCountry = country;
+			listPromise = options.fetchJson(
+				options.buildUrl( options.location.endpoints.list, { level: 'region', country: country } ),
+				{ method: 'GET', headers: options.nonceHeader() }
+			).then(
+				function( body ) {
+					return body && Array.isArray( body.localities ) ? body.localities : [];
+				},
+				function( error ) {
+					logError( error );
+
+					return [];
+				}
+			);
+
+			return listPromise;
+		}
+
+		function handleChange() {
+			var selected = el.options[ el.selectedIndex ];
+			var text = selected ? selected.text : '';
+
+			if ( ! text || text === lastHandledText ) {
+				return; // nothing selected, or the SAME event delivered a second time (dual-world binding).
+			}
+
+			lastHandledText = text;
+
+			fetchRegionList().then( function( entries ) {
+				for ( var i = 0; i < entries.length; i++ ) {
+					var candidate = entries[ i ];
+
+					if ( candidate && candidate.record && candidate.record.label === text ) {
+						options.onSelect( { record: candidate.record } );
+
+						return;
+					}
+				}
+			} );
+		}
+
+		var unbind = bindChangeBothWorlds( el, handleChange );
+
+		return {
+			el: el,
+			detach: function() {
+				unbind();
+			},
+		};
+	}
+
+	registry[ 'related-list:region' ] = attachRelatedListRegion;
+
+	// -------------------------------------------------------------------------
+	// Shared select2-ish field builder — turns a plain <input> into a <select> select2 CAN
+	// enhance (select2 requires a real <select>; it cannot attach to an arbitrary text input).
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Replaces `input` with a fresh `<select>` carrying the SAME id/name/class, populated and
+	 * kept in sync by `strategy`, dual-world bound for selection, and select2-enhanced when the
+	 * `selectWoo`/select2 script has actually loaded (see the file docblock's SELECT2 IS
+	 * OPTIONAL section).
+	 *
+	 * `input` is fully removed from the document while the `<select>` is live — never left in
+	 * place under a different id, and never left in place under the SAME id (a duplicate id
+	 * would make every `getElementById( fieldId )` lookup elsewhere in this layer ambiguous).
+	 * `detach()` restores it verbatim, in the same DOM position.
+	 *
+	 * @param {HTMLInputElement} input
+	 * @param {Object}           options   See the file docblock's shared contract.
+	 * @param {{ajax: boolean, fetchEntries: function(string): Promise<Array>}} strategy
+	 *   `ajax: false` — `fetchEntries()` is called ONCE (a static, region-scoped full list —
+	 *   `related-list` settlement); the `<select>` is populated with real `<option>` elements
+	 *   up front, and select2 (when present) gets NO `ajax` config at all — it search-filters
+	 *   the already-fetched options locally, which is exactly the "related list" UX (spec D7).
+	 *   `ajax: true` — `fetchEntries( term )` is wired as select2's OWN `ajax.transport`
+	 *   (`ajax-select2` mode); each response's entries are MERGED into the lookup map (never
+	 *   replaced — a later pick may resolve an item fetched several keystrokes ago), and
+	 *   nothing is pre-populated: the field starts genuinely empty, matching a live suggest
+	 *   search rather than a bounded list.
+	 * @returns {{detach: function(): void, el: Element}|null}
+	 */
+	function buildSelectField( input, options, strategy ) {
+		if ( ! input || ! input.parentNode ) {
+			return null;
+		}
+
+		var select = document.createElement( 'select' );
+
+		select.id = input.id;
+		select.name = input.name || '';
+		select.className = input.className;
+
+		input.parentNode.insertBefore( select, input );
+		input.parentNode.removeChild( input );
+
+		/** @type {Object.<string, Object>} locality key -> the record it resolves to. */
+		var dataByKey = {};
+		var lastHandledValue = null;
+
+		/**
+		 * Applies a batch of `{key, label, level, record}` entries (Task 8/13's shared
+		 * `to_response_records()` wire shape) — either REPLACING the select's whole option set
+		 * (the static list strategy) or MERGING into the lookup map only, leaving the DOM to
+		 * select2's own remote-results rendering (the ajax strategy).
+		 *
+		 * @param {Array}   entries
+		 * @param {boolean} replaceOptions
+		 * @returns {void}
+		 */
+		function applyEntries( entries, replaceOptions ) {
+			if ( replaceOptions ) {
+				while ( select.firstChild ) {
+					select.removeChild( select.firstChild );
+				}
+
+				dataByKey = {};
+			}
+
+			( entries || [] ).forEach( function( entry ) {
+				var record = entry && entry.record;
+
+				if ( ! record || ! entry.key ) {
+					return;
+				}
+
+				dataByKey[ entry.key ] = record;
+
+				if ( replaceOptions ) {
+					var option = document.createElement( 'option' );
+
+					option.value = entry.key;
+					option.textContent = record.label || entry.label || '';
+
+					select.appendChild( option );
+				}
+			} );
+		}
+
+		function handleChange() {
+			var value = select.value;
+			var record = dataByKey[ value ];
+
+			if ( ! record || value === lastHandledValue ) {
+				return;
+			}
+
+			lastHandledValue = value;
+
+			options.onSelect( { record: record } );
+		}
+
+		var unbind = bindChangeBothWorlds( select, handleChange );
+
+		var $select = window.jQuery ? window.jQuery( select ) : null;
+		var select2Initialized = false;
+
+		/**
+		 * Initializes select2 on `select`, once — a no-op when the `selectWoo`/select2 script
+		 * never loaded (jQuery absent entirely, or present without the plugin — see the file
+		 * docblock). Safe to call more than once; only the FIRST call does anything.
+		 *
+		 * @returns {void}
+		 */
+		function ensureSelect2() {
+			if ( select2Initialized || ! $select || 'function' !== typeof $select.select2 ) {
+				return;
+			}
+
+			select2Initialized = true;
+
+			var config = { width: '100%' };
+
+			if ( strategy.ajax ) {
+				config.ajax = {
+					transport: function( params, success, failure ) {
+						var term = params && params.data && params.data.term ? params.data.term : '';
+
+						strategy.fetchEntries( term ).then( function( entries ) {
+							applyEntries( entries, false );
+
+							success( {
+								results: ( entries || [] ).map( function( entry ) {
+									return {
+										id: entry.key,
+										text: entry.record && entry.record.label ? entry.record.label : entry.label,
+									};
+								} ),
+							} );
+						}, failure );
+					},
+				};
+			}
+
+			$select.select2( config );
+		}
+
+		if ( strategy.ajax ) {
+			// select2's own `ajax.transport` (wired above) drives population per keystroke —
+			// nothing to pre-fetch. Without select2 available at all, the field is simply an
+			// empty native <select> a customer cannot search; `ajax-select2` mode is only ever
+			// offered by the store setting when the real plugin is expected to be present.
+			ensureSelect2();
+		} else {
+			strategy.fetchEntries( '' ).then(
+				function( entries ) {
+					applyEntries( entries, true );
+					ensureSelect2();
+				},
+				function( error ) {
+					logError( error );
+					applyEntries( [], true );
+					ensureSelect2();
+				}
+			);
+		}
+
+		return {
+			el: select,
+			detach: function() {
+				unbind();
+
+				if ( select2Initialized && $select && 'function' === typeof $select.select2 ) {
+					try {
+						$select.select2( 'destroy' );
+					} catch ( e ) {
+						logError( e );
+					}
+				}
+
+				if ( select.parentNode ) {
+					select.parentNode.insertBefore( input, select );
+					select.parentNode.removeChild( select );
+				}
+			},
+		};
+	}
+
+	// -------------------------------------------------------------------------
+	// related-list: settlement — select2 fed by the FULL per-region /location/list
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Attaches the `related-list` settlement (city) renderer — spec D7, Task 13: "the city
+	 * level in this mode is a select2 populated from `/location/list` scoped to the chosen
+	 * region." Scoped via `options.parentKey()` (the SAME live region-record-key scoping the
+	 * baseline typeahead's own `within` param already uses for this level — country-wide when
+	 * no region is selected yet, exactly like the suggest path).
+	 *
+	 * @param {Element} el
+	 * @param {Object}  options
+	 * @returns {{detach: function(): void, el: Element}|null}
+	 */
+	function attachRelatedListSettlement( el, options ) {
+		if ( ! el || 'INPUT' !== el.tagName ) {
+			return null;
+		}
+
+		return buildSelectField( el, options, {
+			ajax: false,
+			fetchEntries: function() {
+				var params = { level: 'settlement', country: options.country() };
+				var within = options.parentKey();
+
+				if ( within ) {
+					params.within = within;
+				}
+
+				return options.fetchJson(
+					options.buildUrl( options.location.endpoints.list, params ),
+					{ method: 'GET', headers: options.nonceHeader() }
+				).then(
+					function( body ) {
+						return body && Array.isArray( body.localities ) ? body.localities : [];
+					},
+					function( error ) {
+						logError( error );
+
+						return [];
+					}
+				);
+			},
+		} );
+	}
+
+	registry[ 'related-list:settlement' ] = attachRelatedListSettlement;
+
+	// -------------------------------------------------------------------------
+	// ajax-select2 — select2 remote data through the SAME /location/suggest fetch the
+	// baseline typeahead uses (shared code path, spec Task 13: "not a copy of it").
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Attaches the `ajax-select2` renderer for ANY level (registered under the bare mode key —
+	 * see `location-cascade.js`'s `resolveModeRenderer()`). Uses `options.fetch` — the EXACT
+	 * function `location-cascade.js`'s `fetchFor()` builds for the baseline typeahead at this
+	 * SAME node, already scoped (level/country/within) and already carrying the per-level
+	 * `value` derivation (`fieldValueFor()`) — as select2's own `ajax.transport` data source, so
+	 * a selection here produces the identical record shape a typeahead pick would, through the
+	 * identical `options.onSelect()` → `onSelectFor()` → backwards-fill/`/select` route.
+	 *
+	 * @param {Element} el
+	 * @param {Object}  options
+	 * @returns {{detach: function(): void, el: Element}|null}
+	 */
+	function attachAjaxSelect2( el, options ) {
+		if ( ! el || 'INPUT' !== el.tagName ) {
+			return null;
+		}
+
+		return buildSelectField( el, options, {
+			ajax: true,
+			fetchEntries: function( term ) {
+				return Promise.resolve( options.fetch( term ) ).then( null, function( error ) {
+					logError( error );
+
+					return [];
+				} );
+			},
+		} );
+	}
+
+	registry[ 'ajax-select2' ] = attachAjaxSelect2;
+
+	// -------------------------------------------------------------------------
+	// CommonJS (jest) — individual functions, for direct unit testing without going through
+	// `window.WoodevLocationRenderers` for every single test.
+	// -------------------------------------------------------------------------
+
+	if ( typeof module !== 'undefined' && module.exports ) {
+		module.exports = {
+			attachRelatedListRegion: attachRelatedListRegion,
+			attachRelatedListSettlement: attachRelatedListSettlement,
+			attachAjaxSelect2: attachAjaxSelect2,
+			bindChangeBothWorlds: bindChangeBothWorlds,
+		};
+	}
+
+}() );

--- a/woodev/shipping-method/checkout/class-checkout-config.php
+++ b/woodev/shipping-method/checkout/class-checkout-config.php
@@ -390,6 +390,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *              `wc_states()`'s cast no longer turns a `false`
 		 *              `get_states()` result into a non-empty array (PR #304
 		 *              review findings 1-4).
+		 * @since 2.0.2 `i18n` gained `notPersisted` — the client-side consumer for an honest
+		 *              `persisted: false` `/select` response (Task 13; issue #295 finding 1).
 		 *
 		 * @param \Woodev\Framework\Shipping\Location\Location_Service $service The active, already-confirmed façade.
 		 *
@@ -493,6 +495,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 					// on top, so a hand-typed address was always accepted.
 					'noResultsAddress' => __(
 						'Адрес не найден — введите вручную.',
+						'woodev-plugin-framework'
+					),
+
+					// #295 finding 1 (Task 13): `POST /location/select` answers
+					// `{persisted: false}` when the write failed server-side (typically a guest
+					// whose WooCommerce session/cart cookie has not initialized yet — gotcha
+					// `guest-session-write-needs-the-cart-cookie`) — an honest signal the client
+					// used to read for exactly one thing (not firing `update_checkout`) and
+					// otherwise discard. `location-cascade.js`'s `showNotPersistedNotice()` is
+					// the consumer this string exists for.
+					'notPersisted'     => __(
+						'Не удалось сохранить выбор — попробуйте ещё раз.',
 						'woodev-plugin-framework'
 					),
 				]

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -503,6 +503,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 *              their files existing on disk (location-provider layer Task 9).
 		 * @since 2.1.0 Also enqueues `location.css`, the typeahead listbox's own
 		 *              theme-resistant styles, under the same guard.
+		 * @since 2.1.0 Also enqueues `location-select-modes.js` (Task 13; spec D7), the
+		 *              `related-list`/`ajax-select2` renderer registry — same guard, declared
+		 *              as a dependency of `woodev-location-cascade` so it always registers
+		 *              before the cascade's own boot pass reads it.
 		 *
 		 * @return void
 		 */
@@ -554,6 +558,21 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 			if ( isset( $config['location'] ) ) {
 				$typeahead_built = $this->enqueue_script_if_built( 'woodev-location-typeahead', 'js/frontend/location-typeahead.js', [] );
 
+				// Task 13's `related-list`/`ajax-select2` renderers (spec D7) — depends on
+				// `selectWoo`, the SAME WC-bundled select2 handle `woodev-checkout-field-classic`
+				// already requires, because select2 can only enhance a real `<select>` (see the
+				// file's own SELECT2 IS OPTIONAL AT RUNTIME section). Declared as a dependency of
+				// `woodev-location-cascade` below (never the reverse) so its own registration onto
+				// `window.WoodevLocationRenderers` has always already run by the time the cascade's
+				// `boot()` calls `attachAll()` — the cascade never imports this file directly (spec
+				// D7: "mode is presentation... the cascade must not know which renderer a field
+				// uses"), it only reads the registry that file populates.
+				$select_modes_built = $this->enqueue_script_if_built(
+					'woodev-location-select-modes',
+					'js/frontend/location-select-modes.js',
+					[ 'jquery', 'selectWoo' ]
+				);
+
 				$this->enqueue_script_if_built(
 					'woodev-location-cascade',
 					'js/frontend/location-cascade.js',
@@ -564,6 +583,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 								'woodev-checkout-field-store',
 								'woodev-checkout-field-classic',
 								$typeahead_built ? 'woodev-location-typeahead' : null,
+								$select_modes_built ? 'woodev-location-select-modes' : null,
 							]
 						)
 					)


### PR DESCRIPTION
Клиентская половина задачи 13 (серверная — #304, смерджена) плюс пункт 1 карточки #295.

## Шов рендерера: каскад не знает, кто рисует поле

`location-cascade.js` получил `resolveModeRenderer( entry, node )` — смотрит в реестр `window.WoodevLocationRenderers` по ключу `режим:уровень`, потом по голому `режим`. Каскад собирает ОДИН объект `options` (тот же `fetch`/`onSelect`, что получает базовый typeahead, плюс примитивы `buildUrl`/`fetchJson`/`nonceHeader`/`country()`/`parentKey()`) и отдаёт его тому рендереру, который откликнулся; рендерер, вернувший ложь, проваливается в базовый typeahead. Каскад не импортирует `location-select-modes.js` и не ветвится на том, что рендерер делает, — он только читает реестр, который тот заполняет. Это и есть D7: режим — презентация, провайдер — данные.

Одно узкое задокументированное исключение: под `related-list` уровень «регион» намеренно приезжает как `levels[country].region = false`, потому что states зарегистрированы (в том числе НАШИМ же инжектором) — иначе клиент повесил бы текстовый виджет на селект. `isRelatedListRegionNode()` обходит гейт D15 ровно для пары `related-list` + `region`; все остальные уровни и режимы идут обычным путём.

## Мир событий закреплён настоящим jQuery

select2 сообщает выбор через `.trigger('change')`, который DOM-события не создаёт (готча `jquery-trigger-change-fires-no-native-event`, стоила прохода оператора в s66). Все три рендерера привязываются в обоих мирах, двойная доставка безвредна по построению, и это закреплено мутационным прогоном: удаление jQuery-половины валит тесты.

## #295, пункт 1: у честного сигнала наконец есть потребитель

`settleSelect()` теперь отличает честный `persisted: false` от сетевого отказа и в первом случае показывает покупателю уведомление у того поля, откуда пришёл выбор, снимая его при следующем успешном персисте. Строка приходит с сервера (`notPersisted`) и фильтруема. Рекомендация 2 (инициализация сессии WooCommerce на наших REST-маршрутах) сознательно НЕ делалась — это отдельное решение, и карточка фиксирует, что в бою состояние почти недостижимо.

## Проверка на риге — сделана мной

`main` мог оказаться сломан незаметно: дефект `(array) false` из ревью #304 убивал бы уровень «регион» во ВСЕХ девяти странах. Проверено в браузере на `/classic-checkout/`:

```
levels: AM/AZ/KG/TJ/TM → region:true settlement:true address:false
        BY/KZ/RU/UZ    → region:true settlement:true address:true
renderers: related-list:region, related-list:settlement, ajax-select2
endpoints.list: /wp-json/woodev/v1/location/list
```

Уровни по странам совпадают с замером DaData из s69 (уличные данные только у RU/BY/KZ/UZ). Живой ввод в поле НП доставки:

```
GET /wp-json/woodev/v1/location/suggest?q=Жуковс&level=settlement&country=RU
→ список открыт, 10 подсказок
```

Подписи транслитерированы («Russia, oblast Moskovskaya, gorod Zhukovsky»), потому что WordPress на риге английский, — это шов локали из s70, а не дефект.

## Чего я НЕ проверил

Режимы `related-list` и `ajax-select2` в браузере не гонялись: их предлагает только провайдер с capability `list`, то есть фикстурный, и его надо сделать активным на риге. Сам select2 в зависимостях репозитория отсутствует, поэтому проверено окружение вокруг него, а не его собственное поведение.

## Тесты

jest 999 → **1032**, unit 2032 → **2033**, phpcs и phpstan чисто (пересчитано мной на ветке: 2033 / 5149 ассертов, jest 1032/1032).

## Нужна твоя ручная проверка

Это видимая работа, поэтому не мержу. Чеклист: подсказки НП и адреса на полях доставки, обратное заполнение региона, очистка при смене родителя, восстановление после перезагрузки.

Closes #295