### PR TITLE
feat(checkout): плагин может заменить и сообщение «заполнено некорректно», а не только «не выбрано» (#328)

### DIFF
--- a/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
@@ -380,6 +380,74 @@ class CheckoutHandlerValidateTest extends TestCase {
 	}
 
 	/**
+	 * #328 — the SIBLING outcome had the same defect and no seam. «Поле «Пункт выдачи»
+	 * заполнено некорректно.» sends the customer looking for an input that is not on the
+	 * page, exactly as #327's message did. The framework deliberately ships no
+	 * button-specific DEFAULT for it (for an already-chosen point "filled in incorrectly"
+	 * most likely means "that point is unavailable" — a different statement only the domain
+	 * can vouch for), so what it offers instead is the override.
+	 */
+	public function test_invalid_message_can_be_replaced_wholesale_by_the_plugin(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Выбранное отделение сейчас недоступно.', 'error' );
+
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pickup_point' )
+				->mark_pickup_slot()
+				->set_invalid_message( 'Выбранное отделение сейчас недоступно.' )
+				->set_validate_callback( static fn( $value ) => false )
+				->to_array(),
+		] );
+
+		$this->assertFalse( ( new Checkout_Handler( $fields, 'carrier' ) )->validate( [ 'carrier_pickup_point' => 'PVZ-1' ], [] ) );
+	}
+
+	/**
+	 * Without an override the framework's own template still applies — the seam adds a
+	 * choice, it does not change the default for every field that never asked.
+	 */
+	public function test_invalid_message_keeps_the_framework_template_when_no_override_was_supplied(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Поле «Город» заполнено некорректно.', 'error' );
+
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_city' )
+				->set_label( 'Город' )
+				->set_validate_callback( static fn( $value ) => false )
+				->to_array(),
+		] );
+
+		$this->assertFalse( ( new Checkout_Handler( $fields, 'carrier' ) )->validate( [ 'carrier_city' => 'X' ], [] ) );
+	}
+
+	/**
+	 * A `WP_Error` from the callback carries its OWN words, and they win over the
+	 * override — the plugin said something more specific about THIS value than its own
+	 * generic sentence for the field.
+	 */
+	public function test_a_wp_error_from_the_callback_still_beats_the_supplied_invalid_message(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )
+			->once()
+			->with( 'Этот пункт закрыт на ремонт до 20 августа.', 'error' );
+
+		$fields = Checkout_Fields::from_array( [
+			Field::create( 'carrier_pickup_point' )
+				->mark_pickup_slot()
+				->set_invalid_message( 'Выбранное отделение сейчас недоступно.' )
+				->set_validate_callback(
+					static function ( $value ) {
+						return new \WP_Error( 'closed', 'Этот пункт закрыт на ремонт до 20 августа.' );
+					}
+				)
+				->to_array(),
+		] );
+
+		$this->assertFalse( ( new Checkout_Handler( $fields, 'carrier' ) )->validate( [ 'carrier_pickup_point' => 'PVZ-1' ], [] ) );
+	}
+
+	/**
 	 * The backstop must still fire ALONE — and checkout must still block — when the
 	 * per-field loop does NOT catch the same field because the descriptor's own
 	 * condition-spec method-id list diverges from the list passed to

--- a/woodev/shipping-method/checkout/class-checkout-fields.php
+++ b/woodev/shipping-method/checkout/class-checkout-fields.php
@@ -54,6 +54,19 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 	 *                           vocabulary and Почта РФ has отделения (#327). Honoured by both
 	 *                           paths that can report a missing pickup point, see
 	 *                           {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::validate()}.
+	 *  - `invalid_message`    — the COMPLETE "this value is wrong" error message, the same seam
+	 *                           `required_message` is for the OTHER outcome (#328). `''` (the
+	 *                           default) means "use the framework's template". Reachable only
+	 *                           through a plugin's own {@see Field::set_validate_callback()}
+	 *                           returning a bare `false`; a callback returning a `WP_Error`
+	 *                           already carries its own words and is never overridden here.
+	 *                           Exists for the same reason its sibling does: for a field whose
+	 *                           visible control is a BUTTON, «Поле «Пункт выдачи» заполнено
+	 *                           некорректно.» sends the customer looking for an input that is
+	 *                           not on the page. The framework does NOT coin a button-specific
+	 *                           default for it, because "filled in incorrectly" for a chosen
+	 *                           point most likely means "that point is unavailable" — a
+	 *                           different statement only the domain can make.
 	 *  - `section`            — checkout section: `'order'` (default), `'billing'`, `'shipping'`.
 	 *  - `required`           — `bool` (coerced) OR an array condition-spec when the host plugin
 	 *                           passes a structured condition array; preserved verbatim so the
@@ -261,6 +274,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 		 *     label: string,
 		 *     error_label: string,
 		 *     required_message: string,
+		 *     invalid_message: string,
 		 *     section: string,
 		 *     required: bool|array<string, mixed>,
 		 *     depends_on: string|null,
@@ -286,6 +300,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' 
 				'label'              => (string) ( $definition['label'] ?? '' ),
 				'error_label'        => (string) ( $definition['error_label'] ?? '' ),
 				'required_message'   => (string) ( $definition['required_message'] ?? '' ),
+				'invalid_message'    => (string) ( $definition['invalid_message'] ?? '' ),
 				'section'            => (string) ( $definition['section'] ?? 'order' ),
 				'required'           => is_array( $required ) ? $required : (bool) $required,
 				'depends_on'         => isset( $definition['depends_on'] ) && '' !== (string) $definition['depends_on']

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -1509,16 +1509,40 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		}
 
 		/**
-		 * Builds the default "invalid value" error message for a descriptor.
+		 * Builds the "invalid value" error message for a descriptor: the plugin's own whole
+		 * sentence ({@see Field::set_invalid_message()}) when it supplied one, the
+		 * framework's template otherwise.
+		 *
+		 * The override exists because this message has the SAME defect its sibling had
+		 * (#327, fixed there; #328 for this one): for a field whose visible control is a
+		 * BUTTON, «Поле «Пункт выдачи» заполнено некорректно.» sends the customer looking
+		 * for an input that is not on the page. The framework deliberately ships NO
+		 * button-specific default of its own here, and that asymmetry with
+		 * {@see self::required_message()} is the decision, not an omission: "you did not
+		 * choose a point" is a fact the framework knows, while for an already-chosen point
+		 * "filled in incorrectly" most likely means "that point is unavailable" — a
+		 * different statement only the domain can vouch for. So the framework owns when the
+		 * message appears and the plugin owns the words (#328's own recommendation).
+		 *
+		 * Only reachable through a plugin's {@see Field::set_validate_callback()} returning
+		 * a bare `false`: a callback returning a `WP_Error` supplies its own message, which
+		 * {@see self::validate()} uses instead of ever calling this.
 		 *
 		 * @since 1.5.0
 		 * @since 2.0.2 Label resolution delegated to {@see message_label()} (adds `error_label`).
+		 * @since 2.0.2 A plugin can replace the whole sentence (#328).
 		 *
 		 * @param array<string, mixed> $field normalized field descriptor
 		 *
 		 * @return string
 		 */
 		private static function invalid_message( array $field ): string {
+			$supplied = (string) ( $field['invalid_message'] ?? '' );
+
+			if ( '' !== $supplied ) {
+				return $supplied;
+			}
+
 			/* translators: %s: checkout field label */
 			return sprintf( __( 'Поле «%s» заполнено некорректно.', 'woodev-plugin-framework' ), self::message_label( $field ) );
 		}

--- a/woodev/shipping-method/checkout/class-field.php
+++ b/woodev/shipping-method/checkout/class-field.php
@@ -167,6 +167,38 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Field' ) ) :
 		}
 
 		/**
+		 * Replaces the WHOLE "this value is wrong" checkout error message for this field —
+		 * the sibling seam to {@see self::set_required_message()}, for the OTHER outcome
+		 * (#328).
+		 *
+		 * Reached only when this field's own {@see self::set_validate_callback()} returns a
+		 * bare `false`. A callback returning a `WP_Error` already carries its own words and
+		 * is never overridden; a callback returning `true` never reaches a message at all.
+		 * So this is a seam for plugins that validate with a boolean and want the failure
+		 * described in their own vocabulary.
+		 *
+		 * WHY THE FRAMEWORK SHIPS NO BUTTON-SPECIFIC DEFAULT HERE, unlike its sibling: for a
+		 * field whose visible control is a BUTTON, «Поле «Пункт выдачи» заполнено
+		 * некорректно.» sends the customer looking for an input that is not on the page —
+		 * the same defect #327 fixed for the "you must supply this" message. But the honest
+		 * replacement is not a rewording: for an already-CHOSEN point, "filled in
+		 * incorrectly" most likely means "that point is unavailable", which is a different
+		 * statement, and only the domain knows whether it is the true one. So the framework
+		 * offers the seam and lets the plugin say it (#328's own recommendation), rather
+		 * than coining a sentence it cannot know is accurate.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $message the complete message shown to the customer.
+		 *
+		 * @return self
+		 */
+		public function set_invalid_message( string $message ): self {
+			$this->def['invalid_message'] = $message;
+			return $this;
+		}
+
+		/**
 		 * Sets the checkout section this field belongs to.
 		 *
 		 * Accepted values: `'order'` (default after normalization), `'billing'`,


### PR DESCRIPTION
Closes #328

#327 починил "«Укажите значение поля «Пункт выдачи»»" для поля, у которого видимый контрол — КНОПКА: сообщение «заполните поле» отправляет покупателя искать поле, которого на странице нет. У соседнего сообщения был тот же дефект и не было шва: колбэк валидации, вернувший голый `false`, по-прежнему давал «Поле «Пункт выдачи» заполнено некорректно.».

## Выбран вариант 2 из трёх, что перечислены в карточке

`Field::set_invalid_message()` в точности повторяет `set_required_message()`, и **своего умолчания для кнопочного поля фреймворк тут сознательно не заводит**. Асимметрия с #327 — это решение, а не недоделка: «вы не выбрали пункт» фреймворк знает наверняка, а для УЖЕ ВЫБРАННОГО пункта «заполнено некорректно» скорее означает «этот пункт недоступен», и это другое утверждение, за которое может отвечать только домен. Фреймворк владеет тем, КОГДА появляется сообщение, плагин — словами.

`WP_Error` из колбэка по-прежнему побеждает переопределение: он говорит про КОНКРЕТНОЕ значение точнее, чем общая фраза про поле.

## Проверка

Путь достижим только через собственный `set_validate_callback()` плагина, поэтому ни фикстура, ни риг его сегодня не исполняют — закреплено тремя юнит-тестами (переопределение honored; умолчание сохраняется, когда его не задали; `WP_Error` всё равно выигрывает), каждый проверен мутацией.

Тесты: **2272 unit / 5632 ассертов**, phpcs и phpstan чисто.