### PR TITLE
fix(pickup): карта ПВЗ адресуется населённым пунктом, а не записью любого уровня (#336)

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -454,7 +454,7 @@ describe( 'persist then trigger (D8)', () => {
 		// Not yet — the persist call has not resolved.
 		expect( triggerSpy.mock.calls.some( ( args ) => args[ 0 ] === 'update_checkout' ) ).toBe( false );
 
-		selectReq.resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
+		selectReq.resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: item.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		expect( triggerSpy.mock.calls.some( ( args ) => args[ 0 ] === 'update_checkout' ) ).toBe( true );
@@ -548,12 +548,14 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		expect( seen ).toEqual( [] ); // not yet — the persist call has not resolved.
 
 		const selectReq = fetchCalls[ fetchCalls.length - 1 ];
-		selectReq.resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
+		selectReq.resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: item.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		// A persisted /select is ALWAYS an explicit choice (issue #309; spec D11) —
 		// `implicit` is `false` regardless of the config's own boot-time value.
-		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: false } ] );
+		// settlementKey (issue #336) matches key here: a direct settlement pick sets
+		// entry.records.settlement to the SAME record.
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: false } ] );
 	} );
 
 	it( 'is a NATIVE event, seen by a plain addEventListener with no jQuery involved', async () => {
@@ -572,10 +574,10 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		};
 
 		selectViaFake( settlementCall, item );
-		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: item.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: 'cdek:city-77', level: 'settlement', implicit: false } ] );
+		expect( seen ).toEqual( [ { key: 'cdek:city-77', level: 'settlement', settlementKey: 'cdek:city-77', implicit: false } ] );
 	} );
 
 	it( 'does NOT fire when /select fails', async () => {
@@ -618,7 +620,13 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: false } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: '', level: '', implicit: false } ] );
+		// settlementKey (issue #336) is EMPTY here too, and that is the whole point of this
+		// branch: `onSelectFor()` wrote entry.records.settlement OPTIMISTICALLY, before the
+		// persist outcome was known, and the server ended up holding nothing. Publishing that
+		// optimistic key would hand pickup-mount.js a confident locality exactly where F1/F2
+		// decided the honest answer is "unknown" — bypassing the DOM fallback those findings
+		// added. The unknown sentinel applies to the WHOLE detail.
+		expect( seen ).toEqual( [ { key: '', level: '', settlementKey: '', implicit: false } ] );
 	} );
 
 	it( 'fires only ONCE, for the FINAL response, when a superseded selection is queued behind it', async () => {
@@ -643,15 +651,15 @@ describe( 'woodev_location_applied (Task 15; issue #159)', () => {
 		selectViaFake( settlementCall, second ); // queued — the first request is still in flight.
 		expect( selectRequests().length ).toBe( 1 );
 
-		selectRequests()[ 0 ].resolve( { current: { key: first.record.key, level: 'settlement' }, persisted: true } );
+		selectRequests()[ 0 ].resolve( { current: { key: first.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: first.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		// The queued (second) selection is dispatched automatically once the first settles.
 		expect( selectRequests().length ).toBe( 2 );
-		selectRequests()[ 1 ].resolve( { current: { key: second.record.key, level: 'settlement' }, persisted: true } );
+		selectRequests()[ 1 ].resolve( { current: { key: second.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: second.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: 'dadata:second', level: 'settlement', implicit: false } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:second', level: 'settlement', settlementKey: 'dadata:second', implicit: false } ] );
 	} );
 } );
 
@@ -727,7 +735,7 @@ describe( '#295 finding 1 — the "not saved" notice consumes persisted: false',
 		};
 
 		selectViaFake( settlementCall, second );
-		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: second.record.key, level: 'settlement' }, persisted: true } );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: second.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: second.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		expect( notice() ).toBeNull();
@@ -799,7 +807,7 @@ describe( 'single-flight /select queue (Finding 2)', () => {
 		selectViaFake( settlementCall, b );
 		expect( selectRequests().length ).toBe( 1 );
 
-		selectRequests()[ 0 ].resolve( { current: { key: a.record.key, level: 'settlement' }, persisted: true } );
+		selectRequests()[ 0 ].resolve( { current: { key: a.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: a.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		// A's resolution must NOT have triggered update_checkout — B was already queued when
@@ -810,7 +818,7 @@ describe( 'single-flight /select queue (Finding 2)', () => {
 		expect( selectRequests().length ).toBe( 2 );
 		expect( JSON.parse( selectRequests()[ 1 ].init.body ) ).toEqual( { record: b.record } );
 
-		selectRequests()[ 1 ].resolve( { current: { key: b.record.key, level: 'settlement' }, persisted: true } );
+		selectRequests()[ 1 ].resolve( { current: { key: b.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: b.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		// Exactly ONE trigger overall, firing for the FINAL (B) selection.
@@ -833,7 +841,7 @@ describe( 'single-flight /select queue (Finding 2)', () => {
 
 		expect( selectRequests().length ).toBe( 1 );
 
-		selectRequests()[ 0 ].resolve( { current: { key: a.record.key, level: 'settlement' }, persisted: true } );
+		selectRequests()[ 0 ].resolve( { current: { key: a.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: a.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		expect( selectRequests().length ).toBe( 2 );
@@ -893,7 +901,7 @@ describe( 'single-flight /select queue (Finding 2)', () => {
 		selectViaFake( settlementCall, a );
 		expect( selectRequests().length ).toBe( 1 );
 
-		selectRequests()[ 0 ].resolve( { current: { key: a.record.key, level: 'settlement' }, persisted: true } );
+		selectRequests()[ 0 ].resolve( { current: { key: a.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: a.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		expect( triggerSpy.mock.calls.filter( ( args ) => args[ 0 ] === 'update_checkout' ).length ).toBe( 1 );
@@ -1607,7 +1615,7 @@ describe( 'Task 13 renderer seam (spec D7)', () => {
 		expect( JSON.parse( selectReq.init.body ) ).toEqual( { record } );
 
 		const triggerSpy = jest.spyOn( window.jQuery.fn, 'trigger' );
-		selectReq.resolve( { current: { key: record.key, level: 'settlement' }, persisted: true } );
+		selectReq.resolve( { current: { key: record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		expect( triggerSpy.mock.calls.some( ( args ) => args[ 0 ] === 'update_checkout' ) ).toBe( true );
@@ -1824,7 +1832,9 @@ describe( 'location chain restore (issue #330, spec §7)', () => {
 			},
 		} );
 
-		expect( seen ).toEqual( [ { key: 'dadata:addr1', level: 'address', implicit: false } ] );
+		// settlementKey (issue #336) comes from the boot-time chain's own settlement entry,
+		// adopted by adoptChain() BEFORE this boot fire — see prefill()'s own docblock.
+		expect( seen ).toEqual( [ { key: 'dadata:addr1', level: 'address', settlementKey: 'dadata:city1', implicit: false } ] );
 	} );
 
 	it( 'adopts a /select response\'s own rebuilt chain, so the very next suggest in the SAME page load is scoped by the settlement it names', async () => {
@@ -1881,6 +1891,70 @@ describe( 'location chain restore (issue #330, spec §7)', () => {
 
 		await flushMicrotasks();
 	};
+
+	// -------------------------------------------------------------------
+	// detail.settlementKey (issue #336) — always entry.records.settlement's OWN key,
+	// regardless of which level the event's own record (`key`/`level`) is for.
+	// -------------------------------------------------------------------
+
+	it( 'settlementKey names the settlement actually picked, not the deeper address just picked (issue #336)', async () => {
+		boot( { settlement: true, address: true } );
+
+		const seen = [];
+		document.body.addEventListener( 'woodev_location_applied', ( event ) => seen.push( event.detail ) );
+
+		await pickSettlement( 'dadata:settlement-pushkino' );
+
+		const addressCall = callFor( 'billing_address_1' );
+
+		// A DIFFERENT settlement's own address (issue #336's own rig measurement: an
+		// address's `city_fias_id` routinely nests a DEEPER settlement than the one the
+		// customer picked) — the server does not repair the chain this time (no `chain`
+		// field), so entry.records.settlement keeps the customer's OWN earlier pick.
+		selectViaFake( addressCall, {
+			key: 'dadata:address-cherkizovo', label: 'дер Черкизово, ул Ленина, 1', level: 'address',
+			record: {
+				key: 'dadata:address-cherkizovo', provider_id: 'dadata', level: 'address', country: 'RU',
+				label: 'дер Черкизово, ул Ленина, 1',
+			},
+		} );
+
+		fetchCalls[ fetchCalls.length - 1 ].resolve( {
+			current: { key: 'dadata:address-cherkizovo', level: 'address' },
+			persisted: true,
+		} );
+		await flushMicrotasks();
+
+		const last = seen[ seen.length - 1 ];
+
+		expect( last.key ).toBe( 'dadata:address-cherkizovo' );
+		expect( last.settlementKey ).toBe( 'dadata:settlement-pushkino' );
+	} );
+
+	it( 'settlementKey is empty when no settlement has ever been picked on this page load (issue #336)', async () => {
+		boot( { settlement: true, address: true } );
+
+		const seen = [];
+		document.body.addEventListener( 'woodev_location_applied', ( event ) => seen.push( event.detail ) );
+
+		const addressCall = callFor( 'billing_address_1' );
+
+		selectViaFake( addressCall, {
+			key: 'dadata:address-typed-only', label: 'ул Тверская, 1', level: 'address',
+			record: {
+				key: 'dadata:address-typed-only', provider_id: 'dadata', level: 'address', country: 'RU',
+				label: 'ул Тверская, 1',
+			},
+		} );
+
+		fetchCalls[ fetchCalls.length - 1 ].resolve( {
+			current: { key: 'dadata:address-typed-only', level: 'address' },
+			persisted: true,
+		} );
+		await flushMicrotasks();
+
+		expect( seen ).toEqual( [ { key: 'dadata:address-typed-only', level: 'address', settlementKey: '', implicit: false } ] );
+	} );
 
 	it( 'DROPS a stale record the server\'s rebuilt chain no longer names — a non-empty chain is authoritative, not merely additive', async () => {
 		// Adversarial review: adopting additively could never REMOVE anything, so a
@@ -1975,7 +2049,7 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 			implicit: true,
 		} );
 
-		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: true } ] );
 	} );
 
 	it( 'fires implicit:false on boot for a real customer choice (config.location.implicit is false)', () => {
@@ -1987,7 +2061,7 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 			implicit: false,
 		} );
 
-		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: false } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: false } ] );
 	} );
 
 	it( 'fires nothing at boot when there is no current record at all', () => {
@@ -2023,7 +2097,9 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 			implicit: true,
 		} );
 
-		expect( seen ).toEqual( [ { key: 'dadata:addr1', level: 'address', implicit: true } ] );
+		// settlementKey (issue #336) is '' — this entry's chain never carried a settlement
+		// entry, so entry.records.settlement was never seeded.
+		expect( seen ).toEqual( [ { key: 'dadata:addr1', level: 'address', settlementKey: '', implicit: true } ] );
 	} );
 
 	it( 'an explicit pick always fires implicit:false, overriding a previously-implicit boot state (spec D11: a real choice drops the flag)', async () => {
@@ -2043,10 +2119,10 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 		};
 
 		selectViaFake( settlementCall, item );
-		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true } );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: item.record.key, level: 'settlement' }, persisted: true, chain: { settlement: { key: item.record.key, level: 'settlement' } } } );
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: 'dadata:city2', level: 'settlement', implicit: false } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:city2', level: 'settlement', settlementKey: 'dadata:city2', implicit: false } ] );
 	} );
 
 	it( 'the initial implicit:true fire is not destroyed by a DOM-replacing renderer running right after it (defect #1 — the fatal one: attachAll() runs AFTER prefill() in boot())', () => {
@@ -2077,7 +2153,7 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 
 		// Sanity: this really does exercise the DOM-destroying renderer path.
 		expect( document.getElementById( 'billing_city' ).tagName ).toBe( 'SELECT' );
-		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: true } ] );
 	} );
 
 	it( 'a later checkout re-render (updated_checkout) neither loses nor duplicates the boot-time signal (defect #2)', () => {
@@ -2094,7 +2170,7 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 			implicit: true,
 		} );
 
-		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: true } ] );
 
 		const fresh = document.createElement( 'input' );
 		fresh.type = 'text';
@@ -2104,7 +2180,7 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 
 		window.jQuery( document.body ).trigger( 'updated_checkout' );
 
-		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', implicit: true } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: true } ] );
 	} );
 
 	it( 'never gates scoping/addressing on the implicit flag — the restored key still scopes the child fetch', () => {
@@ -2205,8 +2281,8 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 		bootSharedLocationEntries( { key: 'dadata:city1', level: 'settlement' }, true );
 
 		expect( seen ).toEqual( [
-			{ key: 'dadata:city1', level: 'settlement', implicit: true },
-			{ key: 'dadata:city1', level: 'settlement', implicit: true },
+			{ key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: true },
+			{ key: 'dadata:city1', level: 'settlement', settlementKey: 'dadata:city1', implicit: true },
 		] );
 	} );
 
@@ -2222,12 +2298,12 @@ describe( 'woodev_location_applied\'s implicit detail (issue #309)', () => {
 			key: 'dadata:kazan', label: 'г Казань', level: 'settlement',
 			record: { key: 'dadata:kazan', provider_id: 'dadata', level: 'settlement', country: 'RU', label: 'г Казань' },
 		} );
-		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: 'dadata:kazan', level: 'settlement' }, persisted: true } );
+		fetchCalls[ fetchCalls.length - 1 ].resolve( { current: { key: 'dadata:kazan', level: 'settlement' }, persisted: true, chain: { settlement: { key: 'dadata:kazan', level: 'settlement' } } } );
 		await flushMicrotasks();
 
 		// ONE event, implicit:false — not two, not still true, and not scoped to "only the
 		// shipping entry knows this now" the way the old per-entry DOM marker was.
-		expect( seen ).toEqual( [ { key: 'dadata:kazan', level: 'settlement', implicit: false } ] );
+		expect( seen ).toEqual( [ { key: 'dadata:kazan', level: 'settlement', settlementKey: 'dadata:kazan', implicit: false } ] );
 	} );
 } );
 
@@ -2487,7 +2563,7 @@ describe( 'Location Provider key invalidation on a local-only clear (review find
 		document.getElementById( 'billing_country' ).value = 'US';
 		document.getElementById( 'billing_country' ).dispatchEvent( new Event( 'change', { bubbles: true } ) );
 
-		expect( seen ).toEqual( [ { key: '', level: '', implicit: false } ] );
+		expect( seen ).toEqual( [ { key: '', level: '', settlementKey: '', implicit: false } ] );
 		// Sanity: this really is a pure client-side clear, never a network call.
 		expect( fetchCalls.length ).toBe( 0 );
 	} );
@@ -2518,7 +2594,7 @@ describe( 'Location Provider key invalidation on a local-only clear (review find
 
 		await flushMicrotasks();
 
-		expect( seen ).toEqual( [ { key: '', level: '', implicit: false } ] );
+		expect( seen ).toEqual( [ { key: '', level: '', settlementKey: '', implicit: false } ] );
 	} );
 
 	it( 'a real pick through the widget does NOT fire the empty-key event before /select resolves', () => {

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -1369,9 +1369,24 @@ test( 'refresh() re-reads the city, so a locality changed while the map is open 
 // -----------------------------------------------------------------------
 
 describe( 'resolveLocalityKey() — Task 15 (issue #159)', () => {
-	function fireLocationApplied( key, level = 'settlement' ) {
+	/**
+	 * @param {string}      key           `detail.key`.
+	 * @param {string}      [level]       `detail.level`, defaults to 'settlement'.
+	 * @param {string|null} [settlementKey] `detail.settlementKey` (issue #336) — omitted
+	 *                                      entirely (never even set on `detail`) when not
+	 *                                      passed, so every PRE-#336 call site here keeps
+	 *                                      exercising `handleLocationApplied()`'s fallback
+	 *                                      to `key` exactly as before this parameter existed.
+	 */
+	function fireLocationApplied( key, level = 'settlement', settlementKey = null ) {
+		const detail = { key, level };
+
+		if ( null !== settlementKey ) {
+			detail.settlementKey = settlementKey;
+		}
+
 		document.body.dispatchEvent(
-			new CustomEvent( 'woodev_location_applied', { detail: { key, level }, bubbles: true } )
+			new CustomEvent( 'woodev_location_applied', { detail, bubbles: true } )
 		);
 	}
 
@@ -1413,6 +1428,71 @@ describe( 'resolveLocalityKey() — Task 15 (issue #159)', () => {
 		await flushAsync();
 
 		expect( queries[ 0 ].locality ).toBe( 'dadata:fias-1' );
+	} );
+
+	test( 'PREFERS config.location.settlementKey over current.key at page load (issue #336)', async () => {
+		// The page-load config and the live `woodev_location_applied` event must speak ONE
+		// vocabulary, or the map addresses itself differently before and after the customer's
+		// first pick. `current.key` here is an ADDRESS-level record (what the customer's
+		// current record becomes as soon as they refine their address); the map must address
+		// by the SETTLEMENT they actually picked.
+		const queries = [];
+		const fieldId = 'settlement_key_pref_field';
+
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div data-woodev-pickup-slot="' + fieldId + '"></div>' +
+			'<input id="' + fieldId + '" type="hidden" value="" />'
+		);
+
+		window.WoodevPickupDataSource = fakeDataSourceFactory( ( query ) => {
+			queries.push( query );
+			return Promise.resolve( [] );
+		} );
+
+		setConfig( makeConfig( {
+			fieldId,
+			strategy: 'bulk',
+			location: { current: { key: 'dadata:address-cherkizovo' }, settlementKey: 'dadata:settlement-pushkino' },
+		} ) );
+		mountAll();
+
+		clickTrigger();
+		await flushAsync();
+
+		expect( queries[ 0 ].locality ).toBe( 'dadata:settlement-pushkino' );
+	} );
+
+	test( 'falls back to current.key when config.location.settlementKey is empty (issue #336 — the half #334\'s rule must not be copied onto)', async () => {
+		// A customer who typed an address without ever picking a settlement has no settlement
+		// record at all. Refusing here — the storage key's correct behaviour — would turn a
+		// working map into «в этом населённом пункте нет пунктов выдачи», a regression rather
+		// than a fix.
+		const queries = [];
+		const fieldId = 'settlement_key_fallback_field';
+
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div data-woodev-pickup-slot="' + fieldId + '"></div>' +
+			'<input id="' + fieldId + '" type="hidden" value="" />'
+		);
+
+		window.WoodevPickupDataSource = fakeDataSourceFactory( ( query ) => {
+			queries.push( query );
+			return Promise.resolve( [] );
+		} );
+
+		setConfig( makeConfig( {
+			fieldId,
+			strategy: 'bulk',
+			location: { current: { key: 'dadata:address-typed-only' }, settlementKey: '' },
+		} ) );
+		mountAll();
+
+		clickTrigger();
+		await flushAsync();
+
+		expect( queries[ 0 ].locality ).toBe( 'dadata:address-typed-only' );
 	} );
 
 	test( 'an empty config.location.current.key falls back to the DOM read (review finding F1)', async () => {
@@ -1590,6 +1670,114 @@ describe( 'resolveLocalityKey() — Task 15 (issue #159)', () => {
 		await flushAsync();
 
 		expect( queries[ 0 ].locality ).toBe( 'Москва' );
+	} );
+
+	// -------------------------------------------------------------------
+	// detail.settlementKey (issue #336) — the map PREFERS it over detail.key,
+	// falling back to detail.key only when settlementKey is absent/empty. This is the
+	// OPPOSITE asymmetry from #334's storage-key rule — see handleLocationApplied()'s
+	// own docblock for why a fallback here is a needed recovery, not a mis-file.
+	// -------------------------------------------------------------------
+
+	test( 'prefers detail.settlementKey over detail.key when both are present (issue #336)', async () => {
+		const fieldId = 'pickup_locality_settlement_key_preferred_test';
+
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div data-woodev-pickup-slot="' + fieldId + '"></div>' +
+			'<input id="' + fieldId + '" type="hidden" value="" />'
+		);
+
+		const queries = [];
+		window.WoodevPickupDataSource = fakeDataSourceFactory( ( query ) => {
+			queries.push( query );
+			return Promise.resolve( [] );
+		} );
+
+		setConfig( makeConfig( {
+			fieldId,
+			strategy: 'bulk',
+			location: { current: { key: 'dadata:fias-1' } },
+		} ) );
+		mountAll();
+
+		// An address pick: `key` is the deeper address record's own key, but
+		// `settlementKey` names the settlement the customer actually picked — the map
+		// must address itself by settlementKey, not the address key. Fired BEFORE the
+		// first resolveLocalityKey() read, so handleLocationApplied() writes it directly
+		// (see that function's own docblock — it never needs a prior "seeded" read).
+		fireLocationApplied( 'dadata:address-cherkizovo', 'address', 'dadata:settlement-pushkino' );
+
+		clickTrigger();
+		await flushAsync();
+
+		expect( queries[ 0 ].locality ).toBe( 'dadata:settlement-pushkino' );
+	} );
+
+	test( 'falls back to detail.key when detail.settlementKey is absent (older cascade build)', async () => {
+		const fieldId = 'pickup_locality_settlement_key_absent_test';
+
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div data-woodev-pickup-slot="' + fieldId + '"></div>' +
+			'<input id="' + fieldId + '" type="hidden" value="" />'
+		);
+
+		const queries = [];
+		window.WoodevPickupDataSource = fakeDataSourceFactory( ( query ) => {
+			queries.push( query );
+			return Promise.resolve( [] );
+		} );
+
+		setConfig( makeConfig( {
+			fieldId,
+			strategy: 'bulk',
+			location: { current: { key: 'dadata:fias-1' } },
+		} ) );
+		mountAll();
+
+		// No settlementKey at all on this event — mirrors an older cascade build that has
+		// not shipped the field yet.
+		fireLocationApplied( 'dadata:city-77' );
+
+		clickTrigger();
+		await flushAsync();
+
+		expect( queries[ 0 ].locality ).toBe( 'dadata:city-77' );
+	} );
+
+	test( 'falls back to detail.key when detail.settlementKey is an empty string (a chain with no settlement — issue #336)', async () => {
+		const fieldId = 'pickup_locality_settlement_key_empty_test';
+
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div data-woodev-pickup-slot="' + fieldId + '"></div>' +
+			'<input id="' + fieldId + '" type="hidden" value="" />'
+		);
+
+		const queries = [];
+		window.WoodevPickupDataSource = fakeDataSourceFactory( ( query ) => {
+			queries.push( query );
+			return Promise.resolve( [] );
+		} );
+
+		setConfig( makeConfig( {
+			fieldId,
+			strategy: 'bulk',
+			location: { current: { key: 'dadata:fias-1' } },
+		} ) );
+		mountAll();
+
+		// An address typed without ever picking a settlement — location-cascade.js's own
+		// fireLocationApplied() degrades settlementKey to '' in exactly this case (spec
+		// §4.4: backwardsFill() writes DOM text only, never a settlement record). A working
+		// map must still address by the address's own key, never refuse.
+		fireLocationApplied( 'dadata:address-typed-only', 'address', '' );
+
+		clickTrigger();
+		await flushAsync();
+
+		expect( queries[ 0 ].locality ).toBe( 'dadata:address-typed-only' );
 	} );
 } );
 

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -125,14 +125,19 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 	}
 
 	/**
-	 * A spy {@see Location_Resolution_Cache}: counts resolve_for() calls and
-	 * returns a configured value, WITHOUT touching any session — used to prove
-	 * `resolve_for()` never even reaches the cache when there is no customer
-	 * record at all.
+	 * A spy {@see Location_Resolution_Cache}: counts resolve_for() calls,
+	 * captures the LAST record it was called with (issue #336 — proves
+	 * {@see Location_Service::resolve_for()}'s optional `$record` argument
+	 * reaches the cache unchanged, rather than being silently re-derived from
+	 * the customer's current record), and returns a configured value, WITHOUT
+	 * touching any session — also used to prove `resolve_for()` never even
+	 * reaches the cache when there is no customer record at all.
 	 */
 	final class Location_Service_Spy_Resolution_Cache extends Location_Resolution_Cache {
 
 		public int $calls = 0;
+
+		public ?Location_Record $last_record = null;
 
 		/** @var mixed */
 		private $return_value;
@@ -143,6 +148,7 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 
 		public function resolve_for( Shipping_Plugin $plugin, Location_Record $record ) {
 			++$this->calls;
+			$this->last_record = $record;
 
 			return $this->return_value;
 		}
@@ -663,6 +669,56 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 
 			$this->assertSame( 'city-code-42', $result );
 			$this->assertSame( 1, $spy_cache->calls );
+		}
+
+		/**
+		 * Issue #336: the pickup map addresses itself by the settlement-preferred
+		 * record {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::current_location_record()}
+		 * resolves, which need not be the customer's CURRENT record (e.g. current is
+		 * address-level, settlement is an ancestor). `resolve_for()`'s explicit `$record`
+		 * argument must reach the cache AS GIVEN, not be silently overridden by the
+		 * customer's current record — the cache never even reads the current record when
+		 * an explicit one is passed.
+		 */
+		public function test_resolve_for_resolves_the_explicit_record_when_one_is_passed(): void {
+			$store     = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$spy_cache = new Location_Service_Spy_Resolution_Cache( 'city-code-settlement' );
+			$service   = new Location_Service( Location_Provider_Registry::instance(), $store, $spy_cache );
+			$plugin    = $this->plugin();
+
+			// The CURRENT record is address-level, a DIFFERENT key from the explicit
+			// settlement record passed to resolve_for() below.
+			$service->set_customer_record( $this->record( 'dadata:address-current' ) );
+
+			$explicit_record = $this->record( 'dadata:settlement-explicit' );
+
+			$result = $service->resolve_for( $plugin, $explicit_record );
+
+			$this->assertSame( 'city-code-settlement', $result );
+			$this->assertSame( 1, $spy_cache->calls );
+			$this->assertNotNull( $spy_cache->last_record );
+			$this->assertSame( 'dadata:settlement-explicit', $spy_cache->last_record->key(), 'the explicit record must reach the cache, not the current one' );
+		}
+
+		/**
+		 * Issue #336: the default (`null`) must stay exactly today's behaviour — resolve
+		 * for the customer's CURRENT record. This is a regression guard for the parameter's
+		 * own default value, distinct from `test_resolve_for_delegates_to_the_resolution_cache_with_the_current_record`
+		 * above (which never even names the parameter).
+		 */
+		public function test_resolve_for_defaults_to_the_current_record_when_no_record_is_passed(): void {
+			$store     = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$spy_cache = new Location_Service_Spy_Resolution_Cache( 'city-code-42' );
+			$service   = new Location_Service( Location_Provider_Registry::instance(), $store, $spy_cache );
+			$plugin    = $this->plugin();
+
+			$service->set_customer_record( $this->record( 'dadata:fias-1' ) );
+
+			$result = $service->resolve_for( $plugin, null );
+
+			$this->assertSame( 'city-code-42', $result );
+			$this->assertNotNull( $spy_cache->last_record );
+			$this->assertSame( 'dadata:fias-1', $spy_cache->last_record->key() );
 		}
 
 		public function test_resolve_for_uses_the_real_resolution_cache_end_to_end(): void {

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -1216,6 +1216,57 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 		}
 
 		/**
+		 * Builds an ADDRESS-level record with an explicit `ancestors` set — issue #336's
+		 * settlement-preferred/current-fallback tests need to control whether the chain
+		 * {@see Customer_Location_Store::set()} rebuilds keeps a shallower settlement record
+		 * or drops it, and only an address record naming that settlement's key in its own
+		 * `ancestors` proves ancestry (mirrors `CustomerLocationStoreTest::record_with_ancestors()`).
+		 *
+		 * @param string   $key       The record's own key.
+		 * @param string[] $ancestors The `ancestors` set to publish.
+		 */
+		private function address_record( string $key, array $ancestors ): Location_Record {
+			return Location_Record::from_array(
+				[
+					'key'         => $key,
+					'provider_id' => explode( ':', $key )[0],
+					'level'       => Location_Record::LEVEL_ADDRESS,
+					'country'     => 'RU',
+					'ancestors'   => $ancestors,
+				]
+			);
+		}
+
+		/**
+		 * Builds a {@see Pickup_Handler_Location_Fixture_Plugin} whose customer store holds a
+		 * TWO-LEVEL chain (issue #336) — `$settlement` written first, then `$address` (which
+		 * must name `$settlement`'s key in its own `ancestors` for {@see Customer_Location_Store::set()}
+		 * to keep the settlement level rather than drop it — see {@see self::address_record()}).
+		 * `current` ends up at the address level, exactly what an address pick inside an
+		 * already-chosen settlement looks like on the rig (issue #336's own measurement).
+		 *
+		 * @param Location_Record      $settlement The settlement-level record picked first.
+		 * @param Location_Record      $address    The address-level record picked second.
+		 * @param Location_Adapter|null $adapter   Optional adapter for {@see Pickup_Handler::location_context()}.
+		 */
+		private function location_plugin_with_chain( Location_Record $settlement, Location_Record $address, ?Location_Adapter $adapter = null ): Pickup_Handler_Location_Fixture_Plugin {
+			$instance = ( new \ReflectionClass( Pickup_Handler_Location_Fixture_Plugin::class ) )->newInstanceWithoutConstructor();
+
+			$store = new Pickup_Handler_Customer_Location_Store_Probe( new Pickup_Handler_Location_Fake_Session() );
+			$store->set( $settlement );
+			$store->set( $address );
+
+			$instance->fake_adapter          = $adapter;
+			$instance->fake_location_service = new Pickup_Handler_Location_Service_Active_Probe(
+				Location_Provider_Registry::instance(),
+				$store,
+				true
+			);
+
+			return $instance;
+		}
+
+		/**
 		 * Installs a faithful-enough Brain Monkey stand-in for `sanitize_hex_color()` —
 		 * NOT currently stubbed anywhere else in this codebase. Verified against real
 		 * WordPress core (`wp-includes/formatting.php`): returns the input UNCHANGED (no
@@ -1367,6 +1418,67 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$config = $this->make_handler( [ 'plugin' => $plugin ] )->get_js_config();
 
 			$this->assertSame( 'dadata:fias-1', $config['location']['current']['key'] );
+		}
+
+		/**
+		 * `location_config_block()`'s `current.key` follows the SAME settlement-preferred
+		 * rule as `current_location_record()` (issue #336) — see that method's own tests
+		 * under "current_location_record() settlement-preferred / current-fallback rule"
+		 * for the full reasoning; this proves the SAME preference reaches the browser
+		 * config, not just `location_context()`'s server-side enrichment.
+		 */
+		public function test_config_carries_the_settlement_record_key_when_the_chain_has_one(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			Functions\when( 'rest_url' )->justReturn( 'https://example.test/wp-json/woodev/v1' );
+			Functions\when( 'wp_create_nonce' )->justReturn( 'NONCE' );
+			Functions\when( 'wc_ship_to_billing_address_only' )->justReturn( false );
+
+			$settlement = $this->location_record( 'dadata:settlement-pushkino' );
+			$address    = $this->address_record( 'dadata:address-cherkizovo', [ 'dadata:settlement-pushkino' ] );
+
+			$plugin = $this->location_plugin_with_chain( $settlement, $address );
+			$config = $this->make_handler( [ 'plugin' => $plugin ] )->get_js_config();
+
+			// The settlement rides in its OWN field. `current` keeps meaning the CURRENT
+			// record — an earlier draft wrote the settlement into `current.key` itself, which
+			// left the block naming one record in `current` while `implicit` described another
+			// (adversarial review).
+			$this->assertSame( 'dadata:settlement-pushkino', $config['location']['settlementKey'] );
+			$this->assertSame(
+				'dadata:address-cherkizovo',
+				$config['location']['current']['key'],
+				'current must still identify the CURRENT record, not the map\'s addressing locality'
+			);
+		}
+
+		/**
+		 * The fallback half of the same rule — an address typed without ever picking a
+		 * settlement must still publish a usable key (its own), never `''`, which would
+		 * needlessly disable the browser's own DOM fallback (gotcha
+		 * `an-empty-domain-key-is-not-a-key` — `''` must stay reserved for "no record at
+		 * all").
+		 */
+		public function test_config_carries_the_current_record_key_when_the_chain_has_no_settlement(): void {
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			Functions\when( 'rest_url' )->justReturn( 'https://example.test/wp-json/woodev/v1' );
+			Functions\when( 'wp_create_nonce' )->justReturn( 'NONCE' );
+			Functions\when( 'wc_ship_to_billing_address_only' )->justReturn( false );
+
+			$address = $this->address_record( 'dadata:address-typed-only', [] );
+
+			$plugin = $this->location_plugin( $address, null, true );
+			$config = $this->make_handler( [ 'plugin' => $plugin ] )->get_js_config();
+
+			$this->assertSame(
+				'',
+				$config['location']['settlementKey'],
+				'no settlement in the chain — the field says so honestly rather than naming the address'
+			);
+			$this->assertSame(
+				'dadata:address-typed-only',
+				$config['location']['current']['key'],
+				'and the browser falls back to THIS, so the map keeps working (the half #334\'s rule must not be copied onto)'
+			);
 		}
 
 		/**
@@ -1586,6 +1698,92 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$handler = $this->make_handler( [ 'plugin' => $this->location_plugin( $record, $adapter ) ] );
 
 			$this->assertNull( $handler->location_context() );
+		}
+
+		// -------------------------------------------------------------------------
+		// current_location_record() settlement-preferred / current-fallback rule
+		// (issue #336), exercised through location_context() — current_location_record()
+		// is `protected` and has exactly one caller.
+		// -------------------------------------------------------------------------
+
+		/**
+		 * Issue #336's own rig measurement: after picking a settlement then an address
+		 * inside it, `current` sits at the address level, whose OWN settlement component
+		 * can be a DIFFERENT, deeper locality than the one the customer chose (9 of 10
+		 * addresses under «г Пушкино» nested a different settlement). The map must
+		 * address itself by the settlement the customer actually picked, not the
+		 * current record.
+		 */
+		public function test_location_context_addresses_by_the_settlement_record_when_the_chain_has_one(): void {
+			$settlement = $this->location_record( 'dadata:settlement-pushkino' );
+			$address    = $this->address_record( 'dadata:address-cherkizovo', [ 'dadata:settlement-pushkino' ] );
+			$adapter    = new class implements Location_Adapter {
+				public function resolve( Location_Record $record ) {
+					return 'carrier-city';
+				}
+			};
+
+			$plugin  = $this->location_plugin_with_chain( $settlement, $address, $adapter );
+			$handler = $this->make_handler( [ 'plugin' => $plugin ] );
+
+			$context = $handler->location_context();
+
+			$this->assertNotNull( $context );
+			$this->assertSame( 'dadata:settlement-pushkino', $context['record']->key(), 'the map must address by the settlement the customer picked, not the deeper address record' );
+		}
+
+		/**
+		 * Deliberately the OPPOSITE of #334's storage-key rule (spec: "Deliberately OUT of
+		 * scope" section) — a customer who typed an address WITHOUT ever picking a
+		 * settlement (`backwardsFill()` writes the settlement FIELD's text but creates no
+		 * settlement RECORD) must still see pickup points: the map falls back to the
+		 * current (address) record rather than refusing.
+		 */
+		public function test_location_context_falls_back_to_the_current_record_when_the_chain_has_no_settlement(): void {
+			// No settlement ever picked — an address record with NO ancestors at all, the
+			// one-entry chain #336's own "known, accepted degradation" section describes.
+			$address = $this->address_record( 'dadata:address-typed-only', [] );
+			$adapter = new class implements Location_Adapter {
+				public function resolve( Location_Record $record ) {
+					return 'carrier-city';
+				}
+			};
+
+			$plugin  = $this->location_plugin( $address, $adapter );
+			$handler = $this->make_handler( [ 'plugin' => $plugin ] );
+
+			$context = $handler->location_context();
+
+			$this->assertNotNull( $context, 'a working map must not regress into refusing here' );
+			$this->assertSame( 'dadata:address-typed-only', $context['record']->key() );
+		}
+
+		/**
+		 * `location_context()` must resolve the adapter for the SAME record it returns
+		 * (issue #336) — the settlement-preferred one, not a re-derived current record —
+		 * so the carrier's own city resolution agrees with what the map is addressed by.
+		 */
+		public function test_location_context_resolves_the_adapter_against_the_settlement_record_not_the_current_one(): void {
+			$settlement = $this->location_record( 'dadata:settlement-pushkino' );
+			$address    = $this->address_record( 'dadata:address-cherkizovo', [ 'dadata:settlement-pushkino' ] );
+
+			$adapter = new class implements Location_Adapter {
+				/** @var string[] */
+				public array $received_keys = [];
+
+				public function resolve( Location_Record $record ) {
+					$this->received_keys[] = $record->key();
+
+					return 'carrier-city';
+				}
+			};
+
+			$plugin  = $this->location_plugin_with_chain( $settlement, $address, $adapter );
+			$handler = $this->make_handler( [ 'plugin' => $plugin ] );
+
+			$handler->location_context();
+
+			$this->assertSame( [ 'dadata:settlement-pushkino' ], $adapter->received_keys, 'the adapter must resolve for the settlement record, never the deeper current one' );
 		}
 
 		/**

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -82,17 +82,28 @@
  * async ready queue, since — unlike that file — this one must keep working even in a jQuery-
  * less test harness for its own non-jQuery-producer paths).
  *
- * `woodev_location_applied` (Task 15; issue #159; `implicit` added issue #309, spec D11/§4.6):
- * a native, bubbling `CustomEvent` on `document.body`, `detail: { key, level, implicit }`,
- * fired from {@see settleSelect} on the SAME "this response is final and persisted" condition
- * as the `update_checkout` trigger above — see that function's own docblock — AND from
- * {@see prefill} on boot, when `config.location.current` already names a record (see below).
- * This is a NATIVE event, never a jQuery `.trigger()` (unlike `update_checkout`, which
- * WooCommerce itself only ever fires through jQuery): this module is the event's own
- * producer, so there is no third-party dispatch mechanism to accommodate the way
- * `pickup-mount.js`'s dual-world `updated_checkout` binding has to. `pickup-mount.js`'s own
+ * `woodev_location_applied` (Task 15; issue #159; `implicit` added issue #309, spec D11/§4.6;
+ * `settlementKey` added issue #336):
+ * a native, bubbling `CustomEvent` on `document.body`, `detail: { key, level, settlementKey,
+ * implicit }`, fired from {@see settleSelect} on the SAME "this response is final and
+ * persisted" condition as the `update_checkout` trigger above — see that function's own
+ * docblock — AND from {@see prefill} on boot, when `config.location.current` already names a
+ * record (see below). This is a NATIVE event, never a jQuery `.trigger()` (unlike
+ * `update_checkout`, which WooCommerce itself only ever fires through jQuery): this module is
+ * the event's own producer, so there is no third-party dispatch mechanism to accommodate the
+ * way `pickup-mount.js`'s dual-world `updated_checkout` binding has to. `pickup-mount.js`'s own
  * `resolveLocalityKey()` is the intended consumer of `key`/`level` — it tracks the customer's
  * current Location Provider layer key without ever reading a checkout DOM field.
+ *
+ * `detail.settlementKey` (issue #336) is a SEPARATE field, never a replacement for `key`:
+ * issue #309's `implicit` flag and other consumers ride on `key` meaning "the record THIS
+ * event describes", which must stay the current/just-persisted record at whatever level it
+ * sits at. `settlementKey` instead always names the settlement the customer has actually
+ * picked, if any — see {@see fireLocationApplied}'s own docblock for exactly how it is
+ * derived and why. `pickup-mount.js`'s pickup map prefers it over `key`, falling back to
+ * `key` only when `settlementKey` is absent/empty, mirroring
+ * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::current_location_record()}'s own
+ * settlement-preferred, current-record-fallback rule server-side.
  *
  * `detail.implicit` (issue #309; spec D11/§4.6) is this event's SECOND consumer surface:
  * `config.location.implicit` had ZERO consumers anywhere in this codebase before this — a
@@ -1007,7 +1018,7 @@
 			// (`Location_Controller::handle_select_request()` never writes implicit — spec
 			// D11) — `implicit` is unconditionally `false` here, regardless of what the
 			// PREVIOUS state (boot's own fire, see {@see prefill}) said.
-			fireLocationApplied( record, false );
+			fireLocationApplied( entry, record, false );
 
 			if ( window.jQuery ) {
 				window.jQuery( document.body ).trigger( 'update_checkout' );
@@ -1020,7 +1031,7 @@
 			showNotPersistedNotice( entry );
 			// Nothing was persisted, so there is no record to flag as a default guess —
 			// `false`, same as every other "the record is now unknown" fire below.
-			fireLocationApplied( null, false );
+			fireLocationApplied( entry, null, false );
 		}
 	}
 
@@ -1051,18 +1062,57 @@
 	 * tells a listener to ignore them. A consumer that reads `implicit` ALONE, without
 	 * checking `key`, will conclude the customer made a choice they never made.
 	 *
+	 * `detail.settlementKey` (issue #336) is ALWAYS `entry.records['settlement']`'s own key when
+	 * one exists, REGARDLESS of `record`/`level` — it is not "the settlement component of THIS
+	 * event's record", it is "whichever settlement the customer has actually picked so far",
+	 * exactly what {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::current_location_record()}
+	 * now prefers server-side. `entry.records.settlement` is kept current by {@see adoptChain}
+	 * (boot restore AND every `/select` response) and by {@see onSelectFor} on a direct settlement
+	 * pick — never by {@see backwardsFill}, which only ever writes DOM text, never a record (spec
+	 * §4.4) — so an address typed without ever picking a settlement correctly yields `''` here,
+	 * same sentinel as `key`. `pickup-mount.js` prefers this field and falls back to `key` when it
+	 * is absent/empty — see that file's own `handleLocationApplied()` docblock for why the map's
+	 * rule is the OPPOSITE of the storage key's (#334): a fallback there is a needed recovery, not
+	 * a mis-file.
+	 *
+	 * @param {Object}  entry
 	 * @param {Object}  record   The just-persisted record (D8's own full, round-tripped
 	 *                           shape), or `null` when the current locality is now unknown.
 	 * @param {boolean} implicit Whether the record this event describes is a default guess
 	 *                           rather than the customer's own choice.
 	 * @returns {void}
 	 */
-	function fireLocationApplied( record, implicit ) {
+	function fireLocationApplied( entry, record, implicit ) {
 		var key = record && 'string' === typeof record.key ? record.key : '';
 		var level = record && 'string' === typeof record.level ? record.level : '';
+		var settlementRecord = entry && entry.records ? entry.records.settlement : null;
+
+		// PUBLISHED ONLY WHEN THE SERVER HAS VOUCHED FOR IT, on two independent counts:
+		//
+		// 1. `key` must be non-empty. An empty `key` is this event's own "the customer's
+		//    locality is UNKNOWN right now" sentinel (review findings F1/F2), and it exists
+		//    so `pickup-mount.js` degrades to its DOM read instead of acting on state the
+		//    layer cannot vouch for. Publishing a settlement beside it would hand the picker
+		//    a confident answer precisely where the honest one is "I do not know", silently
+		//    bypassing the fallback F1 added.
+		// 2. The settlement record must be `confirmed` — i.e. adopted from the SERVER's own
+		//    chain ({@see adoptChain}), not the optimistic write {@see onSelectFor} makes
+		//    before the round trip resolves. Adversarial review's case: the customer picks a
+		//    settlement, then an address in a DIFFERENT locality, and `/select` answers
+		//    `persisted: true` but carries no usable chain — the optimistic settlement then
+		//    survives and the map would query the locality the customer just left.
+		//
+		// Both reduce to the same rule: this event never names a locality the layer cannot
+		// stand behind, and `pickup-mount.js`'s DOM fallback is the designed degradation.
+		var settlementKey = '' !== key && settlementRecord && true === settlementRecord.confirmed && 'string' === typeof settlementRecord.key
+			? settlementRecord.key
+			: '';
 
 		document.body.dispatchEvent(
-			new CustomEvent( 'woodev_location_applied', { detail: { key: key, level: level, implicit: !! implicit }, bubbles: true } )
+			new CustomEvent( 'woodev_location_applied', {
+				detail: { key: key, level: level, settlementKey: settlementKey, implicit: !! implicit },
+				bubbles: true,
+			} )
 		);
 	}
 
@@ -1613,7 +1663,7 @@
 		if ( cleared && isActiveAddressSection( section ) ) {
 			// Nothing is known to be implicit about a cleared record — false, same reasoning
 			// as {@see settleSelect}'s own `notPersisted` branch.
-			fireLocationApplied( null, false );
+			fireLocationApplied( entry, null, false );
 		}
 	}
 
@@ -1723,7 +1773,7 @@
 					if ( null === entry.records[ level ] && isActiveAddressSection( section ) ) {
 						// Same "nothing known to be implicit about an unknown record" reasoning
 						// as {@see clearCountryScope}.
-						fireLocationApplied( null, false );
+						fireLocationApplied( entry, null, false );
 					}
 				} );
 			}
@@ -1887,7 +1937,13 @@
 			// Only the cascade's OWN levels, so a rogue/extra key cannot plant a record
 			// under a level nothing here will ever read back.
 			if ( LEVELS.indexOf( level ) !== -1 && node && 'string' === typeof node.key && node.key ) {
-				adopted[ level ] = { key: node.key };
+				// `confirmed` marks PROVENANCE, not validity: this record came from the
+				// SERVER's own chain, so it is one the server actually holds — unlike the
+				// optimistic write `onSelectFor()` makes before any round trip resolves.
+				// {@see fireLocationApplied} publishes a settlement key only for a confirmed
+				// record, so an optimistic one can never be handed to `pickup-mount.js` as
+				// the map's addressing locality (adversarial review).
+				adopted[ level ] = { key: node.key, confirmed: true };
 			}
 		} );
 
@@ -1980,12 +2036,20 @@
 			// a silent no-op) degrades to EXACTLY today's single-level seed, and `current` always
 			// wins over its own chain entry for its own level regardless.
 			adoptChain( entry, entry.location.chain );
-			entry.records[ current.level ] = { key: current.key };
+
+			// `confirmed` for the same reason every chain entry above carries it: this seed
+			// is the SERVER's own rendered config block, not an optimistic client write —
+			// {@see fireLocationApplied} may publish it as the map's addressing locality.
+			// Without it this line would DOWNGRADE the record adoptChain() just confirmed
+			// for this very level.
+			entry.records[ current.level ] = { key: current.key, confirmed: true };
 
 			// The event still fires for `current` ONLY, unchanged — the chain is restoration
 			// plumbing for scoping (see scopeKeyFor()), never a second source of "the customer's
 			// current locality" for a listener like pickup-mount.js's own resolveLocalityKey().
-			fireLocationApplied( { key: current.key, level: current.level }, !! entry.location.implicit );
+			// `entry.records.settlement` is already seeded by adoptChain() above, so
+			// fireLocationApplied() picks up settlementKey from it correctly even on this boot fire.
+			fireLocationApplied( entry, { key: current.key, level: current.level }, !! entry.location.implicit );
 		}
 	}
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -1272,8 +1272,18 @@
 
 		if ( ! Object.prototype.hasOwnProperty.call( resolvedLocalityKey, config.fieldId ) ) {
 			var current = config.location.current;
+			var settlementKey = config.location.settlementKey;
 
-			resolvedLocalityKey[ config.fieldId ] = current && 'string' === typeof current.key ? current.key : '';
+			// PREFERS `settlementKey` (issue #336), exactly as {@see handleLocationApplied}
+			// prefers the event detail of the same name — the page-load config and the live
+			// event have to speak ONE vocabulary or the map would address itself differently
+			// before and after the customer's first pick. Falls back to `current.key` when the
+			// chain holds no settlement (an address typed with no settlement ever picked): the
+			// map must keep working there, which is the half of #336 that is deliberately NOT
+			// the storage key's refuse-rather-than-fall-back rule.
+			resolvedLocalityKey[ config.fieldId ] = 'string' === typeof settlementKey && settlementKey
+				? settlementKey
+				: ( current && 'string' === typeof current.key ? current.key : '' );
 		}
 
 		var key = resolvedLocalityKey[ config.fieldId ];
@@ -1285,19 +1295,34 @@
 	 * Handles `woodev_location_applied` (Task 15; issue #159; `location-cascade.js`'s own
 	 * event, fired once the customer's `/select` round-trip actually persisted) — updates
 	 * {@see resolvedLocalityKey} for EVERY currently-registered, Location-Provider-backed
-	 * pickup config, so {@see resolveLocalityKey} tracks the customer's real current locality
+	 * pickup config, so {@see resolveLocalityKey} tracks the map's addressing locality
 	 * without re-reading `config.location.current.key` (a PAGE-LOAD snapshot, never refreshed
 	 * on its own).
+	 *
+	 * PREFERS `detail.settlementKey` (issue #336) over `detail.key`, falling back to `key` only
+	 * when `settlementKey` is absent/empty (an older cascade build, or a chain with no
+	 * settlement — e.g. an address typed without ever picking one, spec §4.4's
+	 * `backwardsFill()`). This is DELIBERATELY THE OPPOSITE asymmetry from #334's storage-key
+	 * rule (`Provider_Selection_Scope::current_locality()`, which REFUSES rather than falls
+	 * back): a fallback KEY there would silently mis-file the customer's chosen pickup point,
+	 * but a REFUSED map here would regress a picker that works today — see
+	 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::current_location_record()}'s own
+	 * docblock for the full reasoning, which this function mirrors client-side. `key` itself
+	 * keeps its exact prior meaning — issue #309's `implicit` flag and other consumers ride on
+	 * it — only the field THIS function adopts for `resolvedLocalityKey` changes.
 	 *
 	 * A field WITHOUT `config.location` (a plugin that has not wired the layer) is skipped —
 	 * its own `resolveLocalityKey()` falls back to the DOM read regardless, so writing an
 	 * entry here for it would only be dead state.
 	 *
-	 * @param {CustomEvent} event `detail: { key, level }` — only `key` is read here.
+	 * @param {CustomEvent} event `detail: { key, level, settlementKey, implicit }` — `key` and
+	 *                            `settlementKey` are read here.
 	 * @returns {void}
 	 */
 	function handleLocationApplied( event ) {
-		var key = event && event.detail && 'string' === typeof event.detail.key ? event.detail.key : '';
+		var detail = event && event.detail ? event.detail : {};
+		var settlementKey = 'string' === typeof detail.settlementKey ? detail.settlementKey : '';
+		var key = settlementKey ? settlementKey : ( 'string' === typeof detail.key ? detail.key : '' );
 
 		collectConfigs().forEach( function( config ) {
 			if ( config.location ) {

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -710,21 +710,39 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		}
 
 		/**
-		 * Resolves `$plugin`'s carrier identity for the customer's CURRENT
-		 * location record — cached (Task 5, spec D9).
+		 * Resolves `$plugin`'s carrier identity for a location record — cached
+		 * (Task 5, spec D9).
+		 *
+		 * `$record` defaults to `null`, which resolves for the customer's
+		 * CURRENT record, exactly as before this parameter existed — every
+		 * pre-existing caller is unaffected. Pass an explicit `$record` to
+		 * resolve for a DIFFERENT record the caller has already chosen to
+		 * address by (issue #336: {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::location_context()}
+		 * passes the settlement-preferred record
+		 * {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler::current_location_record()}
+		 * resolved, so the adapter resolves the carrier city for the SAME
+		 * record the pickup map is addressed by, not a re-derived current one).
 		 *
 		 * Returns `null` in two situations a caller cannot tell apart from the
-		 * return value alone: the customer has no location record at all yet
-		 * (this method never even reaches the cache/adapter in that case — see
+		 * return value alone: `$record` is `null` (explicit or defaulted) and
+		 * the customer has no CURRENT record at all yet (this method never even
+		 * reaches the cache/adapter in that case — see
 		 * {@see self::get_customer_record()} first if the distinction
-		 * matters), or the carrier genuinely does not serve the customer's
+		 * matters), or the carrier genuinely does not serve the given
 		 * locality (a legitimate, cached answer from
 		 * {@see Location_Resolution_Cache::resolve_for()} itself).
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Added the optional `$record` parameter (issue #336). The
+		 *              default (`null`) is unchanged — do NOT flip it; this
+		 *              method has other callers that must keep resolving
+		 *              against the customer's current record.
 		 *
 		 * @param \Woodev\Framework\Shipping\Shipping_Plugin $plugin The plugin
-		 *        whose adapter should resolve the customer's current locality.
+		 *        whose adapter should resolve the given locality.
+		 * @param Location_Record|null                       $record The record
+		 *        to resolve for. `null` (default) resolves for the customer's
+		 *        current record.
 		 *
 		 * @return mixed|null The plugin's carrier identity (opaque to the
 		 *                     framework), or `null` (no record yet, or the
@@ -733,14 +751,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * @throws \Throwable Re-thrown, after logging, when the adapter itself
 		 *                     threw — see {@see Location_Resolution_Cache::resolve_for()}.
 		 */
-		public function resolve_for( \Woodev\Framework\Shipping\Shipping_Plugin $plugin ) {
-			$current = $this->get_customer_record();
+		public function resolve_for( \Woodev\Framework\Shipping\Shipping_Plugin $plugin, ?Location_Record $record = null ) {
+			if ( null === $record ) {
+				$current = $this->get_customer_record();
 
-			if ( null === $current ) {
-				return null;
+				if ( null === $current ) {
+					return null;
+				}
+
+				$record = $current['record'];
 			}
 
-			return $this->resolution_cache->resolve_for( $plugin, $current['record'] );
+			return $this->resolution_cache->resolve_for( $plugin, $record );
 		}
 
 		/**

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -2288,9 +2288,22 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		}
 
 		/**
-		 * Gets the customer's current Location Provider layer record (Task 15; issue
-		 * #159), or `null` when {@see self::$plugin} was not wired, or the layer has no
-		 * current record yet.
+		 * Gets the record the pickup MAP addresses itself by (Task 15; issue #159), or
+		 * `null` when {@see self::$plugin} was not wired, or the layer has no record at
+		 * all yet.
+		 *
+		 * PREFERS the settlement-level record
+		 * ({@see \Woodev\Framework\Shipping\Location\Location_Service::get_customer_record_at()})
+		 * and FALLS BACK to the current record — deliberately the OPPOSITE asymmetry from
+		 * `Provider_Selection_Scope::current_locality()` (#334), which refuses (`''`)
+		 * rather than fall back. The two callers have opposite failure modes: a fallback
+		 * STORAGE KEY silently mis-files the customer's chosen pickup point, so #334
+		 * refuses instead. A REFUSED map, on the other hand, is a REGRESSION — a customer
+		 * who typed an address without ever picking a settlement (the cascade's backwards
+		 * fill writes the settlement FIELD's text but creates no settlement RECORD) would
+		 * see «в этом населённом пункте нет пунктов выдачи» on a map that works today.
+		 * See `docs-internal/specs/2026-08-15-location-chain-design.md` → "Deliberately
+		 * OUT of scope" for the full reasoning (issue #336).
 		 *
 		 * `protected` — same test-seam reasoning as every other accessor on this class
 		 * (see {@see self::selection()}): a probe substitutes a
@@ -2298,6 +2311,13 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 * needing to be a real function in the unit-test process.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Prefers the settlement-level record over the current one, falling
+		 *              back to the current record only when the chain holds no settlement
+		 *              (issue #336) — previously this always returned the current record,
+		 *              which after an address pick is the DEEPEST settlement component of
+		 *              the address row, not the one the customer chose (issue #336's rig
+		 *              measurement: 9 of 10 addresses under «г Пушкино» nested a different
+		 *              settlement).
 		 *
 		 * @return Location_Record|null
 		 */
@@ -2321,7 +2341,15 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 			 */
 			$this->bridge_wc_context();
 
-			$current = $this->plugin->get_location_service()->get_customer_record();
+			$service = $this->plugin->get_location_service();
+
+			$settlement = $service->get_customer_record_at( Location_Record::LEVEL_SETTLEMENT );
+
+			if ( null !== $settlement ) {
+				return $settlement;
+			}
+
+			$current = $service->get_customer_record();
 
 			return null !== $current ? $current['record'] : null;
 		}
@@ -2352,6 +2380,11 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 * would fatal the very first time the controller called it.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Passes {@see self::current_location_record()}'s record explicitly to
+		 *              {@see \Woodev\Framework\Shipping\Location\Location_Service::resolve_for()}
+		 *              (issue #336) — that record now prefers the settlement level, and the
+		 *              adapter must resolve the carrier city for the SAME record this method
+		 *              returns, not re-derive the plain current record on its own.
 		 *
 		 * @return array{record: Location_Record, resolved_identity: mixed}|null
 		 */
@@ -2367,7 +2400,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 			}
 
 			try {
-				$resolved_identity = $this->plugin->get_location_service()->resolve_for( $this->plugin );
+				$resolved_identity = $this->plugin->get_location_service()->resolve_for( $this->plugin, $record );
 			} catch ( \Throwable $exception ) {
 				return null;
 			}
@@ -2416,6 +2449,14 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 * convention {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config::build_location_block()}
 		 * already uses for its own sibling `implicit` key.
 		 *
+		 * `current.key` follows the SAME settlement-preferred, current-record-fallback rule as
+		 * {@see self::current_location_record()} (issue #336) — it is what
+		 * `location-cascade.js` restores `entry.records['settlement']` from at boot, and what
+		 * `pickup-mount.js` falls back to when a `woodev_location_applied` event carries no
+		 * `settlementKey`. `implicit` stays tied to the CURRENT record, not the settlement one:
+		 * it answers "was the customer's own current pick a real choice", a question about the
+		 * current record regardless of which record addresses the map.
+		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 Also gates on {@see \Woodev\Framework\Shipping\Location\Location_Service::is_active()},
 		 *              not just on {@see self::$plugin} being non-null (review finding F1,
@@ -2427,21 +2468,44 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 *              a DOM attribute from `location-cascade.js`, which could not survive a
 		 *              checkout re-render, a select2-rendering presentation mode, or two entries
 		 *              sharing one location block.
+		 * @since 2.0.2 Publishes `settlementKey` — the map's own addressing locality, the
+		 *              settlement-level record's key or `''` (issue #336). `current`/`implicit`
+		 *              keep their exact prior meaning: an earlier draft wrote the settlement
+		 *              into `current.key` itself, which left the block naming one record in
+		 *              `current` while `implicit` described another. The browser prefers
+		 *              `settlementKey` and falls back to `current.key` — deliberately the
+		 *              OPPOSITE of #334's storage-key rule, which must refuse rather than fall
+		 *              back (see {@see self::current_location_record()}).
 		 *
-		 * @return array{current: array{key: string}, implicit: bool}|null
+		 * @return array{current: array{key: string}, settlementKey: string, implicit: bool}|null
 		 */
 		protected function location_config_block(): ?array {
 			if ( null === $this->plugin || ! $this->plugin->get_location_service()->is_active() ) {
 				return null;
 			}
 
-			$customer = $this->plugin->get_location_service()->get_customer_record();
+			$service  = $this->plugin->get_location_service();
+			$customer = $service->get_customer_record();
+
+			$settlement = $service->get_customer_record_at( Location_Record::LEVEL_SETTLEMENT );
 
 			return [
-				'current'  => [
+				// `current` still means EXACTLY what its name says — the customer's CURRENT
+				// record — and `implicit` describes that same record. An earlier draft of
+				// #336 wrote the settlement key in here instead, which made the block
+				// self-contradictory (`current.key` naming one record while `implicit`
+				// described another) and broke the field's contract for every other reader.
+				'current'       => [
 					'key' => null !== $customer ? $customer['record']->key() : '',
 				],
-				'implicit' => null !== $customer && (bool) $customer['implicit'],
+				// The map's addressing locality rides in its OWN field, mirroring the
+				// `settlementKey` detail on `location-cascade.js`'s `woodev_location_applied`
+				// event exactly, so browser and page-load config speak one vocabulary.
+				// `''` when the chain holds no settlement — `pickup-mount.js` then falls back
+				// to `current.key`, which is the fallback #336 exists to preserve (a customer
+				// who typed an address without picking a settlement must still see points).
+				'settlementKey' => null !== $settlement ? $settlement->key() : '',
+				'implicit'      => null !== $customer && (bool) $customer['implicit'],
 			];
 		}
 


### PR DESCRIPTION
Closes #336

Третья жертва того же корня, что #334/#330: `Pickup_Handler::current_location_record()` и `location_config_block()` читали ТЕКУЩУЮ запись покупателя, поэтому после уточнения адреса карта резолвила город карьера по самому глубокому компоненту НП адресной строки, а не по тому НП, который покупатель выбрал. Замер (риг, живая DaData): поиск адреса, ограниченный «г Пушкино», возвращает 9 строк из 10 с вложенным `settlement_fias_id`.

## Правило тут СПЕЦИАЛЬНО противоположно правилу #334

И оба докблока теперь это проговаривают, потому что следующий читатель иначе «починит» несогласованность не в ту сторону:

- **ключ хранения** выбранного ПВЗ обязан ОТКАЗЫВАТЬ (`''`), когда НП нет — фолбэк там молча кладёт точку под чужим ключом;
- **карта** обязана ПРЕДПОЧИТАТЬ НП, но ОТКАТЫВАТЬСЯ на текущую запись: покупатель, который ввёл адрес, не выбирая НП, должен по-прежнему видеть точки. Отказ там превратил бы работающую карту в «в этом населённом пункте нет пунктов выдачи», то есть был бы регрессией, а не фиксом.

## Что сделано

- `current_location_record()` предпочитает запись уровня settlement, откатывается на текущую.
- `Location_Service::resolve_for()` принимает необязательную запись (умолчание `null` — прежнее поведение), чтобы путь ПВЗ резолвил ровно ту запись, которой адресуется.
- Блок конфига публикует `settlementKey` ОТДЕЛЬНЫМ полем; `current`/`implicit` сохраняют прежний смысл. Ранняя версия писала НП прямо в `current.key`, и блок начинал противоречить сам себе — `current` называл одну запись, а `implicit` описывал другую.
- Событие `woodev_location_applied` получило деталь `settlementKey`; `pickup-mount.js` предпочитает её в ОБОИХ местах (живое событие и конфиг страницы), чтобы они говорили на одном словаре. Публикуется только для `confirmed`-записи — принятой из ЦЕПОЧКИ СЕРВЕРА, а не оптимистично записанной до ответа, — и никогда рядом с пустым `key`, который и есть сентинел «локальность неизвестна», на котором держится откат пикера на чтение из DOM.

## Состязательное ревью

Codex инлайн-бандлом с канарейкой. **Все три находки приняты и починены**, две из них — про несогласованность, внесённую первой версией правки: `current.key`, переставший означать текущую запись, и `settlementKey`, публиковавшийся из оптимистичной записи, которую сервер мог не сохранить. Третья — тест, закрепивший это как правильное поведение.

Заодно фикстуры `/select` в `location-cascade.test.js` приведены к форме, которую реально шлёт сервер: фикстура беднее продакшена прячет поведение продакшена.

## Проверка

- Тесты: **2269 unit / 5626 ассертов, 1117 jest, 110 интеграционных**, phpcs и phpstan чисто.
- Пробник на риге закрывает обе половины правила: цепочка только с адресом → адресуемся адресной записью, `current_locality()` отказывает; цепочка НП + адрес → адресуемся НП.
- В браузере при АДРЕСНОЙ текущей записи маршрут точек отдаёт **812 точек** по ключу НП, ошибок в консоли нет.