### PR TITLE
feat(location): политика дефолтного населённого пункта (задача 14, D11)

### DIFF
--- a/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
+++ b/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
@@ -160,6 +160,47 @@ class Fake_List_Location_Provider extends Abstract_Location_Provider {
 }
 
 /**
+ * A `locate`-capable fake provider (Task 14) — {@see Fake_Location_Provider}
+ * never overrides `locate()`, so its reflection-derived capability set never
+ * contains `locate`; this fixture exists specifically to exercise the
+ * `geoip` default-locality policy's OFFERED-options gate.
+ */
+class Fake_Locate_Location_Provider extends Abstract_Location_Provider {
+
+	private string $id;
+	private string $name;
+
+	public function __construct( string $id, string $name ) {
+		$this->id   = $id;
+		$this->name = $name;
+	}
+
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	public function get_name(): string {
+		return $this->name;
+	}
+
+	public function get_countries(): array {
+		return [ 'RU' ];
+	}
+
+	protected function declare_suggest_levels(): array {
+		return [ Location_Record::LEVEL_REGION ];
+	}
+
+	public function suggest( string $query, Location_Scope $scope ): array {
+		return [];
+	}
+
+	public function locate( string $ip ): ?Location_Record {
+		return null;
+	}
+}
+
+/**
  * @covers \Woodev\Framework\Shipping\Location\Location_Provider_Registry
  * @covers \Woodev\Framework\Shipping\Location\Location_Settings
  */
@@ -1298,5 +1339,261 @@ final class LocationProviderRegistryTest extends TestCase {
 		$states = $registry->inject_related_list_states( 'not-an-array' );
 
 		$this->assertIsArray( $states );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 14 — get_offered_default_locality_policies() / get_default_locality_policy():
+	// default + clamp against the offered set, mirroring the field_mode block above.
+	// -------------------------------------------------------------------------
+
+	public function test_default_locality_policy_offered_options_default_to_off_and_fixed_only(): void {
+		// A provider that does NOT declare `locate` — deliberately explicit
+		// (not "providers=[], falls back to the bundled DaData") because the
+		// REAL bundled Dadata_Provider (Task 7) genuinely DOES declare `locate`
+		// (its `iplocate/address` endpoint) whenever its class happens to be
+		// autoloaded elsewhere in the same test run — unlike `list`, which it
+		// genuinely lacks (see the field_mode clamp test's own precedent,
+		// which that asymmetry is why it does NOT apply here unmodified).
+		$provider = new Fake_Location_Provider( 'acme', 'ACME' );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		$this->stub_active_provider_option( 'acme' );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame(
+			[ Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF, Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED ],
+			$registry->get_offered_default_locality_policies()
+		);
+	}
+
+	public function test_default_locality_policy_geoip_offered_when_the_active_provider_has_locate(): void {
+		$provider = new Fake_Locate_Location_Provider( 'geo-fixture', 'Geo Fixture' );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		$this->stub_active_provider_option( 'geo-fixture' );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame(
+			[
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF,
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP,
+			],
+			$registry->get_offered_default_locality_policies()
+		);
+	}
+
+	public function test_default_locality_policy_defaults_to_off(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->justReturn( null );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame( Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF, $registry->get_default_locality_policy() );
+	}
+
+	public function test_default_locality_policy_returns_the_stored_value_when_it_is_offered(): void {
+		$provider = new Fake_Locate_Location_Provider( 'geo-fixture', 'Geo Fixture' );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'geo-fixture';
+				}
+				if ( 'woodev_location_default_locality_policy' === $name ) {
+					return Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP;
+				}
+
+				return $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame( Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP, $registry->get_default_locality_policy() );
+	}
+
+	/**
+	 * A stored `geoip` value from BEFORE a provider switch to a non-`locate`
+	 * provider must never be served as-is — clamps to `off`, mirroring
+	 * {@see LocationProviderRegistryTest::test_field_mode_clamps_a_stored_value_the_current_active_provider_no_longer_supports()}.
+	 */
+	public function test_default_locality_policy_clamps_a_stored_geoip_value_the_current_provider_no_longer_supports(): void {
+		// A stored 'geoip' value from BEFORE a switch AWAY from a `locate`-capable
+		// provider — the NOW-active provider explicitly does not declare `locate`.
+		// See test_default_locality_policy_offered_options_default_to_off_and_fixed_only()'s
+		// own comment for why "providers=[], falls back to DaData" is NOT used here.
+		$provider = new Fake_Location_Provider( 'acme', 'ACME' );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'acme';
+				}
+				if ( 'woodev_location_default_locality_policy' === $name ) {
+					return Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP;
+				}
+
+				return $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertSame( Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF, $registry->get_default_locality_policy() );
+	}
+
+	public function test_default_locality_policy_is_off_while_the_gate_is_closed(): void {
+		$registry = Location_Provider_Registry::instance();
+
+		$this->assertSame( Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF, $registry->get_default_locality_policy() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 14 — get_default_locality_record() / set_default_locality_record():
+	// the merchant-picked FIXED record, serialized as JSON.
+	// -------------------------------------------------------------------------
+
+	public function test_default_locality_record_is_null_when_unset(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->justReturn( null );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertNull( $registry->get_default_locality_record() );
+	}
+
+	public function test_default_locality_record_round_trips_through_set_and_get(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->justReturn( null );
+		Functions\when( 'update_option' )->justReturn( true );
+		Functions\when( 'wp_json_encode' )->alias( static fn( $data ) => json_encode( $data ) );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$record = Location_Record::from_array(
+			[
+				'key'         => 'dadata:fias-1',
+				'provider_id' => 'dadata',
+				'level'       => Location_Record::LEVEL_SETTLEMENT,
+				'country'     => 'RU',
+				'label'       => 'Москва',
+			]
+		);
+
+		$registry->set_default_locality_record( $record );
+
+		$fetched = $registry->get_default_locality_record();
+
+		$this->assertNotNull( $fetched );
+		$this->assertSame( 'dadata:fias-1', $fetched->key() );
+	}
+
+	public function test_default_locality_record_is_null_for_invalid_json(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				return 'woodev_location_default_locality_record' === $name ? 'not-json{{{' : $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertNull( $registry->get_default_locality_record() );
+	}
+
+	public function test_default_locality_record_is_null_while_the_gate_is_closed(): void {
+		$registry = Location_Provider_Registry::instance();
+
+		$this->assertNull( $registry->get_default_locality_record() );
+	}
+
+	public function test_set_default_locality_record_is_a_no_op_while_the_gate_is_closed(): void {
+		$registry = Location_Provider_Registry::instance();
+
+		$record = Location_Record::from_array(
+			[
+				'key'         => 'dadata:fias-1',
+				'provider_id' => 'dadata',
+				'level'       => Location_Record::LEVEL_SETTLEMENT,
+				'country'     => 'RU',
+			]
+		);
+
+		// Must not throw/fatal — there is no settings handler to write through.
+		$registry->set_default_locality_record( $record );
+
+		$this->assertNull( $registry->get_default_locality_record() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Task 14 — get_default_locality_needs_repick() / set_default_locality_needs_repick():
+	// the informational "stale foreign-namespace default" flag.
+	// -------------------------------------------------------------------------
+
+	public function test_default_locality_needs_repick_defaults_to_false(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->justReturn( null );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$this->assertFalse( $registry->get_default_locality_needs_repick() );
+	}
+
+	public function test_default_locality_needs_repick_round_trips(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->justReturn( null );
+		Functions\when( 'update_option' )->justReturn( true );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$registry->set_default_locality_needs_repick( true );
+		$this->assertTrue( $registry->get_default_locality_needs_repick() );
+
+		$registry->set_default_locality_needs_repick( false );
+		$this->assertFalse( $registry->get_default_locality_needs_repick() );
+	}
+
+	public function test_default_locality_needs_repick_is_false_while_the_gate_is_closed(): void {
+		$registry = Location_Provider_Registry::instance();
+
+		// Must not throw/fatal — there is no settings handler to write through.
+		$registry->set_default_locality_needs_repick( true );
+
+		$this->assertFalse( $registry->get_default_locality_needs_repick() );
 	}
 }

--- a/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
+++ b/tests/unit/Shipping/Location/LocationProviderRegistryTest.php
@@ -1596,4 +1596,166 @@ final class LocationProviderRegistryTest extends TestCase {
 
 		$this->assertFalse( $registry->get_default_locality_needs_repick() );
 	}
+
+	// -------------------------------------------------------------------------
+	// Review finding F4: `default_locality_record` / `default_locality_needs_repick`
+	// stay registered (the internal read/write machinery still works) but are
+	// registered WITHOUT a control — never an editable widget on the settings
+	// page.
+	// -------------------------------------------------------------------------
+
+	public function test_default_locality_record_and_needs_repick_have_no_control(): void {
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [] );
+		Functions\when( 'get_option' )->justReturn( null );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$handler = $registry->get_settings_handler();
+		$this->assertNotNull( $handler );
+
+		$record_setting = $handler->get_setting( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_RECORD );
+		$this->assertNotNull( $record_setting, 'the setting itself must stay registered — internal read/write still needs it' );
+		$this->assertNull( $record_setting->get_control(), 'mutant: registering a control here re-exposes the raw-JSON textarea on the settings page' );
+
+		$repick_setting = $handler->get_setting( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK );
+		$this->assertNotNull( $repick_setting );
+		$this->assertNull( $repick_setting->get_control(), 'mutant: registering a control here re-exposes the editable toggle a merchant could use to mask a stranded default' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Review finding F4: apply_default_locality_status_note() — the settings
+	// page must say so when the `fixed` policy is not actually configured,
+	// computed LIVE (never from the orphaned needs_repick flag, which
+	// Location_Service no longer writes per review finding F2(a)).
+	// -------------------------------------------------------------------------
+
+	public function test_status_note_is_empty_when_the_policy_is_not_fixed(): void {
+		$provider = new Fake_Location_Provider( 'acme', 'ACME' );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'acme';
+				}
+
+				return $default; // default_locality_policy unset -> 'off'.
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$setting = $registry->get_settings_handler()->get_setting( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY );
+		$this->assertSame( '', $setting->get_description() );
+	}
+
+	public function test_status_note_warns_when_fixed_has_no_valid_record(): void {
+		$provider = new Fake_Location_Provider( 'acme', 'ACME' );
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'acme';
+				}
+				if ( 'woodev_location_default_locality_policy' === $name ) {
+					return Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED;
+				}
+
+				return $default; // default_locality_record left unset.
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$setting = $registry->get_settings_handler()->get_setting( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY );
+		$this->assertNotSame( '', $setting->get_description(), 'an unconfigured fixed policy must not stay silent — mutant: removing this branch' );
+	}
+
+	public function test_status_note_warns_when_the_stored_record_no_longer_matches_the_active_provider(): void {
+		$provider = new Fake_Location_Provider( 'acme', 'ACME' );
+
+		$record = Location_Record::from_array(
+			[
+				'key'         => 'other-provider:city-1',
+				'provider_id' => 'other-provider',
+				'level'       => Location_Record::LEVEL_SETTLEMENT,
+				'country'     => 'RU',
+				'label'       => 'Москва',
+			]
+		);
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) use ( $record ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'acme';
+				}
+				if ( 'woodev_location_default_locality_policy' === $name ) {
+					return Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED;
+				}
+				if ( 'woodev_location_default_locality_record' === $name ) {
+					return json_encode( $record->to_array() );
+				}
+
+				return $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$setting = $registry->get_settings_handler()->get_setting( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY );
+		$this->assertNotSame( '', $setting->get_description(), 'a record picked under a DIFFERENT provider than the one now active must surface live, without relying on a stored flag' );
+	}
+
+	public function test_status_note_is_empty_when_fixed_has_a_valid_matching_record(): void {
+		$provider = new Fake_Location_Provider( 'acme', 'ACME' );
+
+		$record = Location_Record::from_array(
+			[
+				'key'         => 'acme:city-1',
+				'provider_id' => 'acme',
+				'level'       => Location_Record::LEVEL_SETTLEMENT,
+				'country'     => 'RU',
+				'label'       => 'Москва',
+			]
+		);
+
+		Functions\when( 'add_action' )->justReturn( true );
+		$this->stub_providers_filter( [ $provider ] );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) use ( $record ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'acme';
+				}
+				if ( 'woodev_location_default_locality_policy' === $name ) {
+					return Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED;
+				}
+				if ( 'woodev_location_default_locality_record' === $name ) {
+					return json_encode( $record->to_array() );
+				}
+
+				return $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$setting = $registry->get_settings_handler()->get_setting( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY );
+		$this->assertSame( '', $setting->get_description(), 'a correctly-namespaced record under the active provider has nothing to warn about' );
+	}
 }

--- a/tests/unit/Shipping/Location/LocationServiceDefaultTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceDefaultTest.php
@@ -417,29 +417,47 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$this->assertCount( 1, $active_provider->suggest_calls, 'the new provider must be queried exactly once' );
 			$this->assertCount( 0, $stale_provider->suggest_calls, 'the OLD provider is never re-consulted — it is no longer in the chain' );
 
-			// The re-resolution must be scoped correctly: RU/settlement, with the
-			// stale record's own region as the parent constraint.
+			// The re-resolution must be scoped correctly: RU/settlement, WITH a
+			// parent constraint (the stale record's own region) — never a bare
+			// country-wide scope (review finding F3's own mutant: reverting
+			// scope_for_reresolution() to Location_Scope::for_country() alone
+			// would still pass a country()/level() assertion, which is why this
+			// also pins has_parent()/parent_components() explicitly).
 			[ $query, $scope ] = $captured;
 			$this->assertSame( 'Москва', $query, 'the query text is the stale record\'s own label' );
 			$this->assertSame( 'RU', $scope->country() );
 			$this->assertSame( Location_Record::LEVEL_SETTLEMENT, $scope->level() );
+			$this->assertTrue( $scope->has_parent(), 'the re-resolution scope must carry a parent constraint, never a bare country-wide search' );
+			$this->assertSame(
+				[ 'region' => [ 'name' => 'Московская область', 'type' => 'обл' ] ],
+				$scope->parent_components(),
+				'the parent constraint must be the stale record\'s OWN region'
+			);
 
-			$this->assertFalse( $registry->get_default_locality_needs_repick(), 'a successful re-resolution must clear the flag' );
-
-			// The re-resolved record REPLACES the stale one in the merchant setting —
-			// "on first use" (spec §4.6): only the FIRST customer pays this cost.
-			$replaced = $registry->get_default_locality_record();
-			$this->assertNotNull( $replaced );
-			$this->assertSame( 'prov-b:new-city', $replaced->key() );
+			// Review finding F2(a): a customer-facing getter must never mutate
+			// store settings — the merchant's stored record and the informational
+			// flag are BOTH left exactly as they were, regardless of how many
+			// anonymous requests just resolved a value for themselves.
+			$still_stale = $registry->get_default_locality_record();
+			$this->assertNotNull( $still_stale );
+			$this->assertSame( 'prov-a:old-city', $still_stale->key(), 'a customer-facing getter must never REPLACE the merchant\'s stored default' );
+			$this->assertFalse( $registry->get_default_locality_needs_repick(), 'a customer-facing getter must never WRITE the needs-repick flag either' );
 		}
 
 		/**
-		 * Proves "on first use" literally: a SECOND customer (a brand-new
-		 * session — nothing customer-specific carries over) hitting a FRESH
-		 * registry rebuilt from the (now updated) persisted option must get the
-		 * fast path — the provider is never re-queried a second time.
+		 * Review finding F2(a)'s direct regression test, replacing the OLD
+		 * "only the first customer pays" behavior this PR's earlier revision
+		 * relied on: that optimization persisted the re-resolved record onto
+		 * the MERCHANT's own setting from inside a getter the public,
+		 * unauthenticated `/location/suggest` route reaches for every
+		 * anonymous guest — i.e. the vulnerability itself. Two SEPARATE
+		 * customers (fresh sessions, a fresh registry rebuilt from the SAME
+		 * unchanged option each time, mirroring an entirely new PHP process
+		 * per guest request) must EACH independently pay the re-resolution
+		 * cost, and the merchant's stored option must stay byte-for-byte the
+		 * stale value throughout — nothing a guest does ever advances it.
 		 */
-		public function test_fixed_default_only_the_first_customer_pays_the_re_resolution_cost(): void {
+		public function test_fixed_default_re_resolution_is_never_persisted_to_settings_and_repeats_per_customer(): void {
 			$options = [];
 
 			Functions\when( 'get_option' )->alias(
@@ -457,43 +475,54 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 
 			$active_provider = new Default_Test_Fake_Provider(
 				'prov-b',
-				fn() => [ $this->record( 'prov-b:new-city' ) ]
+				fn() => [ $this->record( 'prov-b:new-city', Location_Record::LEVEL_SETTLEMENT ) ]
 			);
 
-			$stale = $this->record( 'prov-a:old-city' );
+			$stale = $this->record( 'prov-a:old-city', Location_Record::LEVEL_SETTLEMENT, [ 'region' => [ 'name' => 'Московская область', 'type' => 'обл' ] ] );
 
 			$options['woodev_location_active_provider']         = 'prov-b';
 			$options['woodev_location_default_locality_policy'] = Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED;
 			$options['woodev_location_default_locality_record'] = wp_json_encode( $stale->to_array() );
 
-			// Request 1: a fresh registry, a fresh (empty) customer.
+			// Customer 1: a fresh registry, a fresh (empty) session.
 			$registry_1 = $this->activate( [ $active_provider ] );
 			$customer_1 = $this->service( $registry_1 );
 			$result_1   = $customer_1->get_customer_record();
 
 			$this->assertSame( 'prov-b:new-city', $result_1['record']->key() );
 			$this->assertCount( 1, $active_provider->suggest_calls );
+			$this->assertSame(
+				wp_json_encode( $stale->to_array() ),
+				$options['woodev_location_default_locality_record'],
+				'the merchant option must be UNCHANGED after the first customer\'s resolution'
+			);
 
-			// Request 2: simulate an entirely new PHP process — reset the
-			// singleton (activate() alone is a no-op the second time around:
-			// collect() guards on "already collected this request") and rebuild
-			// it, reading get_option() from scratch. The fake options table
-			// above now holds request 1's WRITE.
+			// Customer 2: a genuinely SEPARATE guest — a new registry rebuilt
+			// from the (still unchanged) option, and a new session. Mirrors an
+			// entirely new PHP process the way the old "first customer pays"
+			// test did — the difference under this fix is what it now proves:
+			// the provider IS queried again, because nothing was persisted for
+			// customer 2 to find.
 			Location_Provider_Registry::instance()->reset_for_tests();
 			Settings_Page_Registry::instance()->reset_for_tests();
 			$registry_2 = $this->activate( [ $active_provider ] );
-			$customer_2 = $this->service( $registry_2 ); // brand-new session — a different customer.
+			$customer_2 = $this->service( $registry_2 );
 			$result_2   = $customer_2->get_customer_record();
 
-			$this->assertSame( 'prov-b:new-city', $result_2['record']->key(), 'the second customer must see the ALREADY re-resolved record' );
-			$this->assertCount( 1, $active_provider->suggest_calls, 'the provider must NOT be queried a second time' );
+			$this->assertSame( 'prov-b:new-city', $result_2['record']->key() );
+			$this->assertCount( 2, $active_provider->suggest_calls, 'a second, separate customer must pay its OWN re-resolution cost — mutant: persisting the re-resolved record to the merchant option' );
+			$this->assertSame(
+				wp_json_encode( $stale->to_array() ),
+				$options['woodev_location_default_locality_record'],
+				'the merchant option must STILL be unchanged — an anonymous customer never re-points it'
+			);
 		}
 
-		public function test_fixed_default_re_resolution_failure_treats_default_as_unset_and_flags_repick(): void {
+		public function test_fixed_default_re_resolution_failure_treats_default_as_unset(): void {
 			$stale_provider  = new Default_Test_Fake_Provider( 'prov-a', static fn() => [] );
 			$active_provider = new Default_Test_Fake_Provider( 'prov-b', static fn() => [] ); // no match at all
 
-			$stale = $this->record( 'prov-a:old-city' );
+			$stale = $this->record( 'prov-a:old-city', Location_Record::LEVEL_SETTLEMENT, [ 'region' => [ 'name' => 'Московская область', 'type' => 'обл' ] ] );
 
 			$this->stub_default_locality_options(
 				'prov-b',
@@ -506,10 +535,14 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$result  = $service->get_customer_record();
 
 			$this->assertNull( $result, 'a failed re-resolution must treat the default as unset' );
-			$this->assertTrue( $registry->get_default_locality_needs_repick(), 'the settings surface must be flagged as needing re-picking' );
 
 			// The stale record itself must be left UNTOUCHED — a later manual fix
-			// (or the provider coming back with a match) is not foreclosed.
+			// (or the provider coming back with a match) is not foreclosed. No
+			// needs-repick assertion here any more (review finding F2(a)): the
+			// flag is no longer written from this customer-facing path at all —
+			// see test_fixed_default_status_note_reflects_a_stranded_record_live()
+			// in LocationProviderRegistryTest for the LIVE equivalent this
+			// class's settings page now surfaces instead.
 			$still_stale = $registry->get_default_locality_record();
 			$this->assertSame( 'prov-a:old-city', $still_stale->key() );
 		}
@@ -523,7 +556,7 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$stale_provider  = new Default_Test_Fake_Provider( 'prov-a', static fn() => [] );
 			$active_provider = new Default_Test_Fake_Provider( 'prov-b', static fn() => [] );
 
-			$stale = $this->record( 'prov-a:old-city' );
+			$stale = $this->record( 'prov-a:old-city', Location_Record::LEVEL_SETTLEMENT, [ 'region' => [ 'name' => 'Московская область', 'type' => 'обл' ] ] );
 
 			$this->stub_default_locality_options(
 				'prov-b',
@@ -538,6 +571,184 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$this->assertNull( $service->get_customer_record() );
 
 			$this->assertCount( 2, $active_provider->suggest_calls, 'nothing was persisted after a failure, so every read retries' );
+		}
+
+		// -------------------------------------------------------------------
+		// policy `fixed` — F2(b)/F3: never accept an ambiguous `$records[0]`
+		// -------------------------------------------------------------------
+
+		/**
+		 * The motivating F2 scenario itself: two DIFFERENT places share the
+		 * exact same display label at the exact same level (e.g. "Мирный" in
+		 * Архангельская область AND in Якутия) — blindly taking `$records[0]`
+		 * would silently re-point the merchant to whichever one the provider
+		 * happens to list first. Mutant this pins: reverting
+		 * self::unambiguous_match()'s call site back to `$records[0] ?? null`.
+		 */
+		public function test_fixed_default_an_ambiguous_match_is_refused_not_guessed(): void {
+			$wrong_place  = $this->record( 'prov-b:mirny-arkhangelsk', Location_Record::LEVEL_SETTLEMENT, [ 'label' => 'Мирный' ] );
+			$also_matches = $this->record( 'prov-b:mirny-yakutia', Location_Record::LEVEL_SETTLEMENT, [ 'label' => 'Мирный' ] );
+
+			$active_provider = new Default_Test_Fake_Provider( 'prov-b', static fn() => [ $wrong_place, $also_matches ] );
+
+			$stale = $this->record(
+				'prov-a:mirny',
+				Location_Record::LEVEL_SETTLEMENT,
+				[ 'label' => 'Мирный', 'region' => [ 'name' => 'Архангельская область', 'type' => 'обл' ] ]
+			);
+
+			$this->stub_default_locality_options(
+				'prov-b',
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				wp_json_encode( $stale->to_array() )
+			);
+			$registry = $this->activate( [ $active_provider ] );
+
+			$service = $this->service( $registry );
+			$result  = $service->get_customer_record();
+
+			$this->assertNull( $result, 'two equally-labeled candidates must refuse, never pick either one' );
+			$this->assertCount( 1, $active_provider->suggest_calls );
+
+			$still_stale = $registry->get_default_locality_record();
+			$this->assertSame( 'prov-a:mirny', $still_stale->key(), 'the ambiguous match must never replace the stale record' );
+		}
+
+		/**
+		 * Position-independence: the FIRST returned candidate does not match
+		 * the stale record at all, and the SECOND one does. A blind
+		 * `$records[0] ?? null` would return the wrong candidate; the correct
+		 * behavior finds the one genuine match regardless of its position.
+		 */
+		public function test_fixed_default_a_unique_match_is_found_even_when_not_first(): void {
+			$unrelated    = $this->record( 'prov-b:unrelated', Location_Record::LEVEL_SETTLEMENT, [ 'label' => 'Совершенно другой город' ] );
+			$exact_match  = $this->record( 'prov-b:new-city', Location_Record::LEVEL_SETTLEMENT, [ 'label' => 'Мирный' ] );
+
+			$active_provider = new Default_Test_Fake_Provider( 'prov-b', static fn() => [ $unrelated, $exact_match ] );
+
+			$stale = $this->record(
+				'prov-a:mirny',
+				Location_Record::LEVEL_SETTLEMENT,
+				[ 'label' => 'Мирный', 'region' => [ 'name' => 'Архангельская область', 'type' => 'обл' ] ]
+			);
+
+			$this->stub_default_locality_options(
+				'prov-b',
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				wp_json_encode( $stale->to_array() )
+			);
+			$registry = $this->activate( [ $active_provider ] );
+
+			$service = $this->service( $registry );
+			$result  = $service->get_customer_record();
+
+			$this->assertNotNull( $result );
+			$this->assertSame( 'prov-b:new-city', $result['record']->key(), 'the ONE candidate that actually matches must be found regardless of its position in the array' );
+		}
+
+		// -------------------------------------------------------------------
+		// policy `fixed` — F2: an empty parent-component set must refuse
+		// rather than silently degrade to a country-wide search
+		// -------------------------------------------------------------------
+
+		public function test_fixed_default_refuses_to_re_resolve_a_settlement_with_no_parent_component(): void {
+			// No 'region'/'district' — parent_components_above() returns [].
+			$stale = $this->record( 'prov-a:old-city', Location_Record::LEVEL_SETTLEMENT );
+
+			$active_provider = new Default_Test_Fake_Provider(
+				'prov-b',
+				fn() => [ $this->record( 'prov-b:new-city', Location_Record::LEVEL_SETTLEMENT ) ]
+			);
+
+			$this->stub_default_locality_options(
+				'prov-b',
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				wp_json_encode( $stale->to_array() )
+			);
+			$registry = $this->activate( [ $active_provider ] );
+
+			$service = $this->service( $registry );
+			$result  = $service->get_customer_record();
+
+			$this->assertNull( $result, 'no parent component to narrow by must refuse, never silently search the whole country' );
+			$this->assertCount( 0, $active_provider->suggest_calls, 'the provider must never even be queried — mutant: dropping the empty-parent-components guard' );
+		}
+
+		// -------------------------------------------------------------------
+		// policy `fixed` — F3 test gap: the '' === $query refusal already
+		// existed in code but nothing pinned it
+		// -------------------------------------------------------------------
+
+		public function test_fixed_default_refuses_to_re_resolve_with_an_empty_query(): void {
+			// No label AND no settlement component to fall back to —
+			// query_text_for() returns ''.
+			$stale = Location_Record::from_array(
+				[
+					'key'         => 'prov-a:old-city',
+					'provider_id' => 'prov-a',
+					'level'       => Location_Record::LEVEL_SETTLEMENT,
+					'country'     => 'RU',
+				]
+			);
+
+			$active_provider = new Default_Test_Fake_Provider( 'prov-b', static fn() => [ $this->record( 'prov-b:new-city' ) ] );
+
+			$this->stub_default_locality_options(
+				'prov-b',
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				wp_json_encode( $stale->to_array() )
+			);
+			$registry = $this->activate( [ $active_provider ] );
+
+			$service = $this->service( $registry );
+			$result  = $service->get_customer_record();
+
+			$this->assertNull( $result, 'an empty derived query must refuse — a blank string is never a legitimate search key' );
+			$this->assertCount( 0, $active_provider->suggest_calls, 'mutant: deleting the \'\' === $query refusal would let this call the provider' );
+		}
+
+		// -------------------------------------------------------------------
+		// F1: a persist failure (no session — the guest REST scenario) must
+		// still serve the resolved value, and must not re-trigger resolution
+		// within the same request
+		// -------------------------------------------------------------------
+
+		/**
+		 * Mirrors the public `/location/suggest` REST path's own worst case
+		 * (review finding F1): `Customer_Location_Store::set()` degrades to
+		 * `false` when no session exists yet (gotcha
+		 * `guest-session-write-needs-the-cart-cookie`) — a `null` fake session,
+		 * unlike every other test in this class. Mutant this pins: a store
+		 * whose `set()` fails re-triggering resolve_default() (an extra
+		 * `locate()` call) on a second read within the SAME request.
+		 */
+		public function test_a_persist_failure_still_serves_the_resolved_value_and_is_not_re_triggered(): void {
+			$located  = $this->record( 'geo:by-ip' );
+			$provider = new Default_Test_Fake_Locate_Provider( 'geo', static fn() => $located );
+
+			$this->stub_default_locality_options( 'geo', Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP );
+			$registry = $this->activate( [ $provider ] );
+
+			\WC_Geolocation::$address = '203.0.113.5';
+
+			// No session at all — Customer_Location_Store::set() degrades to
+			// false, exactly the REST guest scenario F1 describes.
+			$store   = new Default_Test_Customer_Store_Probe( null );
+			$service = new Location_Service( $registry, $store );
+
+			$first  = $service->get_customer_record();
+			$second = $service->get_customer_record();
+
+			$this->assertNotNull( $first, 'a failed persist must still serve the resolved value for THIS call' );
+			$this->assertSame( 'geo:by-ip', $first['record']->key() );
+			$this->assertTrue( $first['implicit'] );
+
+			$this->assertNotNull( $second, 'the memoized value must still be served on a second call within the same request' );
+			$this->assertSame( 'geo:by-ip', $second['record']->key() );
+
+			$this->assertCount( 1, $provider->locate_calls, 'a persist failure must never re-trigger resolution within the same request' );
+
+			\WC_Geolocation::$address = null;
 		}
 
 		// -------------------------------------------------------------------

--- a/tests/unit/Shipping/Location/LocationServiceDefaultTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceDefaultTest.php
@@ -1,0 +1,648 @@
+<?php
+/**
+ * Unit tests for Location_Service::resolve_default() and the lazy trigger in
+ * get_customer_record() — the store-level default-locality policy (Task 14;
+ * spec D11, §4.6): `off` (nothing resolved, nothing stored), `fixed` (the
+ * merchant-picked record, stored implicit on first read; an existing
+ * EXPLICIT record is never touched; a provider switch strands the stored
+ * record and it is re-resolved by components through the new provider on
+ * first use, a failure flagging the settings surface rather than serving a
+ * stale foreign-namespace record), and `geoip` (the active provider's
+ * `locate( $ip )`, called once per resolution, never failure-cached).
+ *
+ * @package Woodev\Tests\Unit\Shipping\Location
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Location {
+
+	use Brain\Monkey\Functions;
+	use Woodev\Framework\Shipping\Location\Abstract_Location_Provider;
+	use Woodev\Framework\Shipping\Location\Customer_Location_Store;
+	use Woodev\Framework\Shipping\Location\Location_Provider_Registry;
+	use Woodev\Framework\Shipping\Location\Location_Record;
+	use Woodev\Framework\Shipping\Location\Location_Scope;
+	use Woodev\Framework\Shipping\Location\Location_Service;
+	use Woodev\Framework\Settings\Settings_Page_Registry;
+	use Woodev\Tests\Unit\TestCase;
+
+	require_once dirname( __DIR__, 4 ) . '/woodev/class-plugin-exception.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/class-control.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/class-setting.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/abstract-class-settings.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-settings-section.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-settings-provider.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-settings-page-registry.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-locality-key.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-record.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-scope.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/interface-location-provider.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/abstract-location-provider.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-settings.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-provider-registry.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-customer-location-store.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-resolution-cache.php';
+	require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-service.php';
+
+	// The `geoip` policy reads WC_Geolocation::get_ip_address() — the same
+	// minimal double LocationControllerTest already uses (see that stub
+	// file's own docblock for the full rationale).
+	if ( ! class_exists( '\\WC_Geolocation' ) ) {
+		require_once dirname( __DIR__ ) . '/Rest_Api/wc-geolocation-stub.php';
+	}
+
+	/**
+	 * Minimal in-memory `\WC_Session` stand-in — same shape as every other
+	 * Task 4/5/6 test's own fake session (e.g. `Location_Service_Fake_Session`
+	 * in `LocationServiceTest`).
+	 */
+	final class Default_Test_Fake_Session {
+
+		/** @var array<string, mixed> */
+		private array $store = [];
+
+		/**
+		 * @param string $key     Session key.
+		 * @param mixed  $default Fallback when the key is absent.
+		 *
+		 * @return mixed
+		 */
+		public function get( $key, $default = null ) {
+			return $this->store[ $key ] ?? $default;
+		}
+
+		/**
+		 * @param string $key   Session key.
+		 * @param mixed  $value Value to store.
+		 *
+		 * @return void
+		 */
+		public function set( $key, $value ): void {
+			$this->store[ $key ] = $value;
+		}
+	}
+
+	/**
+	 * Probe substituting a {@see Default_Test_Fake_Session} (or `null`) for the
+	 * real `WC()->session` global — mirrors `Location_Service_Customer_Store_Probe`.
+	 */
+	final class Default_Test_Customer_Store_Probe extends Customer_Location_Store {
+
+		private ?Default_Test_Fake_Session $fake_session;
+
+		public function __construct( ?Default_Test_Fake_Session $fake_session ) {
+			$this->fake_session = $fake_session;
+		}
+
+		protected function session() {
+			return $this->fake_session;
+		}
+	}
+
+	/**
+	 * A suggest-only fake provider: id/countries/levels are fixed at
+	 * construction, `suggest()` is driven by a closure and spied. Never
+	 * overrides `locate()` — used for every `fixed`-policy test, where a
+	 * `locate` capability would be a false widening of what is under test.
+	 */
+	class Default_Test_Fake_Provider extends Abstract_Location_Provider {
+
+		private string $id;
+
+		/** @var callable */
+		private $suggest_callback;
+
+		/** @var array<int, array{0: string, 1: Location_Scope}> */
+		public array $suggest_calls = [];
+
+		public function __construct( string $id, callable $suggest_callback ) {
+			$this->id               = $id;
+			$this->suggest_callback = $suggest_callback;
+		}
+
+		public function get_id(): string {
+			return $this->id;
+		}
+
+		public function get_name(): string {
+			return $this->id;
+		}
+
+		public function get_countries(): array {
+			return [ 'RU' ];
+		}
+
+		protected function declare_suggest_levels(): array {
+			return Location_Record::LEVELS;
+		}
+
+		public function suggest( string $query, Location_Scope $scope ): array {
+			$this->suggest_calls[] = [ $query, $scope ];
+
+			return ( $this->suggest_callback )( $query, $scope );
+		}
+	}
+
+	/**
+	 * A `locate`-capable fake provider — a SEPARATE class from
+	 * {@see Default_Test_Fake_Provider} (never `suggest()`-only) because
+	 * capability discovery is reflection-based: only a class that genuinely
+	 * OVERRIDES `locate()` ever reports {@see \Woodev\Framework\Shipping\Location\Location_Provider::CAPABILITY_LOCATE}.
+	 */
+	class Default_Test_Fake_Locate_Provider extends Abstract_Location_Provider {
+
+		private string $id;
+
+		/** @var callable */
+		private $locate_callback;
+
+		/** @var array<int, string> */
+		public array $locate_calls = [];
+
+		public function __construct( string $id, callable $locate_callback ) {
+			$this->id              = $id;
+			$this->locate_callback = $locate_callback;
+		}
+
+		public function get_id(): string {
+			return $this->id;
+		}
+
+		public function get_name(): string {
+			return $this->id;
+		}
+
+		public function get_countries(): array {
+			return [ 'RU' ];
+		}
+
+		protected function declare_suggest_levels(): array {
+			return Location_Record::LEVELS;
+		}
+
+		public function suggest( string $query, Location_Scope $scope ): array {
+			return [];
+		}
+
+		public function locate( string $ip ): ?Location_Record {
+			$this->locate_calls[] = $ip;
+
+			return ( $this->locate_callback )( $ip );
+		}
+	}
+
+	/**
+	 * @covers \Woodev\Framework\Shipping\Location\Location_Service
+	 * @covers \Woodev\Framework\Shipping\Location\Location_Provider_Registry
+	 */
+	final class LocationServiceDefaultTest extends TestCase {
+
+		protected function setUp(): void {
+			parent::setUp();
+
+			Functions\when( 'remove_action' )->justReturn( true );
+			Functions\when( '__' )->returnArg( 1 );
+			Functions\when( 'get_option' )->justReturn( null );
+			Functions\when( 'update_option' )->justReturn( true );
+			Functions\when( 'delete_option' )->justReturn( true );
+			Functions\when( 'wp_json_encode' )->alias( static fn( $data ) => json_encode( $data ) );
+			Functions\when( 'wp_parse_args' )->alias(
+				static function ( $args, $defaults = [] ) {
+					return array_merge( (array) $defaults, (array) $args );
+				}
+			);
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			Functions\when( 'is_user_logged_in' )->justReturn( false );
+
+			Location_Provider_Registry::instance()->reset_for_tests();
+			Settings_Page_Registry::instance()->reset_for_tests();
+		}
+
+		protected function tearDown(): void {
+			Location_Provider_Registry::instance()->reset_for_tests();
+			Settings_Page_Registry::instance()->reset_for_tests();
+			parent::tearDown();
+		}
+
+		/**
+		 * @param \Woodev\Framework\Shipping\Location\Location_Provider[] $providers Providers to register.
+		 */
+		private function stub_providers_filter( array $providers ): void {
+			Functions\when( 'apply_filters' )->alias(
+				static function ( string $tag, $default = null ) use ( $providers ) {
+					if ( Location_Provider_Registry::FILTER_PROVIDERS === $tag ) {
+						return $providers;
+					}
+
+					return $default;
+				}
+			);
+		}
+
+		/**
+		 * Stubs `get_option` for the store-level settings this task adds, plus
+		 * `active_provider` — every other option name falls through to the
+		 * given `$default` (matching real `get_option()` semantics).
+		 *
+		 * @param string      $active_provider_id Active provider id.
+		 * @param string|null $policy             `default_locality_policy` value, or `null` to leave unset (defaults to `off`).
+		 * @param string|null $record_json        `default_locality_record` JSON value, or `null` to leave unset.
+		 */
+		private function stub_default_locality_options( string $active_provider_id, ?string $policy = null, ?string $record_json = null ): void {
+			Functions\when( 'get_option' )->alias(
+				static function ( $name, $default = null ) use ( $active_provider_id, $policy, $record_json ) {
+					if ( 'woodev_location_active_provider' === $name ) {
+						return $active_provider_id;
+					}
+					if ( 'woodev_location_default_locality_policy' === $name && null !== $policy ) {
+						return $policy;
+					}
+					if ( 'woodev_location_default_locality_record' === $name && null !== $record_json ) {
+						return $record_json;
+					}
+
+					return $default;
+				}
+			);
+		}
+
+		/**
+		 * Opens the gate, registers `$providers`, and collects — the real
+		 * `Location_Settings` handler this task's methods read/write through
+		 * is built as a side effect of `collect()`.
+		 *
+		 * @param \Woodev\Framework\Shipping\Location\Location_Provider[] $providers Providers to register.
+		 *
+		 * @return Location_Provider_Registry
+		 */
+		private function activate( array $providers ): Location_Provider_Registry {
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( $providers );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			return $registry;
+		}
+
+		private function service( Location_Provider_Registry $registry, ?Default_Test_Fake_Session $session = null ): Location_Service {
+			$store = new Default_Test_Customer_Store_Probe( $session ?? new Default_Test_Fake_Session() );
+
+			return new Location_Service( $registry, $store );
+		}
+
+		private function record(
+			string $key,
+			string $level = Location_Record::LEVEL_SETTLEMENT,
+			array $extra = []
+		): Location_Record {
+			return Location_Record::from_array(
+				array_merge(
+					[
+						'key'         => $key,
+						'provider_id' => explode( ':', $key )[0],
+						'level'       => $level,
+						'country'     => 'RU',
+						'label'       => 'Москва',
+					],
+					$extra
+				)
+			);
+		}
+
+		// -------------------------------------------------------------------
+		// policy `off` — resolve_default() null, nothing stored
+		// -------------------------------------------------------------------
+
+		public function test_policy_off_resolve_default_is_null(): void {
+			$registry = $this->activate( [] );
+			$service  = $this->service( $registry );
+
+			$this->assertNull( $service->resolve_default() );
+		}
+
+		/**
+		 * Mirrors the private `Customer_Location_Store::STORAGE_KEY` literal —
+		 * same discipline `CustomerLocationStoreTest` itself uses (its own
+		 * `SESSION_KEY`/`META_KEY` local consts), since the real constant is
+		 * private and this test asserts against the session's raw contents.
+		 */
+		private const SESSION_STORAGE_KEY = 'woodev_customer_location';
+
+		public function test_policy_off_get_customer_record_is_null_and_nothing_is_stored(): void {
+			$registry = $this->activate( [] );
+			$session  = new Default_Test_Fake_Session();
+			$service  = $this->service( $registry, $session );
+
+			$this->assertNull( $service->get_customer_record() );
+			$this->assertNull( $session->get( self::SESSION_STORAGE_KEY ), 'nothing must be written to the session under the off policy' );
+		}
+
+		// -------------------------------------------------------------------
+		// policy `fixed` — served as-is (no stranding), stored implicit on
+		// first read, an existing EXPLICIT record is never touched
+		// -------------------------------------------------------------------
+
+		public function test_policy_fixed_is_stored_implicit_on_first_read_when_no_record_exists(): void {
+			$provider = new Default_Test_Fake_Provider( 'prov-a', static fn() => [] );
+
+			$stored = $this->record( 'prov-a:city-1' );
+			// The option stubs must be in place BEFORE activate()'s collect() runs
+			// register_settings() — mirrors stub_dadata_token()'s own ordering
+			// discipline in LocationServiceTest.
+			$this->stub_default_locality_options( 'prov-a', Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED, wp_json_encode( $stored->to_array() ) );
+			$registry = $this->activate( [ $provider ] );
+
+			$service = $this->service( $registry );
+
+			$fetched = $service->get_customer_record();
+
+			$this->assertNotNull( $fetched );
+			$this->assertSame( 'prov-a:city-1', $fetched['record']->key() );
+			$this->assertTrue( $fetched['implicit'], 'a resolved default must be flagged implicit' );
+			$this->assertCount( 0, $provider->suggest_calls, 'the provider is not the active-namespace mismatch case — no re-resolution needed' );
+		}
+
+		public function test_policy_fixed_never_overwrites_an_existing_explicit_record(): void {
+			$provider = new Default_Test_Fake_Provider( 'prov-a', fn() => [ $this->record( 'prov-a:should-not-be-used' ) ] );
+
+			$stored = $this->record( 'prov-a:default-city' );
+			$this->stub_default_locality_options( 'prov-a', Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED, wp_json_encode( $stored->to_array() ) );
+			$registry = $this->activate( [ $provider ] );
+
+			$service = $this->service( $registry );
+
+			$explicit = $this->record( 'prov-a:customer-own-choice' );
+			$service->set_customer_record( $explicit, false );
+
+			$fetched = $service->get_customer_record();
+
+			$this->assertSame( 'prov-a:customer-own-choice', $fetched['record']->key() );
+			$this->assertFalse( $fetched['implicit'] );
+			$this->assertCount( 0, $provider->suggest_calls, 'resolve_default() must never even run once a real record already exists' );
+		}
+
+		// -------------------------------------------------------------------
+		// policy `fixed` — provider switch strands the stored default
+		// (spec §4.6/D15 amendment)
+		// -------------------------------------------------------------------
+
+		public function test_fixed_default_re_resolves_through_the_new_provider_when_stranded(): void {
+			$stale_provider  = new Default_Test_Fake_Provider( 'prov-a', static fn() => [] );
+			$captured        = null;
+			$active_provider = new Default_Test_Fake_Provider(
+				'prov-b',
+				function ( string $query, Location_Scope $scope ) use ( &$captured ) {
+					$captured = [ $query, $scope ];
+
+					return [ $this->record( 'prov-b:new-city', Location_Record::LEVEL_SETTLEMENT ) ];
+				}
+			);
+
+			$stale = $this->record( 'prov-a:old-city', Location_Record::LEVEL_SETTLEMENT, [ 'region' => [ 'name' => 'Московская область', 'type' => 'обл' ] ] );
+
+			$this->stub_default_locality_options(
+				'prov-b',
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				wp_json_encode( $stale->to_array() )
+			);
+			$registry = $this->activate( [ $stale_provider, $active_provider ] );
+
+			$service = $this->service( $registry );
+			$result  = $service->get_customer_record();
+
+			$this->assertNotNull( $result );
+			$this->assertSame( 'prov-b:new-city', $result['record']->key(), 'the stale foreign-namespace record must never be served' );
+			$this->assertTrue( $result['implicit'] );
+			$this->assertCount( 1, $active_provider->suggest_calls, 'the new provider must be queried exactly once' );
+			$this->assertCount( 0, $stale_provider->suggest_calls, 'the OLD provider is never re-consulted — it is no longer in the chain' );
+
+			// The re-resolution must be scoped correctly: RU/settlement, with the
+			// stale record's own region as the parent constraint.
+			[ $query, $scope ] = $captured;
+			$this->assertSame( 'Москва', $query, 'the query text is the stale record\'s own label' );
+			$this->assertSame( 'RU', $scope->country() );
+			$this->assertSame( Location_Record::LEVEL_SETTLEMENT, $scope->level() );
+
+			$this->assertFalse( $registry->get_default_locality_needs_repick(), 'a successful re-resolution must clear the flag' );
+
+			// The re-resolved record REPLACES the stale one in the merchant setting —
+			// "on first use" (spec §4.6): only the FIRST customer pays this cost.
+			$replaced = $registry->get_default_locality_record();
+			$this->assertNotNull( $replaced );
+			$this->assertSame( 'prov-b:new-city', $replaced->key() );
+		}
+
+		/**
+		 * Proves "on first use" literally: a SECOND customer (a brand-new
+		 * session — nothing customer-specific carries over) hitting a FRESH
+		 * registry rebuilt from the (now updated) persisted option must get the
+		 * fast path — the provider is never re-queried a second time.
+		 */
+		public function test_fixed_default_only_the_first_customer_pays_the_re_resolution_cost(): void {
+			$options = [];
+
+			Functions\when( 'get_option' )->alias(
+				static function ( $name, $default = null ) use ( &$options ) {
+					return array_key_exists( $name, $options ) ? $options[ $name ] : $default;
+				}
+			);
+			Functions\when( 'update_option' )->alias(
+				static function ( $name, $value ) use ( &$options ) {
+					$options[ $name ] = $value;
+
+					return true;
+				}
+			);
+
+			$active_provider = new Default_Test_Fake_Provider(
+				'prov-b',
+				fn() => [ $this->record( 'prov-b:new-city' ) ]
+			);
+
+			$stale = $this->record( 'prov-a:old-city' );
+
+			$options['woodev_location_active_provider']         = 'prov-b';
+			$options['woodev_location_default_locality_policy'] = Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED;
+			$options['woodev_location_default_locality_record'] = wp_json_encode( $stale->to_array() );
+
+			// Request 1: a fresh registry, a fresh (empty) customer.
+			$registry_1 = $this->activate( [ $active_provider ] );
+			$customer_1 = $this->service( $registry_1 );
+			$result_1   = $customer_1->get_customer_record();
+
+			$this->assertSame( 'prov-b:new-city', $result_1['record']->key() );
+			$this->assertCount( 1, $active_provider->suggest_calls );
+
+			// Request 2: simulate an entirely new PHP process — reset the
+			// singleton (activate() alone is a no-op the second time around:
+			// collect() guards on "already collected this request") and rebuild
+			// it, reading get_option() from scratch. The fake options table
+			// above now holds request 1's WRITE.
+			Location_Provider_Registry::instance()->reset_for_tests();
+			Settings_Page_Registry::instance()->reset_for_tests();
+			$registry_2 = $this->activate( [ $active_provider ] );
+			$customer_2 = $this->service( $registry_2 ); // brand-new session — a different customer.
+			$result_2   = $customer_2->get_customer_record();
+
+			$this->assertSame( 'prov-b:new-city', $result_2['record']->key(), 'the second customer must see the ALREADY re-resolved record' );
+			$this->assertCount( 1, $active_provider->suggest_calls, 'the provider must NOT be queried a second time' );
+		}
+
+		public function test_fixed_default_re_resolution_failure_treats_default_as_unset_and_flags_repick(): void {
+			$stale_provider  = new Default_Test_Fake_Provider( 'prov-a', static fn() => [] );
+			$active_provider = new Default_Test_Fake_Provider( 'prov-b', static fn() => [] ); // no match at all
+
+			$stale = $this->record( 'prov-a:old-city' );
+
+			$this->stub_default_locality_options(
+				'prov-b',
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				wp_json_encode( $stale->to_array() )
+			);
+			$registry = $this->activate( [ $stale_provider, $active_provider ] );
+
+			$service = $this->service( $registry );
+			$result  = $service->get_customer_record();
+
+			$this->assertNull( $result, 'a failed re-resolution must treat the default as unset' );
+			$this->assertTrue( $registry->get_default_locality_needs_repick(), 'the settings surface must be flagged as needing re-picking' );
+
+			// The stale record itself must be left UNTOUCHED — a later manual fix
+			// (or the provider coming back with a match) is not foreclosed.
+			$still_stale = $registry->get_default_locality_record();
+			$this->assertSame( 'prov-a:old-city', $still_stale->key() );
+		}
+
+		/**
+		 * No-failure-caching, extended to the provider-switch case (mirrors the
+		 * `geoip` policy's own "no failure caching" discipline): a re-resolution
+		 * failure is retried on the very next call, never sticky.
+		 */
+		public function test_fixed_default_re_resolution_failure_is_retried_not_cached(): void {
+			$stale_provider  = new Default_Test_Fake_Provider( 'prov-a', static fn() => [] );
+			$active_provider = new Default_Test_Fake_Provider( 'prov-b', static fn() => [] );
+
+			$stale = $this->record( 'prov-a:old-city' );
+
+			$this->stub_default_locality_options(
+				'prov-b',
+				Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+				wp_json_encode( $stale->to_array() )
+			);
+			$registry = $this->activate( [ $stale_provider, $active_provider ] );
+
+			$service = $this->service( $registry );
+
+			$this->assertNull( $service->get_customer_record() );
+			$this->assertNull( $service->get_customer_record() );
+
+			$this->assertCount( 2, $active_provider->suggest_calls, 'nothing was persisted after a failure, so every read retries' );
+		}
+
+		// -------------------------------------------------------------------
+		// policy `geoip` — locate( $ip ) called ONCE per resolution, stored
+		// implicit; failure/null -> no store write, next call may retry
+		// -------------------------------------------------------------------
+
+		public function test_policy_geoip_locate_is_called_once_and_result_is_stored_implicit(): void {
+			$located  = $this->record( 'geo:by-ip' );
+			$provider = new Default_Test_Fake_Locate_Provider( 'geo', static fn() => $located );
+
+			$this->stub_default_locality_options( 'geo', Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP );
+			$registry = $this->activate( [ $provider ] );
+
+			\WC_Geolocation::$address = '203.0.113.5';
+
+			$service = $this->service( $registry );
+
+			$this->assertSame( 0, count( $provider->locate_calls ) );
+			$fetched = $service->get_customer_record();
+
+			$this->assertNotNull( $fetched );
+			$this->assertSame( 'geo:by-ip', $fetched['record']->key() );
+			$this->assertTrue( $fetched['implicit'] );
+			$this->assertSame( [ '203.0.113.5' ], $provider->locate_calls );
+
+			\WC_Geolocation::$address = null;
+		}
+
+		/**
+		 * Pins the LAZY claim against its own neighbouring value: a second
+		 * read within the same customer session must NOT call locate() again
+		 * (1, not 2) — the record persisted by the first call is what the
+		 * second call finds and short-circuits on.
+		 */
+		public function test_policy_geoip_is_not_resolved_again_once_a_record_exists(): void {
+			$located  = $this->record( 'geo:by-ip' );
+			$provider = new Default_Test_Fake_Locate_Provider( 'geo', static fn() => $located );
+
+			$this->stub_default_locality_options( 'geo', Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP );
+			$registry = $this->activate( [ $provider ] );
+
+			\WC_Geolocation::$address = '203.0.113.5';
+
+			$service = $this->service( $registry );
+			$service->get_customer_record();
+			$service->get_customer_record();
+
+			$this->assertCount( 1, $provider->locate_calls, 'exactly once, not twice — the lazy trigger must not fire on every read' );
+
+			\WC_Geolocation::$address = null;
+		}
+
+		public function test_policy_geoip_locate_miss_stores_nothing_and_the_next_call_retries(): void {
+			$provider = new Default_Test_Fake_Locate_Provider( 'geo', static fn() => null );
+
+			$this->stub_default_locality_options( 'geo', Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP );
+			$registry = $this->activate( [ $provider ] );
+
+			\WC_Geolocation::$address = '203.0.113.5';
+
+			$service = $this->service( $registry );
+
+			$this->assertNull( $service->get_customer_record() );
+			$this->assertNull( $service->get_customer_record() );
+
+			$this->assertCount( 2, $provider->locate_calls, 'no failure caching — geo-IP is transient, every call retries' );
+
+			\WC_Geolocation::$address = null;
+		}
+
+		public function test_policy_geoip_is_offered_only_when_the_active_provider_has_locate(): void {
+			// A provider that does NOT declare `locate` at all.
+			$provider = new Default_Test_Fake_Provider( 'no-locate', static fn() => [] );
+
+			// The store setting is stuck at 'geoip' from a PREVIOUS provider that
+			// did support it — clamps to 'off' now, exactly like get_field_mode()
+			// clamps a stale 'related-list' value.
+			$this->stub_default_locality_options( 'no-locate', Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP );
+			$registry = $this->activate( [ $provider ] );
+
+			$this->assertSame(
+				[ Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF, Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED ],
+				$registry->get_offered_default_locality_policies()
+			);
+			$this->assertSame( Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF, $registry->get_default_locality_policy() );
+
+			$service = $this->service( $registry );
+			$this->assertNull( $service->resolve_default(), 'a clamped-away geoip policy must resolve nothing' );
+		}
+
+		public function test_policy_geoip_is_offered_when_the_active_provider_has_locate(): void {
+			$provider = new Default_Test_Fake_Locate_Provider( 'geo', static fn() => null );
+
+			$this->stub_default_locality_options( 'geo' );
+			$registry = $this->activate( [ $provider ] );
+
+			$this->assertSame(
+				[
+					Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF,
+					Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED,
+					Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP,
+				],
+				$registry->get_offered_default_locality_policies()
+			);
+		}
+	}
+}

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -37,6 +37,13 @@ if ( ! class_exists( '\\WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/wp-rest-controller-stub.php';
 }
 
+// Task 14: handle_admin_locate_request()'s own `WC_Geolocation::get_ip_address()`
+// fallback needs this double — same stub RestRateLimitTraitTest already uses (see
+// that file's own require for the full rationale).
+if ( ! class_exists( '\\WC_Geolocation' ) ) {
+	require_once __DIR__ . '/wc-geolocation-stub.php';
+}
+
 /**
  * Minimal \WP_REST_Request stand-in — identical shape/rationale to
  * PickupControllerTest's own namespace-scoped double (see that file's
@@ -152,9 +159,28 @@ final class Location_Controller_Fake_Service extends Location_Service {
 	public array $is_country_supported_calls = [];
 
 	/**
+	 * Task 14: {@see self::supports_locate()}'s own return value, and
+	 * {@see self::locate()}'s own return value/spy — a SEPARATE pair from the
+	 * `/suggest`/`/select`/`/list` fakes above, since the admin-only
+	 * `/default-locality/locate` route resolves through these two
+	 * {@see Location_Service} methods directly, not through `$provider`.
+	 *
+	 * @var bool
+	 */
+	private bool $supports_locate;
+
+	/** @var Location_Record|null */
+	private ?Location_Record $locate_result;
+
+	/** @var array<int, string> */
+	public array $locate_calls = [];
+
+	/**
 	 * @param array<string, Location_Provider>|null $providers_by_level                    Optional level => provider map — see {@see self::$providers_by_level}.
 	 * @param Location_Provider|null                 $active_provider_for_level_blind_check See {@see self::$active_provider_for_level_blind_check}.
 	 * @param Location_Provider|null                 $list_provider                         Task 13: {@see self::provider_for_list()}'s return value.
+	 * @param bool                                    $supports_locate                       Task 14: {@see self::supports_locate()}'s own return value.
+	 * @param Location_Record|null                   $locate_result                         Task 14: {@see self::locate()}'s own return value.
 	 */
 	public function __construct(
 		bool $active = true,
@@ -164,7 +190,9 @@ final class Location_Controller_Fake_Service extends Location_Service {
 		bool $country_supported = true,
 		?array $providers_by_level = null,
 		?Location_Provider $active_provider_for_level_blind_check = null,
-		?Location_Provider $list_provider = null
+		?Location_Provider $list_provider = null,
+		bool $supports_locate = false,
+		?Location_Record $locate_result = null
 	) {
 		$this->active                                = $active;
 		$this->provider                               = $provider;
@@ -174,6 +202,18 @@ final class Location_Controller_Fake_Service extends Location_Service {
 		$this->providers_by_level                     = $providers_by_level;
 		$this->active_provider_for_level_blind_check = $active_provider_for_level_blind_check;
 		$this->list_provider                          = $list_provider;
+		$this->supports_locate                        = $supports_locate;
+		$this->locate_result                          = $locate_result;
+	}
+
+	public function supports_locate(): bool {
+		return $this->supports_locate;
+	}
+
+	public function locate( string $ip ): ?Location_Record {
+		$this->locate_calls[] = $ip;
+
+		return $this->locate_result;
 	}
 
 	public function provider_for_list( ?string $country = null ): ?Location_Provider {
@@ -376,6 +416,9 @@ final class LocationControllerTest extends TestCase {
 			}
 		);
 		Functions\when( 'rest_ensure_response' )->returnArg();
+		// Task 14: check_admin_permission()'s own denial status, and
+		// handle_admin_locate_request()'s WC_Geolocation fallback path.
+		Functions\when( 'rest_authorization_required_code' )->justReturn( 401 );
 	}
 
 	private function record( string $key = 'dadata:fias-1', string $level = Location_Record::LEVEL_SETTLEMENT ): Location_Record {
@@ -1267,5 +1310,167 @@ final class LocationControllerTest extends TestCase {
 		$this->assertNotNull( $captured );
 		$this->assertTrue( $captured->has_parent() );
 		$this->assertSame( $parent, $captured->parent_record() );
+	}
+
+	// -------------------------------------------------------------------
+	// check_admin_permission() (Task 14) — capability gate for the two
+	// admin-only /default-locality/* routes.
+	// -------------------------------------------------------------------
+
+	public function test_check_admin_permission_rejects_without_the_capability(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$ctrl = new Location_Controller_Probe( new Location_Controller_Fake_Service() );
+
+		$result = $ctrl->check_admin_permission( new WP_REST_Request() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	public function test_check_admin_permission_accepts_with_the_capability(): void {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$ctrl = new Location_Controller_Probe( new Location_Controller_Fake_Service() );
+
+		$result = $ctrl->check_admin_permission( new WP_REST_Request() );
+
+		$this->assertTrue( $result );
+	}
+
+	// -------------------------------------------------------------------
+	// /default-locality/suggest (Task 14) — the admin picker's own search;
+	// shares perform_suggest() with the public /suggest route, so this only
+	// spot-checks the shared behaviour still holds through the admin entry
+	// point rather than re-proving every case LocationControllerTest already
+	// covers for handle_suggest_request() above.
+	// -------------------------------------------------------------------
+
+	public function test_admin_suggest_rejects_an_unknown_level(): void {
+		$service = new Location_Controller_Fake_Service( true, null );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => 'galaxy', 'country' => 'RU' ] );
+		$result  = $ctrl->handle_admin_suggest_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_admin_suggest_happy_path_returns_shaped_suggestions(): void {
+		$record   = Location_Record::from_array(
+			[
+				'key'         => 'dadata:fias-1',
+				'provider_id' => 'dadata',
+				'level'       => Location_Record::LEVEL_SETTLEMENT,
+				'country'     => 'RU',
+				'label'       => 'Москва',
+			]
+		);
+		$provider = new Location_Controller_Fake_Provider( static fn() => [ $record ] );
+		$service  = new Location_Controller_Fake_Service( true, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_admin_suggest_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertCount( 1, $result['suggestions'] );
+		$this->assertSame( 'dadata:fias-1', $result['suggestions'][0]['key'] );
+	}
+
+	public function test_admin_suggest_no_provider_for_level_returns_empty_200(): void {
+		$service = new Location_Controller_Fake_Service( true, null );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => Location_Record::LEVEL_ADDRESS, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_admin_suggest_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( [ 'suggestions' => [] ], $result );
+	}
+
+	// -------------------------------------------------------------------
+	// /default-locality/locate (Task 14) — the admin picker's geo-IP preview.
+	// -------------------------------------------------------------------
+
+	public function test_admin_locate_returns_404_when_the_active_provider_has_no_locate_capability(): void {
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null, false );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'ip' => '203.0.113.9' ] );
+		$result  = $ctrl->handle_admin_locate_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+		$this->assertCount( 0, $service->locate_calls, 'locate() must never even be called once the capability check fails' );
+	}
+
+	public function test_admin_locate_happy_path_returns_shaped_location(): void {
+		$record  = Location_Record::from_array(
+			[
+				'key'         => 'dadata:fias-1',
+				'provider_id' => 'dadata',
+				'level'       => Location_Record::LEVEL_SETTLEMENT,
+				'country'     => 'RU',
+				'label'       => 'Москва',
+			]
+		);
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null, true, $record );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'ip' => '203.0.113.9' ] );
+		$result  = $ctrl->handle_admin_locate_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( [ '203.0.113.9' ], $service->locate_calls, 'the EXPLICIT ip param must be used verbatim, not overridden by the request IP' );
+		$this->assertSame( 'dadata:fias-1', $result['location']['key'] );
+	}
+
+	public function test_admin_locate_returns_null_location_as_200_not_an_error(): void {
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null, true, null );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'ip' => '203.0.113.9' ] );
+		$result  = $ctrl->handle_admin_locate_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( [ 'location' => null ], $result );
+	}
+
+	public function test_admin_locate_falls_back_to_the_request_ip_when_no_ip_param_is_given(): void {
+		$record  = $this->record();
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null, true, $record );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$_SERVER['REMOTE_ADDR'] = '198.51.100.7';
+
+		$request = new WP_REST_Request( [] );
+		$result  = $ctrl->handle_admin_locate_request( $request );
+
+		unset( $_SERVER['REMOTE_ADDR'] );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( [ '198.51.100.7' ], $service->locate_calls );
+	}
+
+	/**
+	 * `get_client_ip()` (the rate-limit trait's own helper) deliberately falls
+	 * back to the literal string `'unknown'` rather than `''` — this route
+	 * must NOT reuse it for this reason: handing `'unknown'` to a provider's
+	 * `locate()` as though it were a real IP would be worse than refusing.
+	 */
+	public function test_admin_locate_returns_400_when_no_ip_can_be_determined_at_all(): void {
+		$service = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, null, true, $this->record() );
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		unset( $_SERVER['REMOTE_ADDR'] ); // WC_Geolocation stub falls back to this.
+
+		$request = new WP_REST_Request( [] );
+		$result  = $ctrl->handle_admin_locate_request( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertCount( 0, $service->locate_calls );
 	}
 }

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -395,6 +395,26 @@ final class Location_Controller_Probe extends Location_Controller {
 }
 
 /**
+ * Review finding F1(b): spies on {@see Location_Controller::bridge_wc_session()}
+ * without needing `WC()`/`wc_load_cart()` to be real functions in the
+ * unit-test process — mirrors {@see Location_Controller_Probe}'s own
+ * rate-limit bypass, plus this one extra seam.
+ */
+final class Location_Controller_Session_Bridge_Probe extends Location_Controller {
+
+	/** @var int */
+	public int $bridge_calls = 0;
+
+	protected function is_rate_limited( string $key_prefix, int $max, int $window = 60 ): bool {
+		return false;
+	}
+
+	protected function bridge_wc_session(): void {
+		++$this->bridge_calls;
+	}
+}
+
+/**
  * @covers \Woodev\Framework\Shipping\Rest_Api\Location_Controller
  */
 final class LocationControllerTest extends TestCase {
@@ -1473,4 +1493,60 @@ final class LocationControllerTest extends TestCase {
 		$this->assertSame( 400, $result->get_error_data()['status'] );
 		$this->assertCount( 0, $service->locate_calls );
 	}
+
+	// -------------------------------------------------------------------
+	// Review finding F1(b): the WooCommerce cart/session must be BRIDGED
+	// (mirrors Pickup_Controller/Pickup_Handler's own wc_load_cart() bridge)
+	// on every customer-facing route that can reach
+	// Location_Service::get_customer_record() — without it, a guest's
+	// session never starts on a plain REST request and the lazy
+	// default-locality trigger can never persist what it resolves.
+	// -------------------------------------------------------------------
+
+	public function test_suggest_bridges_the_wc_session(): void {
+		$provider = new Location_Controller_Fake_Provider( static fn() => [] );
+		$service  = new Location_Controller_Fake_Service( true, $provider );
+		$ctrl     = new Location_Controller_Session_Bridge_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => Location_Record::LEVEL_REGION, 'country' => 'RU' ] );
+		$ctrl->handle_suggest_request( $request );
+
+		$this->assertSame( 1, $ctrl->bridge_calls, 'mutant: dropping the bridge_wc_session() call from perform_suggest()' );
+	}
+
+	public function test_admin_suggest_also_bridges_the_wc_session(): void {
+		$provider = new Location_Controller_Fake_Provider( static fn() => [] );
+		$service  = new Location_Controller_Fake_Service( true, $provider );
+		$ctrl     = new Location_Controller_Session_Bridge_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => Location_Record::LEVEL_REGION, 'country' => 'RU' ] );
+		$ctrl->handle_admin_suggest_request( $request );
+
+		$this->assertSame( 1, $ctrl->bridge_calls, 'the admin picker shares perform_suggest() with the public route, so it bridges too' );
+	}
+
+	public function test_list_bridges_the_wc_session(): void {
+		$provider = new Location_Controller_Fake_List_Provider( static fn() => [] );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Session_Bridge_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU' ] );
+		$ctrl->handle_list_request( $request );
+
+		$this->assertSame( 1, $ctrl->bridge_calls, 'mutant: dropping the bridge_wc_session() call from handle_list_request()' );
+	}
+
+	// {@see Location_Controller::bridge_wc_session()}'s own internal
+	// `WC()`/`wc_load_cart()` branch mirrors
+	// {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::current_cart_weight_grams()}'s
+	// already-proven bridge verbatim (same "already loaded? no-op; function
+	// missing? no-op; otherwise call it" shape) — not re-tested here via a
+	// real `WC()` stub, deliberately: Brain Monkey's Patchwork-based
+	// `Functions\when( 'WC' )` redefinition leaks `function_exists( 'WC' )`
+	// as permanently `true` for the REST of that PHPUnit process (the same
+	// reason Customer_Location_Store::session()'s own docblock gives for why
+	// ITS test seam is a protected accessor instead). The tests above already
+	// prove every customer-facing handler that can reach
+	// Location_Service::get_customer_record() calls the bridge — that is the
+	// part specific to this controller.
 }

--- a/woodev/shipping-method/location/class-location-provider-registry.php
+++ b/woodev/shipping-method/location/class-location-provider-registry.php
@@ -1439,6 +1439,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 				$default_locality_policy_options
 			);
 
+			$this->apply_default_locality_status_note();
+
 			\Woodev\Framework\Settings\Settings_Page_Registry::instance()->register_service(
 				\Woodev\Framework\Settings\Settings_Provider::create(
 					self::SETTINGS_SERVICE_ID,
@@ -1453,6 +1455,76 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 					]
 				)
 			);
+		}
+
+		/**
+		 * Surfaces the `fixed` default-locality policy's "nothing usable is
+		 * actually configured" state on the settings page (review finding F4),
+		 * rather than leaving it silent: no picker UI ships in this task (a
+		 * separate, later card), so a merchant who selects `fixed` and never
+		 * picks a record — or whose picked record no longer matches the
+		 * currently ACTIVE provider — would otherwise see nothing telling them
+		 * the policy is not actually doing anything for a customer right now.
+		 *
+		 * Appends to the `default_locality_policy` select's own description
+		 * (read by {@see \Woodev\Framework\Settings\Field_Schema::from_handler()}
+		 * exactly like any other setting's description) rather than exposing
+		 * {@see self::SETTING_DEFAULT_LOCALITY_RECORD} /
+		 * {@see self::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK} as editable
+		 * controls — see {@see Location_Settings::register_settings()}'s own
+		 * docblock for why those two stay machine-owned, never merchant-typed.
+		 *
+		 * Computed LIVE against {@see self::get_active_provider()} rather than
+		 * read from the (still-registered, but no longer written by
+		 * {@see Location_Service}) `needs_repick` flag: review finding F2
+		 * forbids the customer-facing getter that used to keep that flag
+		 * honest from writing store settings at all, so nothing updates a
+		 * stored flag any more — a LIVE check can never go stale the way a
+		 * stored one, now orphaned, would. This deliberately compares against
+		 * the ACTIVE provider alone rather than replicating
+		 * {@see Location_Service::provider_for_level()}'s full D15
+		 * chosen-then-bundled-fallback walk: duplicating that chain here would
+		 * only drift from it, and for an informational admin note (not a
+		 * runtime gate) "did the store switch away from the provider this was
+		 * picked under" is the common case this exists to catch.
+		 *
+		 * Called from {@see self::register_settings()} once `$this->settings_handler`
+		 * exists — {@see self::get_default_locality_policy()} /
+		 * {@see self::get_default_locality_record()} / {@see self::get_active_provider()}
+		 * all read through it.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return void
+		 */
+		private function apply_default_locality_status_note(): void {
+			if ( self::DEFAULT_LOCALITY_POLICY_FIXED !== $this->get_default_locality_policy() ) {
+				return;
+			}
+
+			$setting = $this->settings_handler->get_setting( self::SETTING_DEFAULT_LOCALITY_POLICY );
+
+			if ( null === $setting ) {
+				return; // Defensive: register_settings() above always registers this id.
+			}
+
+			$record = $this->get_default_locality_record();
+
+			if ( null === $record ) {
+				$setting->set_description(
+					__( 'Локация по умолчанию не настроена: пока не будет сохранена корректная запись, эта политика ничего не применит.', 'woodev-plugin-framework' )
+				);
+
+				return;
+			}
+
+			$active = $this->get_active_provider();
+
+			if ( null === $active || $active->get_id() !== $record->provider_id() ) {
+				$setting->set_description(
+					__( 'Зафиксированная локация была выбрана через другого провайдера и может не подойти текущему — рекомендуется выбрать её заново.', 'woodev-plugin-framework' )
+				);
+			}
 		}
 
 		/**

--- a/woodev/shipping-method/location/class-location-provider-registry.php
+++ b/woodev/shipping-method/location/class-location-provider-registry.php
@@ -161,6 +161,86 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		public const FIELD_MODES = [ self::MODE_TYPEAHEAD, self::MODE_RELATED_LIST, self::MODE_AJAX_SELECT2 ];
 
 		/**
+		 * The store setting id holding the default-locality policy (Task 14; spec
+		 * D11): `off` | `fixed` | `geoip`. See {@see self::get_offered_default_locality_policies()}
+		 * for how `geoip` is gated by the active provider's `locate` capability, and
+		 * {@see self::get_default_locality_policy()} for the read-side clamp.
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const SETTING_DEFAULT_LOCALITY_POLICY = 'default_locality_policy';
+
+		/**
+		 * The store setting id holding the merchant-picked FIXED default locality
+		 * (Task 14; spec D11), serialized as JSON ({@see Location_Record::to_array()}).
+		 * Only meaningful when {@see self::SETTING_DEFAULT_LOCALITY_POLICY} is
+		 * {@see self::DEFAULT_LOCALITY_POLICY_FIXED}; picked through the admin-only
+		 * suggest context on {@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller}.
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const SETTING_DEFAULT_LOCALITY_RECORD = 'default_locality_record';
+
+		/**
+		 * The store setting id holding the "needs re-picking" flag (spec §4.6/D15
+		 * amendment): set when the FIXED default's provider namespace is stranded by
+		 * a provider switch and re-resolution through the new provider fails — see
+		 * {@see Location_Service::resolve_default()}. Purely informational for the
+		 * settings surface; never gates resolution itself.
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const SETTING_DEFAULT_LOCALITY_NEEDS_REPICK = 'default_locality_needs_repick';
+
+		/**
+		 * Default-locality policy: no default is ever resolved
+		 * ({@see Location_Service::resolve_default()} returns `null`).
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const DEFAULT_LOCALITY_POLICY_OFF = 'off';
+
+		/**
+		 * Default-locality policy: the merchant-picked
+		 * {@see self::SETTING_DEFAULT_LOCALITY_RECORD} is served (re-resolved through
+		 * the current provider first, when its namespace was stranded by a provider
+		 * switch — spec §4.6/D15 amendment).
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const DEFAULT_LOCALITY_POLICY_FIXED = 'fixed';
+
+		/**
+		 * Default-locality policy: the active provider's `locate( $ip )` capability
+		 * resolves a default from the customer's IP address. Only OFFERED when the
+		 * active provider declares {@see Location_Provider::CAPABILITY_LOCATE} — see
+		 * {@see self::get_offered_default_locality_policies()}.
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const DEFAULT_LOCALITY_POLICY_GEOIP = 'geoip';
+
+		/**
+		 * Every default-locality policy this layer knows about, in the fixed
+		 * offering order {@see self::get_offered_default_locality_policies()} always
+		 * returns them in.
+		 *
+		 * @since 2.0.2
+		 * @var string[]
+		 */
+		public const DEFAULT_LOCALITY_POLICIES = [
+			self::DEFAULT_LOCALITY_POLICY_OFF,
+			self::DEFAULT_LOCALITY_POLICY_FIXED,
+			self::DEFAULT_LOCALITY_POLICY_GEOIP,
+		];
+
+		/**
 		 * Filter tag: lets a plugin register its own {@see Location_Provider}
 		 * instances alongside the bundled ones. Receives (and must return) a plain
 		 * list — any entry not implementing {@see Location_Provider} is rejected
@@ -849,6 +929,216 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 			return in_array( $stored, $offered, true ) ? $stored : self::MODE_TYPEAHEAD;
 		}
 
+		// -----------------------------------------------------------------
+		// Default-locality policy (Task 14; spec D11) — same offered/clamp
+		// shape as get_offered_field_modes()/get_field_mode() above, gated
+		// by the CAPABILITY_LOCATE capability instead of CAPABILITY_LIST.
+		// -----------------------------------------------------------------
+
+		/**
+		 * The actual gate {@see self::get_offered_default_locality_policies()}
+		 * answers from — factored out as a static, provider-in/policies-out pure
+		 * function so {@see self::register_settings()} can compute the SAME answer
+		 * at construction time, mirroring {@see self::offered_field_modes_for()}
+		 * exactly.
+		 *
+		 * `off` and `fixed` are unconditional — picking a fixed locality needs no
+		 * provider capability beyond `suggest()`, which every provider implements.
+		 * `geoip` is offered only when `$provider` declares
+		 * {@see Location_Provider::CAPABILITY_LOCATE}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Provider|null $provider The provider to gate against, or
+		 *                                          `null` (no provider active).
+		 *
+		 * @return string[] Subset of {@see self::DEFAULT_LOCALITY_POLICIES}, always
+		 *                  containing {@see self::DEFAULT_LOCALITY_POLICY_OFF} and
+		 *                  {@see self::DEFAULT_LOCALITY_POLICY_FIXED}.
+		 */
+		private static function offered_default_locality_policies_for( ?Location_Provider $provider ): array {
+			$policies = [ self::DEFAULT_LOCALITY_POLICY_OFF, self::DEFAULT_LOCALITY_POLICY_FIXED ];
+
+			if ( null !== $provider && in_array( Location_Provider::CAPABILITY_LOCATE, $provider->get_capabilities(), true ) ) {
+				$policies[] = self::DEFAULT_LOCALITY_POLICY_GEOIP;
+			}
+
+			return $policies;
+		}
+
+		/**
+		 * Gets the default-locality policies the STORE SETTING is allowed to offer
+		 * right now (Task 14; spec D11), gated by the ACTIVE provider's OWN
+		 * `locate` capability.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string[] Subset of {@see self::DEFAULT_LOCALITY_POLICIES}.
+		 */
+		public function get_offered_default_locality_policies(): array {
+			return self::offered_default_locality_policies_for( $this->get_active_provider() );
+		}
+
+		/**
+		 * User-facing labels for every policy in {@see self::DEFAULT_LOCALITY_POLICIES}
+		 * — mirrors {@see self::field_mode_labels()}'s own single-source-of-Russian-copy
+		 * shape.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, string> policy => label.
+		 */
+		private static function default_locality_policy_labels(): array {
+			return [
+				self::DEFAULT_LOCALITY_POLICY_OFF   => __( 'Отключено', 'woodev-plugin-framework' ),
+				self::DEFAULT_LOCALITY_POLICY_FIXED => __( 'Фиксированная локация', 'woodev-plugin-framework' ),
+				self::DEFAULT_LOCALITY_POLICY_GEOIP => __( 'По IP-адресу покупателя', 'woodev-plugin-framework' ),
+			];
+		}
+
+		/**
+		 * Builds the `default_locality_policy` select's `id => label` options map,
+		 * gated against `$provider` via {@see self::offered_default_locality_policies_for()}
+		 * — mirrors {@see self::offered_field_mode_options()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Provider|null $provider The provider to gate against.
+		 *
+		 * @return array<string, string>
+		 */
+		private static function offered_default_locality_policy_options_for( ?Location_Provider $provider ): array {
+			$labels  = self::default_locality_policy_labels();
+			$options = [];
+
+			foreach ( self::offered_default_locality_policies_for( $provider ) as $policy ) {
+				$options[ $policy ] = $labels[ $policy ];
+			}
+
+			return $options;
+		}
+
+		/**
+		 * Gets the store's default-locality policy (Task 14; spec D11), clamped
+		 * against {@see self::get_offered_default_locality_policies()} so a
+		 * previously-saved `geoip` value the CURRENT active provider no longer
+		 * backs (e.g. the store switched away from a `locate`-capable provider)
+		 * never silently keeps resolving through a capability that is no longer
+		 * there — falls back to {@see self::DEFAULT_LOCALITY_POLICY_OFF}, exactly
+		 * like {@see self::get_field_mode()} falls back to {@see self::MODE_TYPEAHEAD}.
+		 *
+		 * Returns {@see self::DEFAULT_LOCALITY_POLICY_OFF} outright while the gate
+		 * is closed — mirrors {@see self::get_field_mode()}'s own early return.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		public function get_default_locality_policy(): string {
+			if ( null === $this->settings_handler ) {
+				return self::DEFAULT_LOCALITY_POLICY_OFF;
+			}
+
+			$stored  = (string) $this->settings_handler->get_value( self::SETTING_DEFAULT_LOCALITY_POLICY );
+			$offered = $this->get_offered_default_locality_policies();
+
+			return in_array( $stored, $offered, true ) ? $stored : self::DEFAULT_LOCALITY_POLICY_OFF;
+		}
+
+		/**
+		 * Gets the merchant-picked FIXED default locality record, or `null` when
+		 * unset, the gate is closed, or the stored value is not valid JSON /
+		 * does not build a valid {@see Location_Record} — never throws (same
+		 * degrade-to-null discipline {@see Customer_Location_Store::parse_stored()}
+		 * applies to a corrupt stored blob).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return Location_Record|null
+		 */
+		public function get_default_locality_record(): ?Location_Record {
+			if ( null === $this->settings_handler ) {
+				return null;
+			}
+
+			$raw = $this->settings_handler->get_value( self::SETTING_DEFAULT_LOCALITY_RECORD, false );
+
+			if ( ! is_string( $raw ) || '' === $raw ) {
+				return null;
+			}
+
+			$decoded = json_decode( $raw, true );
+
+			if ( ! is_array( $decoded ) ) {
+				return null;
+			}
+
+			try {
+				return Location_Record::from_array( $decoded );
+			} catch ( \InvalidArgumentException $exception ) {
+				return null;
+			}
+		}
+
+		/**
+		 * Writes the merchant-picked FIXED default locality record, serialized as
+		 * JSON — through the settings handler's own {@see \Woodev_Abstract_Settings::update_value()}
+		 * (gotcha `woodev-setting-get-value-is-cached-not-a-live-option-read`:
+		 * writing the option directly would leave this SAME request's cached
+		 * {@see \Woodev_Setting::$value} stale). A no-op while the gate is closed
+		 * — there is no settings handler to write through.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Record $record The record to store.
+		 *
+		 * @return void
+		 */
+		public function set_default_locality_record( Location_Record $record ): void {
+			if ( null === $this->settings_handler ) {
+				return;
+			}
+
+			$this->settings_handler->update_value( self::SETTING_DEFAULT_LOCALITY_RECORD, wp_json_encode( $record->to_array() ) );
+		}
+
+		/**
+		 * Gets whether the FIXED default needs re-picking (spec §4.6/D15
+		 * amendment): the merchant's stored record's provider namespace was
+		 * stranded by a provider switch and {@see Location_Service::resolve_default()}'s
+		 * own re-resolution attempt through the new provider failed. Purely
+		 * informational — never gates resolution itself.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return bool
+		 */
+		public function get_default_locality_needs_repick(): bool {
+			if ( null === $this->settings_handler ) {
+				return false;
+			}
+
+			return (bool) $this->settings_handler->get_value( self::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK );
+		}
+
+		/**
+		 * Writes the "needs re-picking" flag — see {@see self::get_default_locality_needs_repick()}.
+		 * A no-op while the gate is closed.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param bool $needs_repick Whether the FIXED default currently needs re-picking.
+		 *
+		 * @return void
+		 */
+		public function set_default_locality_needs_repick( bool $needs_repick ): void {
+			if ( null === $this->settings_handler ) {
+				return;
+			}
+
+			$this->settings_handler->update_value( self::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK, $needs_repick );
+		}
+
 		/**
 		 * Whether {@see self::inject_related_list_states()} itself successfully
 		 * injected `$country`'s `woocommerce_states` options THIS request AND
@@ -1122,6 +1412,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 		 *              {@see self::resolve_active_provider_for_id()} instead of a
 		 *              direct `$this->providers[ $id ]` lookup (PR #304 review
 		 *              finding 6).
+		 * @since 2.0.2 Also builds the `default_locality_policy` select's OFFERED
+		 *              options (Task 14; spec D11), gated exactly like
+		 *              `field_mode` is above.
 		 *
 		 * @return void
 		 */
@@ -1135,9 +1428,16 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Provider
 				$provider_options[ $id ] = $provider->get_name();
 			}
 
-			$field_mode_options = self::offered_field_mode_options( $active_provider );
+			$field_mode_options              = self::offered_field_mode_options( $active_provider );
+			$default_locality_policy_options = self::offered_default_locality_policy_options_for( $active_provider );
 
-			$this->settings_handler = new Location_Settings( self::SETTINGS_SERVICE_ID, $provider_options, $provider_fields, $field_mode_options );
+			$this->settings_handler = new Location_Settings(
+				self::SETTINGS_SERVICE_ID,
+				$provider_options,
+				$provider_fields,
+				$field_mode_options,
+				$default_locality_policy_options
+			);
 
 			\Woodev\Framework\Settings\Settings_Page_Registry::instance()->register_service(
 				\Woodev\Framework\Settings\Settings_Provider::create(

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -129,11 +129,42 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * choose your locality" prompt, spec §4.6 — an implicit default must
 		 * never look like a real customer answer).
 		 *
+		 * This is the LAZY TRIGGER for the store-level default-locality policy
+		 * (Task 14; spec D11, §4.6): when the customer has NO record at all
+		 * yet, {@see self::resolve_default()} is consulted and, when it
+		 * answers a record, written back through {@see Customer_Location_Store::set()}
+		 * flagged `implicit` — so every caller of this method (cart shipping
+		 * calculation, checkout render) gets the default with zero extra
+		 * wiring, and a policy that resolves nothing (`off`, or a `geoip`/
+		 * `fixed` miss) costs nothing beyond the one resolution attempt. Once
+		 * a record exists — real or implicit — this method never resolves a
+		 * default again for it: the early return above short-circuits before
+		 * {@see self::resolve_default()} is ever reached, which is also what
+		 * keeps this NOT running on every request (a second call within the
+		 * same request, or a later request once the write above landed, finds
+		 * `$current` non-null and returns immediately).
+		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Added the lazy default-locality resolution trigger
+		 *              (Task 14; spec D11).
 		 *
 		 * @return array{record: Location_Record, implicit: bool, saved_at: int}|null
 		 */
 		public function get_customer_record(): ?array {
+			$current = $this->customer_store->get();
+
+			if ( null !== $current ) {
+				return $current;
+			}
+
+			$default = $this->resolve_default();
+
+			if ( null === $default ) {
+				return null;
+			}
+
+			$this->customer_store->set( $default, true );
+
 			return $this->customer_store->get();
 		}
 
@@ -155,6 +186,297 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 */
 		public function set_customer_record( Location_Record $record, bool $implicit = false ): bool {
 			return $this->customer_store->set( $record, $implicit );
+		}
+
+		/**
+		 * Resolves the store-level default locality (Task 14; spec D11, §4.6):
+		 * `off` -> `null`; `fixed` -> the merchant-picked record (re-resolved
+		 * through the current provider first when a provider switch stranded
+		 * its namespace — see {@see self::resolve_fixed_default()});
+		 * `geoip` -> the active provider's `locate( $ip )` answer for the
+		 * customer's IP (via `WC_Geolocation::get_ip_address()`).
+		 *
+		 * Called ONLY from {@see self::get_customer_record()}'s lazy trigger
+		 * when the customer has no record at all yet — never proactively, and
+		 * never on a request that already has one. Nothing here is stored;
+		 * the caller decides whether/how to persist the result.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return Location_Record|null
+		 */
+		public function resolve_default(): ?Location_Record {
+			$policy = $this->registry->get_default_locality_policy();
+
+			if ( Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_FIXED === $policy ) {
+				return $this->resolve_fixed_default();
+			}
+
+			if ( Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_GEOIP === $policy ) {
+				return $this->resolve_geoip_default();
+			}
+
+			return null;
+		}
+
+		/**
+		 * Resolves the `fixed` default-locality policy (spec §4.6/D15
+		 * amendment): the merchant's stored record is served AS-IS when the
+		 * D15 chain still resolves the SAME provider for its level — meaning
+		 * its `provider_id` namespace is still valid — otherwise it is
+		 * STRANDED (the store switched providers since it was picked) and
+		 * gets re-resolved by components through whichever provider the chain
+		 * now resolves for that level ({@see self::reresolve_fixed_default()}).
+		 * A successful re-resolution REPLACES the stored record (so only the
+		 * FIRST customer to hit this after a provider switch pays the
+		 * re-resolution cost — every later call already finds a
+		 * correctly-namespaced record and takes the fast path above). A
+		 * failed re-resolution (nothing to re-resolve THROUGH, or the new
+		 * provider's `suggest()` finds no match) treats the default as unset
+		 * for this call AND flags the settings surface — a stale
+		 * foreign-namespace record is never served either way.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return Location_Record|null
+		 */
+		private function resolve_fixed_default(): ?Location_Record {
+			$stored = $this->registry->get_default_locality_record();
+
+			if ( null === $stored ) {
+				return null;
+			}
+
+			$current_provider = $this->provider_for_level( $stored->level() );
+
+			if ( null !== $current_provider && $current_provider->get_id() === $stored->provider_id() ) {
+				$this->registry->set_default_locality_needs_repick( false );
+
+				return $stored;
+			}
+
+			$resolved = null !== $current_provider ? $this->reresolve_fixed_default( $current_provider, $stored ) : null;
+
+			if ( null === $resolved ) {
+				$this->registry->set_default_locality_needs_repick( true );
+
+				return null;
+			}
+
+			$this->registry->set_default_locality_record( $resolved );
+			$this->registry->set_default_locality_needs_repick( false );
+
+			return $resolved;
+		}
+
+		/**
+		 * Re-resolves a stranded `fixed` default THROUGH `$provider` — the D15
+		 * chain's current answer for `$stored`'s own level, which is by
+		 * construction NOT the provider `$stored->provider_id()` names
+		 * (that is exactly what makes it stranded, see
+		 * {@see self::resolve_fixed_default()}). Queries `$provider->suggest()`
+		 * with `$stored`'s own label (or, failing that, its own level's
+		 * component name) scoped to `$stored`'s parent components, and takes
+		 * the first match — the same "first result is the best result"
+		 * convention the client cascade itself relies on. Never throws: a
+		 * provider failure, or no match at all, both resolve to `null`.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Provider $provider The provider to re-resolve through.
+		 * @param Location_Record   $stored   The stranded stored record.
+		 *
+		 * @return Location_Record|null
+		 */
+		private function reresolve_fixed_default( Location_Provider $provider, Location_Record $stored ): ?Location_Record {
+			$query = self::query_text_for( $stored );
+
+			if ( '' === $query ) {
+				return null;
+			}
+
+			try {
+				$records = $provider->suggest( $query, self::scope_for_reresolution( $stored ) );
+			} catch ( \Throwable $exception ) {
+				return null;
+			}
+
+			return $records[0] ?? null;
+		}
+
+		/**
+		 * Builds the lookup scope {@see self::reresolve_fixed_default()} queries
+		 * `$stored`'s replacement through — the country/level pair plus,
+		 * for a settlement/address-level record, the components ABOVE its own
+		 * level (`Location_Scope::within_components()`, built specifically for
+		 * this "have components, no record from THIS provider yet" case — see
+		 * that method's own docblock). A region-level record has no parent to
+		 * constrain by, so it scopes by country alone.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Record $stored The stranded stored record.
+		 *
+		 * @return Location_Scope
+		 */
+		private static function scope_for_reresolution( Location_Record $stored ): Location_Scope {
+			if ( Location_Record::LEVEL_REGION === $stored->level() ) {
+				return Location_Scope::for_country( $stored->country(), $stored->level() );
+			}
+
+			return Location_Scope::within_components( $stored->country(), $stored->level(), self::parent_components_above( $stored ) );
+		}
+
+		/**
+		 * Extracts the component groups ABOVE `$record`'s own level — region
+		 * (+district) for a settlement-level record, region/district/settlement
+		 * for an address-level one — in the shape
+		 * {@see Location_Scope::within_components()} expects. A region-level
+		 * record has nothing above it, so this returns `[]` for one (never
+		 * called for that level anyway — see {@see self::scope_for_reresolution()}).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Record $record The record to extract parent components from.
+		 *
+		 * @return array<string, mixed>
+		 */
+		private static function parent_components_above( Location_Record $record ): array {
+			$components = [];
+
+			if ( Location_Record::LEVEL_REGION === $record->level() ) {
+				return $components;
+			}
+
+			if ( null !== $record->region() ) {
+				$components['region'] = $record->region();
+			}
+
+			if ( null !== $record->district() ) {
+				$components['district'] = $record->district();
+			}
+
+			if ( Location_Record::LEVEL_ADDRESS === $record->level() && null !== $record->settlement() ) {
+				$components['settlement'] = $record->settlement();
+			}
+
+			return $components;
+		}
+
+		/**
+		 * The free-text query {@see self::reresolve_fixed_default()} searches
+		 * the new provider with: `$record`'s own display label when it has
+		 * one, otherwise the name of its own level's component group
+		 * (region/settlement/street), otherwise `''` — an empty query is the
+		 * caller's signal to give up rather than issue a call no provider
+		 * could usefully answer.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Record $record The record to derive a query from.
+		 *
+		 * @return string
+		 */
+		private static function query_text_for( Location_Record $record ): string {
+			if ( '' !== $record->label() ) {
+				return $record->label();
+			}
+
+			switch ( $record->level() ) {
+				case Location_Record::LEVEL_REGION:
+					$component = $record->region();
+					break;
+
+				case Location_Record::LEVEL_SETTLEMENT:
+					$component = $record->settlement();
+					break;
+
+				default:
+					$component = $record->street();
+					break;
+			}
+
+			return null !== $component ? (string) $component['name'] : '';
+		}
+
+		/**
+		 * Resolves the `geoip` default-locality policy (spec D11): the
+		 * customer's own IP (`WC_Geolocation::get_ip_address()`, mirroring the
+		 * trusted-IP discipline {@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller}'s
+		 * own rate-limit trait already uses) run through {@see self::locate()}.
+		 * An unresolvable IP resolves to `null` the same way every other
+		 * `locate()` miss does — see that method's own docblock.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return Location_Record|null
+		 */
+		private function resolve_geoip_default(): ?Location_Record {
+			if ( ! class_exists( '\\WC_Geolocation' ) ) {
+				return null;
+			}
+
+			$ip = (string) \WC_Geolocation::get_ip_address();
+
+			if ( '' === $ip ) {
+				return null;
+			}
+
+			return $this->locate( $ip );
+		}
+
+		/**
+		 * Resolves a geo-IP lookup through the active provider's `locate()`
+		 * capability, when it declares one. Shared by {@see self::resolve_geoip_default()}
+		 * (the `geoip` default-locality policy) and the admin-only
+		 * default-locality picker's own "locate" action
+		 * ({@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller::handle_admin_locate_request()}) —
+		 * both need the exact same "does the active provider even support
+		 * this, and if so what does it say for this IP" answer.
+		 *
+		 * No `locate` capability ({@see self::supports_locate()}), a
+		 * `locate()` miss (`null`), or a thrown failure all resolve to `null`
+		 * alike — geo-IP is a legitimate, non-exceptional "no answer" outcome
+		 * (see {@see Location_Provider::locate()}'s own docblock), never
+		 * cached as a failure by this method (a caller that wants
+		 * retry-avoidance implements its own, as {@see self::resolve_geoip_default()}'s
+		 * own docblock notes none is needed for that call site).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $ip IPv4 or IPv6 address.
+		 *
+		 * @return Location_Record|null
+		 */
+		public function locate( string $ip ): ?Location_Record {
+			if ( ! $this->supports_locate() ) {
+				return null;
+			}
+
+			try {
+				return $this->registry->get_active_provider()->locate( $ip );
+			} catch ( \Throwable $exception ) {
+				return null;
+			}
+		}
+
+		/**
+		 * Whether the active provider currently declares the `locate`
+		 * capability — the same "is there anything to even ask" check
+		 * {@see self::locate()} makes internally, exposed separately so a
+		 * caller (the admin-only `/default-locality/locate` route) can tell
+		 * "this capability does not exist right now" (a 404-worthy, "this
+		 * stopped being true" condition) apart from "it exists but this
+		 * particular IP resolved to nothing" (a legitimate 200 + null).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return bool
+		 */
+		public function supports_locate(): bool {
+			$provider = $this->registry->get_active_provider();
+
+			return null !== $provider && in_array( Location_Provider::CAPABILITY_LOCATE, $provider->get_capabilities(), true );
 		}
 
 		/**

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -62,6 +62,31 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		private Location_Resolution_Cache $resolution_cache;
 
 		/**
+		 * Memoizes a resolved-but-NOT-persisted default for the rest of THIS
+		 * request (review finding F1): a guest REST request has no session yet
+		 * until {@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller}'s
+		 * own session bridge runs (WooCommerce does not initialize `WC()->session`
+		 * for a plain custom REST route — gotcha `guest-session-write-needs-the-
+		 * cart-cookie`), so {@see Customer_Location_Store::set()} can legitimately
+		 * return `false` right after {@see self::resolve_default()} succeeded.
+		 * Without this, {@see self::get_customer_record()} would (a) lose the
+		 * answer it just computed by re-reading a store that never persisted it,
+		 * AND (b) re-run {@see self::resolve_default()} — a fresh provider call,
+		 * for `geoip` — on every subsequent call within the SAME request.
+		 *
+		 * Deliberately NOT set when {@see self::resolve_default()} itself
+		 * returns `null` (a genuine "no answer" miss, e.g. an unresolvable
+		 * geo-IP, or a `fixed` re-resolution that found nothing) — that case
+		 * keeps retrying on every call, exactly as before this fix, since there
+		 * is nothing to memoize (see `LocationServiceDefaultTest`'s own
+		 * "no failure caching" tests, which this must not break).
+		 *
+		 * @since 2.0.2
+		 * @var Location_Record|null
+		 */
+		private ?Location_Record $unpersisted_default = null;
+
+		/**
 		 * Constructor.
 		 *
 		 * Every collaborator is optional and defaults to the production
@@ -147,6 +172,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * @since 2.0.2
 		 * @since 2.0.2 Added the lazy default-locality resolution trigger
 		 *              (Task 14; spec D11).
+		 * @since 2.0.2 Memoizes a resolved-but-unpersisted default for the rest
+		 *              of the request, and serves it directly rather than
+		 *              re-reading a store that failed to write it (review
+		 *              finding F1 — {@see self::$unpersisted_default}).
 		 *
 		 * @return array{record: Location_Record, implicit: bool, saved_at: int}|null
 		 */
@@ -157,15 +186,47 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 				return $current;
 			}
 
+			if ( null !== $this->unpersisted_default ) {
+				return self::implicit_entry( $this->unpersisted_default );
+			}
+
 			$default = $this->resolve_default();
 
 			if ( null === $default ) {
 				return null;
 			}
 
-			$this->customer_store->set( $default, true );
+			if ( $this->customer_store->set( $default, true ) ) {
+				return $this->customer_store->get();
+			}
 
-			return $this->customer_store->get();
+			// The write failed (no session yet on this guest REST request — see
+			// self::$unpersisted_default). The resolution itself still
+			// succeeded: serve it for THIS call, and remember it so a later
+			// call in the SAME request neither loses it nor re-triggers
+			// resolve_default() a second time.
+			$this->unpersisted_default = $default;
+
+			return self::implicit_entry( $default );
+		}
+
+		/**
+		 * Builds the {@see self::get_customer_record()} response shape for a
+		 * resolved default that {@see Customer_Location_Store::set()} could not
+		 * (yet) persist — see {@see self::$unpersisted_default}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Record $record The resolved default.
+		 *
+		 * @return array{record: Location_Record, implicit: bool, saved_at: int}
+		 */
+		private static function implicit_entry( Location_Record $record ): array {
+			return [
+				'record'   => $record,
+				'implicit' => true,
+				'saved_at' => time(),
+			];
 		}
 
 		/**
@@ -224,19 +285,43 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * amendment): the merchant's stored record is served AS-IS when the
 		 * D15 chain still resolves the SAME provider for its level — meaning
 		 * its `provider_id` namespace is still valid — otherwise it is
-		 * STRANDED (the store switched providers since it was picked) and
-		 * gets re-resolved by components through whichever provider the chain
-		 * now resolves for that level ({@see self::reresolve_fixed_default()}).
-		 * A successful re-resolution REPLACES the stored record (so only the
-		 * FIRST customer to hit this after a provider switch pays the
-		 * re-resolution cost — every later call already finds a
-		 * correctly-namespaced record and takes the fast path above). A
-		 * failed re-resolution (nothing to re-resolve THROUGH, or the new
-		 * provider's `suggest()` finds no match) treats the default as unset
-		 * for this call AND flags the settings surface — a stale
-		 * foreign-namespace record is never served either way.
+		 * STRANDED (the store switched providers since it was picked) and is
+		 * re-resolved by components through whichever provider the chain now
+		 * resolves for that level ({@see self::reresolve_fixed_default()}), for
+		 * THIS call only.
+		 *
+		 * PURE READ, no store-settings write (review finding F2): this method
+		 * is reached from {@see self::get_customer_record()}'s lazy trigger,
+		 * which the public, unauthenticated `/location/suggest` route reaches
+		 * for every anonymous guest — a customer-facing getter must never
+		 * mutate the merchant's `default_locality_record` /
+		 * `default_locality_needs_repick` store settings, or an anonymous
+		 * visitor's search-box keystrokes could silently re-point the
+		 * merchant's configured default to whatever a re-resolution happens to
+		 * match. Earlier revisions REPLACED the stored record here so only the
+		 * first customer after a provider switch paid the re-resolution cost;
+		 * that "optimization" WAS the vulnerability, so it is gone — every
+		 * stranded request now re-computes, but each CUSTOMER still only pays
+		 * once, because the computed record is written to THAT customer's own
+		 * session/account via {@see self::get_customer_record()}'s caller, not
+		 * to the shared merchant setting. Persisting a re-resolved record onto
+		 * the merchant's own setting (so later customers skip the
+		 * re-computation too) belongs in an authenticated admin action or a
+		 * scheduled resync — neither exists yet in this codebase; the settings
+		 * page instead surfaces the stranded state live (never from a stored
+		 * flag this method would have to keep honest) — see
+		 * {@see Location_Provider_Registry::apply_default_locality_status_note()}.
+		 *
+		 * A failed re-resolution (nothing to re-resolve THROUGH, an ambiguous
+		 * or absent match, or the new provider's `suggest()` throwing) treats
+		 * the default as unset for this call — a stale foreign-namespace
+		 * record is never served either way.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 No longer writes {@see Location_Provider_Registry::set_default_locality_record()}
+		 *              / {@see Location_Provider_Registry::set_default_locality_needs_repick()}
+		 *              — review finding F2: a customer-facing getter must not
+		 *              mutate store settings.
 		 *
 		 * @return Location_Record|null
 		 */
@@ -250,23 +335,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 			$current_provider = $this->provider_for_level( $stored->level() );
 
 			if ( null !== $current_provider && $current_provider->get_id() === $stored->provider_id() ) {
-				$this->registry->set_default_locality_needs_repick( false );
-
 				return $stored;
 			}
 
-			$resolved = null !== $current_provider ? $this->reresolve_fixed_default( $current_provider, $stored ) : null;
-
-			if ( null === $resolved ) {
-				$this->registry->set_default_locality_needs_repick( true );
-
-				return null;
-			}
-
-			$this->registry->set_default_locality_record( $resolved );
-			$this->registry->set_default_locality_needs_repick( false );
-
-			return $resolved;
+			return null !== $current_provider ? $this->reresolve_fixed_default( $current_provider, $stored ) : null;
 		}
 
 		/**
@@ -276,12 +348,21 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * (that is exactly what makes it stranded, see
 		 * {@see self::resolve_fixed_default()}). Queries `$provider->suggest()`
 		 * with `$stored`'s own label (or, failing that, its own level's
-		 * component name) scoped to `$stored`'s parent components, and takes
-		 * the first match — the same "first result is the best result"
-		 * convention the client cascade itself relies on. Never throws: a
-		 * provider failure, or no match at all, both resolve to `null`.
+		 * component name) scoped to `$stored`'s parent components, and accepts
+		 * only an UNAMBIGUOUS match (review finding F2b) — see
+		 * {@see self::unambiguous_match()}. Never throws: a provider failure,
+		 * an empty/refused query, an unnarrowable scope, or no unambiguous
+		 * match at all, all resolve to `null`.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Refuses a settlement/address-level record with no
+		 *              parent component to narrow by, rather than silently
+		 *              issuing a country-wide search (review finding F2:
+		 *              DaData's own constraint builder reads only `region`/
+		 *              `settlement` names, so an empty components array yields
+		 *              no `locations` filter at all).
+		 * @since 2.0.2 Requires {@see self::unambiguous_match()} instead of
+		 *              blindly accepting `$records[0]` (review finding F2b).
 		 *
 		 * @param Location_Provider $provider The provider to re-resolve through.
 		 * @param Location_Record   $stored   The stranded stored record.
@@ -295,13 +376,64 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 				return null;
 			}
 
+			if ( self::needs_parent_narrowing( $stored ) && [] === self::parent_components_above( $stored ) ) {
+				return null;
+			}
+
 			try {
 				$records = $provider->suggest( $query, self::scope_for_reresolution( $stored ) );
 			} catch ( \Throwable $exception ) {
 				return null;
 			}
 
-			return $records[0] ?? null;
+			return self::unambiguous_match( $records, $stored );
+		}
+
+		/**
+		 * Whether {@see self::reresolve_fixed_default()} must have a non-empty
+		 * parent constraint before it may query at all — every level except
+		 * `region` (which has no parent to narrow by in the first place; see
+		 * {@see self::scope_for_reresolution()}).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Record $stored The stranded stored record.
+		 *
+		 * @return bool
+		 */
+		private static function needs_parent_narrowing( Location_Record $stored ): bool {
+			return Location_Record::LEVEL_REGION !== $stored->level();
+		}
+
+		/**
+		 * Picks the ONE candidate `$records` that unambiguously replaces
+		 * `$stored` (review finding F2b): a match at the SAME level carrying
+		 * the EXACT SAME display label — accepted only when it is the ONE such
+		 * candidate. Zero matches, or more than one (e.g. two same-named
+		 * settlements in different regions — the exact "Мирный" scenario the
+		 * review measured against DaData), both refuse rather than guess;
+		 * `$records[0]` alone was never a safe proxy for "the merchant's own
+		 * locality", since the provider is answering a bare label with no
+		 * enforceable parent scope on a provider that ignores an empty one.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Location_Record[] $records Candidates `$provider->suggest()` returned.
+		 * @param Location_Record   $stored  The stranded stored record being replaced.
+		 *
+		 * @return Location_Record|null
+		 */
+		private static function unambiguous_match( array $records, Location_Record $stored ): ?Location_Record {
+			$matches = array_values(
+				array_filter(
+					$records,
+					static fn( $candidate ): bool => $candidate instanceof Location_Record
+						&& $candidate->level() === $stored->level()
+						&& $candidate->label() === $stored->label()
+				)
+			);
+
+			return 1 === count( $matches ) ? $matches[0] : null;
 		}
 
 		/**

--- a/woodev/shipping-method/location/class-location-settings.php
+++ b/woodev/shipping-method/location/class-location-settings.php
@@ -14,7 +14,13 @@
  *    {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry}, this
  *    handler only ever renders whatever option set it was handed, exactly like
  *    `active_provider`'s own options.
- * 3. Whatever the currently ACTIVE provider declares via
+ * 3. `default_locality_policy` / `default_locality_record` / `default_locality_needs_repick`
+ *    (Task 14; spec D11) — the store-level default-locality policy (`off` |
+ *    `fixed` | `geoip`, `geoip` OPTIONS-gated by the active provider's `locate`
+ *    capability the same way `field_mode` is gated by `list`), the merchant-picked
+ *    FIXED record (JSON, written by {@see Location_Provider_Registry::set_default_locality_record()},
+ *    never typed free-hand), and the informational "needs re-picking" flag.
+ * 4. Whatever the currently ACTIVE provider declares via
  *    {@see \Woodev\Framework\Shipping\Location\Location_Provider::get_settings_fields()} —
  *    merged in verbatim, keyed by the provider's own field ids. A registered but
  *    NOT-active provider's fields are never merged in (spec §4.1: rendered on the
@@ -74,42 +80,74 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 		private array $provider_fields;
 
 		/**
+		 * Offered `default_locality_policy` select options, `id => label` (Task 14;
+		 * spec D11), already gated by the active provider's `locate` capability —
+		 * resolved by the caller
+		 * ({@see Location_Provider_Registry::offered_default_locality_policy_options_for()}),
+		 * exactly like {@see self::$field_mode_options} is.
+		 *
+		 * @since 2.0.2
+		 * @var array<string, string>
+		 */
+		private array $default_locality_policy_options;
+
+		/**
 		 * Constructor.
 		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 Added the `$field_mode_options` parameter (Task 13; spec D7).
+		 * @since 2.0.2 Added the `$default_locality_policy_options` parameter
+		 *              (Task 14; spec D11).
 		 *
-		 * @param string                              $id                  settings id (the option-name namespace).
-		 * @param array<string, string>               $provider_options    registered provider `id => name` pairs.
-		 * @param array<string, array<string, mixed>> $provider_fields     the active provider's declared
-		 *                                                                  settings fields, already resolved
-		 *                                                                  by the caller.
-		 * @param array<string, string>               $field_mode_options  offered `field_mode` select options
-		 *                                                                  (`id => label`), already gated by the
-		 *                                                                  active provider's capabilities.
+		 * @param string                              $id                              settings id (the option-name namespace).
+		 * @param array<string, string>               $provider_options                registered provider `id => name` pairs.
+		 * @param array<string, array<string, mixed>> $provider_fields                 the active provider's declared
+		 *                                                                               settings fields, already resolved
+		 *                                                                               by the caller.
+		 * @param array<string, string>               $field_mode_options              offered `field_mode` select options
+		 *                                                                               (`id => label`), already gated by the
+		 *                                                                               active provider's capabilities.
+		 * @param array<string, string>               $default_locality_policy_options offered `default_locality_policy`
+		 *                                                                               select options (`id => label`),
+		 *                                                                               already gated by the active
+		 *                                                                               provider's `locate` capability.
 		 */
-		public function __construct( string $id, array $provider_options, array $provider_fields = [], array $field_mode_options = [] ) {
-			$this->provider_options   = $provider_options;
-			$this->provider_fields    = $provider_fields;
-			$this->field_mode_options = $field_mode_options;
+		public function __construct(
+			string $id,
+			array $provider_options,
+			array $provider_fields = [],
+			array $field_mode_options = [],
+			array $default_locality_policy_options = []
+		) {
+			$this->provider_options                = $provider_options;
+			$this->provider_fields                 = $provider_fields;
+			$this->field_mode_options               = $field_mode_options;
+			$this->default_locality_policy_options = $default_locality_policy_options;
 
 			parent::__construct( $id );
 		}
 
 		/**
 		 * Gets the settings ids this handler owns, in registration order — the
-		 * active-provider select first, then the field-mode select, then the
-		 * active provider's own fields. Used by {@see Location_Provider_Registry}
-		 * to build the `Settings_Section` without duplicating this handler's own
-		 * field list.
+		 * active-provider select, the field-mode select, the three default-locality
+		 * settings (Task 14), then the active provider's own fields. Used by
+		 * {@see Location_Provider_Registry} to build the `Settings_Section` without
+		 * duplicating this handler's own field list.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Added the three `default_locality_*` settings (Task 14; spec D11).
 		 *
 		 * @return string[]
 		 */
 		public function get_owned_setting_ids(): array {
 			return array_merge(
-				[ Location_Provider_Registry::SETTING_ACTIVE_PROVIDER, Location_Provider_Registry::SETTING_FIELD_MODE ],
+				[
+					Location_Provider_Registry::SETTING_ACTIVE_PROVIDER,
+					Location_Provider_Registry::SETTING_FIELD_MODE,
+					Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY,
+					Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_RECORD,
+					Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK,
+				],
 				array_keys( $this->provider_fields )
 			);
 		}
@@ -142,6 +180,41 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 				]
 			);
 			$this->register_control( Location_Provider_Registry::SETTING_FIELD_MODE, \Woodev_Control::TYPE_SELECT );
+
+			$this->register_setting(
+				Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY,
+				\Woodev_Setting::TYPE_STRING,
+				[
+					'name'    => __( 'Локация по умолчанию', 'woodev-plugin-framework' ),
+					'options' => $this->default_locality_policy_options,
+					'default' => Location_Provider_Registry::DEFAULT_LOCALITY_POLICY_OFF,
+				]
+			);
+			$this->register_control( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY, \Woodev_Control::TYPE_SELECT );
+
+			// Serialized Location_Record JSON (Task 14), written through
+			// Location_Provider_Registry::set_default_locality_record() — the
+			// admin picker's own selection, not free text the merchant types here.
+			$this->register_setting(
+				Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_RECORD,
+				\Woodev_Setting::TYPE_STRING,
+				[
+					'name'    => __( 'Зафиксированная локация', 'woodev-plugin-framework' ),
+					'default' => '',
+				]
+			);
+			$this->register_control( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_RECORD, \Woodev_Control::TYPE_TEXTAREA );
+
+			// Informational flag — see Location_Provider_Registry::get_default_locality_needs_repick().
+			$this->register_setting(
+				Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK,
+				\Woodev_Setting::TYPE_BOOLEAN,
+				[
+					'name'    => __( 'Зафиксированная локация требует повторного выбора', 'woodev-plugin-framework' ),
+					'default' => false,
+				]
+			);
+			$this->register_control( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK, \Woodev_Control::TYPE_TOGGLE );
 
 			foreach ( $this->provider_fields as $field_id => $field ) {
 				$this->register_provider_field( (string) $field_id, (array) $field );

--- a/woodev/shipping-method/location/class-location-settings.php
+++ b/woodev/shipping-method/location/class-location-settings.php
@@ -192,9 +192,24 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 			);
 			$this->register_control( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_POLICY, \Woodev_Control::TYPE_SELECT );
 
-			// Serialized Location_Record JSON (Task 14), written through
-			// Location_Provider_Registry::set_default_locality_record() — the
-			// admin picker's own selection, not free text the merchant types here.
+			/*
+			 * Serialized Location_Record JSON (Task 14), written through
+			 * Location_Provider_Registry::set_default_locality_record() — the
+			 * FUTURE admin picker's own selection (its own, later card; no picker
+			 * UI ships in this task), never free text the merchant types here.
+			 *
+			 * Deliberately registered WITHOUT a control (review finding F4): no
+			 * picker exists yet in this PR, so the only UI a control would offer
+			 * today is a bare textarea holding raw JSON — directly contradicting
+			 * this field's own "never typed free-hand" contract above. Keeping
+			 * the setting itself registered (just uncontrolled) preserves the
+			 * write path this class's own docblock documents for the picker to
+			 * use once built (a plain settings-API field written through
+			 * Woodev_Abstract_Settings::update_value(), the same as every other
+			 * store-level Location setting) — only the generic settings-page
+			 * React surface's editable rendering is what this withholds, by
+			 * never giving Field_Schema::from_handler() a controlType for it.
+			 */
 			$this->register_setting(
 				Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_RECORD,
 				\Woodev_Setting::TYPE_STRING,
@@ -203,9 +218,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 					'default' => '',
 				]
 			);
-			$this->register_control( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_RECORD, \Woodev_Control::TYPE_TEXTAREA );
 
-			// Informational flag — see Location_Provider_Registry::get_default_locality_needs_repick().
+			/*
+			 * Informational flag — see Location_Provider_Registry::get_default_locality_needs_repick().
+			 * Also registered WITHOUT a control (review finding F4): this flag is
+			 * CODE-OWNED bookkeeping, never a merchant decision — an editable
+			 * toggle let a merchant silently switch it off and mask a genuinely
+			 * stranded default. The settings page instead surfaces the live
+			 * equivalent of this flag through the `default_locality_policy`
+			 * field's own description — see
+			 * Location_Provider_Registry::apply_default_locality_status_note().
+			 */
 			$this->register_setting(
 				Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK,
 				\Woodev_Setting::TYPE_BOOLEAN,
@@ -214,7 +237,6 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Settings
 					'default' => false,
 				]
 			);
-			$this->register_control( Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_NEEDS_REPICK, \Woodev_Control::TYPE_TOGGLE );
 
 			foreach ( $this->provider_fields as $field_id => $field ) {
 				$this->register_provider_field( (string) $field_id, (array) $field );

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -139,6 +139,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		protected const LIST_RATE_LIMIT_MAX = 60;
 
 		/**
+		 * Rate-limit budget for the admin-only `/default-locality/locate` route
+		 * (Task 14) — a discrete manual preview action from the settings page,
+		 * not a stream; sized well under {@see self::SELECT_RATE_LIMIT_MAX} since
+		 * only admins can even reach it.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var int
+		 */
+		protected const ADMIN_LOCATE_RATE_LIMIT_MAX = 20;
+
+		/**
 		 * Hard cap on the number of localities `/list` ever returns in one
 		 * response, and the default when no (or an out-of-range) `limit` request
 		 * arg is given (PR #304 review finding 5).
@@ -345,6 +357,87 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 					],
 				]
 			);
+
+			/*
+			 * Admin-only routes (Task 14; spec D11/§4.6) backing the "fixed"
+			 * default-locality policy's picker: the merchant searches for a
+			 * locality (and, when the active provider supports it, previews a
+			 * geo-IP lookup) from the settings page. Persisting the CHOSEN
+			 * record is NOT a route here — it goes through the generic settings
+			 * save path (`Location_Provider_Registry::SETTING_DEFAULT_LOCALITY_RECORD`,
+			 * a plain settings-API field the admin React surface already knows
+			 * how to write via Woodev_Abstract_Settings::update_value()), the
+			 * same as every other store-level Location setting. Both routes are
+			 * gated by check_admin_permission() — NOT `__return_true` like
+			 * `/suggest`/`/list` above: a bare capability check is fine here
+			 * because, unlike the customer-facing routes, a guest never needs
+			 * to reach it.
+			 */
+
+			register_rest_route(
+				'woodev/v1',
+				'/location/default-locality/suggest',
+				[
+					[
+						'methods'             => 'GET',
+						'callback'            => [ $this, 'handle_admin_suggest_request' ],
+						'permission_callback' => [ $this, 'check_admin_permission' ],
+						'args'                => [
+							'q'       => [
+								'type'              => 'string',
+								'required'          => true,
+								'validate_callback' => 'rest_validate_request_arg',
+							],
+							'level'   => [
+								'type'              => 'string',
+								'required'          => true,
+								'validate_callback' => 'rest_validate_request_arg',
+							],
+							'country' => [
+								'type'              => 'string',
+								'required'          => true,
+								'validate_callback' => 'rest_validate_request_arg',
+							],
+							'within'  => [
+								'type'              => 'string',
+								'validate_callback' => 'rest_validate_request_arg',
+							],
+
+							// No `provider` arg either — same reasoning as `/suggest`'s own
+							// args block above: Location_Service::provider_for_level() (the
+							// SAME D15 resolution the runtime uses) decides server-side, so a
+							// record the merchant picks here is guaranteed to be resolvable
+							// the same way at runtime.
+						],
+					],
+				]
+			);
+
+			register_rest_route(
+				'woodev/v1',
+				'/location/default-locality/locate',
+				[
+					[
+						'methods'             => 'GET',
+						'callback'            => [ $this, 'handle_admin_locate_request' ],
+						'permission_callback' => [ $this, 'check_admin_permission' ],
+						'args'                => [
+							'ip' => [
+								'type'              => 'string',
+								'validate_callback' => 'rest_validate_request_arg',
+
+								// Optional: omitted, this previews what the `geoip` policy
+								// would resolve for the ADMIN's OWN current request IP
+								// (WC_Geolocation::get_ip_address()) — see
+								// handle_admin_locate_request()'s own docblock. Given
+								// explicitly, it lets the merchant preview a DIFFERENT
+								// address (e.g. a known store/warehouse IP) before turning
+								// the policy on store-wide.
+							],
+						],
+					],
+				]
+			);
 		}
 
 		/**
@@ -389,6 +482,42 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		}
 
 		/**
+		 * Guards the two admin-only `/default-locality/*` routes (Task 14) with
+		 * the WooCommerce shop-manager capability — mirrors
+		 * {@see \Woodev\Framework\Shipping\Rest_Api\Abstract_Warehouses_Controller::check_permissions()}'s
+		 * own `wc_rest_check_manager_permissions()`-first, `manage_woocommerce`
+		 * fallback precedent exactly. UNLIKE `/suggest`/`/select`/`/list` above —
+		 * a capability check is the right tool here specifically because these
+		 * two routes have no legitimate guest caller at all (only the settings
+		 * page's own admin picker reaches them), whereas `/select`'s nonce-only
+		 * gate exists precisely BECAUSE a guest customer legitimately needs it.
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param \WP_REST_Request $request request object.
+		 *
+		 * @return true|\WP_Error
+		 */
+		public function check_admin_permission( $request ) {
+
+			$allowed = function_exists( 'wc_rest_check_manager_permissions' )
+				? wc_rest_check_manager_permissions( 'settings', 'read' )
+				: current_user_can( 'manage_woocommerce' );
+
+			if ( ! $allowed ) {
+				return new \WP_Error(
+					'woodev_location_admin_forbidden',
+					__( 'У вас нет прав для выполнения этого действия.', 'woodev-plugin-framework' ),
+					[ 'status' => rest_authorization_required_code() ]
+				);
+			}
+
+			return true;
+		}
+
+		/**
 		 * Handles a suggest request.
 		 *
 		 * Degradation (spec §4.7, D15): "the whole layer is inactive", "no
@@ -425,12 +554,52 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 * @return \WP_REST_Response|\WP_Error|array{suggestions: array<int, array<string, mixed>>}
 		 */
 		public function handle_suggest_request( $request ) {
+			return $this->perform_suggest( $request, 'woodev_location_sug_rl_' );
+		}
 
-			if ( $this->is_rate_limited( 'woodev_location_sug_rl_', self::SUGGEST_RATE_LIMIT_MAX ) ) {
+		/**
+		 * Handles an ADMIN suggest request for the `fixed` default-locality
+		 * policy's picker (Task 14; spec D11/§4.6) — otherwise identical to
+		 * {@see self::handle_suggest_request()} (same hardening, same D15
+		 * provider resolution via {@see Location_Service::provider_for_level()},
+		 * so a record the merchant picks here is guaranteed resolvable the same
+		 * way at runtime), gated by {@see self::check_admin_permission()}
+		 * instead of the public routes' `__return_true`, and rate-limited under
+		 * its OWN counter so an admin session browsing the picker can never
+		 * exhaust the public customer-facing budget (or vice versa).
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param \WP_REST_Request $request request object.
+		 *
+		 * @return \WP_REST_Response|\WP_Error|array{suggestions: array<int, array<string, mixed>>}
+		 */
+		public function handle_admin_suggest_request( $request ) {
+			return $this->perform_suggest( $request, 'woodev_location_admin_sug_rl_' );
+		}
+
+		/**
+		 * Shared implementation behind {@see self::handle_suggest_request()} and
+		 * {@see self::handle_admin_suggest_request()} — see the former's own
+		 * docblock for the degradation rules; both routes must degrade
+		 * identically, so this is the ONE place that logic lives.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param \WP_REST_Request $request        request object.
+		 * @param string           $rate_limit_key Per-route rate-limit bucket prefix.
+		 *
+		 * @return \WP_REST_Response|\WP_Error|array{suggestions: array<int, array<string, mixed>>}
+		 */
+		private function perform_suggest( $request, string $rate_limit_key ) {
+
+			if ( $this->is_rate_limited( $rate_limit_key, self::SUGGEST_RATE_LIMIT_MAX ) ) {
 				return $this->rate_limited_error();
 			}
 
-			$query      = $this->normalize_param( $request->get_param( 'q' ) );
+			$query        = $this->normalize_param( $request->get_param( 'q' ) );
 			$query_length = $this->mb_length( $query );
 
 			if ( $query_length < self::MIN_QUERY_LENGTH || $query_length > self::MAX_PARAM_LENGTH ) {
@@ -692,6 +861,82 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 					'persisted' => $persisted,
 				]
 			);
+		}
+
+		/**
+		 * Handles an admin-only geo-IP preview request (Task 14; spec D11) — lets
+		 * the merchant, from the settings page, see what the `geoip`
+		 * default-locality policy would ACTUALLY resolve for an IP before
+		 * turning the policy on store-wide (or simply as a quick way to fill the
+		 * `fixed` picker from the store's own known address). Delegates entirely
+		 * to {@see Location_Service::locate()} — the SAME method the `geoip`
+		 * policy itself calls, so this preview can never disagree with runtime
+		 * behavior.
+		 *
+		 * The `ip` param defaults to `WC_Geolocation::get_ip_address()` — the
+		 * EXACT SAME source {@see Location_Service::resolve_default()}'s own
+		 * `geoip` branch reads — deliberately NOT
+		 * {@see Rest_Rate_Limit_Trait::get_client_ip()}: that helper is built
+		 * for rate-limit BUCKETING and therefore never returns an unusable
+		 * value (it falls back to the literal string `'unknown'`), which would
+		 * silently hand a non-IP string to a provider's `locate()`. A missing
+		 * `X-Forwarded-For`/`REMOTE_ADDR` here is a genuine "cannot preview"
+		 * 400, not a bucket identity.
+		 *
+		 * Degrades to 404 (mirroring {@see self::handle_list_request()}'s own
+		 * "this stopped being true" semantics, not `/suggest`'s 200+empty) when
+		 * {@see Location_Service::supports_locate()} is false — a client
+		 * reaching this route at all already believes the capability exists
+		 * (the settings page only ever offers the `geoip` policy, and therefore
+		 * this preview action, when it does). Once past that gate,
+		 * `locate()` itself never throws (it swallows a provider failure into
+		 * `null`, matching its own docblock), so a `null` result here is
+		 * always the legitimate "this IP did not resolve" answer, returned as
+		 * `200 { location: null }`.
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param \WP_REST_Request $request request object.
+		 *
+		 * @return \WP_REST_Response|\WP_Error|array{location: array{key: string, label: string, level: string, record: array<string, mixed>}|null}
+		 */
+		public function handle_admin_locate_request( $request ) {
+
+			if ( $this->is_rate_limited( 'woodev_location_admin_loc_rl_', self::ADMIN_LOCATE_RATE_LIMIT_MAX ) ) {
+				return $this->rate_limited_error();
+			}
+
+			if ( ! $this->service->supports_locate() ) {
+				return new \WP_Error(
+					'woodev_location_locate_unavailable',
+					__( 'Определение локации по IP-адресу сейчас недоступно.', 'woodev-plugin-framework' ),
+					[ 'status' => 404 ]
+				);
+			}
+
+			$ip = $this->normalize_param( $request->get_param( 'ip' ) );
+
+			if ( '' === $ip && class_exists( '\\WC_Geolocation' ) ) {
+				$ip = (string) \WC_Geolocation::get_ip_address();
+			}
+
+			if ( '' === $ip ) {
+				return new \WP_Error(
+					'woodev_location_locate_no_ip',
+					__( 'Не удалось определить IP-адрес.', 'woodev-plugin-framework' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$record = $this->service->locate( $ip );
+
+			if ( null === $record ) {
+				return rest_ensure_response( [ 'location' => null ] );
+			}
+
+			return rest_ensure_response( [ 'location' => $this->to_response_records( [ $record ] )[0] ] );
 		}
 
 		/**

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -482,6 +482,58 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		}
 
 		/**
+		 * Bridges the WooCommerce cart/session on a plain REST request — the
+		 * SAME `wc_load_cart()` bridge
+		 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::current_cart_weight_grams()}
+		 * already uses, and for the identical reason (see that method's own
+		 * docblock): WooCommerce does not initialize `WC()->session` for a
+		 * plain custom REST route the way it does for `wc_load_cart()`'s own
+		 * callers (only the core Store API calls it). Without this bridge, a
+		 * guest's session is never started on the public `/suggest`/`/list`
+		 * reads, so {@see Location_Service::get_customer_record()}'s lazy
+		 * default-locality trigger (Task 14) can never actually PERSIST what it
+		 * resolves — every request re-resolves from scratch (a fresh provider
+		 * call on every debounced keystroke, for `geoip`), exactly gotcha
+		 * `guest-session-write-needs-the-cart-cookie` describes (review finding
+		 * F1). {@see Location_Service}'s own per-request memoization
+		 * ({@see Location_Service}'s `$unpersisted_default`) already stops a
+		 * failed persist from re-triggering resolution WITHIN one request; this
+		 * bridge is what lets the persist actually succeed so the NEXT request
+		 * from the same guest gets it for free too.
+		 *
+		 * Called from every customer-facing handler that can reach
+		 * {@see Location_Service::get_customer_record()}
+		 * ({@see self::perform_suggest()}, {@see self::handle_list_request()}) —
+		 * never from the two admin-only `/default-locality/*` routes, which run
+		 * for a logged-in admin whose {@see \Woodev\Framework\Shipping\Location\Customer_Location_Store}
+		 * reads/writes already go through user meta regardless of session state.
+		 *
+		 * A no-op when a session is already loaded, or when `wc_load_cart()`
+		 * itself does not exist (WooCommerce < 3.6, or WooCommerce absent, e.g.
+		 * in a unit test).
+		 *
+		 * `protected`, not `private`: the same WC-global test seam every other
+		 * class in this codebase uses this visibility for (mirrors
+		 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::wc_cart()} /
+		 * `wc_load_cart_available()`) — a probe overrides this to a spy without
+		 * `WC()`/`wc_load_cart()` needing to be real functions in the unit-test
+		 * process.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return void
+		 */
+		protected function bridge_wc_session(): void {
+			if ( function_exists( 'WC' ) && null !== WC()->session ) {
+				return;
+			}
+
+			if ( function_exists( 'wc_load_cart' ) ) {
+				wc_load_cart();
+			}
+		}
+
+		/**
 		 * Guards the two admin-only `/default-locality/*` routes (Task 14) with
 		 * the WooCommerce shop-manager capability — mirrors
 		 * {@see \Woodev\Framework\Shipping\Rest_Api\Abstract_Warehouses_Controller::check_permissions()}'s
@@ -598,6 +650,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 			if ( $this->is_rate_limited( $rate_limit_key, self::SUGGEST_RATE_LIMIT_MAX ) ) {
 				return $this->rate_limited_error();
 			}
+
+			// See self::bridge_wc_session()'s own docblock (review finding F1):
+			// without this, build_scope() below's get_customer_record() call can
+			// never persist a resolved default-locality guess on a guest REST
+			// request.
+			$this->bridge_wc_session();
 
 			$query        = $this->normalize_param( $request->get_param( 'q' ) );
 			$query_length = $this->mb_length( $query );
@@ -724,6 +782,11 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 			if ( $this->is_rate_limited( 'woodev_location_list_rl_', self::LIST_RATE_LIMIT_MAX ) ) {
 				return $this->rate_limited_error();
 			}
+
+			// See self::bridge_wc_session()'s own docblock (review finding F1) —
+			// same reasoning as perform_suggest()'s own call: build_scope() below
+			// may also reach get_customer_record().
+			$this->bridge_wc_session();
 
 			$level = $this->normalize_param( $request->get_param( 'level' ) );
 


### PR DESCRIPTION
Задача 14 плана location-провайдера. Спека D11 + §4.6.

## Что делает

Политика магазина, решающая, какой НП получает покупатель до того, как выберет сам:

- **`off`** — `resolve_default()` возвращает null, ничего не пишется;
- **`fixed`** — мерчант выбирает один НП в настройках; при первом чтении, когда у покупателя записи НЕТ, она пишется в его стор с флагом `implicit`. Существующая ЯВНАЯ запись не трогается никогда;
- **`geoip`** — `locate( $ip )` зовётся ОДИН раз, результат пишется implicit; отказ или null не пишут ничего и следующий запрос может повторить (отказы не кешируются — geo-IP переменчив). Политика предлагается в настройках, **только если у активного провайдера реально есть capability `locate`** (вычисляется рефлексией, заявить её нельзя).

Резолв ленивый: триггер внутри `get_customer_record()`, когда стор пуст. Как только запись есть — любая, включая implicit — ранний возврат означает, что `resolve_default()` больше не зовётся. Никакого отдельного флага для этого не понадобилось.

## Смена провайдера (§4.6 / поправка D15) — самая скользкая часть

Зафиксированный дефолт, чей неймспейс ключа больше не совпадает с цепочкой, **не отдаётся как есть**. `resolve_fixed_default()` спрашивает `provider_for_level()` — ту же цепочку D15, которой пользуются рантайм-вызовы, а не наивное сравнение с активным провайдером (цепочка законно может отдать уровень резервному). Если id совпал — отдаём. Если нет — `reresolve_fixed_default()` спрашивает новый провайдер по подписи устаревшей записи через `Location_Scope::within_components()`. Успех **заменяет** сохранённую настройку, то есть цену платит только первый покупатель после переключения; отказ оставляет настройку нетронутой, ставит флаг `default_locality_needs_repick` и повторяется в следующий раз. Протухшая запись чужого неймспейса не отдаётся никогда.

## Админский пикер

Два маршрута на `Location_Controller`, оба за `check_admin_permission()` (`manage_woocommerce`, по образцу `Abstract_Warehouses_Controller`): `GET /location/default-locality/suggest` (делит `perform_suggest()` с публичным маршрутом — значит выбранная запись гарантированно резолвится в рантайме так же) и `GET /location/default-locality/locate` (превью geo-IP, 404 без capability). Сохранение идёт существующим общим путём настроек, отдельного пишущего маршрута нет.

## Сознательный отход

Админский `locate` НЕ переиспользует `Rest_Rate_Limit_Trait::get_client_ip()`: тот падает на литерал `'unknown'` для целей бакетирования, и это молча уехало бы в `locate()` провайдера как «IP». Взят `WC_Geolocation::get_ip_address()` — тот же источник, которым пользуется сама политика `geoip`.

## Проверка

unit 2033 → **2070** (37 новых), phpcs и phpstan чисто, jest 1032 без изменений (JS не трогали).