### PR TITLE
fix(api): mask secret headers on the response half of the log broadcast

### DIFF
--- a/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
+++ b/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
@@ -65,9 +65,9 @@ class Testable_Api_Base extends \Woodev_API_Base {
 	/**
 	 * Exposes the protected request-header sanitizer under test.
 	 *
-	 * @return array<string, string>
+	 * @return array<string, string>|null
 	 */
-	public function get_sanitized_headers_for_test(): array {
+	public function get_sanitized_headers_for_test(): ?array {
 		return $this->get_sanitized_request_headers();
 	}
 
@@ -78,6 +78,17 @@ class Testable_Api_Base extends \Woodev_API_Base {
 	 */
 	public function get_sanitized_response_headers_for_test() {
 		return $this->get_sanitized_response_headers();
+	}
+
+	/**
+	 * Exposes the protected response broadcast payload under test, end to end —
+	 * i.e. through {@see \Woodev_API_Base::get_response_data_for_broadcast()}
+	 * itself, not just the sanitizer it is supposed to call.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_response_data_for_broadcast_for_test(): array {
+		return $this->get_response_data_for_broadcast();
 	}
 
 	/**
@@ -113,6 +124,26 @@ class Testable_Api_Base_With_Custom_Secret extends Testable_Api_Base {
 	 */
 	protected function get_secret_header_names(): array {
 		return array_merge( parent::get_secret_header_names(), [ 'X-Custom-Secret' ] );
+	}
+}
+
+/**
+ * A subclass overriding get_request_headers() to return `null` instead of an
+ * array. `get_request_headers()` carries no return type, so this is a legal
+ * override in the wild -- and the request-side sanitizer must survive it the
+ * same way the response side already survives a `null`
+ * get_response_headers() (no response received yet), rather than fataling
+ * inside the logging path with a TypeError.
+ */
+class Testable_Api_Base_With_Null_Request_Headers extends Testable_Api_Base {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_request_headers() {
+		return null;
 	}
 }
 
@@ -344,5 +375,145 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 		$api = new Testable_Api_Base();
 
 		$this->assertNull( $api->get_sanitized_response_headers_for_test() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Adversarial-review follow-up (PR #315) — closes the gaps a critic pass
+	// found in the #300 fix itself: no end-to-end coverage of the actual call
+	// site, array-valued headers, missing Cookie/vendor-token names, and a
+	// TypeError hazard on a non-array get_request_headers() override.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * #300's actual fix line is `get_response_data_for_broadcast()` calling the
+	 * sanitizer instead of the raw getter. Every other test in this file drives
+	 * `get_sanitized_response_headers()` directly, so none of them would fail
+	 * if the call site quietly reverted to
+	 * `'headers' => $this->get_response_headers()` — this is the test that
+	 * would (mutation-tested: reverting class-api-base.php's
+	 * `get_response_data_for_broadcast()` to the raw getter turns this test
+	 * red while the rest of this file stays green).
+	 *
+	 * @return void
+	 */
+	public function test_get_response_data_for_broadcast_masks_headers(): void {
+		$cookie = 'sessionid=deadbeefcafefeed';
+
+		$api = new Testable_Api_Base();
+		$api->set_response_headers_for_test( [ 'Set-Cookie' => $cookie ] );
+
+		$broadcast = $api->get_response_data_for_broadcast_for_test();
+
+		$this->assertArrayHasKey( 'headers', $broadcast );
+		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $broadcast['headers']['Set-Cookie'] );
+		$this->assertStringNotContainsString(
+			$cookie,
+			print_r( $broadcast, true ),
+			'the cookie leaked into the response broadcast payload'
+		);
+	}
+
+	/**
+	 * WordPress folds a duplicated response header — e.g. two `Set-Cookie`
+	 * lines, the normal shape of a session-establishing response — into an
+	 * ARRAY of values, not a string (see
+	 * wp-includes/class-wp-http-requests-response.php). The sanitizer must
+	 * mask each element and keep the array shape: casting the whole array
+	 * with `(string)` emits an `Array to string conversion` warning and
+	 * collapses the header to the literal string `"Array"`.
+	 *
+	 * @return void
+	 */
+	public function test_array_valued_response_header_is_masked_element_wise(): void {
+		$cookie_a = 'sessionid=deadbeefcafefeed';
+		$cookie_b = 'csrftoken=00112233445566778899';
+
+		$api = new Testable_Api_Base();
+		$api->set_response_headers_for_test( [ 'Set-Cookie' => [ $cookie_a, $cookie_b ] ] );
+
+		$headers = $api->get_sanitized_response_headers_for_test();
+
+		$this->assertIsArray( $headers['Set-Cookie'], 'the array shape of a duplicated header must survive masking' );
+		$this->assertSame(
+			[ str_repeat( '*', strlen( $cookie_a ) ), str_repeat( '*', strlen( $cookie_b ) ) ],
+			$headers['Set-Cookie']
+		);
+
+		$serialized = print_r( $headers, true );
+		$this->assertStringNotContainsString( $cookie_a, $serialized );
+		$this->assertStringNotContainsString( $cookie_b, $serialized );
+	}
+
+	/**
+	 * `Set-Cookie` (response) already had a masked twin; `Cookie` — the
+	 * REQUEST-side header carrying the same session token back to the server
+	 * on every subsequent call — did not. Locks in the request-side twin.
+	 *
+	 * @return void
+	 */
+	public function test_cookie_request_header_is_masked(): void {
+		$cookie = 'sessionid=deadbeefcafefeed';
+
+		$api = new Testable_Api_Base();
+		$api->set_headers_for_test( [ 'Cookie' => $cookie ] );
+
+		$headers = $api->get_sanitized_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $headers['Cookie'] );
+	}
+
+	/**
+	 * Credential-bearing header names an adversarial review found passing
+	 * through the pre-fix default list in plaintext: `X-Subject-Token`
+	 * (OpenStack Identity), `Refresh-Token`/`X-Refresh-Token`,
+	 * `X-Amz-Security-Token`, `Authentication-Info`, `Set-Cookie2`,
+	 * `X-CSRF-Token`.
+	 *
+	 * @dataProvider provider_newly_added_secret_header_names
+	 *
+	 * @param string $header_name Header name expected to be in the default list.
+	 * @return void
+	 */
+	public function test_newly_added_default_list_entries_are_masked( string $header_name ): void {
+		$secret = 'secret-value-that-must-never-reach-the-log';
+
+		$api = new Testable_Api_Base();
+		$api->set_response_headers_for_test( [ $header_name => $secret ] );
+
+		$headers = $api->get_sanitized_response_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers[ $header_name ] );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_newly_added_secret_header_names(): array {
+		return [
+			'X-Subject-Token'      => [ 'X-Subject-Token' ],
+			'Refresh-Token'        => [ 'Refresh-Token' ],
+			'X-Refresh-Token'      => [ 'X-Refresh-Token' ],
+			'X-Amz-Security-Token' => [ 'X-Amz-Security-Token' ],
+			'Authentication-Info'  => [ 'Authentication-Info' ],
+			'Set-Cookie2'          => [ 'Set-Cookie2' ],
+			'X-CSRF-Token'         => [ 'X-CSRF-Token' ],
+		];
+	}
+
+	/**
+	 * A subclass overriding `get_request_headers()` to return something other
+	 * than an array (e.g. `null`) must not fatal the logging path. Before
+	 * #300 extracted a strictly `array`-typed `mask_secret_headers()`, a
+	 * non-array value here only ever produced a PHP warning from
+	 * `foreach ( null as ... )`. This base class is vendored into out-of-repo
+	 * plugins, so a TypeError here is reachable in the wild — a logging call
+	 * must never kill a checkout.
+	 *
+	 * @return void
+	 */
+	public function test_non_array_request_headers_override_does_not_throw(): void {
+		$api = new Testable_Api_Base_With_Null_Request_Headers();
+
+		$this->assertNull( $api->get_sanitized_headers_for_test() );
 	}
 }

--- a/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
+++ b/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
@@ -1,22 +1,30 @@
 <?php
 /**
  * Unit tests for Woodev_API_Base::get_sanitized_request_headers() /
- * get_secret_request_header_names() — issue #288.
+ * get_sanitized_response_headers() / get_secret_header_names() — issues #288, #300.
  *
- * Woodev_API_Base::broadcast_request() hands the sanitized request headers to the
- * documented `woodev_{api_id}_api_request_performed` action, i.e. to any attached
- * request logger. Before this fix, the sanitizer masked ONLY the `Authorization`
- * header by exact key match; any other credential header (e.g. a vendor-specific
- * `X-Secret`) rode the broadcast in plaintext. This file pins:
+ * Woodev_API_Base::broadcast_request() hands the sanitized request AND response
+ * headers to the documented `woodev_{api_id}_api_request_performed` action, i.e. to
+ * any attached request logger. #288 fixed the outgoing half: before it, the
+ * sanitizer masked ONLY the `Authorization` request header by exact key match, so
+ * any other credential header (e.g. a vendor-specific `X-Secret`) rode the
+ * broadcast in plaintext. #300 is the symmetric fix for the incoming half: response
+ * headers were broadcast completely raw — no sanitizer ran on them at all, so a
+ * `Set-Cookie` (session token) or a token-refresh header (`X-Auth-Token` etc.)
+ * returned by the carrier leaked into the log unmasked. This file pins:
  *
- * - `Authorization` stays masked (regression guard — the payment-gateway tree
- *   shares this base class);
- * - every other header name in the default {@see \Woodev_API_Base::get_secret_request_header_names()}
- *   list is masked too;
+ * - `Authorization` stays masked on the request side (regression guard — the
+ *   payment-gateway tree shares this base class);
+ * - every other header name in the default {@see \Woodev_API_Base::get_secret_header_names()}
+ *   list is masked too, on BOTH the request and the response side;
+ * - `Set-Cookie` is masked on the response side;
  * - the match is case-insensitive, while the returned array preserves the
- *   ORIGINAL key casing the request actually sent;
- * - a subclass can extend the list with its own header name;
- * - a non-secret header passes through untouched.
+ *   ORIGINAL key casing the request/response actually carried;
+ * - a subclass can extend the list with its own header name, and the extension
+ *   covers both directions through the single shared seam;
+ * - a non-secret header passes through untouched, on both sides;
+ * - response headers that are `null` (no response received yet) pass through
+ *   unchanged rather than being coerced into an array.
  *
  * @package Woodev\Tests\Unit\Api
  */
@@ -45,12 +53,31 @@ class Testable_Api_Base extends \Woodev_API_Base {
 	}
 
 	/**
-	 * Exposes the protected sanitizer under test.
+	 * Seeds the response headers under test, bypassing the HTTP transport.
+	 *
+	 * @param array<string, string> $headers Header name/value pairs, casing as received.
+	 * @return void
+	 */
+	public function set_response_headers_for_test( array $headers ): void {
+		$this->response_headers = $headers;
+	}
+
+	/**
+	 * Exposes the protected request-header sanitizer under test.
 	 *
 	 * @return array<string, string>
 	 */
 	public function get_sanitized_headers_for_test(): array {
 		return $this->get_sanitized_request_headers();
+	}
+
+	/**
+	 * Exposes the protected response-header sanitizer under test.
+	 *
+	 * @return array<string, string>|null
+	 */
+	public function get_sanitized_response_headers_for_test() {
+		return $this->get_sanitized_response_headers();
 	}
 
 	/**
@@ -74,7 +101,8 @@ class Testable_Api_Base extends \Woodev_API_Base {
 
 /**
  * A subclass extending the default credential-header list with a header the
- * base class does not know about — proves the extension seam works.
+ * base class does not know about — proves the extension seam works, for both
+ * the request and the response sanitizer, since both read the same list.
  */
 class Testable_Api_Base_With_Custom_Secret extends Testable_Api_Base {
 
@@ -83,8 +111,8 @@ class Testable_Api_Base_With_Custom_Secret extends Testable_Api_Base {
 	 *
 	 * @return array<int, string>
 	 */
-	protected function get_secret_request_header_names(): array {
-		return array_merge( parent::get_secret_request_header_names(), [ 'X-Custom-Secret' ] );
+	protected function get_secret_header_names(): array {
+		return array_merge( parent::get_secret_header_names(), [ 'X-Custom-Secret' ] );
 	}
 }
 
@@ -146,7 +174,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 	}
 
 	/**
-	 * A subclass extending get_secret_request_header_names() gets its custom
+	 * A subclass extending get_secret_header_names() gets its custom
 	 * header masked through the same shared logic — no divergent sanitizer needed.
 	 *
 	 * @return void
@@ -211,5 +239,110 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 		$headers = $api->get_sanitized_headers_for_test();
 
 		$this->assertSame( 'application/json', $headers['Content-Type'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// #300 — response-header sanitization. Before this fix, get_response_data_for_broadcast()
+	// handed get_response_headers() straight to the broadcast, with no sanitizer
+	// at all: not even the single hardcoded name the request side had before #288.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * `Set-Cookie` is the response-side header the card calls out explicitly: a
+	 * carrier may hand back a session cookie that must never reach the log.
+	 *
+	 * @return void
+	 */
+	public function test_set_cookie_response_header_is_masked(): void {
+		$cookie = 'sessionid=deadbeefcafefeed; Path=/; HttpOnly';
+
+		$api = new Testable_Api_Base();
+		$api->set_response_headers_for_test( [ 'Set-Cookie' => $cookie ] );
+
+		$headers = $api->get_sanitized_response_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $headers['Set-Cookie'] );
+		$this->assertStringNotContainsString( $cookie, print_r( $headers, true ), 'the cookie leaked into the sanitized response headers' );
+	}
+
+	/**
+	 * A token-refresh response header from the shared default list (the same list
+	 * the request side uses) is masked symmetrically on the response side too.
+	 *
+	 * @return void
+	 */
+	public function test_default_list_masks_a_credential_header_on_the_response_side(): void {
+		$refreshed_token = 'refreshed-token-value-that-must-never-reach-the-log';
+
+		$api = new Testable_Api_Base();
+		$api->set_response_headers_for_test( [ 'X-Auth-Token' => $refreshed_token ] );
+
+		$headers = $api->get_sanitized_response_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $refreshed_token ) ), $headers['X-Auth-Token'] );
+	}
+
+	/**
+	 * The response-side match is case-insensitive and preserves original key casing,
+	 * mirroring the request-side guarantee.
+	 *
+	 * @return void
+	 */
+	public function test_response_match_is_case_insensitive_but_preserves_original_key_casing(): void {
+		$cookie = 'sessionid=deadbeefcafefeed';
+
+		$api = new Testable_Api_Base();
+		$api->set_response_headers_for_test( [ 'set-cookie' => $cookie ] );
+
+		$headers = $api->get_sanitized_response_headers_for_test();
+
+		$this->assertArrayHasKey( 'set-cookie', $headers );
+		$this->assertArrayNotHasKey( 'Set-Cookie', $headers );
+		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $headers['set-cookie'] );
+	}
+
+	/**
+	 * A subclass extending get_secret_header_names() gets its custom header
+	 * masked on the response side too — one seam, both directions.
+	 *
+	 * @return void
+	 */
+	public function test_subclass_extension_covers_the_response_side_too(): void {
+		$secret = 'secret-value-that-must-never-reach-the-log';
+
+		$api = new Testable_Api_Base_With_Custom_Secret();
+		$api->set_response_headers_for_test( [ 'X-Custom-Secret' => $secret ] );
+
+		$headers = $api->get_sanitized_response_headers_for_test();
+
+		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['X-Custom-Secret'] );
+	}
+
+	/**
+	 * A response header that carries no credential passes through unmasked.
+	 *
+	 * @return void
+	 */
+	public function test_non_secret_response_header_passes_through_untouched(): void {
+		$api = new Testable_Api_Base();
+		$api->set_response_headers_for_test( [ 'Content-Type' => 'application/json' ] );
+
+		$headers = $api->get_sanitized_response_headers_for_test();
+
+		$this->assertSame( 'application/json', $headers['Content-Type'] );
+	}
+
+	/**
+	 * Before any response is received (e.g. the transport itself failed),
+	 * get_response_headers() is `null`. The sanitizer must pass that through
+	 * unchanged rather than coercing it into an array, so the broadcast payload
+	 * shape for a failed request is unaffected by this fix.
+	 *
+	 * @return void
+	 */
+	public function test_null_response_headers_pass_through_unchanged(): void {
+		$api = new Testable_Api_Base();
+
+		$this->assertNull( $api->get_sanitized_response_headers_for_test() );
 	}
 }

--- a/tests/unit/Shipping/Location/DadataApiClientTest.php
+++ b/tests/unit/Shipping/Location/DadataApiClientTest.php
@@ -96,7 +96,7 @@ final class DadataApiClientTest extends TestCase {
 	// Broadcast — the woodev_location_dadata_api_request_performed action must
 	// never carry the Clean secret in plaintext. Masking is now the base class's
 	// job (issue #288: Woodev_API_Base::get_sanitized_request_headers() masks
-	// every header named in get_secret_request_header_names(), which already
+	// every header named in get_secret_header_names(), which already
 	// includes X-Secret by default) — this client no longer needs its own
 	// override; these tests pin that the shared default still covers it.
 	// -------------------------------------------------------------------------

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -299,21 +299,41 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *
 		 * Masks the VALUE of every header whose name (matched case-insensitively —
 		 * HTTP header names are case-insensitive) appears in
-		 * {@see self::get_secret_request_header_names()}, using the same convention
+		 * {@see self::get_secret_header_names()}, using the same convention
 		 * as before (`*` repeated to the value's original length). The original key
 		 * casing sent on the wire is preserved in the returned array; only the
 		 * comparison is case-insensitive.
 		 *
-		 * @since 2.0.2 masks every header from {@see self::get_secret_request_header_names()},
+		 * @since 2.0.2 masks every header from {@see self::get_secret_header_names()},
 		 *              not only `Authorization`.
 		 *
 		 * @return array<string, string>
 		 */
 		protected function get_sanitized_request_headers() {
+			return self::mask_secret_headers( $this->get_request_headers(), $this->get_secret_header_names() );
+		}
 
-			$headers = $this->get_request_headers();
+		/**
+		 * Masks the VALUE of every header whose name (matched case-insensitively —
+		 * HTTP header names are case-insensitive) appears in $secret_names, using
+		 * the convention `*` repeated to the value's original length. The original
+		 * key casing is preserved in the returned array; only the comparison is
+		 * case-insensitive.
+		 *
+		 * Shared by {@see self::get_sanitized_request_headers()} and
+		 * {@see self::get_sanitized_response_headers()} so both directions of the
+		 * `woodev_{api_id}_api_request_performed` broadcast mask header names
+		 * identically — one masking routine, never two that can drift apart.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<string, string> $headers      Header name/value pairs, casing as sent/received.
+		 * @param array<int, string>    $secret_names Header names to mask, matched case-insensitively.
+		 * @return array<string, string>
+		 */
+		private static function mask_secret_headers( array $headers, array $secret_names ): array {
 
-			$secret_names = array_map( 'strtolower', $this->get_secret_request_header_names() );
+			$secret_names = array_map( 'strtolower', $secret_names );
 
 			/*
 			 * Membership is decided by header NAME alone, never by the value being
@@ -332,29 +352,34 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		}
 
 		/**
-		 * Names of the request headers whose values carry a credential and must be
-		 * masked before {@see self::get_sanitized_request_headers()} hands the
-		 * request off to `woodev_{api_id}_api_request_performed` — the documented
-		 * action any attached request logger listens on.
+		 * Names of the request or response headers whose values carry a credential
+		 * and must be masked before {@see self::get_sanitized_request_headers()} or
+		 * {@see self::get_sanitized_response_headers()} hand the request/response off
+		 * to `woodev_{api_id}_api_request_performed` — the documented action any
+		 * attached request logger listens on.
 		 *
 		 * This is the extension point for an API client that authenticates with a
-		 * header other than `Authorization` (e.g. a vendor-specific API-secret
-		 * header): override this method in the subclass and return
-		 * `array_merge( parent::get_secret_request_header_names(), [ 'X-My-Header' ] )`
-		 * rather than overriding {@see self::get_sanitized_request_headers()} itself —
-		 * one extra name here is masked exactly like every other credential header,
-		 * with no risk of drifting from the shared masking logic.
+		 * header other than `Authorization`, or whose responses carry a credential
+		 * under a vendor-specific name (e.g. a refreshed-token header): override this
+		 * method in the subclass and return
+		 * `array_merge( parent::get_secret_header_names(), [ 'X-My-Header' ] )`
+		 * rather than overriding the sanitizers themselves — one extra name here is
+		 * masked exactly like every other credential header, in both directions, with
+		 * no risk of drifting from the shared masking logic.
 		 *
 		 * The default list covers `Authorization` (never regress this — the
 		 * payment-gateway tree shares this base class and its production request
 		 * logs depend on it staying masked) plus the header names real third-party
-		 * APIs are commonly seen using for a second credential.
+		 * APIs are commonly seen using for a second credential, and `Set-Cookie`
+		 * (a response header that can carry a session token).
 		 *
-		 * @since 2.0.2
+		 * @since 2.0.2 renamed from `get_secret_request_header_names()` and now also
+		 *              consulted by {@see self::get_sanitized_response_headers()};
+		 *              added `Set-Cookie` to the default list.
 		 *
 		 * @return array<int, string>
 		 */
-		protected function get_secret_request_header_names(): array {
+		protected function get_secret_header_names(): array {
 			return [
 				'Authorization',
 				'Proxy-Authorization',
@@ -364,6 +389,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				'X-Auth-Token',
 				'X-Access-Token',
 				'X-Secret',
+				'Set-Cookie',
 			];
 		}
 
@@ -418,6 +444,33 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			return $this->response_headers;
 		}
 
+		/**
+		 * Gets the sanitized response headers, for logging.
+		 *
+		 * Masks the VALUE of every header whose name (matched case-insensitively)
+		 * appears in {@see self::get_secret_header_names()} — the same list, and the
+		 * same masking convention, used for the outgoing request headers by
+		 * {@see self::get_sanitized_request_headers()}. Response headers are the
+		 * other half of the same log broadcast and can carry a credential the
+		 * request never had, e.g. `Set-Cookie` or a refreshed-token header a carrier
+		 * returns on a token-refresh call.
+		 *
+		 * {@see self::get_response_headers()} returns `null` before a response has
+		 * been received (e.g. when the transport itself failed); that is passed
+		 * through unchanged rather than coerced to an array, so the broadcast payload
+		 * shape is unaffected by this method's addition.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, string>|null
+		 */
+		protected function get_sanitized_response_headers() {
+
+			$headers = $this->get_response_headers();
+
+			return is_array( $headers ) ? self::mask_secret_headers( $headers, $this->get_secret_header_names() ) : $headers;
+		}
+
 		protected function get_raw_response_body() {
 			return $this->raw_response_body;
 		}
@@ -430,13 +483,17 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * Gets the response data for broadcasting the request.
 		 * Overriding this method allows child classes to customize the response data when broadcasting the request.
 		 *
+		 * @since 2.0.2 `headers` is now {@see self::get_sanitized_response_headers()}
+		 *              instead of the raw {@see self::get_response_headers()} — see #300.
+		 *              The `body` policy is unchanged.
+		 *
 		 * @return array
 		 */
 		protected function get_response_data_for_broadcast() {
 			return array(
 				'code'    => $this->get_response_code(),
 				'message' => $this->get_response_message(),
-				'headers' => $this->get_response_headers(),
+				'headers' => $this->get_sanitized_response_headers(),
 				'body'    => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
 			);
 		}

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -304,13 +304,27 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * casing sent on the wire is preserved in the returned array; only the
 		 * comparison is case-insensitive.
 		 *
-		 * @since 2.0.2 masks every header from {@see self::get_secret_header_names()},
-		 *              not only `Authorization`.
+		 * {@see self::get_request_headers()} is not return-typed, so a subclass
+		 * override is free to return something other than an array (e.g. `null`);
+		 * that is passed through unchanged rather than handed to
+		 * {@see self::mask_secret_headers()}, mirroring the guard
+		 * {@see self::get_sanitized_response_headers()} already applies for the same
+		 * reason — a logging call must never fatal a request.
 		 *
-		 * @return array<string, string>
+		 * @since 2.0.2 masks every header from {@see self::get_secret_header_names()},
+		 *              not only `Authorization`; guards against a non-array
+		 *              {@see self::get_request_headers()} override instead of letting
+		 *              {@see self::mask_secret_headers()}'s `array` type hint fatal.
+		 *
+		 * @return array<string, string>|null
 		 */
 		protected function get_sanitized_request_headers() {
-			return self::mask_secret_headers( $this->get_request_headers(), $this->get_secret_header_names() );
+
+			$headers = $this->get_request_headers();
+
+			return is_array( $headers )
+				? self::mask_secret_headers( $headers, $this->get_secret_header_names() )
+				: $headers;
 		}
 
 		/**
@@ -320,18 +334,32 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * key casing is preserved in the returned array; only the comparison is
 		 * case-insensitive.
 		 *
+		 * A header value can itself be an array: WordPress's HTTP transport
+		 * (`WP_HTTP_Requests_Response::get_headers()`) folds a duplicated response
+		 * header — e.g. multiple `Set-Cookie` lines, the normal shape of a
+		 * session-establishing response — into an array of values rather than a
+		 * string. Each element is masked individually so the array shape survives;
+		 * casting the whole array with `(string)` would emit an
+		 * `Array to string conversion` warning and collapse it into the literal
+		 * string `"Array"`.
+		 *
 		 * Shared by {@see self::get_sanitized_request_headers()} and
 		 * {@see self::get_sanitized_response_headers()} so both directions of the
 		 * `woodev_{api_id}_api_request_performed` broadcast mask header names
-		 * identically — one masking routine, never two that can drift apart.
+		 * identically — one masking routine, never two that can drift apart. Marked
+		 * `protected` rather than `private` so a subclass overriding either
+		 * sanitizer can reuse it instead of re-implementing the masking convention.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 masks array-valued headers element-wise instead of casting the
+		 *              whole array to a string.
 		 *
-		 * @param array<string, string> $headers      Header name/value pairs, casing as sent/received.
-		 * @param array<int, string>    $secret_names Header names to mask, matched case-insensitively.
-		 * @return array<string, string>
+		 * @param array<string, mixed> $headers Header name/value pairs (value: string, or array<int, string>
+		 *                              for a duplicated header), casing as sent/received.
+		 * @param array<int, string>   $secret_names Header names to mask, matched case-insensitively.
+		 * @return array<string, mixed>
 		 */
-		private static function mask_secret_headers( array $headers, array $secret_names ): array {
+		protected static function mask_secret_headers( array $headers, array $secret_names ): array {
 
 			$secret_names = array_map( 'strtolower', $secret_names );
 
@@ -343,9 +371,14 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			 * the value, so an empty header still logs as empty.
 			 */
 			foreach ( $headers as $name => $value ) {
-				if ( in_array( strtolower( (string) $name ), $secret_names, true ) ) {
-					$headers[ $name ] = str_repeat( '*', strlen( (string) $value ) );
+
+				if ( ! in_array( strtolower( (string) $name ), $secret_names, true ) ) {
+					continue;
 				}
+
+				$headers[ $name ] = is_array( $value )
+					? array_map( static fn( $item ) => str_repeat( '*', strlen( (string) $item ) ), $value )
+					: str_repeat( '*', strlen( (string) $value ) );
 			}
 
 			return $headers;
@@ -370,12 +403,23 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * The default list covers `Authorization` (never regress this — the
 		 * payment-gateway tree shares this base class and its production request
 		 * logs depend on it staying masked) plus the header names real third-party
-		 * APIs are commonly seen using for a second credential, and `Set-Cookie`
-		 * (a response header that can carry a session token).
+		 * APIs are commonly seen using for a second credential; `Cookie` and
+		 * `Set-Cookie`/`Set-Cookie2` (the request and response sides of the same
+		 * session token); a handful of vendor token-bearing names seen in the wild
+		 * (`X-Subject-Token` — OpenStack Identity, `Refresh-Token`/`X-Refresh-Token`,
+		 * `X-Amz-Security-Token`, `Authentication-Info`, `X-CSRF-Token`).
+		 *
+		 * `Location` is deliberately NOT in this list: it only carries a credential
+		 * under an OAuth2 implicit-grant redirect, a flow this framework does not
+		 * implement, and masking it on every gateway/shipping redirect would destroy
+		 * ordinary debugging of where a request was sent.
 		 *
 		 * @since 2.0.2 renamed from `get_secret_request_header_names()` and now also
 		 *              consulted by {@see self::get_sanitized_response_headers()};
 		 *              added `Set-Cookie` to the default list.
+		 * @since 2.0.2 added `Cookie`, `Set-Cookie2`, `X-Subject-Token`,
+		 *              `Refresh-Token`, `X-Refresh-Token`, `X-Amz-Security-Token`,
+		 *              `Authentication-Info`, `X-CSRF-Token`.
 		 *
 		 * @return array<int, string>
 		 */
@@ -389,7 +433,15 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				'X-Auth-Token',
 				'X-Access-Token',
 				'X-Secret',
+				'Cookie',
 				'Set-Cookie',
+				'Set-Cookie2',
+				'X-Subject-Token',
+				'Refresh-Token',
+				'X-Refresh-Token',
+				'X-Amz-Security-Token',
+				'Authentication-Info',
+				'X-CSRF-Token',
 			];
 		}
 
@@ -461,14 +513,18 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * shape is unaffected by this method's addition.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 declared `?array` — expressible on the platform's PHP 7.4
+		 *              floor and matches the documented `array<string, string>|null`.
 		 *
 		 * @return array<string, string>|null
 		 */
-		protected function get_sanitized_response_headers() {
+		protected function get_sanitized_response_headers(): ?array {
 
 			$headers = $this->get_response_headers();
 
-			return is_array( $headers ) ? self::mask_secret_headers( $headers, $this->get_secret_header_names() ) : $headers;
+			return is_array( $headers )
+				? self::mask_secret_headers( $headers, $this->get_secret_header_names() )
+				: $headers;
 		}
 
 		protected function get_raw_response_body() {


### PR DESCRIPTION
Closes #300.

#288 closed the outgoing half — request headers. The same documented action, `woodev_{api_id}_api_request_performed`, also carries the response, and its headers went in raw: no sanitizer at all, not even a single hardcoded name. What a carrier returns can hold what the request never did — `Set-Cookie` with a session token, `X-Auth-Token` / `X-Access-Token` on refresh.

The issue's recommended option 1: the secret-name seam is generalized to serve both directions (`get_secret_request_header_names()` → `get_secret_header_names()`), `Set-Cookie` joins the default list, and the masking loop is extracted so request and response cannot drift apart.

Measured rather than assumed:
- `handle_response()` already converts the `Requests_Utility_CaseInsensitiveDictionary` to a plain array before storing, so the response sanitizer needs no special-casing — the file did that work already.
- Every call site of the renamed seam was checked with `find_referencing_symbols` plus a repo-wide grep: only this file and its unit test. No production subclass overrides it, so the rename carries no cost.
- `null` response headers (pre-response / `WP_Error` path) pass through unchanged rather than being coerced to an array, so the broadcast payload shape for failed requests is byte-identical to before.

**Deliberately not done:** the response *body* policy is untouched. The issue reserves it for the operator — changing the raw-body fallback would change what is visible in production payment-plugin logs, which is a call for him, not for this PR.

Tests: 6 new in `ApiBaseSanitizedHeadersTest`, covering `Set-Cookie`, a refresh-token header via the default list, case-insensitive matching with original casing preserved, the subclass seam on both directions, non-secret passthrough and `null` passthrough. Mutation-checked: with masking replaced by a passthrough, exactly the 4 masking tests go red and the 2 passthrough tests stay green.

Placeholders in the tests are deliberately low-entropy — a test proving a secret does not leak has failed gitleaks in this repo before.

Local: 2137 → 2143 unit tests, 5375 → 5384 assertions, phpcs and phpstan level 3 clean.