### PR TITLE
feat(location): country falls back to the store setting, then to a filterable default

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -1349,6 +1349,70 @@ describe( 'country fallback chain (issue #296)', () => {
 } );
 
 // -----------------------------------------------------------------------
+// PR #320 review, finding 1: the destructive-clear gate must compare the SAME effective
+// country countryFor() (and the widget's own attach/scope) already resolves — never the raw
+// DOM value. Before this fix, prefill() seeded entry.resolved['billing_country'] from
+// `el.value` ('' for an unselected select), so the customer's first EXPLICIT pick of the very
+// country the fallback was already using read as a real transition and destructively cleared
+// an address that was never stale to begin with.
+// -----------------------------------------------------------------------
+
+describe( 'selecting the fallback\'s own country must not destructively clear (finding 1, PR #320 review)', () => {
+	it( 'reproduction: attaches on the RU fallback, customer fills the address, then explicitly picks "Россия" — nothing is cleared', () => {
+		// "No location by default": #billing_country is present but genuinely unselected
+		// (`value === ''`, WooCommerce's own placeholder option) — the widget attaches on the
+		// server-resolved defaultCountry fallback, exactly like the "steps 2/3" tests above.
+		boot( {
+			settlement: true, address: true, country: '', defaultCountry: 'RU', countries: [ 'RU' ],
+		} );
+
+		// The widget attached under the fallback at all — precondition for the bug to even be
+		// reachable.
+		expect( attachCalls.map( ( c ) => c.el.id ) ).toContain( 'billing_city' );
+
+		// Customer picks a settlement through the widget (a real record, so the field's own
+		// confirmed record is non-null — see the "country switch" describe block above for why
+		// a genuine selection, not a raw `.value` write, is required here).
+		selectViaFake( callFor( 'billing_city' ), {
+			key: 'dadata:msk', label: 'г Москва', value: 'Москва', level: 'settlement',
+			record: {
+				key: 'dadata:msk', provider_id: 'dadata', level: 'settlement', country: 'RU',
+				settlement: { name: 'Москва', type: 'г' }, label: 'г Москва',
+			},
+		} );
+
+		// ...types a street and a postcode by hand, without picking an address suggestion.
+		document.getElementById( 'billing_address_1' ).value = 'ул Тверская, 1';
+		document.getElementById( 'billing_postcode' ).value = '101000';
+
+		// THEN explicitly selects the SAME country every suggestion was already scoped by.
+		document.getElementById( 'billing_country' ).value = 'RU';
+		document.getElementById( 'billing_country' ).dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Москва' );
+		expect( document.getElementById( 'billing_address_1' ).value ).toBe( 'ул Тверская, 1' );
+		expect( document.getElementById( 'billing_postcode' ).value ).toBe( '101000' );
+	} );
+
+	it( 'the SAME reproduction with no country field at all (prefill has nothing to seed, but there is also no field to fire a change on)', () => {
+		// A checkout that dropped the country field entirely never sees a `change` event for it
+		// at all, so the bug this finding describes cannot fire — this pins that the fix does
+		// not depend on a country field existing.
+		boot( { settlement: true, address: true, omitBillingCountry: true, defaultCountry: 'RU', countries: [ 'RU' ] } );
+
+		selectViaFake( callFor( 'billing_city' ), {
+			key: 'dadata:msk', label: 'г Москва', value: 'Москва', level: 'settlement',
+			record: {
+				key: 'dadata:msk', provider_id: 'dadata', level: 'settlement', country: 'RU',
+				settlement: { name: 'Москва', type: 'г' }, label: 'г Москва',
+			},
+		} );
+
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Москва' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
 // Per-section country resolution (Finding 1, PR-C review): a field declared in the
 // `shipping` §8 section (`field.section === 'shipping'`, the SAME convention
 // `class-checkout-fields.php::normalize()` / `Field::set_section()` already establish and

--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -59,16 +59,18 @@ function fieldIdFor( level, section ) {
 
 /**
  * Builds the classic-checkout markup for whichever location fields + postcode the test
- * needs. `billing_country` (and its postcode counterpart) is always present (a native WC
- * field, never declared in `config.fields`). `#shipping_country` and the WC
- * `ship_to_different_address` checkbox are rendered whenever `which.section === 'shipping'`
- * (or `which.withShippingCountry` is set for a test that wants both present) — mirrors WC's
- * OWN classic-checkout template, which always renders both country selects and the toggle
- * checkbox together.
+ * needs. `billing_country` (and its postcode counterpart) is present by default (a native WC
+ * field, never declared in `config.fields`) — `which.omitBillingCountry` drops it entirely
+ * (issue #296: a single-country store commonly removes the field from checkout). `#shipping_country`
+ * and the WC `ship_to_different_address` checkbox are rendered whenever `which.section ===
+ * 'shipping'` (or `which.withShippingCountry` is set for a test that wants both present) —
+ * mirrors WC's OWN classic-checkout template, which always renders both country selects and
+ * the toggle checkbox together; `which.omitShippingCountry` drops the shipping one the same way.
  *
  * @param {{region?: boolean, settlement?: boolean, address?: boolean, section?: string,
  *          shippingCountry?: string, shipToDifferentAddress?: boolean,
- *          withShippingCountry?: boolean}} which
+ *          withShippingCountry?: boolean, omitBillingCountry?: boolean,
+ *          omitShippingCountry?: boolean}} which
  * @param {string} country
  * @returns {void}
  */
@@ -88,7 +90,7 @@ function installMarkup( which, country = 'RU' ) {
 	}
 
 	const postcodeId = 'shipping' === section ? 'shipping_postcode' : 'billing_postcode';
-	const needsShippingCountry = 'shipping' === section || w.withShippingCountry;
+	const needsShippingCountry = ( 'shipping' === section || w.withShippingCountry ) && ! w.omitShippingCountry;
 	const checked = false !== w.shipToDifferentAddress; // defaults to checked (true)
 
 	const shippingMarkup = needsShippingCountry ? `
@@ -99,19 +101,26 @@ function installMarkup( which, country = 'RU' ) {
 		<input type="checkbox" id="ship-to-different-address-checkbox" name="ship_to_different_address" ${ checked ? 'checked' : '' } />
 	` : '';
 
+	const billingCountryMarkup = w.omitBillingCountry ? '' : `
+		<select id="billing_country" name="billing_country">
+			<option value="RU">Россия</option>
+			<option value="US">США</option>
+		</select>
+	`;
+
 	document.body.innerHTML = `
 		<form class="checkout woocommerce-checkout">
-			<select id="billing_country" name="billing_country">
-				<option value="RU">Россия</option>
-				<option value="US">США</option>
-			</select>
+			${ billingCountryMarkup }
 			${ shippingMarkup }
 			${ inputs }
 			<input type="text" id="${ postcodeId }" name="${ postcodeId }" value="" />
 		</form>
 	`;
 
-	document.getElementById( 'billing_country' ).value = country;
+	const billingCountryEl = document.getElementById( 'billing_country' );
+	if ( billingCountryEl ) {
+		billingCountryEl.value = country;
+	}
 
 	const shippingCountryEl = document.getElementById( 'shipping_country' );
 	if ( shippingCountryEl ) {
@@ -146,7 +155,8 @@ function locationField( level, section = 'billing' ) {
  * (`Checkout_Config::build_location_block()`).
  *
  * @param {{region?: boolean, settlement?: boolean, address?: boolean, section?: string,
- *          levels?: Object, countries?: string[], current?: Object|null, implicit?: boolean}} opts
+ *          levels?: Object, countries?: string[], current?: Object|null, implicit?: boolean,
+ *          defaultCountry?: string}} opts
  * @returns {Object}
  */
 function buildConfig( opts ) {
@@ -181,6 +191,9 @@ function buildConfig( opts ) {
 			levels: o.levels || { RU: { region: true, settlement: true, address: true } },
 			current: o.current !== undefined ? o.current : null,
 			implicit: o.implicit !== undefined ? o.implicit : false,
+			// Issue #296: steps 2+3 of the checkout-field -> WC-store-setting -> RU chain,
+			// already merged into ONE value server-side by Location_Service::resolve_default_country().
+			defaultCountry: o.defaultCountry !== undefined ? o.defaultCountry : 'RU',
 			i18n: o.i18n !== undefined ? o.i18n : {
 				noResults: 'Поиск не дал результатов. Попробуйте изменить запрос.',
 				noResultsAddress: 'Адрес не найден — введите вручную.',
@@ -1247,6 +1260,91 @@ describe( 'country switch', () => {
 
 		expect( window.WoodevLocationTypeahead.mock.calls.length ).toBeGreaterThan( attachCountAfterDetach );
 		expect( document.getElementById( 'billing_city' ).value ).toBe( '' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// Country fallback chain (issue #296): `checkout field -> WooCommerce store setting -> RU`.
+// Steps 2+3 are already merged server-side into ONE `entry.location.defaultCountry` value
+// (`Location_Service::resolve_default_country()`, fed through `Checkout_Config::build_location_block()`)
+// — `countryFor()` only ever has ONE fallback of its own to make: the live field, else that
+// value. Before this task, a checkout with no country field at all made `countryFor()` return
+// `''`, which `isCountrySupported()` always rejects — no widget ever attached, and the whole
+// location layer went silently dead with no signal why (the operator's own bug report).
+// -----------------------------------------------------------------------
+
+describe( 'country fallback chain (issue #296)', () => {
+	it( 'step 1: uses the live checkout field value when present and non-empty', () => {
+		boot( {
+			settlement: true, country: 'US', defaultCountry: 'RU',
+			countries: [ 'RU', 'US' ],
+			levels: { RU: { region: true, settlement: true, address: true }, US: { region: false, settlement: true, address: false } },
+		} );
+
+		callFor( 'billing_city' ).fetch( 'Sea' );
+
+		const req = fetchCalls[ fetchCalls.length - 1 ];
+		expect( req.url ).toContain( 'country=US' );
+	} );
+
+	it( 'steps 2/3: falls back to the server-resolved defaultCountry when the field is present but empty', () => {
+		boot( { settlement: true, country: '', defaultCountry: 'RU', countries: [ 'RU' ] } );
+
+		// The bug this closes: isCountrySupported( entry, '' ) was always false, so no widget
+		// ever attached for a country <select> a customer had not chosen from yet.
+		expect( attachCalls.map( ( c ) => c.el.id ) ).toContain( 'billing_city' );
+
+		callFor( 'billing_city' ).fetch( 'Мос' );
+
+		const req = fetchCalls[ fetchCalls.length - 1 ];
+		expect( req.url ).toContain( 'country=RU' );
+	} );
+
+	it( 'steps 2/3: falls back to the server-resolved defaultCountry, and still attaches, when the checkout has no country field at all', () => {
+		boot( { settlement: true, omitBillingCountry: true, defaultCountry: 'RU', countries: [ 'RU' ] } );
+
+		expect( document.getElementById( 'billing_country' ) ).toBeNull();
+		expect( attachCalls.map( ( c ) => c.el.id ) ).toContain( 'billing_city' );
+
+		callFor( 'billing_city' ).fetch( 'Мос' );
+
+		const req = fetchCalls[ fetchCalls.length - 1 ];
+		expect( req.url ).toContain( 'country=RU' );
+	} );
+
+	it( 'never throws, and never attaches a listener to a non-existent country field, when the checkout has no country field at all', () => {
+		// bindChangeWatchers() delegates on document.body (see the file's own docblock on the
+		// two event worlds) — there is nothing to bind TO a node that was never rendered, so
+		// booting with the field entirely absent must not throw.
+		expect( () => boot( { settlement: true, omitBillingCountry: true, defaultCountry: 'RU', countries: [ 'RU' ] } ) ).not.toThrow();
+	} );
+
+	it( 'does not detach the widget across a layout-relevant re-arbitration while the country field stays absent', () => {
+		boot( {
+			settlement: true, omitBillingCountry: true, withShippingCountry: true,
+			defaultCountry: 'RU', countries: [ 'RU' ],
+		} );
+
+		const settlementAttach = callFor( 'billing_city' );
+		const detachesBefore = settlementAttach.detach.mock.calls.length;
+
+		// #shipping_country IS present here — changing it re-runs applyCountryArbitration() for
+		// EVERY entry (handleLayoutRelevantChange()), including this billing-section one, whose
+		// own country is still unavailable from the DOM and must keep resolving to the SAME
+		// server default on every pass — never flap the already-attached widget.
+		document.getElementById( 'shipping_country' ).value = 'US';
+		document.getElementById( 'shipping_country' ).dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( settlementAttach.detach.mock.calls.length ).toBe( detachesBefore );
+	} );
+
+	it( 'a country the fallback names but the layer does not cover still degrades to no widget, never a forced attach', () => {
+		// entry.location.countries never includes the fallback's own answer here — the D15
+		// degradation idiom must still win; a server-side misconfiguration must never force a
+		// widget onto a country this layer genuinely does not serve.
+		boot( { settlement: true, omitBillingCountry: true, defaultCountry: 'RU', countries: [ 'KZ' ] } );
+
+		expect( attachCalls.map( ( c ) => c.el.id ) ).not.toContain( 'billing_city' );
 	} );
 } );
 

--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -86,6 +86,9 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 	/** @var string[] Task 13/issue #294: countries owns_region_states() reports true for. */
 	private array $owned_region_countries;
 
+	/** @var string Issue #296: resolve_default_country() return value. */
+	private string $default_country;
+
 	/**
 	 * @param bool                                                             $active                 is_active() return value.
 	 * @param array<string, bool>                                              $supported_levels       level => whether SOME configured provider serves it,
@@ -102,6 +105,12 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 	 *                                                                                                   call site is unaffected.
 	 * @param string[]                                                          $owned_region_countries Task 13/issue #294: countries owns_region_states()
 	 *                                                                                                   reports `true` for.
+	 * @param string                                                            $default_country        Issue #296: resolve_default_country() return
+	 *                                                                                                   value; defaults to 'RU' so every existing call
+	 *                                                                                                   site is unaffected. Fixed here rather than left
+	 *                                                                                                   to the REAL method (which reads get_option()) —
+	 *                                                                                                   this fake never touches WordPress option state at
+	 *                                                                                                   all, mirroring every other method on this class.
 	 */
 	public function __construct(
 		bool $active,
@@ -109,7 +118,8 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 		?array $customer,
 		array $countries,
 		string $mode = Location_Provider_Registry::MODE_TYPEAHEAD,
-		array $owned_region_countries = []
+		array $owned_region_countries = [],
+		string $default_country = 'RU'
 	) {
 		$this->active                 = $active;
 		$this->supported_levels       = $supported_levels;
@@ -117,10 +127,15 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 		$this->countries               = $countries;
 		$this->mode                    = $mode;
 		$this->owned_region_countries = $owned_region_countries;
+		$this->default_country         = $default_country;
 	}
 
 	public function is_active(): bool {
 		return $this->active;
+	}
+
+	public function resolve_default_country(): string {
+		return $this->default_country;
 	}
 
 	public function get_customer_record(): ?array {
@@ -1018,5 +1033,67 @@ class CheckoutConfigTest extends TestCase {
 			$config['location']['levels']['RU']['region'],
 			'a WC states read of `false` must degrade to states_present=false, not a false-positive conflict'
 		);
+	}
+
+	// -------------------------------------------------------------------------
+	// defaultCountry — issue #296: steps 2+3 of the checkout-field -> WC-store-
+	// setting -> RU chain, exposed to the client next to countries/levels.
+	// -------------------------------------------------------------------------
+
+	public function test_location_block_carries_the_default_country(): void {
+		$service = new Checkout_Config_Fake_Location_Service(
+			true, [ 'settlement' => true ], null, [ 'RU' ], Location_Provider_Registry::MODE_TYPEAHEAD, [], 'KZ'
+		);
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame( 'KZ', $config['location']['defaultCountry'] );
+	}
+
+	/**
+	 * End-to-end through the REAL {@see Location_Service} (not the fixture
+	 * fake above) — the "real body" pairing this task's own seam rule
+	 * requires: {@see Location_Service::resolve_default_country()} genuinely
+	 * reads `get_option( 'woocommerce_default_country' )` and splits the
+	 * `COUNTRY:STATE` shape, mirroring the exact option format a merchant who
+	 * picked a country without naming a state leaves behind.
+	 */
+	public function test_location_block_default_country_reads_the_real_wc_option_through_the_real_service(): void {
+		Location_Provider_Registry::instance()->reset_for_tests();
+		Settings_Page_Registry::instance()->reset_for_tests();
+
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+		Functions\when( 'is_user_logged_in' )->justReturn( false );
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				if ( 'woodev_location_token' === $name ) {
+					return 'tok';
+				}
+				if ( 'woocommerce_default_country' === $name ) {
+					return 'KZ:north';
+				}
+
+				return $default;
+			}
+		);
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$service = new Location_Service( $registry );
+		$this->assertTrue( $service->is_active(), 'the bundled DaData provider must be active+configured for this test to be meaningful' );
+
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame( 'KZ', $config['location']['defaultCountry'] );
 	}
 }

--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -437,6 +437,10 @@ class CheckoutConfigTest extends TestCase {
 				return 'woodev_location_token' === $name ? 'tok' : $default;
 			}
 		);
+		// resolve_default_country() reads wc_get_base_location() (PR #320 review, finding 3) —
+		// this test asserts on `levels`/`countries`, never `defaultCountry`, so any well-formed
+		// stub is fine here.
+		Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'RU', 'state' => '' ] );
 
 		$registry = Location_Provider_Registry::instance();
 		$registry->declare_needed();
@@ -534,6 +538,10 @@ class CheckoutConfigTest extends TestCase {
 				return $default;
 			}
 		);
+		// resolve_default_country() reads wc_get_base_location() (PR #320 review, finding 3) —
+		// this test asserts on `countries`, never `defaultCountry`, so any well-formed stub is
+		// fine here.
+		Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'RU', 'state' => '' ] );
 
 		$registry = Location_Provider_Registry::instance();
 		$registry->declare_needed();
@@ -679,6 +687,10 @@ class CheckoutConfigTest extends TestCase {
 				return $default;
 			}
 		);
+		// resolve_default_country() reads wc_get_base_location() (PR #320 review, finding 3) —
+		// this test asserts on the SERIALIZED config never leaking a secret, never on
+		// `defaultCountry`, so any well-formed stub is fine here.
+		Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'RU', 'state' => '' ] );
 
 		$registry = Location_Provider_Registry::instance();
 		$registry->declare_needed();
@@ -1054,7 +1066,8 @@ class CheckoutConfigTest extends TestCase {
 	 * End-to-end through the REAL {@see Location_Service} (not the fixture
 	 * fake above) — the "real body" pairing this task's own seam rule
 	 * requires: {@see Location_Service::resolve_default_country()} genuinely
-	 * reads `get_option( 'woocommerce_default_country' )` and splits the
+	 * reads `wc_get_base_location()` (PR #320 review, finding 3 — never a raw
+	 * `get_option( 'woocommerce_default_country' )` read) and splits the
 	 * `COUNTRY:STATE` shape, mirroring the exact option format a merchant who
 	 * picked a country without naming a state leaves behind.
 	 */
@@ -1073,16 +1086,10 @@ class CheckoutConfigTest extends TestCase {
 		Functions\when( 'apply_filters' )->returnArg( 2 );
 		Functions\when( 'get_option' )->alias(
 			static function ( $name, $default = null ) {
-				if ( 'woodev_location_token' === $name ) {
-					return 'tok';
-				}
-				if ( 'woocommerce_default_country' === $name ) {
-					return 'KZ:north';
-				}
-
-				return $default;
+				return 'woodev_location_token' === $name ? 'tok' : $default;
 			}
 		);
+		Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'KZ', 'state' => 'north' ] );
 
 		$registry = Location_Provider_Registry::instance();
 		$registry->declare_needed();

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
@@ -89,6 +89,16 @@ final class Checkout_Handler_Fake_Location_Service extends Location_Service {
 	public function owns_region_states( string $country, array $final_states ): bool {
 		return false;
 	}
+
+	/**
+	 * Issue #296: never touches `get_option()` — this fake, like every other
+	 * method above, stays entirely clear of real WordPress option state
+	 * (mirrors `Checkout_Config_Fake_Location_Service`'s own override in
+	 * `CheckoutConfigTest`, for the identical reason).
+	 */
+	public function resolve_default_country(): string {
+		return 'RU';
+	}
 }
 
 /**

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -1173,5 +1173,126 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$this->assertSame( $registry->owns_region_states( 'RU', [] ), $service->owns_region_states( 'RU', [] ) );
 			$this->assertFalse( $service->owns_region_states( 'RU', [] ) );
 		}
+
+		// -------------------------------------------------------------------
+		// resolve_default_country() — issue #296: checkout field -> WooCommerce
+		// store setting -> RU (filterable). No registry/provider state is
+		// touched at all, so every test here uses a bare Location_Service — the
+		// REAL method body runs in every one of them (never a fixture double),
+		// satisfying this task's own "a seam must have at least one real-body
+		// test" rule by construction.
+		// -------------------------------------------------------------------
+
+		private function stub_default_country_option( ?string $raw ): void {
+			Functions\when( 'get_option' )->alias(
+				static function ( $name, $default = null ) use ( $raw ) {
+					if ( 'woocommerce_default_country' === $name ) {
+						return $raw;
+					}
+
+					return $default;
+				}
+			);
+		}
+
+		public function test_resolve_default_country_splits_the_country_from_a_country_state_option(): void {
+			// The exact shape a merchant who picked a country without naming a
+			// state gets (gotcha this project already paid for once on the
+			// STATE half of this same option — see Checkout_Handler's own
+			// handle_checkout_get_value() docblock).
+			$this->stub_default_country_option( 'RU:*' );
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'RU', $service->resolve_default_country() );
+		}
+
+		public function test_resolve_default_country_accepts_a_bare_country_with_no_state_component(): void {
+			$this->stub_default_country_option( 'KZ' );
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'KZ', $service->resolve_default_country() );
+		}
+
+		public function test_resolve_default_country_trims_and_upper_cases(): void {
+			$this->stub_default_country_option( ' kz : some-state ' );
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'KZ', $service->resolve_default_country() );
+		}
+
+		public function test_resolve_default_country_falls_back_to_ru_when_the_option_is_empty(): void {
+			$this->stub_default_country_option( '' );
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'RU', $service->resolve_default_country() );
+		}
+
+		public function test_resolve_default_country_falls_back_to_ru_when_the_option_is_unset(): void {
+			$this->stub_default_country_option( null );
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'RU', $service->resolve_default_country() );
+		}
+
+		/**
+		 * The defensive case the card explicitly calls out: the option holding
+		 * ONLY WooCommerce's `*` "no state" sentinel, with no country and no
+		 * colon at all. A naive un-split read would pass `'*'` straight through
+		 * as if it were a country code; this must be recognised as malformed
+		 * and fall through to the RU default instead of ever leaking `*` into
+		 * a REST response or the checkout config block.
+		 */
+		public function test_resolve_default_country_never_leaks_the_wildcard_sentinel(): void {
+			$this->stub_default_country_option( '*' );
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'RU', $service->resolve_default_country() );
+		}
+
+		public function test_resolve_default_country_honors_the_filter_when_the_option_has_nothing_usable(): void {
+			$this->stub_default_country_option( '' );
+			Functions\when( 'apply_filters' )->alias(
+				static function ( string $tag, $default = null ) {
+					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? 'KZ' : $default;
+				}
+			);
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'KZ', $service->resolve_default_country(), 'a Kazakhstan store must be able to override the RU default' );
+		}
+
+		public function test_resolve_default_country_never_consults_the_filter_when_the_option_already_answers(): void {
+			$this->stub_default_country_option( 'RU:*' );
+			Functions\when( 'apply_filters' )->alias(
+				static function ( string $tag, $default = null ) {
+					// Would answer 'KZ' if wrongly consulted — the store's own setting must win.
+					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? 'KZ' : $default;
+				}
+			);
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'RU', $service->resolve_default_country() );
+		}
+
+		public function test_resolve_default_country_never_returns_a_malformed_filtered_value(): void {
+			$this->stub_default_country_option( '' );
+			Functions\when( 'apply_filters' )->alias(
+				static function ( string $tag, $default = null ) {
+					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? 'Kazakhstan' : $default;
+				}
+			);
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'RU', $service->resolve_default_country(), 'a misbehaving filter must never brick the fallback' );
+		}
 	}
 }

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -1176,21 +1176,49 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 
 		// -------------------------------------------------------------------
 		// resolve_default_country() — issue #296: checkout field -> WooCommerce
-		// store setting -> RU (filterable). No registry/provider state is
-		// touched at all, so every test here uses a bare Location_Service — the
-		// REAL method body runs in every one of them (never a fixture double),
-		// satisfying this task's own "a seam must have at least one real-body
-		// test" rule by construction.
+		// store setting (read via wc_get_base_location(), PR #320 review finding
+		// 3 — never a raw get_option() read) -> RU, filterable on the FINAL
+		// resolved value (PR #320 review finding 2). No registry/provider state
+		// is touched at all, so every test here uses a bare Location_Service —
+		// the REAL method body runs in every one of them (never a fixture
+		// double), satisfying this task's own "a seam must have at least one
+		// real-body test" rule by construction.
 		// -------------------------------------------------------------------
 
-		private function stub_default_country_option( ?string $raw ): void {
+		/**
+		 * Stubs `wc_get_base_location()` the same way WooCommerce's own
+		 * `wc_format_country_state_string()` would split it from the
+		 * `woocommerce_default_country` option — `$raw` is the raw
+		 * `COUNTRY:STATE` (or bare `COUNTRY`, or malformed) value the option
+		 * would otherwise carry; `null` models the option answering nothing at
+		 * all (WC's own default is `'US:CA'` in that case, but this façade must
+		 * never depend on that literal).
+		 *
+		 * ALSO stubs `get_option( 'woocommerce_default_country' )` with the SAME
+		 * raw value (PR #320 review, finding 3's own mutation coverage): a test
+		 * that only stubbed `wc_get_base_location()` would pass unchanged code
+		 * that still reads the OLD, un-filtered `get_option()` straight
+		 * through — because that call would simply hit Brain Monkey's default
+		 * `null` and coincidentally so, not because the fix is actually
+		 * exercised. Stubbing both means the two code paths are fed identical
+		 * data, so a test only diverges when the PRODUCTION CODE actually
+		 * changed which one it reads (or how it treats the result).
+		 *
+		 * @param string|null $raw
+		 */
+		private function stub_base_location( ?string $raw ): void {
+			$raw   = $raw ?? '';
+			$parts = explode( ':', $raw, 2 );
+
+			Functions\when( 'wc_get_base_location' )->justReturn(
+				[
+					'country' => $parts[0],
+					'state'   => $parts[1] ?? '',
+				]
+			);
 			Functions\when( 'get_option' )->alias(
 				static function ( $name, $default = null ) use ( $raw ) {
-					if ( 'woocommerce_default_country' === $name ) {
-						return $raw;
-					}
-
-					return $default;
+					return 'woocommerce_default_country' === $name ? $raw : $default;
 				}
 			);
 		}
@@ -1200,7 +1228,7 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			// state gets (gotcha this project already paid for once on the
 			// STATE half of this same option — see Checkout_Handler's own
 			// handle_checkout_get_value() docblock).
-			$this->stub_default_country_option( 'RU:*' );
+			$this->stub_base_location( 'RU:*' );
 
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
@@ -1208,31 +1236,58 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		}
 
 		public function test_resolve_default_country_accepts_a_bare_country_with_no_state_component(): void {
-			$this->stub_default_country_option( 'KZ' );
+			$this->stub_base_location( 'KZ' );
 
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
 			$this->assertSame( 'KZ', $service->resolve_default_country() );
+		}
+
+		/**
+		 * PR #320 review, finding 3: `wc_get_base_location()` runs the store's
+		 * base location through `apply_filters( 'woocommerce_get_base_location',
+		 * ... )` before returning it — a multi-store/multi-vendor/geo plugin can
+		 * make that answer diverge from the RAW `woocommerce_default_country`
+		 * option. This must be honoured, never bypassed by reading the option
+		 * directly: the two are stubbed to DISAGREE here on purpose, and the
+		 * `wc_get_base_location()` answer must win.
+		 */
+		public function test_resolve_default_country_honors_wc_get_base_location_over_the_raw_option(): void {
+			Functions\when( 'get_option' )->alias(
+				static function ( $name, $default = null ) {
+					// Would answer 'US' if the raw option were wrongly consulted directly.
+					return 'woocommerce_default_country' === $name ? 'US:CA' : $default;
+				}
+			);
+			Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'KZ', 'state' => '' ] );
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame(
+				'KZ',
+				$service->resolve_default_country(),
+				'wc_get_base_location() — which a multi-vendor/geo plugin may filter — must win over a raw option read'
+			);
 		}
 
 		public function test_resolve_default_country_trims_and_upper_cases(): void {
-			$this->stub_default_country_option( ' kz : some-state ' );
+			$this->stub_base_location( ' kz : some-state ' );
 
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
 			$this->assertSame( 'KZ', $service->resolve_default_country() );
 		}
 
-		public function test_resolve_default_country_falls_back_to_ru_when_the_option_is_empty(): void {
-			$this->stub_default_country_option( '' );
+		public function test_resolve_default_country_falls_back_to_ru_when_the_base_location_is_empty(): void {
+			$this->stub_base_location( '' );
 
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
 			$this->assertSame( 'RU', $service->resolve_default_country() );
 		}
 
-		public function test_resolve_default_country_falls_back_to_ru_when_the_option_is_unset(): void {
-			$this->stub_default_country_option( null );
+		public function test_resolve_default_country_falls_back_to_ru_when_wc_get_base_location_answers_nothing_usable(): void {
+			Functions\when( 'wc_get_base_location' )->justReturn( [] );
 
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
@@ -1248,15 +1303,15 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		 * a REST response or the checkout config block.
 		 */
 		public function test_resolve_default_country_never_leaks_the_wildcard_sentinel(): void {
-			$this->stub_default_country_option( '*' );
+			$this->stub_base_location( '*' );
 
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
 			$this->assertSame( 'RU', $service->resolve_default_country() );
 		}
 
-		public function test_resolve_default_country_honors_the_filter_when_the_option_has_nothing_usable(): void {
-			$this->stub_default_country_option( '' );
+		public function test_resolve_default_country_honors_the_filter_when_the_base_location_has_nothing_usable(): void {
+			$this->stub_base_location( '' );
 			Functions\when( 'apply_filters' )->alias(
 				static function ( string $tag, $default = null ) {
 					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? 'KZ' : $default;
@@ -1268,22 +1323,35 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$this->assertSame( 'KZ', $service->resolve_default_country(), 'a Kazakhstan store must be able to override the RU default' );
 		}
 
-		public function test_resolve_default_country_never_consults_the_filter_when_the_option_already_answers(): void {
-			$this->stub_default_country_option( 'RU:*' );
+		/**
+		 * PR #320 review, finding 2: the filter runs on the FINAL resolved
+		 * value, so it must be consulted — and able to WIN — even when the
+		 * store's own base location already answers something usable. This is
+		 * the behaviour the pre-fix code got backwards (it stubbed
+		 * `apply_filters()` to prove the filter was NEVER consulted here); on a
+		 * real WooCommerce install `woocommerce_default_country` is ALWAYS set
+		 * (`WC_Install::create_options()`), so a filter gated the old way could
+		 * never fire on a real store at all.
+		 */
+		public function test_resolve_default_country_the_filter_can_override_the_stores_own_base_location(): void {
+			$this->stub_base_location( 'RU:*' );
 			Functions\when( 'apply_filters' )->alias(
 				static function ( string $tag, $default = null ) {
-					// Would answer 'KZ' if wrongly consulted — the store's own setting must win.
 					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? 'KZ' : $default;
 				}
 			);
 
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
-			$this->assertSame( 'RU', $service->resolve_default_country() );
+			$this->assertSame(
+				'KZ',
+				$service->resolve_default_country(),
+				'the filter must be able to override the store\'s own base location, not only stand in for a missing one'
+			);
 		}
 
 		public function test_resolve_default_country_never_returns_a_malformed_filtered_value(): void {
-			$this->stub_default_country_option( '' );
+			$this->stub_base_location( '' );
 			Functions\when( 'apply_filters' )->alias(
 				static function ( string $tag, $default = null ) {
 					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? 'Kazakhstan' : $default;
@@ -1293,6 +1361,47 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$service = new Location_Service( Location_Provider_Registry::instance() );
 
 			$this->assertSame( 'RU', $service->resolve_default_country(), 'a misbehaving filter must never brick the fallback' );
+		}
+
+		/**
+		 * The same malformed-filter guard, but with a store base location that
+		 * ALREADY resolved to something valid: a garbage filter return must
+		 * leave the store's own already-resolved answer alone, never force it
+		 * down to the hard `RU` default the empty-base-location case falls
+		 * back to.
+		 */
+		public function test_resolve_default_country_a_malformed_filtered_value_keeps_the_stores_own_resolved_country(): void {
+			$this->stub_base_location( 'KZ' );
+			Functions\when( 'apply_filters' )->alias(
+				static function ( string $tag, $default = null ) {
+					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? 'Kazakhstan' : $default;
+				}
+			);
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'KZ', $service->resolve_default_country() );
+		}
+
+		/**
+		 * PR #320 review, finding 5: a filter returning a non-string (an
+		 * object, in the measured reproduction) must never reach a `(string)`
+		 * cast — that throws `Error: Object of class stdClass could not be
+		 * converted to string`, uncaught, which would take down the checkout
+		 * render entirely rather than "degrade to the hard RU default" as the
+		 * old docblock promised.
+		 */
+		public function test_resolve_default_country_never_fatals_when_the_filter_returns_a_non_string_value(): void {
+			$this->stub_base_location( '' );
+			Functions\when( 'apply_filters' )->alias(
+				static function ( string $tag, $default = null ) {
+					return Location_Service::FILTER_DEFAULT_COUNTRY === $tag ? new \stdClass() : $default;
+				}
+			);
+
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame( 'RU', $service->resolve_default_country() );
 		}
 	}
 }

--- a/tests/unit/Shipping/LocationDefaultCountrySeamTest.php
+++ b/tests/unit/Shipping/LocationDefaultCountrySeamTest.php
@@ -204,11 +204,12 @@ namespace Woodev\Tests\Unit\Shipping {
 			);
 			Functions\when( 'rest_ensure_response' )->returnArg();
 			Functions\when( 'apply_filters' )->returnArg( 2 );
-			Functions\when( 'get_option' )->alias(
-				static function ( $name, $default = null ) {
-					return 'woocommerce_default_country' === $name ? 'KZ:north' : $default;
-				}
-			);
+			// Location_Service::resolve_default_country() reads wc_get_base_location() (PR #320
+			// review, finding 3 — never a raw get_option() read); stubbed explicitly here rather
+			// than relying on some OTHER test file having already defined it earlier in the same
+			// process (this file's own tests always run against a fresh, single-test PHPUnit
+			// invocation too — see composer test:unit's own filter usage).
+			Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'KZ', 'state' => 'north' ] );
 
 			$provider = new Seam_Fake_Provider( [ 'KZ' ] );
 			$service  = new Seam_Fake_Location_Service( $provider );
@@ -217,11 +218,17 @@ namespace Woodev\Tests\Unit\Shipping {
 			$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'KZ' ], $service ) )
 				->build( Checkout_Fields::from_array( [] ) );
 
-			// Side 2: the /suggest route, given NO country param at all — exactly
-			// what a checkout with no country field sends (location-cascade.js's
-			// own countryFor(), issue #296).
+			// Side 2: the /suggest route, given an EMPTY `country` param — exactly what a
+			// checkout with no country field sends (location-cascade.js's own countryFor(),
+			// issue #296) and, crucially, the ONLY shape a REAL request can carry: the route
+			// registers `country` as `'required' => true` (class-location-controller.php's own
+			// register_routes()), so WP_REST_Server::dispatch() rejects a request that omits the
+			// key entirely with `rest_missing_callback_param` BEFORE handle_suggest_request() is
+			// ever reached — a request built with no `country` key at all (as this test used to)
+			// pins a shape production could never produce (PR #320 review, finding 4). Mirrors
+			// LocationControllerTest's own `'country' => ''` convention for this exact case.
 			$ctrl    = new Seam_Location_Controller_Probe( $service );
-			$request = new WP_REST_Request( [ 'q' => 'Ал', 'level' => Location_Record::LEVEL_REGION ] );
+			$request = new WP_REST_Request( [ 'q' => 'Ал', 'level' => Location_Record::LEVEL_REGION, 'country' => '' ] );
 			$ctrl->handle_suggest_request( $request );
 
 			$this->assertSame( 'KZ', $config['location']['defaultCountry'] );

--- a/tests/unit/Shipping/LocationDefaultCountrySeamTest.php
+++ b/tests/unit/Shipping/LocationDefaultCountrySeamTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Issue #296 seam-pin test: Checkout_Config::build_location_block()'s own
+ * `defaultCountry` key and Location_Controller::perform_suggest()'s own
+ * empty-`country`-param fallback must resolve to the SAME answer — both are
+ * backed by the ONE Location_Service::resolve_default_country() method
+ * (`checkout field -> WooCommerce store setting -> RU`). This project has
+ * already shipped a layer where each side of a client/server boundary was
+ * independently green in its own tests and quietly disagreed between them;
+ * this file exercises BOTH call sites against the SAME `get_option()` stub
+ * so a future change that moves one side without the other fails here
+ * first, not on a live checkout.
+ *
+ * @package Woodev\Tests\Unit\Shipping
+ */
+
+namespace Woodev\Tests\Unit\Shipping {
+
+	use Brain\Monkey\Functions;
+	use Woodev\Framework\Shipping\Checkout\Checkout_Config;
+	use Woodev\Framework\Shipping\Checkout\Checkout_Fields;
+	use Woodev\Framework\Shipping\Location\Abstract_Location_Provider;
+	use Woodev\Framework\Shipping\Location\Location_Provider;
+	use Woodev\Framework\Shipping\Location\Location_Record;
+	use Woodev\Framework\Shipping\Location\Location_Scope;
+	use Woodev\Framework\Shipping\Location\Location_Service;
+	use Woodev\Framework\Shipping\Rest_Api\Location_Controller;
+	use Woodev\Tests\Unit\TestCase;
+
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/checkout/class-field.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/checkout/class-checkout-fields.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/location/class-locality-key.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/location/class-location-record.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/location/class-location-scope.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/location/interface-location-provider.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/location/abstract-location-provider.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/location/class-location-service.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/checkout/class-checkout-config.php';
+
+	if ( ! class_exists( '\\WP_REST_Controller' ) ) {
+		require_once dirname( __DIR__ ) . '/Shipping/Rest_Api/wp-rest-controller-stub.php';
+	}
+
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/rest-api/trait-rest-rate-limit.php';
+	require_once dirname( __DIR__, 3 ) . '/woodev/shipping-method/rest-api/class-location-controller.php';
+
+	/**
+	 * Minimal \WP_REST_Request stand-in — namespace-scoped, mirrors the same
+	 * double `LocationControllerTest` already defines in its own namespace.
+	 */
+	if ( ! class_exists( __NAMESPACE__ . '\\WP_REST_Request', false ) ) {
+		class WP_REST_Request {
+
+			/** @var array<string, mixed> */
+			private array $params;
+
+			/**
+			 * @param array<string, mixed> $params request params.
+			 */
+			public function __construct( array $params = [] ) {
+				$this->params = $params;
+			}
+
+			/**
+			 * @param string $key param name.
+			 *
+			 * @return mixed|null
+			 */
+			public function get_param( $key ) {
+				return $this->params[ $key ] ?? null;
+			}
+
+			/**
+			 * @param string $key header name.
+			 *
+			 * @return string|null
+			 */
+			public function get_header( $key ) {
+				return null;
+			}
+		}
+	}
+
+	/**
+	 * A single {@see Location_Service} double shared by BOTH sides of the seam
+	 * this file pins — every method Checkout_Config's location block AND
+	 * Location_Controller's `/suggest` route read is fixed here EXCEPT
+	 * {@see Location_Service::resolve_default_country()}, which is
+	 * deliberately left un-overridden so the REAL method (get_option() +
+	 * apply_filters(), both stubbed per test) runs on both call sites.
+	 */
+	final class Seam_Fake_Location_Service extends Location_Service {
+
+		private Location_Provider $provider;
+
+		public function __construct( Location_Provider $provider ) {
+			$this->provider = $provider;
+		}
+
+		public function is_active(): bool {
+			return true;
+		}
+
+		public function get_customer_record(): ?array {
+			return null;
+		}
+
+		public function set_customer_record( Location_Record $record, bool $implicit = false ): bool {
+			return true;
+		}
+
+		public function is_country_supported( string $country, ?string $level = null ): bool {
+			return in_array( strtoupper( trim( $country ) ), $this->provider->get_countries(), true );
+		}
+
+		public function get_supported_countries(): array {
+			return $this->provider->get_countries();
+		}
+
+		public function get_field_mode(): string {
+			return 'typeahead';
+		}
+
+		public function owns_region_states( string $country, array $final_states ): bool {
+			return false;
+		}
+
+		public function get_levels_for_country( string $country ): array {
+			return [ 'region' => true, 'settlement' => true, 'address' => true ];
+		}
+
+		public function provider_for_level( string $level, ?string $country = null ): ?Location_Provider {
+			return $this->provider;
+		}
+	}
+
+	/**
+	 * A suggest-only fake provider covering exactly the countries the test
+	 * hands it, spying on every `suggest()` call's own scope.
+	 */
+	final class Seam_Fake_Provider extends Abstract_Location_Provider {
+
+		/** @var string[] */
+		private array $countries;
+
+		/** @var array<int, array{0: string, 1: Location_Scope}> */
+		public array $suggest_calls = [];
+
+		/**
+		 * @param string[] $countries ISO-3166 alpha-2 codes this fake covers.
+		 */
+		public function __construct( array $countries ) {
+			$this->countries = $countries;
+		}
+
+		public function get_id(): string {
+			return 'seam-fixture';
+		}
+
+		public function get_name(): string {
+			return 'Seam Fixture';
+		}
+
+		public function get_countries(): array {
+			return $this->countries;
+		}
+
+		protected function declare_suggest_levels(): array {
+			return Location_Record::LEVELS;
+		}
+
+		public function suggest( string $query, Location_Scope $scope ): array {
+			$this->suggest_calls[] = [ $query, $scope ];
+
+			return [];
+		}
+	}
+
+	/**
+	 * Bypasses the rate limiter — mirrors `Location_Controller_Probe` in
+	 * `LocationControllerTest`.
+	 */
+	final class Seam_Location_Controller_Probe extends Location_Controller {
+
+		protected function is_rate_limited( string $key_prefix, int $max, int $window = 60 ): bool {
+			return false;
+		}
+	}
+
+	/**
+	 * @covers \Woodev\Framework\Shipping\Location\Location_Service::resolve_default_country
+	 * @covers \Woodev\Framework\Shipping\Checkout\Checkout_Config::build
+	 * @covers \Woodev\Framework\Shipping\Rest_Api\Location_Controller::handle_suggest_request
+	 */
+	final class LocationDefaultCountrySeamTest extends TestCase {
+
+		public function test_checkout_config_and_suggest_agree_on_the_default_country(): void {
+			Functions\when( '__' )->returnArg( 1 );
+			Functions\when( 'wp_unslash' )->returnArg();
+			Functions\when( 'wc_clean' )->alias(
+				static function ( $value ) {
+					return is_string( $value ) ? trim( $value ) : $value;
+				}
+			);
+			Functions\when( 'rest_ensure_response' )->returnArg();
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			Functions\when( 'get_option' )->alias(
+				static function ( $name, $default = null ) {
+					return 'woocommerce_default_country' === $name ? 'KZ:north' : $default;
+				}
+			);
+
+			$provider = new Seam_Fake_Provider( [ 'KZ' ] );
+			$service  = new Seam_Fake_Location_Service( $provider );
+
+			// Side 1: the checkout config block a page load emits.
+			$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'KZ' ], $service ) )
+				->build( Checkout_Fields::from_array( [] ) );
+
+			// Side 2: the /suggest route, given NO country param at all — exactly
+			// what a checkout with no country field sends (location-cascade.js's
+			// own countryFor(), issue #296).
+			$ctrl    = new Seam_Location_Controller_Probe( $service );
+			$request = new WP_REST_Request( [ 'q' => 'Ал', 'level' => Location_Record::LEVEL_REGION ] );
+			$ctrl->handle_suggest_request( $request );
+
+			$this->assertSame( 'KZ', $config['location']['defaultCountry'] );
+			$this->assertCount( 1, $provider->suggest_calls, 'the /suggest route must have reached the provider at all' );
+			$this->assertSame(
+				$config['location']['defaultCountry'],
+				$provider->suggest_calls[0][1]->country(),
+				'the config block and the /suggest fallback must resolve to the SAME country — the whole point of this test'
+			);
+		}
+	}
+}

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -657,6 +657,78 @@ final class LocationControllerTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------
+	// /suggest — issue #296: an empty `country` param (a checkout with no
+	// country field at all sends exactly this — see location-cascade.js's own
+	// countryFor()) falls back through Location_Service::resolve_default_country()
+	// instead of hitting build_scope()'s 400. Location_Controller_Fake_Service
+	// does NOT override resolve_default_country(), so every test below runs
+	// the REAL method body (get_option()/apply_filters(), stubbed per test) —
+	// never a canned fixture value.
+	// -------------------------------------------------------------------
+
+	public function test_suggest_with_no_country_param_falls_back_to_the_wc_store_setting(): void {
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				return 'woocommerce_default_country' === $name ? 'KZ:north' : $default;
+			}
+		);
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		$provider = new Location_Controller_Fake_Provider( static fn() => [], [ 'KZ' ] );
+		$service  = new Location_Controller_Fake_Service( true, $provider, null, true, true );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Ал', 'level' => Location_Record::LEVEL_REGION, 'country' => '' ] );
+		$result  = $ctrl->handle_suggest_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result, 'an empty country must resolve through the fallback chain, never 400' );
+		$this->assertCount( 1, $provider->suggest_calls );
+		$this->assertSame(
+			'KZ',
+			$provider->suggest_calls[0][1]->country(),
+			'must scope by the WooCommerce base country, splitting the "COUNTRY:STATE" option on the first ":"'
+		);
+		$this->assertSame(
+			[ 'KZ', Location_Record::LEVEL_REGION ],
+			$service->is_country_supported_calls[0],
+			'the RESOLVED country must be what is checked for support, not the empty request param'
+		);
+	}
+
+	public function test_suggest_with_no_country_param_and_no_store_setting_falls_back_to_ru(): void {
+		Functions\when( 'get_option' )->justReturn( '' );
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		$provider = new Location_Controller_Fake_Provider( static fn() => [], [ 'RU' ] );
+		$service  = new Location_Controller_Fake_Service( true, $provider, null, true, true );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => Location_Record::LEVEL_REGION, 'country' => '' ] );
+		$result  = $ctrl->handle_suggest_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertCount( 1, $provider->suggest_calls );
+		$this->assertSame( 'RU', $provider->suggest_calls[0][1]->country() );
+	}
+
+	public function test_suggest_a_present_country_param_is_never_overridden_by_the_fallback(): void {
+		// Would answer 'KZ' if the fallback were wrongly consulted for a NON-empty
+		// country — the request's own value must always win when present.
+		Functions\when( 'get_option' )->justReturn( 'KZ' );
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		$provider = new Location_Controller_Fake_Provider( static fn() => [], [ 'RU' ] );
+		$service  = new Location_Controller_Fake_Service( true, $provider, null, true, true );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => Location_Record::LEVEL_REGION, 'country' => 'RU' ] );
+		$ctrl->handle_suggest_request( $request );
+
+		$this->assertCount( 1, $provider->suggest_calls );
+		$this->assertSame( 'RU', $provider->suggest_calls[0][1]->country() );
+	}
+
+	// -------------------------------------------------------------------
 	// /suggest — D15 gate fix (block PR-B): the country check must be gated
 	// by the provider that ACTUALLY serves the requested level (chosen, or
 	// the D15 fallback), never by the active provider unconditionally — both

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -662,16 +662,13 @@ final class LocationControllerTest extends TestCase {
 	// countryFor()) falls back through Location_Service::resolve_default_country()
 	// instead of hitting build_scope()'s 400. Location_Controller_Fake_Service
 	// does NOT override resolve_default_country(), so every test below runs
-	// the REAL method body (get_option()/apply_filters(), stubbed per test) —
-	// never a canned fixture value.
+	// the REAL method body (wc_get_base_location()/apply_filters(), stubbed
+	// per test — PR #320 review, finding 3: wc_get_base_location(), never a
+	// raw get_option() read) — never a canned fixture value.
 	// -------------------------------------------------------------------
 
 	public function test_suggest_with_no_country_param_falls_back_to_the_wc_store_setting(): void {
-		Functions\when( 'get_option' )->alias(
-			static function ( $name, $default = null ) {
-				return 'woocommerce_default_country' === $name ? 'KZ:north' : $default;
-			}
-		);
+		Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'KZ', 'state' => 'north' ] );
 		Functions\when( 'apply_filters' )->returnArg( 2 );
 
 		$provider = new Location_Controller_Fake_Provider( static fn() => [], [ 'KZ' ] );
@@ -696,7 +693,7 @@ final class LocationControllerTest extends TestCase {
 	}
 
 	public function test_suggest_with_no_country_param_and_no_store_setting_falls_back_to_ru(): void {
-		Functions\when( 'get_option' )->justReturn( '' );
+		Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => '', 'state' => '' ] );
 		Functions\when( 'apply_filters' )->returnArg( 2 );
 
 		$provider = new Location_Controller_Fake_Provider( static fn() => [], [ 'RU' ] );

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -268,16 +268,39 @@
 	}
 
 	/**
-	 * The country currently in play for `node` — reads `#shipping_country` for a
-	 * shipping-section node, `#billing_country` for everything else (spec §4.4 amendment,
-	 * Finding 1). Read LIVE at call time, same convention as the rest of this module's own
-	 * live-scope reads (see {@see scopeKeyFor}).
+	 * The country currently in play for `node` (issue #296's own fallback chain — the operator's
+	 * own wording: "поле чекаута → настройка WooCommerce → RU", the last step through a filter,
+	 * no separate option) — reads `#shipping_country` for a shipping-section node,
+	 * `#billing_country` for everything else (spec §4.4 amendment, Finding 1), read LIVE at call
+	 * time, same convention as the rest of this module's own live-scope reads (see
+	 * {@see scopeKeyFor}).
 	 *
-	 * @param {{section?: string}} node
+	 * STEP 1 (the live checkout field) is everything {@see countryValue} answers: a genuinely
+	 * present, non-empty value. STEPS 2+3 (the WooCommerce store's own base country, else a
+	 * PHP-filterable `RU`) are NOT resolved here at all — a shop with no country field on
+	 * checkout, or one whose country `<select>` is present but still unselected, used to make
+	 * {@see isCountrySupported} reject an empty string outright, so NO widget ever attached and
+	 * the whole location layer went silently dead with no signal why. Both remaining steps are
+	 * already merged into ONE value server-side by
+	 * `Location_Service::resolve_default_country()` and handed down as `entry.location.defaultCountry`
+	 * next to `countries`/`levels` (`class-checkout-config.php::build_location_block()`) — the
+	 * SAME method the `/suggest` REST route falls back to for an empty `country` request param,
+	 * so both sides of the client/server boundary answer identically by construction. This
+	 * function therefore has exactly ONE fallback of its own to make, never a second guess at
+	 * what WooCommerce's setting or the RU default might be.
+	 *
+	 * @param {Object}              entry
+	 * @param {{section?: string}}  node
 	 * @returns {string}
 	 */
-	function countryFor( node ) {
-		return countryValue( countryFieldIdFor( node ) );
+	function countryFor( entry, node ) {
+		var live = countryValue( countryFieldIdFor( node ) );
+
+		if ( live ) {
+			return live;
+		}
+
+		return ( entry.location && entry.location.defaultCountry ) || '';
 	}
 
 	/**
@@ -346,7 +369,7 @@
 			return false;
 		}
 
-		var country = countryFor( node );
+		var country = countryFor( entry, node );
 
 		if ( ! isCountrySupported( entry, country ) ) {
 			return false;
@@ -711,7 +734,7 @@
 			var url = buildUrl( entry.location.endpoints.suggest, {
 				q: query,
 				level: node.level,
-				country: countryFor( node ),
+				country: countryFor( entry, node ),
 				within: scopeKeyFor( entry, node.level ),
 			} );
 
@@ -1187,7 +1210,7 @@
 			node: node,
 			location: entry.location,
 			country: function() {
-				return countryFor( node );
+				return countryFor( entry, node );
 			},
 			parentKey: function() {
 				return scopeKeyFor( entry, node.level );
@@ -1224,7 +1247,7 @@
 
 		// Baseline: text+typeahead, gated by the D15 per-country/level chain (spec D7: "text+
 		// typeahead always" is the FLOOR, never conditional on a special renderer existing).
-		if ( ! isLevelServed( entry, countryFor( node ), node.level ) || 'function' !== typeof window.WoodevLocationTypeahead ) {
+		if ( ! isLevelServed( entry, countryFor( entry, node ), node.level ) || 'function' !== typeof window.WoodevLocationTypeahead ) {
 			return;
 		}
 

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -268,6 +268,35 @@
 	}
 
 	/**
+	 * The section a country-field id itself governs — `'shipping'` for `#shipping_country`,
+	 * `'billing'` for everything else, including `#billing_country` and any id this module was
+	 * never told about. The inverse of {@see countryFieldIdFor} (fieldId -> section rather than
+	 * node -> fieldId), needed wherever a caller only has the field id a `change` event fired on
+	 * (see {@see handleFieldChanged}) and must resolve `entry`'s EFFECTIVE country for it via
+	 * {@see countryFor}, which itself takes a `{section}`-shaped node.
+	 *
+	 * PR #320 review, finding 6: deliberately does NOT consult the OTHER country field (a
+	 * shipping-section id never falls back to `#billing_country`'s value, or vice-versa) — a
+	 * shipping-section field present but unselected falls straight through to `entry.location.
+	 * defaultCountry`, the SAME store-wide fallback billing itself uses when its own field is
+	 * unselected, never billing's CURRENT selection. Two reasons this is the right call, not an
+	 * oversight: (1) it is what WooCommerce's own checkout markup already does — both country
+	 * `<select>` elements independently default their selected `<option>` to the store's base
+	 * country (`WC_Countries::get_country_dropdown_options()`), neither one is ever rendered
+	 * pre-filled FROM the other; (2) {@see countryFieldIdFor}'s own docblock (Finding 1 of the
+	 * PR-C review this file already carries) establishes section isolation as a first-class rule
+	 * specifically so a shipping-section field is never arbitrated against `#billing_country` —
+	 * a billing-first shipping fallback would reintroduce exactly the cross-section coupling
+	 * that finding removed, and asymmetrically (billing would still never consult shipping).
+	 *
+	 * @param {string} countryFieldId
+	 * @returns {string}
+	 */
+	function sectionForCountryFieldId( countryFieldId ) {
+		return COUNTRY_FIELD_ID.shipping === countryFieldId ? 'shipping' : 'billing';
+	}
+
+	/**
 	 * The country currently in play for `node` (issue #296's own fallback chain — the operator's
 	 * own wording: "поле чекаута → настройка WooCommerce → RU", the last step through a filter,
 	 * no separate option) — reads `#shipping_country` for a shipping-section node,
@@ -288,6 +317,18 @@
 	 * so both sides of the client/server boundary answer identically by construction. This
 	 * function therefore has exactly ONE fallback of its own to make, never a second guess at
 	 * what WooCommerce's setting or the RU default might be.
+	 *
+	 * THE SAME EFFECTIVE VALUE FEEDS THE DESTRUCTIVE-CLEAR GATE (PR #320 review, finding 1):
+	 * {@see prefill} seeds `entry.resolved[countryFieldId]` through this function, and
+	 * {@see handleFieldChanged} re-derives the SAME thing to compare against on every country
+	 * `change` — never the raw `el.value` either side used to read. A country `<select>` that
+	 * starts unselected (`el.value === ''`, WooCommerce's own "Select a country / region…"
+	 * placeholder under "No location by default") makes the widget attach on the `RU`/store
+	 * fallback exactly like this function already resolves; comparing the RAW DOM value instead
+	 * would seed `''` and then read the customer's very first explicit pick of THAT SAME country
+	 * (`'' -> 'RU'`) as a real transition, wiping the address the fallback had already scoped
+	 * every suggestion by. Routing both sides through this one function keeps the seed and the
+	 * comparison — and the widget's own attach/scope reads — answering the identical question.
 	 *
 	 * @param {Object}              entry
 	 * @param {{section?: string}}  node
@@ -1536,7 +1577,7 @@
 	 * @returns {void}
 	 */
 	function clearCountryScope( entry, countryFieldId ) {
-		var section = countryFieldId === COUNTRY_FIELD_ID.shipping ? 'shipping' : 'billing';
+		var section = sectionForCountryFieldId( countryFieldId );
 		var cleared = false;
 
 		entry.allNodes.forEach( function( node ) {
@@ -1613,11 +1654,21 @@
 		var name = target && target.name ? target.name : '';
 
 		if ( COUNTRY_FIELD_IDS.indexOf( id ) !== -1 ) {
-			var country = cascadeKey( target.value );
+			var section = sectionForCountryFieldId( id );
 
+			// PR #320 review, finding 1: the EFFECTIVE country per entry (live field, else
+			// `entry.location.defaultCountry` — see {@see countryFor}'s own docblock), never the
+			// raw `target.value` — computed per ENTRY (not once, up front) since two entries can
+			// carry different `defaultCountry` values. `target.value` IS already this field's
+			// live DOM value by the time a `change` handler runs, so {@see countryFor} reading
+			// the DOM here answers the SAME thing `target.value` would for a present, non-empty
+			// selection — it only additionally covers the field-absent/unselected case the raw
+			// read got wrong.
 			entries.forEach( function( entry ) {
+				var country = cascadeKey( countryFor( entry, { section: section } ) );
+
 				if ( entry.resolved[ id ] === country ) {
-					return; // programmatic churn or a re-selection of the same country.
+					return; // programmatic churn or a re-selection of the same effective country.
 				}
 
 				entry.resolved[ id ] = country;
@@ -1833,11 +1884,22 @@
 		// `undefined`, reads as a real transition, and empties a restored address on every
 		// page load ({@see handleFieldChanged}, gotcha
 		// `a-programmatic-parent-change-must-not-run-a-destructive-cascade`).
+		//
+		// SEEDED FROM THE EFFECTIVE COUNTRY, NOT THE RAW DOM VALUE (PR #320 review, finding 1):
+		// {@see countryFor} — the SAME resolution the widget itself attached under — not
+		// `el.value` directly. A field present but unselected (`el.value === ''`) must seed the
+		// fallback it is ALREADY effectively scoped by (`RU` or `entry.location.defaultCountry`),
+		// not `''` — seeding the raw empty value made the customer's first explicit pick of that
+		// very same country read as a transition and destructively clear the address the
+		// fallback had already been scoping every suggestion by (see {@see countryFor}'s own
+		// docblock for the full reproduction).
 		COUNTRY_FIELD_IDS.forEach( function( countryFieldId ) {
 			var el = document.getElementById( countryFieldId );
 
 			if ( el ) {
-				entry.resolved[ countryFieldId ] = cascadeKey( el.value );
+				entry.resolved[ countryFieldId ] = cascadeKey(
+					countryFor( entry, { section: sectionForCountryFieldId( countryFieldId ) } )
+				);
 			}
 		} );
 

--- a/woodev/shipping-method/checkout/class-checkout-config.php
+++ b/woodev/shipping-method/checkout/class-checkout-config.php
@@ -50,6 +50,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 	 *     'levels'    => [ country_code => [ 'region' => bool, 'settlement' => bool, 'address' => bool ] ],
 	 *     'current'   => [ 'key' => string, 'level' => string ]|null,
 	 *     'implicit'  => bool,
+	 *     'defaultCountry' => string, // issue #296: checkout field -> WC store setting -> RU
 	 *   ],
 	 * ]
 	 * ```
@@ -484,7 +485,11 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 * @since 2.0.2 `i18n` gained `notPersisted` — the client-side consumer for an honest
 		 *              `persisted: false` `/select` response (Task 13; issue #295 finding 1).
 		 *
-		 * @param \Woodev\Framework\Shipping\Location\Location_Service $service The active, already-confirmed façade.
+		 * @since 2.0.2 Gained `defaultCountry` -- steps 2+3 of the "checkout field -> WC store
+		 *              setting -> RU" fallback chain (issue #296), via
+		 *              {@see \Woodev\Framework\Shipping\Location\Location_Service::resolve_default_country()}.
+		 *
+		 * @param \Woodev\Framework\Shipping\Location\Location_Service $service The active, already-confirmed facade.
 		 *
 		 * @return array{
 		 *     endpoints: array{suggest: string, select: string, list: string},
@@ -493,7 +498,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *     mode: string,
 		 *     levels: array<string, array{region: bool, settlement: bool, address: bool}>,
 		 *     current: array{key: string, level: string}|null,
-		 *     implicit: bool
+		 *     implicit: bool,
+		 *     defaultCountry: string
 		 * }
 		 */
 		private function build_location_block( \Woodev\Framework\Shipping\Location\Location_Service $service ): array {
@@ -604,18 +610,27 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 			);
 
 			return [
-				'endpoints' => [
+				'endpoints'      => [
 					'suggest' => $this->rest_base . '/location/suggest',
 					'select'  => $this->rest_base . '/location/select',
 					'list'    => $this->rest_base . '/location/list',
 				],
-				'nonce'     => $this->nonce,
-				'countries' => array_values( $countries ),
-				'mode'      => $service->get_field_mode(),
-				'levels'    => $levels,
-				'current'   => $current,
-				'implicit'  => $implicit,
-				'i18n'      => array_map( 'strval', (array) $strings ),
+				'nonce'          => $this->nonce,
+				'countries'      => array_values( $countries ),
+				'mode'           => $service->get_field_mode(),
+				'levels'         => $levels,
+				'current'        => $current,
+				'implicit'       => $implicit,
+				// Issue #296: steps 2+3 of the country fallback chain `checkout field ->
+				// WooCommerce store setting -> RU`, already merged into ONE value by
+				// {@see \Woodev\Framework\Shipping\Location\Location_Service::resolve_default_country()}
+				// — the client's own `location-cascade.js::countryFor()` reads step 1 (the live
+				// DOM field) itself and falls back to THIS value only when that field is absent
+				// or empty (a single-country store that dropped the country field entirely used
+				// to leave the whole location layer silently dead — no widget ever attached,
+				// because the client had no country to arbitrate by).
+				'defaultCountry' => $service->resolve_default_country(),
+				'i18n'           => array_map( 'strval', (array) $strings ),
 			];
 		}
 

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -44,6 +44,19 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		public const FILTER_PROVIDER_FOR_LEVEL = 'woodev_location_provider_for_level';
 
 		/**
+		 * Filters the FINAL resolved country for the checkout-field -> WooCommerce-store-setting
+		 * -> `RU` fallback chain (issue #296) — see {@see self::resolve_default_country()} for the
+		 * full chain and why this filter runs on every resolution, not only when the store's own
+		 * base location is unusable (PR #320 review, finding 2). Left in place even though nothing
+		 * in this codebase consumes it yet (project preference: extension hooks are not gated on
+		 * having a consumer).
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const FILTER_DEFAULT_COUNTRY = 'woodev_location_default_country';
+
+		/**
 		 * @since 2.0.2
 		 * @var Location_Provider_Registry
 		 */
@@ -646,19 +659,6 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		}
 
 		/**
-		 * Filters the last-resort country for the checkout-field -> WooCommerce-store-setting ->
-		 * `RU` fallback chain (issue #296) — the step {@see self::resolve_default_country()}
-		 * reaches only when the store's OWN `woocommerce_default_country` option is unset or
-		 * malformed too. A Kazakhstan store, for instance, hooks this to return `'KZ'`. Left in
-		 * place even though nothing in this codebase consumes it yet (project preference:
-		 * extension hooks are not gated on having a consumer).
-		 *
-		 * @since 2.0.2
-		 * @var string
-		 */
-		public const FILTER_DEFAULT_COUNTRY = 'woodev_location_default_country';
-
-		/**
 		 * Resolves the store-wide fallback country for a checkout that has NO country field at
 		 * all (issue #296) — steps 2+3 of the chain `checkout field -> WooCommerce store setting
 		 * -> RU`; step 1 (the live checkout field itself) is read by each CALLER, never here:
@@ -671,38 +671,102 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * already paid for once: a seam where each side of a client/server boundary shipped its
 		 * own, independently-green implementation that quietly disagreed.
 		 *
-		 * Step 2 reads WooCommerce's `woocommerce_default_country` option directly (never
-		 * `wc_get_base_location()`/`WC()` — this façade already reads `get_option()` directly
-		 * elsewhere, e.g. {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::resolve_stored_active_provider_id()},
-		 * and a `WC()`-mediated call would poison Brain Monkey's function table for the rest of
-		 * the unit-test process — see `Checkout_Config::wc_states()`'s own docblock for the
-		 * measured cost of that mistake). That option is stored as `COUNTRY:STATE` (e.g. `RU:*`
-		 * for a merchant who picked a country without naming a state) — a bare, un-split read
-		 * would treat the literal string `'RU:*'` as the country code, which is not a well-formed
-		 * ISO-3166 alpha-2 code and is exactly the class of mistake that once leaked WooCommerce's
-		 * `*` "no state" sentinel to a customer's «Регион» field (gotcha this project has already
-		 * paid for on the STATE half of this same option). {@see self::parse_country_component()}
-		 * splits on the FIRST `:` and validates the result.
+		 * Step 2 reads {@see wc_get_base_location()} — WooCommerce's OWN accessor for "the
+		 * store's base country/state", NOT a raw `get_option( 'woocommerce_default_country' )`
+		 * read (PR #320 review, finding 3): `wc_get_base_location()` runs the store's location
+		 * through `apply_filters( 'woocommerce_get_base_location', ... )` first, which a
+		 * multi-store, multi-vendor, or geo plugin may hook to answer something other than the
+		 * literal option value — bypassing it made this façade's idea of "the store's base
+		 * country" quietly diverge from WooCommerce's own. This is a PLAIN function, not the
+		 * `WC()` singleton accessor: the earlier justification for reading `get_option()` directly
+		 * ("a `WC()`-mediated call would poison Brain Monkey's function table", see
+		 * `Checkout_Config::wc_states()`'s own docblock for that measured cost) conflated the two
+		 * — `wc_get_base_location()` is exactly as stubbable per-test as `get_option()` itself
+		 * (`Brain\Monkey\Functions\when( 'wc_get_base_location' )`, the same convention already
+		 * used elsewhere in this codebase, e.g.
+		 * {@see \Woodev\Framework\Shipping\Shipping_Plugin::add_countries_admin_notices()}'s own
+		 * `wc_get_base_location()['country'] ?? ''` read), and calling it poisons nothing.
+		 * `wc_get_base_location()` already splits WooCommerce's `COUNTRY:STATE` option format
+		 * (e.g. `RU:*` for a merchant who picked a country without naming a state) into
+		 * `['country' => ..., 'state' => ...]` — a raw, un-split read would treat the literal
+		 * string `'RU:*'` as the country code, which is not a well-formed ISO-3166 alpha-2 code
+		 * and is exactly the class of mistake that once leaked WooCommerce's `*` "no state"
+		 * sentinel to a customer's «Регион» field (gotcha this project has already paid for on the
+		 * STATE half of this same option) — {@see self::parse_country_component()} validates the
+		 * country component regardless.
 		 *
-		 * Step 3 (the filter above) only runs when step 2 yields nothing usable; its OWN result
-		 * is validated too, so a filter callback returning garbage degrades to the hard `'RU'`
-		 * default rather than ever propagating a malformed value to a REST response or the
-		 * checkout config block.
+		 * Step 3 (the filter) now runs on the FINAL resolved value on EVERY call, not only when
+		 * step 2 yields nothing usable (PR #320 review, finding 2 — the WordPress convention, and
+		 * the only reading under which the filter is an actual escape hatch): on a real
+		 * WooCommerce install `woocommerce_default_country` is never unset or malformed —
+		 * `WC_Install::create_options()` `add_option()`s the General-settings default (`'US:CA'`)
+		 * on activation, and the settings page's own country dropdown cannot emit anything else —
+		 * so a filter gated on "step 2 answered nothing" could NEVER fire on a real store, and this
+		 * project's own worked example ("a Kazakhstan store hooks this to return `KZ`") was
+		 * unreachable: a Kazakhstan store's `woocommerce_default_country` already resolves to `KZ`
+		 * via step 2, leaving the filter nothing to add. Running it on the final value instead lets
+		 * a plugin override the STORE'S OWN base country too, not merely stand in for a missing
+		 * one — the only way this filter is ever consulted on a real install. Its own result is
+		 * re-validated exactly like step 2's; a non-string return degrades silently rather than
+		 * ever being cast (PR #320 review, finding 5 — `(string) $object` on a misbehaving filter's
+		 * return would fatal the checkout render, not "degrade to the hard RU default" as promised),
+		 * and a string that fails validation (or an unset filter, the default) leaves the
+		 * already-resolved value untouched.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Reads {@see wc_get_base_location()} instead of a raw `get_option()` call,
+		 *              and applies {@see self::FILTER_DEFAULT_COUNTRY} to the FINAL resolved value
+		 *              on every call rather than only when the store setting is unusable (PR #320
+		 *              review, findings 2 and 3).
 		 *
 		 * @return string Upper-cased ISO-3166 alpha-2 country code — never empty, never malformed.
 		 */
 		public function resolve_default_country(): string {
-			$country = self::parse_country_component( (string) get_option( 'woocommerce_default_country', '' ) );
+			$resolved = self::parse_country_component( self::base_location_country() );
 
-			if ( '' === $country ) {
-				$country = self::parse_country_component(
-					(string) apply_filters( self::FILTER_DEFAULT_COUNTRY, 'RU' )
-				);
+			if ( '' === $resolved ) {
+				$resolved = 'RU';
 			}
 
-			return '' === $country ? 'RU' : $country;
+			/**
+			 * Filters the FINAL resolved fallback country for the checkout-field ->
+			 * WooCommerce-store-setting -> `RU` chain (issue #296) — see this method's own
+			 * docblock (PR #320 review, finding 2) for why this runs on EVERY resolution, not
+			 * only when the store's own base location is unusable.
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param string $resolved The chain's own answer before this filter runs — the
+			 *                         store's base-location country, or `'RU'` when that is
+			 *                         unusable.
+			 */
+			$filtered = apply_filters( self::FILTER_DEFAULT_COUNTRY, $resolved );
+
+			if ( is_string( $filtered ) ) {
+				$parsed = self::parse_country_component( $filtered );
+
+				if ( '' !== $parsed ) {
+					return $parsed;
+				}
+			}
+
+			return $resolved;
+		}
+
+		/**
+		 * The store's own base-location country, straight from
+		 * {@see wc_get_base_location()} — see {@see self::resolve_default_country()}'s own
+		 * docblock for why this reads WooCommerce's accessor rather than the raw option.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string Raw country component, possibly empty or malformed — validated by the
+		 *                 caller via {@see self::parse_country_component()}.
+		 */
+		private static function base_location_country(): string {
+			$location = wc_get_base_location();
+
+			return is_array( $location ) ? (string) ( $location['country'] ?? '' ) : '';
 		}
 
 		/**

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -646,6 +646,83 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		}
 
 		/**
+		 * Filters the last-resort country for the checkout-field -> WooCommerce-store-setting ->
+		 * `RU` fallback chain (issue #296) — the step {@see self::resolve_default_country()}
+		 * reaches only when the store's OWN `woocommerce_default_country` option is unset or
+		 * malformed too. A Kazakhstan store, for instance, hooks this to return `'KZ'`. Left in
+		 * place even though nothing in this codebase consumes it yet (project preference:
+		 * extension hooks are not gated on having a consumer).
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		public const FILTER_DEFAULT_COUNTRY = 'woodev_location_default_country';
+
+		/**
+		 * Resolves the store-wide fallback country for a checkout that has NO country field at
+		 * all (issue #296) — steps 2+3 of the chain `checkout field -> WooCommerce store setting
+		 * -> RU`; step 1 (the live checkout field itself) is read by each CALLER, never here:
+		 * {@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller::perform_suggest()} reads
+		 * the request's own `country` param first and only reaches this method when that is
+		 * empty, and `location-cascade.js`'s own `countryFor()` reads the live DOM field first
+		 * and only falls back to the `defaultCountry` this method feeds into
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}.
+		 * BOTH call sites resolve through this ONE method for the ONE reason this project has
+		 * already paid for once: a seam where each side of a client/server boundary shipped its
+		 * own, independently-green implementation that quietly disagreed.
+		 *
+		 * Step 2 reads WooCommerce's `woocommerce_default_country` option directly (never
+		 * `wc_get_base_location()`/`WC()` — this façade already reads `get_option()` directly
+		 * elsewhere, e.g. {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::resolve_stored_active_provider_id()},
+		 * and a `WC()`-mediated call would poison Brain Monkey's function table for the rest of
+		 * the unit-test process — see `Checkout_Config::wc_states()`'s own docblock for the
+		 * measured cost of that mistake). That option is stored as `COUNTRY:STATE` (e.g. `RU:*`
+		 * for a merchant who picked a country without naming a state) — a bare, un-split read
+		 * would treat the literal string `'RU:*'` as the country code, which is not a well-formed
+		 * ISO-3166 alpha-2 code and is exactly the class of mistake that once leaked WooCommerce's
+		 * `*` "no state" sentinel to a customer's «Регион» field (gotcha this project has already
+		 * paid for on the STATE half of this same option). {@see self::parse_country_component()}
+		 * splits on the FIRST `:` and validates the result.
+		 *
+		 * Step 3 (the filter above) only runs when step 2 yields nothing usable; its OWN result
+		 * is validated too, so a filter callback returning garbage degrades to the hard `'RU'`
+		 * default rather than ever propagating a malformed value to a REST response or the
+		 * checkout config block.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string Upper-cased ISO-3166 alpha-2 country code — never empty, never malformed.
+		 */
+		public function resolve_default_country(): string {
+			$country = self::parse_country_component( (string) get_option( 'woocommerce_default_country', '' ) );
+
+			if ( '' === $country ) {
+				$country = self::parse_country_component(
+					(string) apply_filters( self::FILTER_DEFAULT_COUNTRY, 'RU' )
+				);
+			}
+
+			return '' === $country ? 'RU' : $country;
+		}
+
+		/**
+		 * Splits WooCommerce's `COUNTRY:STATE` option format (e.g. `'RU:*'`) and validates the
+		 * country component alone — see {@see self::resolve_default_country()}'s own docblock for
+		 * why a bare, un-split read is exactly the mistake this method exists to prevent.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $raw Raw option/filter value, possibly `COUNTRY:STATE`, possibly malformed.
+		 *
+		 * @return string Upper-cased 2-letter country code, or `''` when malformed/absent.
+		 */
+		private static function parse_country_component( string $raw ): string {
+			$country = strtoupper( trim( explode( ':', $raw, 2 )[0] ) );
+
+			return 1 === preg_match( '/^[A-Z]{2}$/', $country ) ? $country : '';
+		}
+
+		/**
 		 * Whether a provider covers `$country` (spec D2: a STATIC,
 		 * PHP-answerable list — see {@see Location_Provider::get_countries()}
 		 * — so this needs no network call and can arbitrate server-side).

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -639,6 +639,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 * identically, so this is the ONE place that logic lives.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 An empty `country` param now falls back through
+		 *              {@see \Woodev\Framework\Shipping\Location\Location_Service::resolve_default_country()}
+		 *              instead of reaching `build_scope()`'s own 400 (issue #296).
 		 *
 		 * @param \WP_REST_Request $request        request object.
 		 * @param string           $rate_limit_key Per-route rate-limit bucket prefix.
@@ -687,7 +690,22 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 			}
 
 			$country = $this->normalize_param( $request->get_param( 'country' ) );
-			$within  = $this->cap_length( $this->normalize_param( $request->get_param( 'within' ) ), self::MAX_PARAM_LENGTH );
+
+			// Issue #296: a checkout with no country field at all (common for a single-country
+			// store) sends `''` here — location-cascade.js's own `countryFor()` degrades to `''`
+			// once its own client-side fallback (the live field, then
+			// `config.location.defaultCountry`) has nothing left to try. Mirroring the SAME
+			// fallback server-side (through the ONE shared
+			// {@see \Woodev\Framework\Shipping\Location\Location_Service::resolve_default_country()}
+			// {@see Checkout_Config::build_location_block()} already feeds `defaultCountry` from)
+			// keeps this a genuine `/suggest` read for the store's own base country instead of the
+			// 400 an un-split `''` would otherwise hit in build_scope() below. A request that DOES
+			// carry a country — even an unsupported one — is never second-guessed here.
+			if ( '' === $country ) {
+				$country = $this->service->resolve_default_country();
+			}
+
+			$within = $this->cap_length( $this->normalize_param( $request->get_param( 'within' ) ), self::MAX_PARAM_LENGTH );
 
 			try {
 				$scope = $this->build_scope( $country, $level, $within );


### PR DESCRIPTION
Closes #296. The operator approved the chain on 14.08.2026: **checkout field → WooCommerce store setting → `RU`**, with the last step behind a filter and no separate option.

Shops that sell to one country routinely delete the country field from checkout. When they do, the location layer today is not merely degraded — it is dead: `countryValue()` returns `''`, `isCountrySupported()` can never match it, and `isNodeActive()` returns false before the level gate is even reached, so no widget attaches at all.

**The server side turned out worse than the card described.** It is not silent: `Location_Scope::for_country( '', … )` rejects the empty string outright and `perform_suggest()` turns that into a **400**. So a client with no country field was already getting errors, not nothing.

What was built:
- `Location_Service::resolve_default_country()` reads the store's base country via `wc_get_base_location()` (not a raw `get_option()` read — see the post-review update below) — the option is stored as `RU:*`, and this repo has already leaked that `*` sentinel into a customer-visible "Регион" field once. The parsed value is validated as a two-letter ISO code.
- The `woodev_location_default_country` filter runs on the **final** resolved value (not only when the store setting is unusable — see the post-review update below), and **the filter's own result is re-validated**, so a misbehaving filter cannot leak garbage into a scope.
- `build_location_block()` exports `defaultCountry` beside `countries`/`levels`; `countryFor()` reads the live DOM field first and falls back to it. One client-side fallback, because steps 2 and 3 are already merged server-side.
- `perform_suggest()` resolves the same way when the request's `country` is empty, so both sides of the seam answer identically.

`tests/unit/Shipping/LocationDefaultCountrySeamTest.php` pins that explicitly: it drives `Checkout_Config::build()` and `Location_Controller::handle_suggest_request()` off the **same** service instance and asserts both land on `KZ` — so a future change cannot move one side without the other. None of the fakes override `resolve_default_country()`, so its real body executes throughout the suite rather than being stubbed away.

Requirement 5 from the card needed no fix and got a test instead: the `change` watcher is delegated on `document.body`, never bound to `#billing_country`, so an absent node was already structurally safe.

Collateral found and fixed: `CheckoutHandlerEnqueueTest`'s fake service does not override every method, so an unconditional `get_option()` in `build_location_block()` broke two of its tests through Brain Monkey's process-wide stubbing — the same hazard this repo's own `wc_states()` docblock warns about.

Follow-up filed separately: `/list` (used by `related-list` mode) has the identical empty-country 400 exposure and was deliberately left out of scope.

**Rig check:** remove or clear the country field on checkout and confirm the settlement typeahead still attaches and returns suggestions scoped to the store's base country.

---

## Post-review update (adversarial review, PR #320)

An adversarial review (probes reproduced against this code, WooCommerce's own source read for the base-location and settings-registration claims) found five real defects in the fallback chain above. All five are fixed in the follow-up commit on this branch.

1. **(HIGH) Selecting the country the fallback was already using wiped the customer's address.** `countryFor()` resolves an *effective* country (live field → `defaultCountry`), but the destructive-clear gate (`prefill()`'s seeding, `handleFieldChanged()`'s comparison) compared the **raw DOM value** instead. With WooCommerce's "No location by default" (an unselected country `<select>`), the widget attached on the `RU` fallback; the customer filled in a settlement/street/postcode, then explicitly picked «Россия» — the SAME country every suggestion was already scoped by — and the entire address was cleared. Fixed by routing both the seed and the comparison through `countryFor()` itself, never `el.value`/`target.value`. Reproduced and mutation-verified with a dedicated jest test.

2. **(HIGH) The filter, and the whole `RU` fallback leg, were unreachable on any real store.** `WC_Install::create_options()` `add_option()`s `woocommerce_default_country` (default `US:CA`) on every WooCommerce install, and the settings page is a country dropdown that cannot emit a malformed value — so `resolve_default_country()`'s "step 2 answered nothing" gate on the filter could never open on a real store. Consequences: this PR's own worked example ("a Kazakhstan store hooks the filter to return `KZ`") was impossible (a Kazakhstan store's setting already resolves `KZ` via step 2, leaving nothing for the filter to add); there was no way to override the layer's country short of changing the store's WC base location; and a store that never touched base location resolved the WC default `US`, which DaData does not serve — the `#296` headline bug stayed unfixed for exactly that store. **Fixed by moving the filter to run on the FINAL resolved value** (`apply_filters( self::FILTER_DEFAULT_COUNTRY, $resolved )`, re-validated), so it can now override the store's own base country too, not merely stand in for a missing one. This widens the filter's reach beyond the original "последний шаг через фильтр" wording — it is the only reading under which the escape hatch actually exists on a real store, so it is implemented that way; flagging the widened scope here per the review's own request in case the operator wants to overrule it.

3. **(MEDIUM) `wc_get_base_location()` was bypassed.** The code read `get_option( 'woocommerce_default_country' )` raw, skipping `wc_get_base_location()`'s own `apply_filters( 'woocommerce_get_base_location', … )` — a multi-store/multi-vendor/geo plugin hooking that filter made this façade's idea of "the store's base country" quietly diverge from WooCommerce's own. The original justification (avoiding a `WC()`-style Brain Monkey poisoning cost) conflated `WC()`, the singleton accessor, with `wc_get_base_location()`, a plain function exactly as stubbable per-test as `get_option()` — and already called unstubbed elsewhere in this same codebase (`Shipping_Plugin::add_countries_admin_notices()`). Switched to `wc_get_base_location()['country']`.

4. **(MEDIUM) The server-side fallback was unreachable from the client, and the seam test pinned an impossible request shape.** The client's `buildUrl()` drops empty params and `country` is `'required' => true` on `/suggest`, so an empty country is never sent by this client — it is omitted, and `WP_REST_Server::dispatch()` 400s with `rest_missing_callback_param` before `perform_suggest()` ever runs. `LocationDefaultCountrySeamTest` built its request with no `country` key at all, bypassing REST arg validation and pinning a shape production could never produce. Rewritten to `'country' => ''`, the shape `LocationControllerTest` already uses; the server-side fallback stays in place as defence-in-depth for a hand-made request.

5. **(MEDIUM) A filter returning a non-scalar was a fatal, not a graceful degrade.** `(string) apply_filters( … )` throws `Error: Object of class stdClass could not be converted to string`, uncaught — taking down the checkout render, while the docblock promised garbage "degrades to the hard `RU` default". Guarded with `is_string()` before casting/validating.

**Left as-is, decided and justified (LOW, finding 6):** with `#shipping_country` present-but-empty and "ship to a different address" checked, the shipping section falls back straight to the store's own `defaultCountry`, never to billing's current value. Kept this way: (a) it matches WooCommerce's own checkout markup, where both country `<select>` elements independently default to the store's base country — neither is ever pre-filled FROM the other; (b) this file's own `countryFieldIdFor()` docblock (Finding 1 of the prior PR-C review) already establishes section isolation as a first-class rule specifically so a shipping-section field is never arbitrated against `#billing_country` — a billing-first shipping fallback would reintroduce exactly the cross-section coupling that finding removed, and asymmetrically (billing would still never consult shipping). Documented in the new `sectionForCountryFieldId()` helper's own docblock.

**Also done (LOW, finding 7):** moved `FILTER_DEFAULT_COUNTRY` into the constant block at the top of `Location_Service`, next to `FILTER_PROVIDER_FOR_LEVEL` — where every other filter constant in this file lives.

**Verification:** every finding was reproduced against the pre-fix code and confirmed red before the fix (JS: 1 dedicated reproduction test; PHP: 4 `LocationServiceTest` cases isolating findings 2/3/5 individually, one for each), then green after. Full suites: PHP unit 2152 → 2155 (0 failures, 71 skipped both before/after — pre-existing, unrelated), jest 1081 → 1083, `composer phpcs` and `composer phpstan` (level 3) both clean.
