### PR TITLE
fix(checkout): human wording in pickup validation messages, and one message instead of two

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -1103,10 +1103,15 @@ function woodev_test_shipping_method_plugin_init(): void {
 						// get_checkout_handler() runs on every request (incl. REST) via the
 						// plugin's register(), before WC lazily loads the shipping-method class, so
 						// referencing that class constant here would fatal "class not found".
+						// A `label` is set explicitly (issue #134: the fixture used to leave it
+						// unset entirely) so the rig demo shows the field's contract correctly —
+						// e.g. wherever a management UI lists field descriptors by `label`. The
+						// checkout form itself stays unaffected: `type` is `hidden`, so no `<label>`
+						// is ever rendered regardless of this value.
 						\Woodev\Framework\Shipping\Checkout\Presets\Pickup_Field::create(
 							'carrier_pickup_point',
 							[ 'woodev_test_shipping' ]
-						),
+						)->set_label( 'Пункт выдачи' ),
 
 						// 4-6. Location Provider layer fields (block PR-C rig-visibility
 						// pull-forward) — shipping-section region/settlement/address, each

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -1103,15 +1103,17 @@ function woodev_test_shipping_method_plugin_init(): void {
 						// get_checkout_handler() runs on every request (incl. REST) via the
 						// plugin's register(), before WC lazily loads the shipping-method class, so
 						// referencing that class constant here would fatal "class not found".
-						// A `label` is set explicitly (issue #134: the fixture used to leave it
-						// unset entirely) so the rig demo shows the field's contract correctly —
-						// e.g. wherever a management UI lists field descriptors by `label`. The
-						// checkout form itself stays unaffected: `type` is `hidden`, so no `<label>`
-						// is ever rendered regardless of this value.
+						// No explicit `label` here (issue #134): the field's visible control is the
+						// pickup-point button/modal, not a native input, so a checkout-form label
+						// would render as a stray, unlabelled `<p class="form-row">` (WooCommerce
+						// renders a `<label>` for any non-empty `label` even on a hidden field — see
+						// `woocommerce_form_field()`'s `case 'hidden':`). The fixture's contract is
+						// shown correctly via `Pickup_Field::create()`'s default `error_label`
+						// («Пункт выдачи»), which drives the buyer-facing checkout messages.
 						\Woodev\Framework\Shipping\Checkout\Presets\Pickup_Field::create(
 							'carrier_pickup_point',
 							[ 'woodev_test_shipping' ]
-						)->set_label( 'Пункт выдачи' ),
+						),
 
 						// 4-6. Location Provider layer fields (block PR-C rig-visibility
 						// pull-forward) — shipping-section region/settlement/address, each

--- a/tests/unit/Shipping/Checkout/CheckoutFieldsTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutFieldsTest.php
@@ -33,6 +33,26 @@ class CheckoutFieldsTest extends TestCase {
 		$this->assertFalse( $field['required'] );
 	}
 
+	// -------------------------------------------------------------------------
+	// error_label — messages-only label (#299, #134)
+	// -------------------------------------------------------------------------
+
+	public function test_normalize_error_label_defaults_to_empty_string(): void {
+		$field = Checkout_Fields::normalize( [ 'id' => 'x' ] );
+		$this->assertSame( '', $field['error_label'] );
+	}
+
+	public function test_normalize_carries_error_label_through(): void {
+		$field = Checkout_Fields::normalize( [ 'id' => 'carrier_pickup_point', 'error_label' => 'Пункт выдачи' ] );
+		$this->assertSame( 'Пункт выдачи', $field['error_label'] );
+	}
+
+	public function test_normalize_error_label_is_independent_of_label(): void {
+		$field = Checkout_Fields::normalize( [ 'id' => 'x', 'label' => '', 'error_label' => 'Пункт выдачи' ] );
+		$this->assertSame( '', $field['label'] );
+		$this->assertSame( 'Пункт выдачи', $field['error_label'] );
+	}
+
 	public function test_normalize_keeps_condition_spec_required_as_array(): void {
 		$spec = [ 'state' => 'chosen_shipping_method', 'operator' => 'in', 'value' => [ 'carrier_pickup' ] ];
 		$this->assertSame( $spec, Checkout_Fields::normalize( [ 'id' => 'pvz', 'required' => $spec ] )['required'] );

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerInjectTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerInjectTest.php
@@ -160,28 +160,30 @@ class CheckoutHandlerInjectTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// WC-array label falls back to error_label (#299, #134): WooCommerce's own
-	// required-field message reads THIS array key, so a blank visual `label`
-	// (legitimate for a hidden pickup-style field) must not leave WC's own
-	// message empty-or-id when a human error_label is available.
+	// WC-array `label` is the visual `label` verbatim, never `error_label`
+	// (#316 review finding 1): woocommerce_form_field() renders a <label> for
+	// ANY non-empty `label`, even on a `hidden` field — it only skips the
+	// `for` attribute — so handing WC our `error_label` would render a stray,
+	// orphaned caption for a field whose real control lives elsewhere (e.g. a
+	// "Choose pickup point" button).
 	// -------------------------------------------------------------------------
 
-	public function test_inject_wc_label_falls_back_to_error_label_when_label_blank(): void {
+	public function test_inject_wc_label_never_falls_back_to_error_label(): void {
 		$fields = Checkout_Fields::from_array( [
 			Field::create( 'carrier_pickup_point' )->set_type( 'hidden' )->set_error_label( 'Пункт выдачи' )->set_section( 'order' )->to_array(),
 		] );
 		$out = ( new Checkout_Handler( $fields, 'carrier' ) )->inject( [ 'order' => [] ] );
 
-		$this->assertSame( 'Пункт выдачи', $out['order']['carrier_pickup_point']['label'] );
+		$this->assertSame( '', $out['order']['carrier_pickup_point']['label'] );
 	}
 
-	public function test_inject_wc_label_keeps_explicit_label_over_error_label(): void {
+	public function test_inject_wc_label_uses_the_explicit_label_verbatim(): void {
 		$fields = Checkout_Fields::from_array( [
 			Field::create( 'carrier_pvz' )->set_type( 'text' )->set_label( 'ПВЗ' )->set_error_label( 'Пункт выдачи' )->set_section( 'order' )->to_array(),
 		] );
 		$out = ( new Checkout_Handler( $fields, 'carrier' ) )->inject( [ 'order' => [] ] );
 
-		$this->assertSame( 'ПВЗ', $out['order']['carrier_pvz']['label'], 'An explicitly-set visual label must win over error_label.' );
+		$this->assertSame( 'ПВЗ', $out['order']['carrier_pvz']['label'], 'error_label must never influence the WC-facing label when a visual label is set.' );
 	}
 
 	public function test_inject_wc_label_stays_empty_when_neither_label_nor_error_label_set(): void {
@@ -190,8 +192,6 @@ class CheckoutHandlerInjectTest extends TestCase {
 		] );
 		$out = ( new Checkout_Handler( $fields, 'carrier' ) )->inject( [ 'order' => [] ] );
 
-		// Never falls to the raw id here — an empty WC label is safer than leaking the
-		// id into a rendered <label> or a WC-authored notice (see inject() docblock).
 		$this->assertSame( '', $out['order']['carrier_pvz']['label'] );
 	}
 

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerInjectTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerInjectTest.php
@@ -159,6 +159,42 @@ class CheckoutHandlerInjectTest extends TestCase {
 		$this->assertTrue( $out['order']['carrier_pvz']['required'] );
 	}
 
+	// -------------------------------------------------------------------------
+	// WC-array label falls back to error_label (#299, #134): WooCommerce's own
+	// required-field message reads THIS array key, so a blank visual `label`
+	// (legitimate for a hidden pickup-style field) must not leave WC's own
+	// message empty-or-id when a human error_label is available.
+	// -------------------------------------------------------------------------
+
+	public function test_inject_wc_label_falls_back_to_error_label_when_label_blank(): void {
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pickup_point' )->set_type( 'hidden' )->set_error_label( 'Пункт выдачи' )->set_section( 'order' )->to_array(),
+		] );
+		$out = ( new Checkout_Handler( $fields, 'carrier' ) )->inject( [ 'order' => [] ] );
+
+		$this->assertSame( 'Пункт выдачи', $out['order']['carrier_pickup_point']['label'] );
+	}
+
+	public function test_inject_wc_label_keeps_explicit_label_over_error_label(): void {
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pvz' )->set_type( 'text' )->set_label( 'ПВЗ' )->set_error_label( 'Пункт выдачи' )->set_section( 'order' )->to_array(),
+		] );
+		$out = ( new Checkout_Handler( $fields, 'carrier' ) )->inject( [ 'order' => [] ] );
+
+		$this->assertSame( 'ПВЗ', $out['order']['carrier_pvz']['label'], 'An explicitly-set visual label must win over error_label.' );
+	}
+
+	public function test_inject_wc_label_stays_empty_when_neither_label_nor_error_label_set(): void {
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pvz' )->set_type( 'hidden' )->set_section( 'order' )->to_array(),
+		] );
+		$out = ( new Checkout_Handler( $fields, 'carrier' ) )->inject( [ 'order' => [] ] );
+
+		// Never falls to the raw id here — an empty WC label is safer than leaking the
+		// id into a rendered <label> or a WC-authored notice (see inject() docblock).
+		$this->assertSame( '', $out['order']['carrier_pvz']['label'] );
+	}
+
 	/**
 	 * A condition-spec `required` (array) must NOT become WC's static `required => true`
 	 * — otherwise WooCommerce's own validation blocks a blank conditional field regardless

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
@@ -239,6 +239,113 @@ class CheckoutHandlerValidateTest extends TestCase {
 	}
 
 	// -----------------------------------------------------------------------
+	// Part C — measured duplication fix + error_label fallback (#299, #134)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Measured duplication: when a `Pickup_Field` preset's condition-spec matches
+	 * EXACTLY the same method id list passed to `set_requires_pickup_methods()`
+	 * (the mainline, non-degenerate usage), both the per-field conditional-required
+	 * loop AND the independent backstop previously fired for the identical blank
+	 * field on the identical submit — two `wc_add_notice()` calls, one condition.
+	 * The per-field loop runs first, so the ONE surviving notice must be the
+	 * `required_message()` text (using the preset's default `error_label`), and the
+	 * backstop's own "Для доставки..." text must NOT appear a second time.
+	 */
+	public function test_exact_match_dedupes_required_and_backstop_into_one_notice(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Заполните поле «Пункт выдачи».', 'error' );
+
+		$fields  = Checkout_Fields::from_array( [
+			\Woodev\Framework\Shipping\Checkout\Presets\Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )->to_array(),
+		] );
+		$handler = new Checkout_Handler( $fields, 'carrier' );
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+
+		$this->assertFalse(
+			$handler->validate( [ 'carrier_pickup_point' => '' ], [ 'chosen_shipping_method' => 'carrier_pickup' ] )
+		);
+	}
+
+	/**
+	 * The backstop must still fire ALONE — and checkout must still block — when the
+	 * per-field loop does NOT catch the same field: `Checkout_Condition`'s `in`
+	 * operator does a strict string match against `chosen_shipping_method` and does
+	 * not tolerate WooCommerce's `method_id:instance_id` shape for a multi-instance
+	 * method, unlike `chosen_method_matches()` (which the backstop uses). This is a
+	 * genuinely reachable divergence, not a hypothetical — proves the dedup guard
+	 * above does not cost this failure mode.
+	 */
+	public function test_backstop_fires_alone_when_condition_spec_diverges_on_instance_suffix(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Для доставки в пункт выдачи выберите значение поля «Пункт выдачи».', 'error' );
+
+		$fields  = Checkout_Fields::from_array( [
+			\Woodev\Framework\Shipping\Checkout\Presets\Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )->to_array(),
+		] );
+		$handler = new Checkout_Handler( $fields, 'carrier' );
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+
+		$this->assertFalse(
+			$handler->validate( [ 'carrier_pickup_point' => '' ], [ 'chosen_shipping_method' => 'carrier_pickup:3' ] )
+		);
+	}
+
+	/**
+	 * required_message() must prefer `error_label` over `label` over `id` (#299,
+	 * #134): a field with an empty `label` no longer leaks its raw id into the
+	 * buyer-facing message when an `error_label` is set.
+	 */
+	public function test_required_message_prefers_error_label_over_label_and_id(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Заполните поле «Пункт выдачи».', 'error' );
+
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pickup_point' )->set_required( true )->set_error_label( 'Пункт выдачи' )->to_array(),
+		] );
+
+		$this->assertFalse( ( new Checkout_Handler( $fields, 'carrier' ) )->validate( [ 'carrier_pickup_point' => '' ], [] ) );
+	}
+
+	/**
+	 * Without an `error_label`, required_message() still falls back to the raw id
+	 * (regression guard — pre-existing safety net for a field nobody labelled at all).
+	 */
+	public function test_required_message_falls_back_to_id_without_error_label_or_label(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Заполните поле «carrier_pickup_point».', 'error' );
+
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pickup_point' )->set_required( true )->to_array(),
+		] );
+
+		$this->assertFalse( ( new Checkout_Handler( $fields, 'carrier' ) )->validate( [ 'carrier_pickup_point' => '' ], [] ) );
+	}
+
+	/**
+	 * invalid_message() must also prefer `error_label` over `label` over `id`,
+	 * matching required_message()'s fallback order.
+	 */
+	public function test_invalid_message_prefers_error_label(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Поле «Пункт выдачи» заполнено некорректно.', 'error' );
+
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pickup_point' )
+				->set_error_label( 'Пункт выдачи' )
+				->set_validate_callback( static fn() => false )
+				->to_array(),
+		] );
+
+		$this->assertFalse( ( new Checkout_Handler( $fields, 'carrier' ) )->validate( [ 'carrier_pickup_point' => 'x' ], [] ) );
+	}
+
+	// -----------------------------------------------------------------------
 	// Part D — entry-point parity for the chosen shipping method
 	// -----------------------------------------------------------------------
 

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
@@ -255,7 +255,7 @@ class CheckoutHandlerValidateTest extends TestCase {
 	public function test_exact_match_dedupes_required_and_backstop_into_one_notice(): void {
 		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
 			->once()
-			->with( 'Заполните поле «Пункт выдачи».', 'error' );
+			->with( 'Укажите значение поля «Пункт выдачи».', 'error' );
 
 		$fields  = Checkout_Fields::from_array( [
 			\Woodev\Framework\Shipping\Checkout\Presets\Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )->to_array(),
@@ -270,26 +270,39 @@ class CheckoutHandlerValidateTest extends TestCase {
 
 	/**
 	 * The backstop must still fire ALONE — and checkout must still block — when the
-	 * per-field loop does NOT catch the same field: `Checkout_Condition`'s `in`
-	 * operator does a strict string match against `chosen_shipping_method` and does
-	 * not tolerate WooCommerce's `method_id:instance_id` shape for a multi-instance
-	 * method, unlike `chosen_method_matches()` (which the backstop uses). This is a
-	 * genuinely reachable divergence, not a hypothetical — proves the dedup guard
-	 * above does not cost this failure mode.
+	 * per-field loop does NOT catch the same field because the descriptor's own
+	 * condition-spec method-id list diverges from the list passed to
+	 * `set_requires_pickup_methods()`. `Checkout_Condition`'s `in` operator does a
+	 * strict string match against `chosen_shipping_method`, so a method id present in
+	 * `requires_pickup_methods` but absent from the condition-spec's `value` list
+	 * never trips the per-field loop's `required` gate.
+	 *
+	 * This IS genuinely reachable: both lists are supplied independently by the host
+	 * plugin (`Pickup_Field::create()`'s second argument vs. `set_requires_pickup_methods()`)
+	 * and nothing enforces they stay in sync. By contrast, a `method_id:instance_id`
+	 * suffix divergence is NOT reachable here — every real entry point normalizes the
+	 * posted method id to its bare form before calling `validate()` (see
+	 * `chosen_shipping_method()` and `process()`, both via `normalize_method_id()`), so
+	 * that shape only ever reaches `validate()` when a test calls it directly.
 	 */
-	public function test_backstop_fires_alone_when_condition_spec_diverges_on_instance_suffix(): void {
+	public function test_backstop_fires_alone_when_requires_pickup_methods_diverges_from_condition_spec(): void {
 		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
 			->once()
 			->with( 'Для доставки в пункт выдачи выберите значение поля «Пункт выдачи».', 'error' );
 
 		$fields  = Checkout_Fields::from_array( [
+			// Condition-spec only lists 'carrier_pickup' — the per-field loop's strict
+			// `in` comparison will not match 'carrier_pickup_express'.
 			\Woodev\Framework\Shipping\Checkout\Presets\Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )->to_array(),
 		] );
 		$handler = new Checkout_Handler( $fields, 'carrier' );
-		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+		// set_requires_pickup_methods() lists a broader set than the condition-spec —
+		// a mismatch a host plugin can genuinely introduce by not keeping both lists
+		// in sync.
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup', 'carrier_pickup_express' ] );
 
 		$this->assertFalse(
-			$handler->validate( [ 'carrier_pickup_point' => '' ], [ 'chosen_shipping_method' => 'carrier_pickup:3' ] )
+			$handler->validate( [ 'carrier_pickup_point' => '' ], [ 'chosen_shipping_method' => 'carrier_pickup_express' ] )
 		);
 	}
 
@@ -301,7 +314,7 @@ class CheckoutHandlerValidateTest extends TestCase {
 	public function test_required_message_prefers_error_label_over_label_and_id(): void {
 		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
 			->once()
-			->with( 'Заполните поле «Пункт выдачи».', 'error' );
+			->with( 'Укажите значение поля «Пункт выдачи».', 'error' );
 
 		$fields = Checkout_Fields::from_array( [
 			Field::create( 'carrier_pickup_point' )->set_required( true )->set_error_label( 'Пункт выдачи' )->to_array(),
@@ -317,7 +330,7 @@ class CheckoutHandlerValidateTest extends TestCase {
 	public function test_required_message_falls_back_to_id_without_error_label_or_label(): void {
 		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
 			->once()
-			->with( 'Заполните поле «carrier_pickup_point».', 'error' );
+			->with( 'Укажите значение поля «carrier_pickup_point».', 'error' );
 
 		$fields = Checkout_Fields::from_array( [
 			Field::create( 'carrier_pickup_point' )->set_required( true )->to_array(),

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
@@ -253,9 +253,18 @@ class CheckoutHandlerValidateTest extends TestCase {
 	 * backstop's own "Для доставки..." text must NOT appear a second time.
 	 */
 	public function test_exact_match_dedupes_required_and_backstop_into_one_notice(): void {
-		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
-			->once()
-			->with( 'Укажите значение поля «Пункт выдачи».', 'error' );
+		// A plain `->once()->with()` expectation only asserts that ONE call matched
+		// those exact arguments — it does NOT reject an ADDITIONAL call with different
+		// arguments (e.g. the backstop's own notice firing on top of the per-field
+		// loop's). Capture every call instead so the dedup guard is actually exercised:
+		// mutating away the `blank_required_ids` skip must redden this test with a
+		// second, different notice.
+		$captured = [];
+		\Brain\Monkey\Functions\when( 'wc_add_notice' )->alias(
+			static function ( $message, $type ) use ( &$captured ) {
+				$captured[] = [ $message, $type ];
+			}
+		);
 
 		$fields  = Checkout_Fields::from_array( [
 			\Woodev\Framework\Shipping\Checkout\Presets\Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )->to_array(),
@@ -265,6 +274,12 @@ class CheckoutHandlerValidateTest extends TestCase {
 
 		$this->assertFalse(
 			$handler->validate( [ 'carrier_pickup_point' => '' ], [ 'chosen_shipping_method' => 'carrier_pickup' ] )
+		);
+
+		$this->assertSame(
+			[ [ 'Укажите значение поля «Пункт выдачи».', 'error' ] ],
+			$captured,
+			'exactly one notice — the backstop must not repeat the per-field loop\'s notice'
 		);
 	}
 
@@ -286,9 +301,15 @@ class CheckoutHandlerValidateTest extends TestCase {
 	 * that shape only ever reaches `validate()` when a test calls it directly.
 	 */
 	public function test_backstop_fires_alone_when_requires_pickup_methods_diverges_from_condition_spec(): void {
-		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
-			->once()
-			->with( 'Для доставки в пункт выдачи выберите значение поля «Пункт выдачи».', 'error' );
+		// Same weakness as the dedup test above: `->once()->with()` cannot detect an
+		// EXTRA call with different arguments, so "fires ALONE" needs every call
+		// captured and the full list asserted, not just one matching call confirmed.
+		$captured = [];
+		\Brain\Monkey\Functions\when( 'wc_add_notice' )->alias(
+			static function ( $message, $type ) use ( &$captured ) {
+				$captured[] = [ $message, $type ];
+			}
+		);
 
 		$fields  = Checkout_Fields::from_array( [
 			// Condition-spec only lists 'carrier_pickup' — the per-field loop's strict
@@ -303,6 +324,12 @@ class CheckoutHandlerValidateTest extends TestCase {
 
 		$this->assertFalse(
 			$handler->validate( [ 'carrier_pickup_point' => '' ], [ 'chosen_shipping_method' => 'carrier_pickup_express' ] )
+		);
+
+		$this->assertSame(
+			[ [ 'Для доставки в пункт выдачи выберите значение поля «Пункт выдачи».', 'error' ] ],
+			$captured,
+			'the backstop must fire ALONE — no additional notice from the per-field loop'
 		);
 	}
 

--- a/tests/unit/Shipping/Checkout/FieldTest.php
+++ b/tests/unit/Shipping/Checkout/FieldTest.php
@@ -75,4 +75,21 @@ class FieldTest extends TestCase {
 		$array = Field::create( 'billing_city' )->source_location( 'settlement' )->to_array();
 		$this->assertArrayNotHasKey( 'source', $array );
 	}
+
+	// -------------------------------------------------------------------------
+	// set_error_label() — messages-only label (#299, #134)
+	// -------------------------------------------------------------------------
+
+	public function test_set_error_label_is_recorded_independently_of_label(): void {
+		$array = Field::create( 'carrier_pickup_point' )
+			->set_error_label( 'Пункт выдачи' )
+			->to_array();
+		$this->assertSame( 'Пункт выдачи', $array['error_label'] );
+		$this->assertArrayNotHasKey( 'label', $array, 'set_error_label() must not touch the visual label key.' );
+	}
+
+	public function test_set_error_label_returns_self_for_chaining(): void {
+		$field = Field::create( 'x' );
+		$this->assertSame( $field, $field->set_error_label( 'y' ) );
+	}
 }

--- a/tests/unit/Shipping/Checkout/PresetsTest.php
+++ b/tests/unit/Shipping/Checkout/PresetsTest.php
@@ -65,4 +65,26 @@ class PresetsTest extends TestCase {
 		$field = Pickup_Field::create( 'carrier_pvz', [ 'carrier_pickup' ] );
 		$this->assertInstanceOf( \Woodev\Framework\Shipping\Checkout\Field::class, $field );
 	}
+
+	// -------------------------------------------------------------------------
+	// error_label default — #299/#134: a hidden pickup field legitimately has
+	// no visual label, so the preset seeds a sensible messages-only default.
+	// -------------------------------------------------------------------------
+
+	public function test_pickup_field_sets_a_default_error_label(): void {
+		$a = Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )->to_array();
+		$this->assertSame( 'Пункт выдачи', $a['error_label'] );
+	}
+
+	public function test_pickup_field_leaves_the_visual_label_unset(): void {
+		$a = Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )->to_array();
+		$this->assertArrayNotHasKey( 'label', $a );
+	}
+
+	public function test_pickup_field_default_error_label_is_overridable(): void {
+		$a = Pickup_Field::create( 'carrier_pickup_point', [ 'carrier_pickup' ] )
+			->set_error_label( 'Пункт самовывоза' )
+			->to_array();
+		$this->assertSame( 'Пункт самовывоза', $a['error_label'] );
+	}
 }

--- a/woodev/shipping-method/checkout/class-checkout-fields.php
+++ b/woodev/shipping-method/checkout/class-checkout-fields.php
@@ -241,11 +241,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 		 *
 		 * @since 1.5.0
 		 * @since 2.0.2 Added `section`, `depends_on`, `source`, `source_kind`,
-		 *              `takeover_condition`; `required` array preserved verbatim;
-		 *              `is_pickup_slot` bool (default false).
-		 * @since 2.0.2 Added `location_level` (location-provider layer Task 9).
-		 * @since 2.0.2 Added `error_label` (default `''`) — a messages-only label
-		 *              independent of `label` (#299, #134).
+		 *              `takeover_condition`, `location_level`, `error_label`;
+		 *              `required` array preserved verbatim; `is_pickup_slot` bool
+		 *              (default false).
 		 *
 		 * @param array<string, mixed> $definition raw field definition
 		 *

--- a/woodev/shipping-method/checkout/class-checkout-fields.php
+++ b/woodev/shipping-method/checkout/class-checkout-fields.php
@@ -38,7 +38,14 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 	 * Core schema keys (all present after {@see normalize()}):
 	 *  - `id`                 — field identifier supplied by the host plugin.
 	 *  - `type`               — input type, e.g. `'text'`, `'hidden'`.
-	 *  - `label`              — human-readable label.
+	 *  - `label`              — human-readable label shown in the checkout form.
+	 *  - `error_label`        — human-readable label used in generated error messages ONLY,
+	 *                           independent of `label`. Falls back to `label`, then to `id`,
+	 *                           when empty — see {@see \Woodev\Framework\Shipping\Checkout\
+	 *                           Checkout_Handler::message_label()}. Exists because a field's
+	 *                           visible control is sometimes not its own native input (e.g. a
+	 *                           hidden pickup-point field driven by a button), so `label` is
+	 *                           legitimately blank while messages still need a human name (#299, #134).
 	 *  - `section`            — checkout section: `'order'` (default), `'billing'`, `'shipping'`.
 	 *  - `required`           — `bool` (coerced) OR an array condition-spec when the host plugin
 	 *                           passes a structured condition array; preserved verbatim so the
@@ -237,6 +244,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 		 *              `takeover_condition`; `required` array preserved verbatim;
 		 *              `is_pickup_slot` bool (default false).
 		 * @since 2.0.2 Added `location_level` (location-provider layer Task 9).
+		 * @since 2.0.2 Added `error_label` (default `''`) — a messages-only label
+		 *              independent of `label` (#299, #134).
 		 *
 		 * @param array<string, mixed> $definition raw field definition
 		 *
@@ -244,6 +253,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 		 *     id: string,
 		 *     type: string,
 		 *     label: string,
+		 *     error_label: string,
 		 *     section: string,
 		 *     required: bool|array<string, mixed>,
 		 *     depends_on: string|null,
@@ -267,6 +277,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 				'id'                 => (string) ( $definition['id'] ?? '' ),
 				'type'               => (string) ( $definition['type'] ?? 'text' ),
 				'label'              => (string) ( $definition['label'] ?? '' ),
+				'error_label'        => (string) ( $definition['error_label'] ?? '' ),
 				'section'            => (string) ( $definition['section'] ?? 'order' ),
 				'required'           => is_array( $required ) ? $required : (bool) $required,
 				'depends_on'         => isset( $definition['depends_on'] ) && '' !== (string) $definition['depends_on']

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -1133,11 +1133,13 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 * a `Pickup_Field` preset's condition-spec and `set_requires_pickup_methods()` are normally
 		 * driven by the same method-id list, so both mechanisms catch the same blank field on the
 		 * same submit). It still fires alone whenever the per-field loop did NOT catch the field —
-		 * e.g. a condition-spec `in` comparison is a strict string match against `chosen_shipping_method`
-		 * and does not tolerate the `method_id:instance_id` shape WooCommerce sends for a multi-instance
-		 * method (unlike {@see chosen_method_matches()}, which the backstop itself uses), or the
-		 * descriptor's `required` spec is missing/malformed — that divergence is the backstop's actual
-		 * reason to exist, so this guard never suppresses it as a class, only the field-id-exact repeat.
+		 * e.g. `set_requires_pickup_methods()`'s id list and the descriptor's own condition-spec
+		 * `value` list are two independently host-supplied lists that nothing keeps in sync: a
+		 * method id can be present in `requires_pickup_methods` while absent from the condition-spec,
+		 * so the per-field loop's strict `in` comparison never trips that field's `required` gate even
+		 * though this backstop's own {@see chosen_method_matches()} check matches — that divergence is
+		 * the backstop's actual reason to exist, so this guard never suppresses it as a class, only the
+		 * field-id-exact repeat.
 		 *
 		 * This guard only dedupes OUR OWN two notices (the per-field loop and the backstop). A field
 		 * declared with a plain-bool `required` (no condition-spec, no pickup backstop involved) still

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -890,6 +890,15 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 * The fully-merged result is passed through the forward `..._checkout_fields`
 		 * filter so the host plugin can refine field args further.
 		 *
+		 * When the descriptor's visual `label` is empty (legitimate for a field whose
+		 * control isn't its own native input, e.g. a hidden pickup-point field), the WC
+		 * array's `label` falls back to the descriptor's `error_label` when set — WC's OWN
+		 * required-field validation substitutes this same array key into its message, so
+		 * this is what keeps THAT message human too, not just ours (#299, #134). Never
+		 * falls further to the raw field `id`: unlike our own generated messages, an empty
+		 * WC label is a safer default than leaking the id into a rendered `<label>` or a
+		 * WC-authored notice.
+		 *
 		 * @since 1.5.0
 		 * @since 2.0.2 Fields are grouped by their own `section`; existing WC args
 		 *              are preserved (conservative merge); options-kind root fields
@@ -930,9 +939,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 				// - an explicit bool `true` → WC `required`;
 				// - a default/`false` required → leave WC's own required flag UNTOUCHED (e.g.
 				// turning `billing_city` into a select must not un-require it).
+				$label         = (string) $field['label'];
 				$our_overrides = [
 					'type'  => (string) $field['type'],
-					'label' => (string) $field['label'],
+					'label' => '' !== $label ? $label : (string) ( $field['error_label'] ?? '' ),
 				];
 
 				if ( is_array( $field['required'] ) ) {
@@ -1128,9 +1138,22 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 * the declared pickup methods AND the `is_pickup_slot` field value is blank, checkout is
 		 * blocked regardless of that field's condition-spec.
 		 *
+		 * The backstop skips its OWN notice when the per-field loop already added a
+		 * required-field error for that exact pickup field id (measured duplication, #299/#134:
+		 * a `Pickup_Field` preset's condition-spec and `set_requires_pickup_methods()` are normally
+		 * driven by the same method-id list, so both mechanisms catch the same blank field on the
+		 * same submit). It still fires alone whenever the per-field loop did NOT catch the field —
+		 * e.g. a condition-spec `in` comparison is a strict string match against `chosen_shipping_method`
+		 * and does not tolerate the `method_id:instance_id` shape WooCommerce sends for a multi-instance
+		 * method (unlike {@see chosen_method_matches()}, which the backstop itself uses), or the
+		 * descriptor's `required` spec is missing/malformed — that divergence is the backstop's actual
+		 * reason to exist, so this guard never suppresses it as a class, only the field-id-exact repeat.
+		 *
 		 * @since 1.5.0
 		 * @since 2.0.2 Added `$state` parameter for conditional-required (A2) evaluation.
 		 * @since 2.0.2 Added independent pickup backstop guard.
+		 * @since 2.0.2 Backstop notice suppressed when the per-field loop already reported the
+		 *              same field id blank-and-required (#299, #134).
 		 *
 		 * @param array<string, mixed> $values clean values keyed by field id
 		 * @param array<string, mixed> $state  flat checkout-state map, e.g.
@@ -1139,7 +1162,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 * @return bool true when every field is valid; false when any field blocks checkout
 		 */
 		public function validate( array $values, array $state = [] ): bool {
-			$valid = true;
+			$valid              = true;
+			$blank_required_ids = [];
 
 			foreach ( $this->fields->get_fields() as $id => $field ) {
 				$value    = $values[ $id ] ?? '';
@@ -1147,7 +1171,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 
 				if ( $required && self::is_blank( $value ) ) {
 					$this->add_error( self::required_message( $field ) );
-					$valid = false;
+					$blank_required_ids[ $id ] = true;
+					$valid                     = false;
 					continue;
 				}
 
@@ -1184,14 +1209,19 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 						$pickup_value = $values[ $pickup_field['id'] ] ?? '';
 
 						if ( self::is_blank( $pickup_value ) ) {
-							$this->add_error(
-								sprintf(
-									/* translators: %s: pickup field label */
-									__( 'Для доставки в пункт выдачи выберите значение поля «%s».', 'woodev-plugin-framework' ),
-									'' !== (string) $pickup_field['label'] ? (string) $pickup_field['label'] : (string) $pickup_field['id']
-								)
-							);
 							$valid = false;
+
+							// Already reported by the per-field loop above — do not repeat the same
+							// failure as a second notice (measured duplication, see method docblock).
+							if ( ! isset( $blank_required_ids[ $pickup_field['id'] ] ) ) {
+								$this->add_error(
+									sprintf(
+										/* translators: %s: pickup field label */
+										__( 'Для доставки в пункт выдачи выберите значение поля «%s».', 'woodev-plugin-framework' ),
+										self::message_label( $pickup_field )
+									)
+								);
+							}
 						}
 					}
 				}
@@ -1377,35 +1407,61 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		}
 
 		/**
+		 * Resolves the label to use in a generated checkout error message for a descriptor.
+		 *
+		 * Falls back from the dedicated `error_label` — a messages-only label independent
+		 * of the visual `label`, see {@see Field::set_error_label()} — to the visual
+		 * `label`, and only as a last resort to the raw field `id`. A field whose visible
+		 * control is not its own native input (e.g. a hidden pickup-point field driven by
+		 * a "Choose pickup point" button) legitimately has an empty visual `label`; falling
+		 * straight to `id` there is what showed the buyer a raw field key (#299, #134).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<string, mixed> $field normalized field descriptor
+		 *
+		 * @return string
+		 */
+		private static function message_label( array $field ): string {
+			$error_label = (string) ( $field['error_label'] ?? '' );
+
+			if ( '' !== $error_label ) {
+				return $error_label;
+			}
+
+			$label = (string) ( $field['label'] ?? '' );
+
+			return '' !== $label ? $label : (string) $field['id'];
+		}
+
+		/**
 		 * Builds the default "required field" error message for a descriptor.
 		 *
 		 * @since 1.5.0
+		 * @since 2.0.2 Label resolution delegated to {@see message_label()} (adds `error_label`).
 		 *
 		 * @param array<string, mixed> $field normalized field descriptor
 		 *
 		 * @return string
 		 */
 		private static function required_message( array $field ): string {
-			$label = '' !== (string) $field['label'] ? (string) $field['label'] : (string) $field['id'];
-
 			/* translators: %s: checkout field label */
-			return sprintf( __( 'Заполните поле «%s».', 'woodev-plugin-framework' ), $label );
+			return sprintf( __( 'Заполните поле «%s».', 'woodev-plugin-framework' ), self::message_label( $field ) );
 		}
 
 		/**
 		 * Builds the default "invalid value" error message for a descriptor.
 		 *
 		 * @since 1.5.0
+		 * @since 2.0.2 Label resolution delegated to {@see message_label()} (adds `error_label`).
 		 *
 		 * @param array<string, mixed> $field normalized field descriptor
 		 *
 		 * @return string
 		 */
 		private static function invalid_message( array $field ): string {
-			$label = '' !== (string) $field['label'] ? (string) $field['label'] : (string) $field['id'];
-
 			/* translators: %s: checkout field label */
-			return sprintf( __( 'Поле «%s» заполнено некорректно.', 'woodev-plugin-framework' ), $label );
+			return sprintf( __( 'Поле «%s» заполнено некорректно.', 'woodev-plugin-framework' ), self::message_label( $field ) );
 		}
 
 		/**

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -890,15 +890,6 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 * The fully-merged result is passed through the forward `..._checkout_fields`
 		 * filter so the host plugin can refine field args further.
 		 *
-		 * When the descriptor's visual `label` is empty (legitimate for a field whose
-		 * control isn't its own native input, e.g. a hidden pickup-point field), the WC
-		 * array's `label` falls back to the descriptor's `error_label` when set — WC's OWN
-		 * required-field validation substitutes this same array key into its message, so
-		 * this is what keeps THAT message human too, not just ours (#299, #134). Never
-		 * falls further to the raw field `id`: unlike our own generated messages, an empty
-		 * WC label is a safer default than leaking the id into a rendered `<label>` or a
-		 * WC-authored notice.
-		 *
 		 * @since 1.5.0
 		 * @since 2.0.2 Fields are grouped by their own `section`; existing WC args
 		 *              are preserved (conservative merge); options-kind root fields
@@ -939,10 +930,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 				// - an explicit bool `true` → WC `required`;
 				// - a default/`false` required → leave WC's own required flag UNTOUCHED (e.g.
 				// turning `billing_city` into a select must not un-require it).
-				$label         = (string) $field['label'];
 				$our_overrides = [
 					'type'  => (string) $field['type'],
-					'label' => '' !== $label ? $label : (string) ( $field['error_label'] ?? '' ),
+					'label' => (string) $field['label'],
 				];
 
 				if ( is_array( $field['required'] ) ) {
@@ -1148,6 +1138,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 * method (unlike {@see chosen_method_matches()}, which the backstop itself uses), or the
 		 * descriptor's `required` spec is missing/malformed — that divergence is the backstop's actual
 		 * reason to exist, so this guard never suppresses it as a class, only the field-id-exact repeat.
+		 *
+		 * This guard only dedupes OUR OWN two notices (the per-field loop and the backstop). A field
+		 * declared with a plain-bool `required` (no condition-spec, no pickup backstop involved) still
+		 * gets both WC's own native "is a required field" notice — via {@see inject()}'s WC `required`
+		 * flag — AND this method's own {@see required_message()} notice; that duplication class is not
+		 * addressed here.
 		 *
 		 * @since 1.5.0
 		 * @since 2.0.2 Added `$state` parameter for conditional-required (A2) evaluation.
@@ -1437,8 +1433,16 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		/**
 		 * Builds the default "required field" error message for a descriptor.
 		 *
+		 * Uses "Укажите" ("specify"/"provide") rather than "Заполните" ("fill in"): the
+		 * latter only reads naturally for a typed input, but this same template also
+		 * covers a hidden pickup-point field whose control is a "Choose pickup point"
+		 * button, so the wording needs to fit both without a second, field-type-specific
+		 * message (#299).
+		 *
 		 * @since 1.5.0
 		 * @since 2.0.2 Label resolution delegated to {@see message_label()} (adds `error_label`).
+		 * @since 2.0.2 Wording changed from "Заполните" to "Укажите" so the shared template
+		 *              also fits button-driven fields, not just typed inputs (#299).
 		 *
 		 * @param array<string, mixed> $field normalized field descriptor
 		 *
@@ -1446,7 +1450,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 */
 		private static function required_message( array $field ): string {
 			/* translators: %s: checkout field label */
-			return sprintf( __( 'Заполните поле «%s».', 'woodev-plugin-framework' ), self::message_label( $field ) );
+			return sprintf( __( 'Укажите значение поля «%s».', 'woodev-plugin-framework' ), self::message_label( $field ) );
 		}
 
 		/**

--- a/woodev/shipping-method/checkout/class-field.php
+++ b/woodev/shipping-method/checkout/class-field.php
@@ -107,6 +107,29 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Field' ) ) :
 		}
 
 		/**
+		 * Sets a dedicated label for generated error messages, independent of
+		 * {@see set_label()}'s visual label.
+		 *
+		 * Use this when the field's visible control is not its own native input
+		 * (e.g. a hidden pickup-point field driven by a "Choose pickup point"
+		 * button): {@see set_label()} is then legitimately left blank, but error
+		 * messages still need a human name instead of falling back to the raw
+		 * field `id` (#299, #134). See
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::message_label()}
+		 * for the full fallback order (`error_label` → `label` → `id`).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $label messages-only label.
+		 *
+		 * @return self
+		 */
+		public function set_error_label( string $label ): self {
+			$this->def['error_label'] = $label;
+			return $this;
+		}
+
+		/**
 		 * Sets the checkout section this field belongs to.
 		 *
 		 * Accepted values: `'order'` (default after normalization), `'billing'`,

--- a/woodev/shipping-method/checkout/presets/class-pickup-field.php
+++ b/woodev/shipping-method/checkout/presets/class-pickup-field.php
@@ -51,7 +51,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Presets\\Pickup_F
 		/**
 		 * Creates a Field builder pre-configured as a hidden pickup-point field.
 		 *
+		 * The field's visual `label` is intentionally left unset — its visible
+		 * control is the pickup-point button/modal, not a native input, so a
+		 * checkout-form label would be redundant. A sensible default
+		 * `error_label` («Пункт выдачи») is set instead, so the framework's own
+		 * required-field messages and WooCommerce's own native message (which
+		 * reads the same array key we hand it) both stay human even though
+		 * `label` is blank (#299, #134). Call {@see Field::set_error_label()}
+		 * again on the returned builder to override the default text.
+		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Set a default `error_label` («Пункт выдачи») (#299, #134).
 		 *
 		 * @param string   $id                Field identifier supplied by the host plugin.
 		 * @param string[] $pickup_method_ids Shipping method ids that indicate a pickup delivery
@@ -69,6 +79,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Presets\\Pickup_F
 			return Field::create( $id )
 				->set_type( 'hidden' )
 				->set_required( $required_spec )
+				->set_error_label( __( 'Пункт выдачи', 'woodev-plugin-framework' ) )
 				->mark_pickup_slot();
 		}
 	}

--- a/woodev/shipping-method/checkout/presets/class-pickup-field.php
+++ b/woodev/shipping-method/checkout/presets/class-pickup-field.php
@@ -55,12 +55,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Presets\\Pickup_F
 		 * control is the pickup-point button/modal, not a native input, so a
 		 * checkout-form label would be redundant. A sensible default
 		 * `error_label` («Пункт выдачи») is set instead, so the framework's own
-		 * required-field messages and WooCommerce's own native message (which
-		 * reads the same array key we hand it) both stay human even though
-		 * `label` is blank (#299, #134). Call {@see Field::set_error_label()}
-		 * again on the returned builder to override the default text.
+		 * required-field messages stay human even though `label` is blank
+		 * (#299, #134). Call {@see Field::set_error_label()} again on the
+		 * returned builder to override the default text.
 		 *
-		 * @since 2.0.2
 		 * @since 2.0.2 Set a default `error_label` («Пункт выдачи») (#299, #134).
 		 *
 		 * @param string   $id                Field identifier supplied by the host plugin.


### PR DESCRIPTION
Closes #299. Closes #134 — the same defect, filed twice (s44 and s71); the two cards are folded together here.

Submitting checkout with no pickup point chosen showed the buyer the internal field id, twice:

```
Заполните поле «carrier_pickup_point».
Для доставки в пункт выдачи выберите значение поля «carrier_pickup_point».
```

**The cards' mechanism was wrong on one point, and the correction matters.** #299 blamed the second message on WooCommerce's own required-field validation. It is not: `inject()` forces WC's `required` flag to a static `false` whenever the descriptor's `required` is a condition-spec array — which `Presets\Pickup_Field::create()` always uses. WC's validation never fires for this field. **Both** messages are ours: the per-field loop in `validate()` and the independent pickup backstop, and in the mainline setup both are driven by the same method-id list, so both catch the same blank field on the same submit.

What changed:
- `error_label` — a messages-only label independent of the visual one, since a blank visual label is the *correct* state for a field whose visible control is a button. Fallback cascade for OUR OWN messages is `error_label → label → id`, used by `required_message()`, `invalid_message()` and the backstop alike. `Pickup_Field::create()` defaults it to «Пункт выдачи», overridable.
- `inject()` hands WC the field's visual `label` **verbatim, never `error_label`**. An earlier version of this PR fell back to `error_label` for WC's own array too — that was itself a bug: `woocommerce_form_field()` renders a `<label>` for ANY non-empty `label`, even on a `hidden` field (it only skips the `for` attribute), so that fallback would have rendered a stray, orphaned «Пункт выдачи» caption on every checkout, in the wrong section, next to nothing. It also bought nothing, since (per the point above) WC's own required validation never fires for this field anyway.
- The duplicate notice is suppressed only where it is *proved* redundant: `validate()` records which ids the per-field loop already flagged, and the backstop skips its own notice for exactly those.
- `required_message()`'s wording changed from «Заполните поле «%s».» (fill in) to «Укажите значение поля «%s».» (specify/provide): the same template also covers this button-driven pickup field, where "fill in" reads wrong. Least-machinery fix — one shared string, no new branching — and it's the message that actually survives the dedup (the per-field loop always runs first).
- Per #134, the rig fixture's pickup field is unchanged in what it conveys: its contract is shown via `Pickup_Field::create()`'s default `error_label`, not by adding a checkout-visible `label` (an earlier version of this PR did that via `set_label()`; that triggered the exact `inject()` bug described above and has been removed).
- Documented explicitly (in `validate()`'s docblock) that the dedup guard only covers our own two notices: a plain-bool `required` field (no condition-spec, no pickup backstop) still gets both WC's native "is a required field" notice and ours.

**The backstop was not deleted, and that is deliberate.** `Checkout_Condition`'s `in` operator matches `chosen_shipping_method` strictly against the descriptor's own condition-spec `value` list. `set_requires_pickup_methods()` takes a separate list, supplied independently by the host plugin, and nothing enforces the two stay in sync — so a host plugin can genuinely register a broader `requires_pickup_methods` list than its `Pickup_Field::create()` condition-spec. When that happens, the per-field loop's strict match misses the field but the backstop's `chosen_method_matches()` still catches it. That's the backstop's real reason to exist, and it's what `test_backstop_fires_alone_when_requires_pickup_methods_diverges_from_condition_spec` exercises. (An earlier version of this PR instead pointed at a `method_id:instance_id` suffix, e.g. `carrier_pickup:3`, as the reachable divergence — that was wrong: both real entry points, `chosen_shipping_method()` and `process()`, normalize the posted method id to its bare form via `normalize_method_id()` before `validate()` ever sees it, so that shape is only reachable by calling `validate()` directly in a test, not from any live checkout flow.)

Data contract untouched: the field id `carrier_pickup_point` is byte-for-byte unchanged; only human-readable text moved.

Local: 2137 → 2153 unit tests, 5398 assertions, phpcs and phpstan level 3 clean, before and after. Mutation-checked per production change, by reverting just that change and confirming red, then restoring: reverting `required_message()`'s wording reddens all 3 tests that assert its literal string (`test_exact_match_dedupes_required_and_backstop_into_one_notice`, `test_required_message_prefers_error_label_over_label_and_id`, `test_required_message_falls_back_to_id_without_error_label_or_label`); reverting `inject()` back to the (removed) `error_label` fallback reddens exactly 1 of the 3 inject-label tests (`test_inject_wc_label_never_falls_back_to_error_label`) — the other 2 assert values that fallback never touched (an explicit label wins regardless; neither-set stays blank regardless), so they pass with or without it by design, not because they're vacuous; disabling the backstop reddens `test_backstop_fires_alone_when_requires_pickup_methods_diverges_from_condition_spec`.

**Correction (re-review):** the dedup guard itself (`if ( ! isset( $blank_required_ids[$pickup_field['id']] ) )` in `validate()`) was NOT actually covered by the above — `test_exact_match_dedupes_required_and_backstop_into_one_notice` and the "fires alone" test both used `Functions\expect('wc_add_notice')->once()->with(...)`, which only asserts that ONE call matched those exact arguments; it does not reject an ADDITIONAL call with different arguments, so mutating the guard to `if ( true )` left the whole suite green. Both tests now capture every `wc_add_notice()` call via `Functions\when(...)->alias(...)` and assert the full list. Re-verified: mutating the guard to `if ( true )` now reddens `test_exact_match_dedupes_required_and_backstop_into_one_notice` (asserts one notice, gets two); a probe duplicating the backstop's own notice reddens `test_backstop_fires_alone_when_requires_pickup_methods_diverges_from_condition_spec` (asserts one notice, gets two). Both mutations restored; full suite green afterward (2153 tests, 5398 assertions, unchanged count). Also corrected `validate()`'s docblock, which still gave the (already-disproven) `method_id:instance_id` divergence as the backstop's reason to exist — it now names the actual reachable one: `set_requires_pickup_methods()`'s id list vs. the descriptor's own condition-spec list, two independently host-supplied lists nothing keeps in sync.

**Needs a rig pass before merge:** this changes what the buyer reads at checkout. Submit `/classic-checkout/` with a pickup method chosen and no point selected — expect one message naming «Пункт выдачи» with "Укажите значение поля" wording, not two naming `carrier_pickup_point`.
