### PR TITLE
feat(location): an implicitly defaulted locality is marked as not the customer's choice

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -534,7 +534,9 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		selectReq.resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement' } ] );
+		// A persisted /select is ALWAYS an explicit choice (issue #309; spec D11) —
+		// `implicit` is `false` regardless of the config's own boot-time value.
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: false } ] );
 	} );
 
 	it( 'is a NATIVE event, seen by a plain addEventListener with no jQuery involved', async () => {
@@ -556,7 +558,7 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: 'cdek:city-77', level: 'settlement' } ] );
+		expect( seen ).toEqual( [ { key: 'cdek:city-77', level: 'settlement', implicit: false } ] );
 	} );
 
 	it( 'does NOT fire when /select fails', async () => {
@@ -599,7 +601,7 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: false } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: '', level: '' } ] );
+		expect( seen ).toEqual( [ { key: '', level: '', implicit: false } ] );
 	} );
 
 	it( 'fires only ONCE, for the FINAL response, when a superseded selection is queued behind it', async () => {
@@ -632,7 +634,7 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		selectRequests()[ 1 ].resolve( { current: { key: second.record.key, level: 'settlement' }, persisted: true } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: 'dadata:second', level: 'settlement' } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:second', level: 'settlement', implicit: false } ] );
 	} );
 } );
 
@@ -1579,55 +1581,90 @@ describe( 'restoring config.location.current on load', () => {
 } );
 
 // -----------------------------------------------------------------------
-// data-woodev-location-implicit DOM marker (issue #309; spec D11/§4.6) —
-// config.location.implicit had ZERO consumers before this: an implicit default must never
-// look like a real customer choice, while staying fully usable for scoping/addressing.
+// woodev_location_applied's `implicit` detail (issue #309; spec D11/§4.6) — replaces an
+// earlier `data-woodev-location-implicit` DOM-attribute attempt (reverted after an adversarial
+// review reproduced five ways it could not work: destroyed at boot by attachAll()'s
+// DOM-replacing renderers, lost on a checkout re-render, permanently stale across two entries
+// sharing one customer record, never cleared on a country change, and impossible to signal for
+// a record whose level has no field in the chain). The event carries the SAME information with
+// none of those failure modes, because it depends on no DOM node existing or surviving.
 // -----------------------------------------------------------------------
 
-describe( 'implicit-locality DOM marker (issue #309)', () => {
-	it( 'marks the CURRENT level\'s field implicit on boot when config.location.implicit is true', () => {
+describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
+	function captureLocationApplied() {
+		const seen = [];
+		document.body.addEventListener( 'woodev_location_applied', ( event ) => seen.push( event.detail ) );
+		return seen;
+	}
+
+	it( 'fires implicit:true on boot when config.location.implicit is true (defect: the old DOM marker could never signal at all for the ajax-select2/related-list modes — see the test below)', () => {
+		const seen = captureLocationApplied();
+
 		boot( {
 			settlement: true,
 			current: { key: 'dadata:city1', level: 'settlement' },
 			implicit: true,
 		} );
 
-		expect(
-			document.getElementById( 'billing_city' ).getAttribute( 'data-woodev-location-implicit' )
-		).toBe( 'true' );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
 	} );
 
-	it( 'does NOT mark the field when config.location.implicit is false (a real customer choice)', () => {
+	it( 'fires implicit:false on boot for a real customer choice (config.location.implicit is false)', () => {
+		const seen = captureLocationApplied();
+
 		boot( {
 			settlement: true,
 			current: { key: 'dadata:city1', level: 'settlement' },
 			implicit: false,
 		} );
 
-		expect(
-			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
-		).toBe( false );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: false } ] );
 	} );
 
-	it( 'marks nothing when there is no current record at all', () => {
+	it( 'fires nothing at boot when there is no current record at all', () => {
+		const seen = captureLocationApplied();
+
 		boot( { settlement: true, current: null, implicit: true } );
 
-		expect(
-			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
-		).toBe( false );
+		expect( seen ).toEqual( [] );
 	} );
 
-	it( 'clears the marker the instant an explicit /select persists (spec D11: a real choice drops the flag)', async () => {
+	it( 'never writes any DOM attribute for the signal — the mechanism this replaces is gone entirely', () => {
 		boot( {
 			settlement: true,
 			current: { key: 'dadata:city1', level: 'settlement' },
 			implicit: true,
 		} );
 
-		expect(
-			document.getElementById( 'billing_city' ).getAttribute( 'data-woodev-location-implicit' )
-		).toBe( 'true' );
+		const el = document.getElementById( 'billing_city' );
 
+		expect( el.getAttributeNames().some( ( name ) => name.indexOf( 'implicit' ) !== -1 ) ).toBe( false );
+	} );
+
+	it( 'still fires implicit:true at boot even when the record\'s level has no field in this entry\'s chain (defect #5 — spec §4.4 explicitly permits this shape)', () => {
+		// The chain here only ever carries 'settlement'; the record names 'address', a level
+		// this entry has no field for at all. chainNodeForLevel() would have returned null for
+		// the OLD DOM mechanism — nothing to mark, no signal, ever. The event needs no field to
+		// exist.
+		const seen = captureLocationApplied();
+
+		boot( {
+			settlement: true,
+			current: { key: 'dadata:addr1', level: 'address' },
+			implicit: true,
+		} );
+
+		expect( seen ).toEqual( [ { key: 'dadata:addr1', level: 'address', implicit: true } ] );
+	} );
+
+	it( 'an explicit pick always fires implicit:false, overriding a previously-implicit boot state (spec D11: a real choice drops the flag)', async () => {
+		boot( {
+			settlement: true,
+			current: { key: 'dadata:city1', level: 'settlement' },
+			implicit: true,
+		} );
+
+		const seen = captureLocationApplied(); // attached AFTER boot — only the pick's own fire matters here.
 		const settlementCall = callFor( 'billing_city' );
 		const item = {
 			key: 'dadata:city2', label: 'г Тверь', level: 'settlement',
@@ -1640,46 +1677,70 @@ describe( 'implicit-locality DOM marker (issue #309)', () => {
 		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
 		await flushMicrotasks();
 
-		expect(
-			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
-		).toBe( false );
+		expect( seen ).toEqual( [ { key: 'dadata:city2', level: 'settlement', implicit: false } ] );
 	} );
 
-	it( 'clears a PREVIOUSLY marked level when the customer explicitly picks a DIFFERENT one', async () => {
+	it( 'the initial implicit:true fire is not destroyed by a DOM-replacing renderer running right after it (defect #1 — the fatal one: attachAll() runs AFTER prefill() in boot())', () => {
+		// Reproduces the OLD mechanism's exact failure timing: a renderer that swaps the
+		// original <input> for a fresh element (mirrors what location-select-modes.js's
+		// buildSelectField() does for real under ajax-select2/related-list — Task 13, spec D7)
+		// runs during attachAll(), which boot() calls right after prefill() already fired the
+		// event. A DOM-attribute mechanism set on the OLD node before this swap would already
+		// be gone; the event has no such dependency.
+		window.WoodevLocationRenderers = {
+			'custom-mode:settlement': ( el ) => {
+				const replacement = document.createElement( 'select' );
+				replacement.id = el.id;
+				el.parentNode.replaceChild( replacement, el );
+
+				return { detach: jest.fn(), el: replacement };
+			},
+		};
+
+		const seen = captureLocationApplied();
+
 		boot( {
-			settlement: true, address: true,
+			settlement: true,
+			current: { key: 'dadata:city1', level: 'settlement' },
+			implicit: true,
+			mode: 'custom-mode',
+		} );
+
+		// Sanity: this really does exercise the DOM-destroying renderer path.
+		expect( document.getElementById( 'billing_city' ).tagName ).toBe( 'SELECT' );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
+	} );
+
+	it( 'a later checkout re-render (updated_checkout) neither loses nor duplicates the boot-time signal (defect #2)', () => {
+		// The old DOM attribute never survived WooCommerce replacing the field fragment,
+		// because nothing re-applied it after reconcileAfterCheckoutUpdate() ran (prefill() is
+		// only ever called once, from boot()). The event already fired once, independent of
+		// any DOM node — a later re-render has nothing to lose and reconcileAfterCheckoutUpdate()
+		// does not need to (and does not) re-fire it.
+		const seen = captureLocationApplied();
+
+		boot( {
+			settlement: true,
 			current: { key: 'dadata:city1', level: 'settlement' },
 			implicit: true,
 		} );
 
-		expect(
-			document.getElementById( 'billing_city' ).getAttribute( 'data-woodev-location-implicit' )
-		).toBe( 'true' );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
 
-		const addressCall = callFor( 'billing_address_1' );
-		const item = {
-			key: 'dadata:addr1', label: 'ул Тверская, 1', level: 'address',
-			record: {
-				key: 'dadata:addr1', provider_id: 'dadata', level: 'address', country: 'RU',
-				street: { name: 'Тверская', type: 'ул' }, house: '1', label: 'г Москва, ул Тверская, д 1',
-			},
-		};
+		const fresh = document.createElement( 'input' );
+		fresh.type = 'text';
+		fresh.id = 'billing_city';
+		fresh.name = 'billing_city';
+		document.getElementById( 'billing_city' ).replaceWith( fresh );
 
-		selectViaFake( addressCall, item );
-		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'address' }, persisted: true } );
-		await flushMicrotasks();
+		window.jQuery( document.body ).trigger( 'updated_checkout' );
 
-		expect(
-			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
-		).toBe( false );
-		expect(
-			document.getElementById( 'billing_address_1' ).hasAttribute( 'data-woodev-location-implicit' )
-		).toBe( false );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
 	} );
 
 	it( 'never gates scoping/addressing on the implicit flag — the restored key still scopes the child fetch', () => {
 		// Sibling assertion to "restoring config.location.current on load" above: the SAME
-		// implicit default marked here must stay fully usable for scoping — spec D11's other
+		// implicit default fired here must stay fully usable for scoping — spec D11's other
 		// half ("implicit records participate in rate calculation").
 		boot( {
 			region: true, settlement: true,
@@ -1687,15 +1748,117 @@ describe( 'implicit-locality DOM marker (issue #309)', () => {
 			implicit: true,
 		} );
 
-		expect(
-			document.getElementById( 'billing_state' ).getAttribute( 'data-woodev-location-implicit' )
-		).toBe( 'true' );
-
 		const settlementCall = callFor( 'billing_city' );
 		settlementCall.fetch( 'Мос' );
 
 		const req = fetchCalls[ fetchCalls.length - 1 ];
 		expect( req.url ).toContain( 'within=' + encodeURIComponent( 'dadata:region9' ) );
+	} );
+
+	/**
+	 * Defect #3 (second-entry regression, per the review): two entries sharing ONE customer
+	 * record — e.g. a billing-section entry and a shipping-section entry both wired to the
+	 * SAME Location_Service — used to each get their OWN `data-woodev-location-implicit` DOM
+	 * marker, and an explicit pick in ONE entry's active section only ever cleared THAT
+	 * entry's own marker, leaving the other permanently stale. The event has no per-entry
+	 * state to diverge: each entry fires its own, identically-valued boot event, and a real
+	 * pick's `implicit: false` is a single global fact a listener applies regardless of which
+	 * entry produced it — mirrors `bootBillingAndShippingEntries()` in the "section-aware
+	 * addressing" describe block below (same shape, `buildConfig()`/`installMarkup()` cannot
+	 * express two sections at once).
+	 */
+	function bootSharedLocationEntries( current, implicit ) {
+		document.body.innerHTML = `
+			<form class="checkout woocommerce-checkout">
+				<select id="billing_country" name="billing_country">
+					<option value="RU">Россия</option>
+				</select>
+				<select id="shipping_country" name="shipping_country">
+					<option value="RU">Россия</option>
+				</select>
+				<input type="checkbox" id="ship-to-different-address-checkbox"
+					name="ship_to_different_address" checked />
+				<input type="text" id="billing_city" name="billing_city" value="" />
+				<input type="text" id="shipping_city" name="shipping_city" value="" />
+			</form>
+		`;
+		document.getElementById( 'billing_country' ).value = 'RU';
+		document.getElementById( 'shipping_country' ).value = 'RU';
+
+		global.jQuery = require( 'jquery' );
+		global.$ = global.jQuery;
+		window.jQuery = global.jQuery;
+
+		window.WoodevCheckoutFieldStore = require(
+			'../../woodev/shipping-method/assets/js/frontend/checkout-field-store.js'
+		);
+
+		fakeTypeahead();
+		mockFetch();
+
+		const sharedLocation = {
+			endpoints: { suggest: SUGGEST_URL, select: SELECT_URL, list: LIST_URL },
+			nonce: 'test-nonce',
+			countries: [ 'RU' ],
+			mode: 'typeahead',
+			levels: { RU: { region: true, settlement: true, address: true } },
+			current,
+			implicit,
+			i18n: {},
+		};
+
+		window[ CONFIG_GLOBAL + '_billing_shared' ] = {
+			fields: { billing_city: locationField( 'settlement', 'billing' ) },
+			endpoint: 'https://example.test/wp-json/woodev/v1/carrier/field-source',
+			nonce: 'test-nonce',
+			takeover: {},
+			location: sharedLocation,
+		};
+		window[ CONFIG_GLOBAL + '_shipping_shared' ] = {
+			fields: { shipping_city: locationField( 'settlement', 'shipping' ) },
+			endpoint: 'https://example.test/wp-json/woodev/v1/carrier/field-source',
+			nonce: 'test-nonce',
+			takeover: {},
+			location: sharedLocation,
+		};
+
+		require( '../../woodev/shipping-method/assets/js/frontend/location-cascade.js' );
+	}
+
+	afterEach( () => {
+		delete window[ CONFIG_GLOBAL + '_billing_shared' ];
+		delete window[ CONFIG_GLOBAL + '_shipping_shared' ];
+	} );
+
+	it( 'two entries sharing one implicit customer record each fire their own identical boot event — no per-entry state to diverge', () => {
+		const seen = captureLocationApplied();
+
+		bootSharedLocationEntries( { key: 'dadata:city1', level: 'settlement' }, true );
+
+		expect( seen ).toEqual( [
+			{ key: 'dadata:city1', level: 'settlement', implicit: true },
+			{ key: 'dadata:city1', level: 'settlement', implicit: true },
+		] );
+	} );
+
+	it( 'an explicit pick in the ACTIVE section fires implicit:false — a listener applies it globally, no OTHER entry is left permanently stale', async () => {
+		bootSharedLocationEntries( { key: 'dadata:city1', level: 'settlement' }, true );
+
+		const seen = captureLocationApplied(); // attached AFTER boot — only the pick's own fire matters here.
+
+		// "ship to a different address" is checked (bootSharedLocationEntries' own markup) —
+		// shipping is the active section; only ITS pick reaches /select (review finding F3,
+		// same gate the "section-aware addressing" describe block exercises directly).
+		selectViaFake( callFor( 'shipping_city' ), {
+			key: 'dadata:kazan', label: 'г Казань', level: 'settlement',
+			record: { key: 'dadata:kazan', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Казань' },
+		} );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: 'dadata:kazan', level: 'settlement' }, persisted: true } );
+		await flushMicrotasks();
+
+		// ONE event, implicit:false — not two, not still true, and not scoped to "only the
+		// shipping entry knows this now" the way the old per-entry DOM marker was.
+		expect( seen ).toEqual( [ { key: 'dadata:kazan', level: 'settlement', implicit: false } ] );
 	} );
 } );
 
@@ -1955,7 +2118,7 @@ describe( 'Location Provider key invalidation on a local-only clear (review find
 		document.getElementById( 'billing_country' ).value = 'US';
 		document.getElementById( 'billing_country' ).dispatchEvent( new Event( 'change', { bubbles: true } ) );
 
-		expect( seen ).toEqual( [ { key: '', level: '' } ] );
+		expect( seen ).toEqual( [ { key: '', level: '', implicit: false } ] );
 		// Sanity: this really is a pure client-side clear, never a network call.
 		expect( fetchCalls.length ).toBe( 0 );
 	} );
@@ -1986,7 +2149,7 @@ describe( 'Location Provider key invalidation on a local-only clear (review find
 
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: '', level: '' } ] );
+		expect( seen ).toEqual( [ { key: '', level: '', implicit: false } ] );
 	} );
 
 	it( 'a real pick through the widget does NOT fire the empty-key event before /select resolves', () => {

--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -146,7 +146,7 @@ function locationField( level, section = 'billing' ) {
  * (`Checkout_Config::build_location_block()`).
  *
  * @param {{region?: boolean, settlement?: boolean, address?: boolean, section?: string,
- *          levels?: Object, countries?: string[], current?: Object|null}} opts
+ *          levels?: Object, countries?: string[], current?: Object|null, implicit?: boolean}} opts
  * @returns {Object}
  */
 function buildConfig( opts ) {
@@ -180,7 +180,7 @@ function buildConfig( opts ) {
 			// a flat per-level map cannot describe it without lying.
 			levels: o.levels || { RU: { region: true, settlement: true, address: true } },
 			current: o.current !== undefined ? o.current : null,
-			implicit: false,
+			implicit: o.implicit !== undefined ? o.implicit : false,
 			i18n: o.i18n !== undefined ? o.i18n : {
 				noResults: 'Поиск не дал результатов. Попробуйте изменить запрос.',
 				noResultsAddress: 'Адрес не найден — введите вручную.',
@@ -1569,6 +1569,127 @@ describe( 'restoring config.location.current on load', () => {
 			region: true, settlement: true,
 			current: { key: 'dadata:region9', level: 'region' },
 		} );
+
+		const settlementCall = callFor( 'billing_city' );
+		settlementCall.fetch( 'Мос' );
+
+		const req = fetchCalls[ fetchCalls.length - 1 ];
+		expect( req.url ).toContain( 'within=' + encodeURIComponent( 'dadata:region9' ) );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// data-woodev-location-implicit DOM marker (issue #309; spec D11/§4.6) —
+// config.location.implicit had ZERO consumers before this: an implicit default must never
+// look like a real customer choice, while staying fully usable for scoping/addressing.
+// -----------------------------------------------------------------------
+
+describe( 'implicit-locality DOM marker (issue #309)', () => {
+	it( 'marks the CURRENT level\'s field implicit on boot when config.location.implicit is true', () => {
+		boot( {
+			settlement: true,
+			current: { key: 'dadata:city1', level: 'settlement' },
+			implicit: true,
+		} );
+
+		expect(
+			document.getElementById( 'billing_city' ).getAttribute( 'data-woodev-location-implicit' )
+		).toBe( 'true' );
+	} );
+
+	it( 'does NOT mark the field when config.location.implicit is false (a real customer choice)', () => {
+		boot( {
+			settlement: true,
+			current: { key: 'dadata:city1', level: 'settlement' },
+			implicit: false,
+		} );
+
+		expect(
+			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
+		).toBe( false );
+	} );
+
+	it( 'marks nothing when there is no current record at all', () => {
+		boot( { settlement: true, current: null, implicit: true } );
+
+		expect(
+			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
+		).toBe( false );
+	} );
+
+	it( 'clears the marker the instant an explicit /select persists (spec D11: a real choice drops the flag)', async () => {
+		boot( {
+			settlement: true,
+			current: { key: 'dadata:city1', level: 'settlement' },
+			implicit: true,
+		} );
+
+		expect(
+			document.getElementById( 'billing_city' ).getAttribute( 'data-woodev-location-implicit' )
+		).toBe( 'true' );
+
+		const settlementCall = callFor( 'billing_city' );
+		const item = {
+			key: 'dadata:city2', label: 'г Тверь', level: 'settlement',
+			record: {
+				key: 'dadata:city2', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Тверь',
+			},
+		};
+
+		selectViaFake( settlementCall, item );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
+		await flushMicrotasks();
+
+		expect(
+			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
+		).toBe( false );
+	} );
+
+	it( 'clears a PREVIOUSLY marked level when the customer explicitly picks a DIFFERENT one', async () => {
+		boot( {
+			settlement: true, address: true,
+			current: { key: 'dadata:city1', level: 'settlement' },
+			implicit: true,
+		} );
+
+		expect(
+			document.getElementById( 'billing_city' ).getAttribute( 'data-woodev-location-implicit' )
+		).toBe( 'true' );
+
+		const addressCall = callFor( 'billing_address_1' );
+		const item = {
+			key: 'dadata:addr1', label: 'ул Тверская, 1', level: 'address',
+			record: {
+				key: 'dadata:addr1', provider_id: 'dadata', level: 'address', country: 'RU',
+				street: { name: 'Тверская', type: 'ул' }, house: '1', label: 'г Москва, ул Тверская, д 1',
+			},
+		};
+
+		selectViaFake( addressCall, item );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'address' }, persisted: true } );
+		await flushMicrotasks();
+
+		expect(
+			document.getElementById( 'billing_city' ).hasAttribute( 'data-woodev-location-implicit' )
+		).toBe( false );
+		expect(
+			document.getElementById( 'billing_address_1' ).hasAttribute( 'data-woodev-location-implicit' )
+		).toBe( false );
+	} );
+
+	it( 'never gates scoping/addressing on the implicit flag — the restored key still scopes the child fetch', () => {
+		// Sibling assertion to "restoring config.location.current on load" above: the SAME
+		// implicit default marked here must stay fully usable for scoping — spec D11's other
+		// half ("implicit records participate in rate calculation").
+		boot( {
+			region: true, settlement: true,
+			current: { key: 'dadata:region9', level: 'region' },
+			implicit: true,
+		} );
+
+		expect(
+			document.getElementById( 'billing_state' ).getAttribute( 'data-woodev-location-implicit' )
+		).toBe( 'true' );
 
 		const settlementCall = callFor( 'billing_city' );
 		settlementCall.fetch( 'Мос' );

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1089,27 +1089,33 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 		 * return a {@see Location_Service} backed by a session probe seeded with `$record`
 		 * (or nothing, when `$record` is `null`).
 		 *
-		 * @param Location_Record|null  $record  The customer's current record, or `null`.
-		 * @param Location_Adapter|null $adapter The adapter `resolve_for()` calls; `null`
-		 *                                       (the default) mirrors a plugin that has not
-		 *                                       wired one.
-		 * @param bool                  $active  What {@see Location_Service::is_active()}
-		 *                                       answers (review finding F1) — defaults to
-		 *                                       `true` (a configured, usable layer), the
-		 *                                       assumption every EXISTING caller of this
-		 *                                       helper already made implicitly before
-		 *                                       `is_active()` gated anything here. Pass
-		 *                                       `false` to build the "wired but never
-		 *                                       configured" plugin the finding itself
-		 *                                       describes.
+		 * @param Location_Record|null  $record   The customer's current record, or `null`.
+		 * @param Location_Adapter|null $adapter  The adapter `resolve_for()` calls; `null`
+		 *                                        (the default) mirrors a plugin that has not
+		 *                                        wired one.
+		 * @param bool                  $active   What {@see Location_Service::is_active()}
+		 *                                        answers (review finding F1) — defaults to
+		 *                                        `true` (a configured, usable layer), the
+		 *                                        assumption every EXISTING caller of this
+		 *                                        helper already made implicitly before
+		 *                                        `is_active()` gated anything here. Pass
+		 *                                        `false` to build the "wired but never
+		 *                                        configured" plugin the finding itself
+		 *                                        describes.
+		 * @param bool                  $implicit Whether `$record` was written as a default
+		 *                                        guess rather than a real customer choice
+		 *                                        (issue #309; spec D11/§4.6) — ignored when
+		 *                                        `$record` is `null`. Defaults to `false`
+		 *                                        (a real choice), the assumption every
+		 *                                        EXISTING caller of this helper already made.
 		 */
-		private function location_plugin( ?Location_Record $record, ?Location_Adapter $adapter = null, bool $active = true ): Pickup_Handler_Location_Fixture_Plugin {
+		private function location_plugin( ?Location_Record $record, ?Location_Adapter $adapter = null, bool $active = true, bool $implicit = false ): Pickup_Handler_Location_Fixture_Plugin {
 			$instance = ( new \ReflectionClass( Pickup_Handler_Location_Fixture_Plugin::class ) )->newInstanceWithoutConstructor();
 
 			$store = new Pickup_Handler_Customer_Location_Store_Probe( new Pickup_Handler_Location_Fake_Session() );
 
 			if ( null !== $record ) {
-				$store->set( $record );
+				$store->set( $record, $implicit );
 			}
 
 			$instance->fake_adapter         = $adapter;
@@ -1270,6 +1276,10 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			// (review finding F1) case where the block must be OMITTED instead.
 			$this->assertArrayHasKey( 'location', $config );
 			$this->assertSame( '', $config['location']['current']['key'] );
+			// No record at all — an implicit flag is only meaningful attached to an actual
+			// record (issue #309; same convention Checkout_Config::build_location_block()
+			// already uses for its own sibling `implicit` key).
+			$this->assertFalse( $config['location']['implicit'] );
 		}
 
 		public function test_config_carries_the_customer_current_record_key(): void {
@@ -1282,6 +1292,44 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$config = $this->make_handler( [ 'plugin' => $plugin ] )->get_js_config();
 
 			$this->assertSame( 'dadata:fias-1', $config['location']['current']['key'] );
+		}
+
+		/**
+		 * Issue #309 (spec D11/§4.6): {@see Pickup_Handler::location_config_block()} used to
+		 * discard {@see Location_Service::get_customer_record()}'s own `implicit` flag —
+		 * {@see Pickup_Handler::current_location_record()} calls that method and narrows the
+		 * result to the bare {@see Location_Record} on the very next line, throwing the flag
+		 * away before `location_config_block()` ever saw it. A plugin/theme reading this
+		 * config needs the flag too, per that method's own docblock ("e.g. to decide whether
+		 * to still show a 'please choose your locality' prompt").
+		 */
+		public function test_config_carries_implicit_false_for_a_real_customer_choice(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			Functions\when( 'rest_url' )->justReturn( 'https://example.test/wp-json/woodev/v1' );
+			Functions\when( 'wp_create_nonce' )->justReturn( 'NONCE' );
+			Functions\when( 'wc_ship_to_billing_address_only' )->justReturn( false );
+
+			$plugin = $this->location_plugin( $this->location_record( 'dadata:fias-1' ), null, true, false );
+			$config = $this->make_handler( [ 'plugin' => $plugin ] )->get_js_config();
+
+			$this->assertSame( 'dadata:fias-1', $config['location']['current']['key'] );
+			$this->assertFalse( $config['location']['implicit'] );
+		}
+
+		/**
+		 * Same seam, the other value — issue #309.
+		 */
+		public function test_config_carries_implicit_true_for_a_default_guess(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			Functions\when( 'rest_url' )->justReturn( 'https://example.test/wp-json/woodev/v1' );
+			Functions\when( 'wp_create_nonce' )->justReturn( 'NONCE' );
+			Functions\when( 'wc_ship_to_billing_address_only' )->justReturn( false );
+
+			$plugin = $this->location_plugin( $this->location_record( 'dadata:fias-1' ), null, true, true );
+			$config = $this->make_handler( [ 'plugin' => $plugin ] )->get_js_config();
+
+			$this->assertSame( 'dadata:fias-1', $config['location']['current']['key'] );
+			$this->assertTrue( $config['location']['implicit'] );
 		}
 
 		/**

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -970,6 +970,14 @@
 	 * caller genuinely means `true`, e.g. {@see prefill}'s own boot fire). See the file
 	 * docblock's own section on `detail.implicit` for which callers pass which value and why.
 	 *
+	 * **`implicit` is meaningful only together with a non-empty `key`.** The clearing paths
+	 * ({@see clearCountryScope}, an edit without a pick) report `implicit: false` while the
+	 * SERVER record — which those paths deliberately never clear, because they POST nothing to
+	 * `/select` — may still hold the implicit default that rates are computed from. That is
+	 * safe only because those same events carry `key: ''`, so the sentinel rule above already
+	 * tells a listener to ignore them. A consumer that reads `implicit` ALONE, without
+	 * checking `key`, will conclude the customer made a choice they never made.
+	 *
 	 * @param {Object}  record   The just-persisted record (D8's own full, round-tripped
 	 *                           shape), or `null` when the current locality is now unknown.
 	 * @param {boolean} implicit Whether the record this event describes is a default guess

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -92,6 +92,15 @@
  * `pickup-mount.js`'s own `resolveLocalityKey()` is the intended consumer — it tracks the
  * customer's current Location Provider layer key without ever reading a checkout DOM field.
  *
+ * `data-woodev-location-implicit` (issue #309; spec D11/§4.6): `config.location.implicit`
+ * had ZERO consumers anywhere in this codebase until this attribute — set by
+ * {@see applyImplicitState} from {@see prefill} on boot and cleared the instant a real
+ * `/select` persists (see {@see settleSelect}). It never gates scoping, addressing, or rate
+ * calculation (those stay implicit-agnostic by design, spec D11's other half) — it exists
+ * purely so a plugin/theme can tell an implicit default apart from the customer's own choice
+ * for ITS OWN "please choose your locality" wording, without the framework inventing that
+ * wording itself.
+ *
  * @file
  * @since 2.1.0
  */
@@ -598,6 +607,11 @@
 			// showNotPersistedNotice()/clearNotPersistedNotice().
 			lastSelectedFieldId: null,
 			notPersistedNotice: null,
+			// Issue #309 (spec §4.6/D11): the level CURRENTLY carrying the
+			// `data-woodev-location-implicit` DOM marker, or `null` when none does — see
+			// applyImplicitState(). At most one level is ever marked per entry, since the
+			// customer-location store holds one whole record, never a per-level partial.
+			implicitLevel: null,
 		};
 	}
 
@@ -633,6 +647,57 @@
 		}
 
 		return null;
+	}
+
+	/**
+	 * Reflects whether the customer's CURRENT Location Provider layer record is an implicit
+	 * default (issue #309; spec D11/§4.6: "implicit records participate in rate calculation
+	 * but never suppress 'please choose your locality' prompts") on the DOM field for
+	 * `level`, via a `data-woodev-location-implicit` attribute — the ONE signal this module
+	 * owns. The customer-facing wording/gate itself stays plugin/theme domain (this project's
+	 * "framework = mechanism, plugin = domain" convention, spec §6): a plugin or theme reads
+	 * this attribute (present ONLY while the current record is a default guess, absent the
+	 * instant it becomes the customer's own choice) to decide whether it still owes the
+	 * customer a nudge — never the other way around, and never gated on mere PRESENCE of a
+	 * value the way rate calculation and the pickup points query correctly are (both keep
+	 * reading `config.location.current`/`resolveLocalityKey()` unchanged — an implicit
+	 * default stays fully usable there, spec D11's other half).
+	 *
+	 * Clears any PREVIOUSLY marked level first: {@see Customer_Location_Store::set()} always
+	 * replaces the customer's WHOLE record (never a per-level partial write — a real
+	 * selection "drops the flag" for the record as a whole, spec D11), so at most one level
+	 * is ever marked implicit per entry — {@see buildEntry()}'s own `implicitLevel`.
+	 *
+	 * A level absent from THIS entry's chain (`chainNodeForLevel()` returns `null`) or whose
+	 * field is not currently in the document is a silent no-op — nothing to mark.
+	 *
+	 * @param {Object}  entry
+	 * @param {string}  level
+	 * @param {boolean} implicit
+	 * @returns {void}
+	 */
+	function applyImplicitState( entry, level, implicit ) {
+		if ( entry.implicitLevel && entry.implicitLevel !== level ) {
+			var previousNode = chainNodeForLevel( entry, entry.implicitLevel );
+			var previousEl = previousNode && document.getElementById( previousNode.fieldId );
+
+			if ( previousEl ) {
+				previousEl.removeAttribute( 'data-woodev-location-implicit' );
+			}
+		}
+
+		var node = chainNodeForLevel( entry, level );
+		var el = node && document.getElementById( node.fieldId );
+
+		if ( el ) {
+			if ( implicit ) {
+				el.setAttribute( 'data-woodev-location-implicit', 'true' );
+			} else {
+				el.removeAttribute( 'data-woodev-location-implicit' );
+			}
+		}
+
+		entry.implicitLevel = implicit ? level : null;
 	}
 
 	/**
@@ -907,6 +972,12 @@
 		if ( shouldTrigger ) {
 			clearNotPersistedNotice( entry );
 			fireLocationApplied( record );
+
+			// Issue #309: a persisted `/select` is ALWAYS an explicit customer choice
+			// (`Location_Controller::handle_select_request()` never writes implicit —
+			// spec D11), so whichever level was marked implicit stops being one now,
+			// regardless of which level record.level itself names.
+			applyImplicitState( entry, record && record.level, false );
 
 			if ( window.jQuery ) {
 				window.jQuery( document.body ).trigger( 'update_checkout' );
@@ -1757,6 +1828,11 @@
 
 		if ( current && current.key && current.level ) {
 			entry.records[ current.level ] = { key: current.key };
+
+			// Issue #309: give `entry.location.implicit` its first real consumer — see
+			// applyImplicitState()'s own docblock for why this reads only as a DOM signal,
+			// never as a reason to withhold `current.key` from scoping/addressing above.
+			applyImplicitState( entry, current.level, !!entry.location.implicit );
 		}
 	}
 

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -82,24 +82,38 @@
  * async ready queue, since — unlike that file — this one must keep working even in a jQuery-
  * less test harness for its own non-jQuery-producer paths).
  *
- * `woodev_location_applied` (Task 15; issue #159): a native, bubbling `CustomEvent` on
- * `document.body`, `detail: { key, level }`, fired from {@see settleSelect} on the SAME
- * "this response is final and persisted" condition as the `update_checkout` trigger above —
- * see that function's own docblock. This is a NATIVE event, never a jQuery `.trigger()`
- * (unlike `update_checkout`, which WooCommerce itself only ever fires through jQuery): this
- * module is the event's own producer, so there is no third-party dispatch mechanism to
- * accommodate the way `pickup-mount.js`'s dual-world `updated_checkout` binding has to.
- * `pickup-mount.js`'s own `resolveLocalityKey()` is the intended consumer — it tracks the
- * customer's current Location Provider layer key without ever reading a checkout DOM field.
+ * `woodev_location_applied` (Task 15; issue #159; `implicit` added issue #309, spec D11/§4.6):
+ * a native, bubbling `CustomEvent` on `document.body`, `detail: { key, level, implicit }`,
+ * fired from {@see settleSelect} on the SAME "this response is final and persisted" condition
+ * as the `update_checkout` trigger above — see that function's own docblock — AND from
+ * {@see prefill} on boot, when `config.location.current` already names a record (see below).
+ * This is a NATIVE event, never a jQuery `.trigger()` (unlike `update_checkout`, which
+ * WooCommerce itself only ever fires through jQuery): this module is the event's own
+ * producer, so there is no third-party dispatch mechanism to accommodate the way
+ * `pickup-mount.js`'s dual-world `updated_checkout` binding has to. `pickup-mount.js`'s own
+ * `resolveLocalityKey()` is the intended consumer of `key`/`level` — it tracks the customer's
+ * current Location Provider layer key without ever reading a checkout DOM field.
  *
- * `data-woodev-location-implicit` (issue #309; spec D11/§4.6): `config.location.implicit`
- * had ZERO consumers anywhere in this codebase until this attribute — set by
- * {@see applyImplicitState} from {@see prefill} on boot and cleared the instant a real
- * `/select` persists (see {@see settleSelect}). It never gates scoping, addressing, or rate
- * calculation (those stay implicit-agnostic by design, spec D11's other half) — it exists
- * purely so a plugin/theme can tell an implicit default apart from the customer's own choice
- * for ITS OWN "please choose your locality" wording, without the framework inventing that
- * wording itself.
+ * `detail.implicit` (issue #309; spec D11/§4.6) is this event's SECOND consumer surface:
+ * `config.location.implicit` had ZERO consumers anywhere in this codebase before this — a
+ * first attempt reflected it onto a `data-woodev-location-implicit` DOM attribute instead,
+ * which measurably could not work (destroyed by {@see attachOne}'s DOM-replacing renderers
+ * whenever `attachAll()` runs right after {@see prefill} in {@see boot}; never re-applied
+ * after a checkout re-render since {@see reconcileAfterCheckoutUpdate} never calls
+ * {@see prefill} again; permanently diverging between two entries that share one customer
+ * record; never cleared by {@see clearCountryScope}; and impossible to signal at all for a
+ * record whose level has no field in a given entry's own chain, spec §4.4). The event has
+ * none of those problems by construction — it depends on no DOM node existing or surviving
+ * anything. `implicit` is `true` ONLY on the boot fire, and only when
+ * `config.location.implicit` says so; every OTHER fire (an explicit `/select` persisting, or
+ * the record becoming unknown — see {@see fireLocationApplied}'s own docblock) is always
+ * `false`, because a persisted `/select` is never itself an implicit write
+ * (`Location_Controller::handle_select_request()` never writes implicit — spec D11) and an
+ * unknown record has nothing to flag as a default guess. This never gates scoping,
+ * addressing, or rate calculation (those stay implicit-agnostic by design, spec D11's other
+ * half) — it exists purely so a plugin/theme can tell an implicit default apart from the
+ * customer's own choice for ITS OWN "please choose your locality" wording, without the
+ * framework inventing that wording itself.
  *
  * @file
  * @since 2.1.0
@@ -607,11 +621,6 @@
 			// showNotPersistedNotice()/clearNotPersistedNotice().
 			lastSelectedFieldId: null,
 			notPersistedNotice: null,
-			// Issue #309 (spec §4.6/D11): the level CURRENTLY carrying the
-			// `data-woodev-location-implicit` DOM marker, or `null` when none does — see
-			// applyImplicitState(). At most one level is ever marked per entry, since the
-			// customer-location store holds one whole record, never a per-level partial.
-			implicitLevel: null,
 		};
 	}
 
@@ -647,57 +656,6 @@
 		}
 
 		return null;
-	}
-
-	/**
-	 * Reflects whether the customer's CURRENT Location Provider layer record is an implicit
-	 * default (issue #309; spec D11/§4.6: "implicit records participate in rate calculation
-	 * but never suppress 'please choose your locality' prompts") on the DOM field for
-	 * `level`, via a `data-woodev-location-implicit` attribute — the ONE signal this module
-	 * owns. The customer-facing wording/gate itself stays plugin/theme domain (this project's
-	 * "framework = mechanism, plugin = domain" convention, spec §6): a plugin or theme reads
-	 * this attribute (present ONLY while the current record is a default guess, absent the
-	 * instant it becomes the customer's own choice) to decide whether it still owes the
-	 * customer a nudge — never the other way around, and never gated on mere PRESENCE of a
-	 * value the way rate calculation and the pickup points query correctly are (both keep
-	 * reading `config.location.current`/`resolveLocalityKey()` unchanged — an implicit
-	 * default stays fully usable there, spec D11's other half).
-	 *
-	 * Clears any PREVIOUSLY marked level first: {@see Customer_Location_Store::set()} always
-	 * replaces the customer's WHOLE record (never a per-level partial write — a real
-	 * selection "drops the flag" for the record as a whole, spec D11), so at most one level
-	 * is ever marked implicit per entry — {@see buildEntry()}'s own `implicitLevel`.
-	 *
-	 * A level absent from THIS entry's chain (`chainNodeForLevel()` returns `null`) or whose
-	 * field is not currently in the document is a silent no-op — nothing to mark.
-	 *
-	 * @param {Object}  entry
-	 * @param {string}  level
-	 * @param {boolean} implicit
-	 * @returns {void}
-	 */
-	function applyImplicitState( entry, level, implicit ) {
-		if ( entry.implicitLevel && entry.implicitLevel !== level ) {
-			var previousNode = chainNodeForLevel( entry, entry.implicitLevel );
-			var previousEl = previousNode && document.getElementById( previousNode.fieldId );
-
-			if ( previousEl ) {
-				previousEl.removeAttribute( 'data-woodev-location-implicit' );
-			}
-		}
-
-		var node = chainNodeForLevel( entry, level );
-		var el = node && document.getElementById( node.fieldId );
-
-		if ( el ) {
-			if ( implicit ) {
-				el.setAttribute( 'data-woodev-location-implicit', 'true' );
-			} else {
-				el.removeAttribute( 'data-woodev-location-implicit' );
-			}
-		}
-
-		entry.implicitLevel = implicit ? level : null;
 	}
 
 	/**
@@ -971,13 +929,12 @@
 
 		if ( shouldTrigger ) {
 			clearNotPersistedNotice( entry );
-			fireLocationApplied( record );
 
 			// Issue #309: a persisted `/select` is ALWAYS an explicit customer choice
-			// (`Location_Controller::handle_select_request()` never writes implicit —
-			// spec D11), so whichever level was marked implicit stops being one now,
-			// regardless of which level record.level itself names.
-			applyImplicitState( entry, record && record.level, false );
+			// (`Location_Controller::handle_select_request()` never writes implicit — spec
+			// D11) — `implicit` is unconditionally `false` here, regardless of what the
+			// PREVIOUS state (boot's own fire, see {@see prefill}) said.
+			fireLocationApplied( record, false );
 
 			if ( window.jQuery ) {
 				window.jQuery( document.body ).trigger( 'update_checkout' );
@@ -988,7 +945,9 @@
 
 		if ( notPersisted ) {
 			showNotPersistedNotice( entry );
-			fireLocationApplied( null );
+			// Nothing was persisted, so there is no record to flag as a default guess —
+			// `false`, same as every other "the record is now unknown" fire below.
+			fireLocationApplied( null, false );
 		}
 	}
 
@@ -1004,15 +963,25 @@
 	 * already uses (gotcha `an-empty-domain-key-is-not-a-key`); a listener must never
 	 * treat an event with an empty `key` as a real locality.
 	 *
-	 * @param {Object} record The just-persisted record (D8's own full, round-tripped shape).
+	 * `implicit` (issue #309; spec D11/§4.6) has NO default — every call site states its own
+	 * intent explicitly, on purpose: this is the ONE piece of this event's contract that is
+	 * NOT derivable from `record` alone (a persisted `/select` never carries its own implicit
+	 * flag — spec D11 — so `record.implicit` would always read `undefined` even where the
+	 * caller genuinely means `true`, e.g. {@see prefill}'s own boot fire). See the file
+	 * docblock's own section on `detail.implicit` for which callers pass which value and why.
+	 *
+	 * @param {Object}  record   The just-persisted record (D8's own full, round-tripped
+	 *                           shape), or `null` when the current locality is now unknown.
+	 * @param {boolean} implicit Whether the record this event describes is a default guess
+	 *                           rather than the customer's own choice.
 	 * @returns {void}
 	 */
-	function fireLocationApplied( record ) {
+	function fireLocationApplied( record, implicit ) {
 		var key = record && 'string' === typeof record.key ? record.key : '';
 		var level = record && 'string' === typeof record.level ? record.level : '';
 
 		document.body.dispatchEvent(
-			new CustomEvent( 'woodev_location_applied', { detail: { key: key, level: level }, bubbles: true } )
+			new CustomEvent( 'woodev_location_applied', { detail: { key: key, level: level, implicit: !! implicit }, bubbles: true } )
 		);
 	}
 
@@ -1561,7 +1530,9 @@
 		} );
 
 		if ( cleared && isActiveAddressSection( section ) ) {
-			fireLocationApplied( null );
+			// Nothing is known to be implicit about a cleared record — false, same reasoning
+			// as {@see settleSelect}'s own `notPersisted` branch.
+			fireLocationApplied( null, false );
 		}
 	}
 
@@ -1659,7 +1630,9 @@
 
 				Promise.resolve().then( function() {
 					if ( null === entry.records[ level ] && isActiveAddressSection( section ) ) {
-						fireLocationApplied( null );
+						// Same "nothing known to be implicit about an unknown record" reasoning
+						// as {@see clearCountryScope}.
+						fireLocationApplied( null, false );
 					}
 				} );
 			}
@@ -1798,6 +1771,19 @@
 	 * `class-checkout-config.php::build_location_block()`) for that level so a child scope
 	 * fetch can use it WITHOUT re-fetching (Task 11 "restore state without re-fetching").
 	 *
+	 * ALSO FIRES `woodev_location_applied` (issue #309; spec D11/§4.6) — give
+	 * `entry.location.implicit` its first real consumer: this is the ONE call site that can
+	 * ever fire the event with `implicit: true`, see the file docblock's own section on
+	 * `detail.implicit` for why. Fired unconditionally whenever a current record exists,
+	 * regardless of which section `entry` belongs to or whether ITS chain even carries a
+	 * field for `current.level` (spec §4.4 explicitly permits a record whose level has no
+	 * matching field) — unlike the old DOM-attribute attempt, this needs no field to exist at
+	 * all. Two entries sharing one customer record (e.g. a billing entry and a shipping entry
+	 * both wired to the SAME `Location_Service`) each fire their own, identically-valued
+	 * event; a listener maintaining ONE piece of state for "is the customer's current
+	 * locality implicit" (never one per entry) sees no divergence, because there IS no
+	 * per-entry state any more for it to diverge from.
+	 *
 	 * @param {Object} entry
 	 * @returns {void}
 	 */
@@ -1829,10 +1815,7 @@
 		if ( current && current.key && current.level ) {
 			entry.records[ current.level ] = { key: current.key };
 
-			// Issue #309: give `entry.location.implicit` its first real consumer — see
-			// applyImplicitState()'s own docblock for why this reads only as a DOM signal,
-			// never as a reason to withhold `current.key` from scoping/addressing above.
-			applyImplicitState( entry, current.level, !!entry.location.implicit );
+			fireLocationApplied( { key: current.key, level: current.level }, !! entry.location.implicit );
 		}
 	}
 

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -2359,25 +2359,43 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 * half): an empty key is now never used to ADDRESS the points query either, it too
 		 * falls back to the DOM read, same as an absent block.
 		 *
+		 * `implicit` (issue #309; spec D11/§4.6) is the flag
+		 * {@see \Woodev\Framework\Shipping\Location\Location_Service::get_customer_record()}'s
+		 * own docblock names this exact use case for — "a caller needs the flag too, e.g. to
+		 * decide whether to still show a 'please choose your locality' prompt" —
+		 * {@see self::current_location_record()} discards it on the very next line after
+		 * reading it (it only ever needed the bare record, for {@see self::location_context()}),
+		 * so this method reads {@see Location_Service::get_customer_record()} directly instead
+		 * of going through that helper, to keep the flag. `false` whenever there is no record
+		 * at all — an implicit flag is only meaningful attached to an actual record, same
+		 * convention {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}
+		 * already uses for its own sibling `implicit` key.
+		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 Also gates on {@see \Woodev\Framework\Shipping\Location\Location_Service::is_active()},
 		 *              not just on {@see self::$plugin} being non-null (review finding F1,
 		 *              rig-verified: a registered-but-unconfigured provider left the pickup
 		 *              picker permanently disabled in every populated city).
+		 * @since 2.0.2 Added `implicit` (issue #309; spec D11/§4.6) — a client-side consumer
+		 *              seam for the flag {@see Location_Service::get_customer_record()} already
+		 *              returns, replacing an earlier DOM-attribute mechanism
+		 *              ({@see \Woodev\Framework\Shipping\Location\Customer_Location_Store})
+		 *              that could not reliably survive a checkout re-render.
 		 *
-		 * @return array{current: array{key: string}}|null
+		 * @return array{current: array{key: string}, implicit: bool}|null
 		 */
 		protected function location_config_block(): ?array {
 			if ( null === $this->plugin || ! $this->plugin->get_location_service()->is_active() ) {
 				return null;
 			}
 
-			$record = $this->current_location_record();
+			$customer = $this->plugin->get_location_service()->get_customer_record();
 
 			return [
-				'current' => [
-					'key' => null !== $record ? $record->key() : '',
+				'current'  => [
+					'key' => null !== $customer ? $customer['record']->key() : '',
 				],
+				'implicit' => null !== $customer && (bool) $customer['implicit'],
 			];
 		}
 

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -2378,9 +2378,10 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 *              picker permanently disabled in every populated city).
 		 * @since 2.0.2 Added `implicit` (issue #309; spec D11/§4.6) — a client-side consumer
 		 *              seam for the flag {@see Location_Service::get_customer_record()} already
-		 *              returns, replacing an earlier DOM-attribute mechanism
-		 *              ({@see \Woodev\Framework\Shipping\Location\Customer_Location_Store})
-		 *              that could not reliably survive a checkout re-render.
+		 *              returns. It replaces an earlier attempt that marked the chain field with
+		 *              a DOM attribute from `location-cascade.js`, which could not survive a
+		 *              checkout re-render, a select2-rendering presentation mode, or two entries
+		 *              sharing one location block.
 		 *
 		 * @return array{current: array{key: string}, implicit: bool}|null
 		 */


### PR DESCRIPTION
Closes #309.

Spec §4.6 says an implicit record takes part in rate calculation but must never suppress the "выберите населённый пункт" prompt. Nothing implemented that difference: the `implicit` flag was written by the store, read back, used internally by `may_overwrite()`, exported into both `Checkout_Config::build_location_block()` and (as of this rework) `Pickup_Handler::location_config_block()` — and, until this PR, consumed by nobody on the client.

## First attempt (superseded)

The original version of this PR marked the DOM field holding the current locality with `data-woodev-location-implicit`, set in `prefill()` on boot and cleared the instant a real `/select` persisted. An adversarial review reproduced five ways that could not work, each confirmed with a probe in a scratch clone:

1. **Destroyed at boot for two of three D7 presentation modes.** `boot()` runs `prefill()` before `attachAll()`. For `ajax-select2` (any level) and `related-list` (settlement), `buildSelectField()` creates a fresh `<select>`, copies only `id`/`name`/`className`, and removes the original `<input>` — the mark is gone before the customer ever sees the field, and nothing re-applies it. With a store configured for either mode, the feature was 100% dead.
2. **Did not survive `updated_checkout`.** `reconcileAfterCheckoutUpdate()` re-attaches widgets and restores values but never re-applies the mark, and `prefill()` only ever ran once, from `boot()`. A guest with a geoip default who picks a shipping method (any checkout re-render) loses the signal.
3. **Permanently stale when two entries share one customer record** — e.g. a billing-section entry and a shipping-section entry both wired to the same `Location_Service`. Each entry tracked its own `implicitLevel`; an explicit pick in one entry's active section only ever cleared that entry's own mark, leaving the other stuck at `true` forever. `applyImplicitState()` also lacked the `isActiveAddressSection()` gate `clearCountryScope()`/`fireLocationApplied()` both already have.
4. **Stale after a country change.** `clearCountryScope()` empties the field value but never clears the mark.
5. **No signal at all when the record's level has no field in the chain** — spec §4.4 explicitly permits this shape, but there is no DOM node to attach an attribute to, while the server always knows the flag regardless.

## What's here instead

Every other cross-module signal in this layer is an event, a hook, or a server-rendered config field — `woodev_location_applied`, `Customer_Location_Store::ACTION_SAVED`, `woodev_location_i18n`, the `location` config blocks. Nothing else publishes state as a DOM attribute. This rework keeps the same design call (framework emits mechanism, never customer-facing wording — no "уточните город" text exists anywhere here, and never will from this PR) but drops the DOM entirely:

- **`woodev_location_applied`'s `detail` gains `implicit`.** This event already fires on exactly the transitions that matter and depends on no DOM node existing or surviving anything. `fireLocationApplied()` now takes an explicit `implicit` argument (no default — every call site states its own intent). `prefill()` fires the event on boot with `config.location.implicit`; that is the only call site that can ever fire `true` — every other fire (an explicit `/select` persisting, or the record becoming unknown) is unconditionally `false`, because a persisted `/select` is never itself an implicit write (`Location_Controller::handle_select_request()` never writes implicit — spec D11).
- **`Pickup_Handler::location_config_block()` gains an `implicit` key.** One array key, not a new mechanism: `current_location_record()` already calls `get_customer_record()` and discards `$current['implicit']` on the very next line, and `Location_Service::get_customer_record()`'s own docblock names this exact use case ("a caller needs the flag too, e.g. to decide whether to still show a 'please choose your locality' prompt") as the reason it returns the flag at all.

Rate calculation, points addressing, and `resolveLocalityKey()` remain fully implicit-agnostic, unchanged — spec D11's other half. No locality gate was added to the pickup trigger (`mountSlot()` still always creates it) — that's a separate, deliberate product decision, not part of this seam.

## Tests

`location-cascade.test.js`: replaced the 6 DOM-marker tests with 11 covering the event's `implicit` — true, false, absent record, a record whose level has no field in the chain, an explicit pick overriding a `true` boot state, a DOM-replacing renderer running immediately after the boot fire (reproduces defect 1's exact timing with a fake renderer), a checkout re-render (defect 2), and two entries sharing one customer record (defect 3) — plus updated the 6 pre-existing `woodev_location_applied` assertions for the new field. `location-cascade.test.js` 88 → 93; full jest suite 1081 → 1086, all green.

`PickupHandlerTest.php`: 2 new tests for `location_config_block()`'s `implicit` key (true and false). PHP suite 2137 → 2139 tests.

Mutation-checked: the boot-time fire, the `implicit` literal inside `fireLocationApplied()`, every call site's own `true`/`false` argument (`settleSelect`'s two branches, `clearCountryScope`, `handleFieldChanged`), and both PHP branches were each reverted in turn and confirmed to redden exactly the tests that claim to cover them — reports are in the implementing commit.

phpcs, phpstan (level 3, no baseline), and both full suites (`composer test:unit`, jest) are clean.

## Rig pass

**Nothing changes visually on the page — there is nothing to inspect in the DOM or eyeball on the rig.** The previous round of instructions asked the operator to check for a `data-woodev-location-implicit` attribute that no longer exists; ignore those. This PR adds a contract surface only: the `implicit` key on `woodev_location_applied`'s event detail and on the pickup config block. **Correction from the fix re-review:** the claim that this event has "no consumer yet" was wrong. `pickup-mount.js` has bound `handleLocationApplied` at module scope since #159, and it writes `resolvedLocalityKey[ config.fieldId ] = detail.key`. Ordering means the new boot fire does reach it — pickup-mount registers during footer script evaluation, while `boot()` is deferred to `DOMContentLoaded` — so `prefill()` now eagerly seeds pickup-mount's locality key on every page load, where previously that event only fired after a customer action. It is a practical no-op: there is a single session record (`STORAGE_KEY = 'woodev_customer_location'`), and both `Checkout_Config::build_location_block()` and `Pickup_Handler::location_config_block()` read it through the same `Location_Service::get_customer_record()`, so the eager seed equals the lazy one. It is stated here because it is a real cross-file interaction that no test boots both modules to cover. The `implicit` key itself still has no consumer, which is fine — that is the `Customer_Location_Store::ACTION_SAVED` precedent. Nothing observable to a human changes; verify via the test suites above, not the browser.

