### PR TITLE
fix(pickup): announce the point address write so the cascade keeps the record (#339)

### DIFF
--- a/docs-internal/GOTCHAS.md
+++ b/docs-internal/GOTCHAS.md
@@ -1,6 +1,6 @@
 # Gotchas — Woodev Plugin Framework
 
-> **Index only.** 153 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
+> **Index only.** 154 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
 > recognise, and a link to the file that holds the detail. Never paste the detail here — a second
 > copy drifts from the first, and this file is read at the start of every session.
 > **Adding one:** create `gotchas/{slug}.md` (format: `DOCS-SCHEMA.md`), then add one line below
@@ -89,6 +89,7 @@
 - [rig/browser] **Playwright MCP does not fire WooCommerce's checkout submit; chrome-devtools MCP does.** → [playwright-mcp-does-not-fire-wc-checkout-ajax](gotchas/playwright-mcp-does-not-fire-wc-checkout-ajax.md) (s44)
 
 ### [framework/wiring] — Responsibilities that moved
+- [framework/wiring] **A module writing into another module's field must ANNOUNCE the write — otherwise the owner reads it as the user's.** → [a-module-that-writes-into-another-modules-field-must-announce-it](gotchas/a-module-that-writes-into-another-modules-field-must-announce-it.md) (s75)
 - [framework/wiring] **An action fired beside a filter must carry the filter's RESULT, not its input.** → [an-action-beside-a-filter-must-carry-the-filters-result](gotchas/an-action-beside-a-filter-must-carry-the-filters-result.md) (s65)
 - [framework/wiring] **A feature built on both sides, with nothing calling it in the middle.** → [built-on-both-sides-with-no-caller-in-the-middle](gotchas/built-on-both-sides-with-no-caller-in-the-middle.md) (s56, extended s59)
 

--- a/docs-internal/gotchas/a-module-that-writes-into-another-modules-field-must-announce-it.md
+++ b/docs-internal/gotchas/a-module-that-writes-into-another-modules-field-must-announce-it.md
@@ -1,0 +1,84 @@
+# [framework/wiring] A module writing into another module's field must ANNOUNCE the write — otherwise the owner reads it as the user's
+
+> Namespace: `framework/*` — added session 75 (2026-08-16), issue #339.
+
+## The trap
+
+Two modules share a DOM field. One owns it and watches `change` to decide whether the value
+still matches its own confirmed state. The other writes into it programmatically.
+
+The owner cannot tell the two apart. A programmatic write arrives as exactly the same event a
+human edit does, carrying exactly the same kind of value — so the owner applies its rule
+("the text no longer matches the record → the record is stale") and throws away state the
+user actually created.
+
+Measured (#339): `pickup-mount.js` writes a selected pickup point's address into the shared
+WooCommerce address fields. `location-cascade.js` owns those fields. The carrier answers
+«Москва» in Cyrillic while the provider had said «Moscow» (the account locale transliterates
+— see [[a-locality-display-name-is-not-an-identifier]]), so the cascade dropped the
+settlement record and the next address search left **without `within`**, country-wide,
+although the customer had picked the city.
+
+**One differing character is enough.** «Санкт-Петербург» vs «Санкт Петербург», «пос.
+Ватутинки» vs «поселок Ватутинки» — the failure does not need an exotic locale.
+
+## Why the obvious fixes are wrong
+
+❌ **Don't write the field at all.** The point may legitimately stand in a NEIGHBOURING
+settlement (ordinary for New Moscow), and these fields are what reach the order. Not writing
+fixes the search scope by corrupting the delivery address.
+
+❌ **Re-resolve the value through a service first** so both sides agree byte for byte. Measured
+on the rig (#339): normalizing the point's address returns the key of the DEEPEST resolved
+object — a house or a street, never the settlement — costs a paid uncached call per selection,
+is an OPTIONAL provider capability whose absence THROWS rather than returning null, and on a
+carrier-shaped string can answer a different address entirely (`Москва Внуково Центральная 6`
+→ `г Москва, ул Центральная, д 6`, `qc = 3` = "alternatives exist, needs manual review").
+
+❌ **Compare keys instead of text.** The carrier's address is a plain string; it has no key.
+
+## Correct: announce, synchronously, BEFORE the write
+
+```js
+// writer — pickup-mount.js
+fireDocumentEvent( 'woodev_pickup_address_replacing', { fields: fields, fieldId: config.fieldId } );
+
+writeAndFireChange( target + '_city', locality, locality );   // …then write
+```
+
+```js
+// owner — location-cascade.js
+function handlePickupAddressReplacing( event ) {
+	var fields = event && event.detail ? event.detail.fields : null;
+	if ( ! fields || 'object' !== typeof fields ) { return; }
+
+	entries.forEach( function ( entry ) {
+		Object.keys( fields ).forEach( function ( fieldId ) {
+			if ( ! nodeInfo( entry, fieldId ) ) { return; }
+			writeSilently( entry, fieldId, String( fields[ fieldId ] ) );   // re-seed `resolved`
+		} );
+	} );
+}
+```
+
+`dispatchEvent()` runs listeners **inline**, so the re-seed completes before the write's own
+`change` is fired — no ordering flag, no timer, no suppression window to leak.
+
+## The two properties that make it safe
+
+1. **Re-seed, never suppress.** The values still land in the fields and the store; only the
+   owner's *confirmed record* survives untouched. Suppressing the write would trade one bug
+   for a wrong delivery address.
+2. **Scoped to the announced write and nothing after it.** The very next genuine manual edit
+   still invalidates. Pin this with a test — a fix that quietly deafens the watcher passes
+   every test about the bug it fixed.
+
+Rig-verified in one run (#339): announced write → record survives, next search carries
+`within`; a hand edit right after → record invalidated, `within` gone.
+
+## Related
+
+- [[a-locality-display-name-is-not-an-identifier]] — why the two spellings differ at all.
+- [[a-programmatic-parent-change-must-not-run-a-destructive-cascade]] — the same family: WooCommerce's own programmatic `change` events.
+- [[a-dom-attribute-is-the-wrong-seam-on-a-woocommerce-checkout]] — publish cross-module state through a channel you own; this event is one.
+- [[built-on-both-sides-with-no-caller-in-the-middle]] — a seam needs both halves wired AND a test that proves the wiring.

--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -2757,3 +2757,149 @@ describe( 'section-aware addressing (review finding F3)', () => {
 		expect( callFor( 'shipping_city' ) ).toBeUndefined();
 	} );
 } );
+
+describe( 'a pickup point address replacement must not read as a manual edit (#339)', () => {
+	function captureLocationApplied() {
+		const seen = [];
+		document.body.addEventListener( 'woodev_location_applied', ( event ) => seen.push( event.detail ) );
+		return seen;
+	}
+
+	/**
+	 * What `pickup-mount.js`'s `applyAddressReplacement()` does to the shared WooCommerce
+	 * address fields: writes the POINT's own address/locality/postcode and fires a real
+	 * `change` on each. Modelled here rather than imported so this file keeps testing only
+	 * what location-cascade.js owns — the seam, not the other module's internals.
+	 *
+	 * @param {Object}  fields    `{ fieldId: value }` — the write pickup-mount is about to make.
+	 * @param {boolean} announced Whether pickup-mount announces the write first (the seam).
+	 */
+	function replaceAddressLikePickupMount( fields, announced ) {
+		if ( announced ) {
+			document.body.dispatchEvent(
+				new CustomEvent( 'woodev_pickup_address_replacing', {
+					detail: { fields: fields },
+					bubbles: true,
+				} )
+			);
+		}
+
+		Object.keys( fields ).forEach( ( fieldId ) => {
+			const el = document.getElementById( fieldId );
+
+			el.value = fields[ fieldId ];
+			el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+	}
+
+	function bootWithPickedSettlement() {
+		boot( { region: true, settlement: true, address: true, countries: [ 'RU' ] } );
+
+		selectViaFake( callFor( 'billing_city' ), {
+			key: 'dadata:0c5b2444', label: 'Moscow', level: 'settlement',
+			record: {
+				key: 'dadata:0c5b2444', provider_id: 'dadata', level: 'settlement',
+				country: 'RU', label: 'Moscow',
+			},
+		} );
+	}
+
+	it( 'reproduction: an UNANNOUNCED write of a different settlement spelling invalidates the record', async () => {
+		// #339 as found in the browser: the customer picked «Moscow» (the account locale
+		// transliterates), the carrier hands back «Москва» in Cyrillic, and the cascade —
+		// correctly, by its own rule — reads the differing text as the customer having edited
+		// the field by hand, so the settlement record goes away and the next address search
+		// leaves without `within`.
+		bootWithPickedSettlement();
+
+		const seen = captureLocationApplied();
+
+		replaceAddressLikePickupMount( {
+			billing_city: 'Москва',
+			billing_address_1: 'ул Новокосинская, д 17 к 6',
+		}, false );
+
+		await flushMicrotasks();
+
+		expect( seen ).toContainEqual( { key: '', level: '', settlementKey: '', implicit: false } );
+	} );
+
+	it( 'the seam: an ANNOUNCED write keeps the record — the cascade re-seeds instead of clearing', async () => {
+		bootWithPickedSettlement();
+
+		const seen = captureLocationApplied();
+
+		replaceAddressLikePickupMount( {
+			billing_city: 'Москва',
+			billing_address_1: 'ул Новокосинская, д 17 к 6',
+		}, true );
+
+		await flushMicrotasks();
+
+		expect( seen ).toEqual( [] );
+	} );
+
+	it( 'the announced write still lands in the fields and the store — silent, not skipped', () => {
+		bootWithPickedSettlement();
+
+		replaceAddressLikePickupMount( {
+			billing_city: 'Москва',
+			billing_address_1: 'ул Новокосинская, д 17 к 6',
+			billing_postcode: '111672',
+		}, true );
+
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Москва' );
+		expect( document.getElementById( 'billing_address_1' ).value ).toBe( 'ул Новокосинская, д 17 к 6' );
+		expect( document.getElementById( 'billing_postcode' ).value ).toBe( '111672' );
+
+		const store = window.WoodevCheckoutFieldStore.getStoreForField( 'billing_city' );
+
+		expect( store.getValue( 'billing_city' ) ).toBe( 'Москва' );
+	} );
+
+	it( 'announcing does NOT disarm the next genuine manual edit', async () => {
+		// The seam must cover exactly the announced write and nothing after it: a customer who
+		// edits the city by hand a moment later still invalidates the record. Without this the
+		// fix would trade #339 for a permanently deaf cascade.
+		bootWithPickedSettlement();
+
+		replaceAddressLikePickupMount( { billing_city: 'Москва' }, true );
+
+		const seen = captureLocationApplied();
+		const field = document.getElementById( 'billing_city' );
+
+		field.value = 'Тверь';
+		field.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		// The invalidation is deferred one microtask (see handleFieldChanged()'s docblock).
+		await flushMicrotasks();
+
+		expect( seen ).toContainEqual( { key: '', level: '', settlementKey: '', implicit: false } );
+	} );
+
+	it( 'an announcement naming a field this entry does not own is ignored', () => {
+		bootWithPickedSettlement();
+
+		expect( () => {
+			document.body.dispatchEvent(
+				new CustomEvent( 'woodev_pickup_address_replacing', {
+					detail: { fields: { shipping_city: 'Москва', not_a_field_at_all: 'x' } },
+					bubbles: true,
+				} )
+			);
+		} ).not.toThrow();
+
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Moscow' );
+	} );
+
+	it( 'a malformed announcement is survivable', () => {
+		bootWithPickedSettlement();
+
+		expect( () => {
+			document.body.dispatchEvent( new CustomEvent( 'woodev_pickup_address_replacing', { bubbles: true } ) );
+			document.body.dispatchEvent(
+				new CustomEvent( 'woodev_pickup_address_replacing', { detail: {}, bubbles: true } )
+			);
+		} ).not.toThrow();
+	} );
+} );

--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -6905,3 +6905,60 @@ describe( 'chosen-address decoding agrees across sources (issue #308 item 1)', (
 		} );
 	} );
 } );
+
+// -------------------------------------------------------------------------
+// #339 — the address replacement announces itself BEFORE it writes, so
+// location-cascade.js can tell it apart from a manual edit
+// -------------------------------------------------------------------------
+
+test( 'the address replacement fires woodev_pickup_address_replacing carrying every field it is about to write', async () => {
+	setConfig( makeConfig( { replaceAddress: { enabled: true, billingOnly: true } } ) );
+	mountAll();
+	clickTrigger();
+
+	const seen = [];
+	document.body.addEventListener( 'woodev_pickup_address_replacing', ( e ) => seen.push( e.detail ) );
+
+	await selectAndConfirm( StubProvider.instances[ 0 ], point() );
+
+	expect( seen ).toHaveLength( 1 );
+	expect( seen[ 0 ].fields ).toEqual( {
+		billing_address_1: 'ул. Ленина, 1',
+		billing_city: 'Москва',
+		billing_postcode: '101000',
+	} );
+	expect( console ).toHaveWarned();
+} );
+
+test( 'the announcement arrives BEFORE the write — a listener still sees the OLD field values', async () => {
+	// The ordering is the whole point (#339): location-cascade.js re-seeds `resolved` from
+	// this event, and that must happen before the `change` events the write fires reach its
+	// own handler. dispatchEvent() runs listeners inline, so "before" is observable here.
+	setConfig( makeConfig( { replaceAddress: { enabled: true, billingOnly: true } } ) );
+	mountAll();
+	clickTrigger();
+
+	const order = [];
+
+	document.body.addEventListener( 'woodev_pickup_address_replacing', () => order.push( 'announced' ) );
+	document.getElementById( 'billing_city' ).addEventListener( 'change', () => order.push( 'city-changed' ) );
+
+	await selectAndConfirm( StubProvider.instances[ 0 ], point() );
+
+	expect( order ).toEqual( [ 'announced', 'city-changed' ] );
+	expect( document.getElementById( 'billing_city' ).value ).toBe( 'Москва' );
+	expect( console ).toHaveWarned();
+} );
+
+test( 'no announcement when replaceAddress is disabled — nothing is written, so nothing to announce', async () => {
+	setConfig( makeConfig( { replaceAddress: { enabled: false, billingOnly: true } } ) );
+	mountAll();
+	clickTrigger();
+
+	const seen = [];
+	document.body.addEventListener( 'woodev_pickup_address_replacing', ( e ) => seen.push( e.detail ) );
+
+	await selectAndConfirm( StubProvider.instances[ 0 ], point() );
+
+	expect( seen ).toEqual( [] );
+} );

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -863,6 +863,65 @@
 	}
 
 	/**
+	 * Handles `woodev_pickup_address_replacing` (issue #339) — `pickup-mount.js` announces,
+	 * one synchronous event BEFORE it happens, that it is about to write a selected pickup
+	 * point's OWN address into the shared WooCommerce address fields (SP-5's
+	 * `applyAddressReplacement()`).
+	 *
+	 * WHY AN ANNOUNCEMENT AND NOT SOMETHING THIS MODULE COULD RECOGNISE ALONE: by the time
+	 * the write arrives it is indistinguishable from a human edit. It carries a different
+	 * SPELLING of the same locality — the carrier answers «Москва» while the provider said
+	 * «Moscow» under an English account locale (gotcha
+	 * `a-locality-display-name-is-not-an-identifier`) — so {@see handleFieldChanged} reads
+	 * "the field's own record no longer matches its text", drops the settlement record, and
+	 * the next address search leaves without `within`, country-wide (#339). That rule is
+	 * right and stays; what was missing is that THIS write is not the customer's.
+	 *
+	 * RE-SEEDING, NOT SUPPRESSING, IS THE WHOLE FIX. The point's address is exactly what must
+	 * reach the order — a point may legitimately stand in a NEIGHBOURING settlement (ordinary
+	 * for New Moscow), so writing the customer's own locality there instead would fix the
+	 * search scope by corrupting the delivery address. The values land; only the CONFIRMED
+	 * RECORD survives untouched, because the customer's own pick is what scopes the next
+	 * search.
+	 *
+	 * Deliberately NOT done by running the point's address through
+	 * `Location_Provider::normalize()` first: measured on the rig 16.08.2026 (see #339), that
+	 * returns the key of the DEEPEST resolved object — a house or a street, never the
+	 * settlement — costs a paid, uncached Clean API call per selection, is an OPTIONAL
+	 * provider capability whose absence THROWS rather than returning null, and on a
+	 * carrier-shaped string can silently answer a different address entirely
+	 * (`Москва Внуково Центральная 6` → `г Москва, ул Центральная, д 6`, `qc = 3`).
+	 *
+	 * Scoped to the announced write and nothing after it: {@see writeSilently} re-seeds
+	 * `entry.resolved` for these exact values only, so the very next genuine manual edit
+	 * invalidates normally.
+	 *
+	 * @internal
+	 *
+	 * @param {CustomEvent} event `detail: { fields: { fieldId: value } }`.
+	 * @returns {void}
+	 */
+	function handlePickupAddressReplacing( event ) {
+		var fields = event && event.detail ? event.detail.fields : null;
+
+		if ( ! fields || 'object' !== typeof fields ) {
+			return;
+		}
+
+		entries.forEach( function( entry ) {
+			Object.keys( fields ).forEach( function( fieldId ) {
+				// Another entry's section, or not a cascade field at all (the announcement
+				// names WooCommerce field ids, which only PARTLY overlap this entry's chain).
+				if ( ! nodeInfo( entry, fieldId ) ) {
+					return;
+				}
+
+				writeSilently( entry, fieldId, String( fields[ fieldId ] ) );
+			} );
+		} );
+	}
+
+	/**
 	 * D8 + single-flight ordering (PR-C review, Finding 2): POSTs `record` to `/select`. Only
 	 * ever ONE `/select` request is in flight per ENTRY at a time — the server holds exactly
 	 * ONE current-location slot per entry's own `Location_Service`
@@ -2062,6 +2121,11 @@
 		suppressWcAddressAutocomplete();
 		bindChangeWatchers();
 		bindCheckoutUpdatedWatcher();
+
+		// Issue #339. A native CustomEvent, like `woodev_location_applied` going the other
+		// way — `dispatchEvent()` runs every listener INLINE, so the re-seed is already done
+		// by the time pickup-mount.js's own write fires its `change`.
+		document.body.addEventListener( 'woodev_pickup_address_replacing', handlePickupAddressReplacing );
 	}
 
 	if ( 'loading' === document.readyState ) {

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -161,7 +161,7 @@
  * it (D-3: the whole point of `ownsChrome` is that the framework renders
  * nothing of its own around a provider that already owns the full picker UI).
  *
- * THE SIX `woodev_pickup_*` EVENTS are native, bubbling `CustomEvent`s fired
+ * THE SEVEN `woodev_pickup_*` EVENTS are native, bubbling `CustomEvent`s fired
  * on `document.body` — exactly like `woodev-modal.js`'s own `woodev_modal_*`
  * events (see that file's docblock for why `jQuery.trigger()` would be
  * invisible to a plain `addEventListener`, and this file's own docblock above
@@ -180,7 +180,12 @@
  * `error` (map script failed to load, embed failed to load) — the kind that
  * breaks the whole map, not a transient dataSource fetch failure the existing
  * degrade-to-notice machinery already recovers from without needing to alarm
- * an external error reporter.
+ * an external error reporter, and `woodev_pickup_address_replacing`
+ * (`{ fields: { fieldId: value }, fieldId }`) fired IMMEDIATELY BEFORE this file writes a
+ * selected point's own address into the shared WooCommerce address fields — the seam
+ * `location-cascade.js` needs to tell that write apart from a human edit (issue #339; see
+ * {@see applyAddressReplacement}). Unlike the other six it is not a notification an
+ * integrator observes after the fact: a listener runs INLINE, before the write lands.
  *
  * `refresh()`, EXPOSED PER SESSION VIA {@see getSession}: re-runs whatever
  * fetch the CURRENT strategy/viewport/type-filter state describes — the hook a
@@ -619,7 +624,7 @@
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Fires one of the four `woodev_pickup_*` events (see the file docblock) — a native,
+	 * Fires one of the `woodev_pickup_*` events (see the file docblock) — a native,
 	 * bubbling `CustomEvent` on `document.body`, exactly matching `woodev-modal.js`'s own
 	 * `emit()`. Seen by both `addEventListener` and jQuery `.on()`; NEVER a jQuery
 	 * `.trigger()`, which would be invisible to a plain `addEventListener` (see the file
@@ -1398,6 +1403,23 @@
 		var address = point && 'string' === typeof point.address ? point.address : '';
 		var locality = point && 'string' === typeof point.locality ? point.locality : '';
 		var postalCode = point && 'string' === typeof point.postal_code ? point.postal_code : '';
+
+		var fields = {};
+
+		fields[ target + '_address_1' ] = address;
+		fields[ target + '_city' ] = locality;
+		fields[ target + '_postcode' ] = postalCode;
+
+		// Issue #339, BEFORE the writes and never after them. These fields are shared with
+		// `location-cascade.js`, which treats a value that no longer matches its confirmed
+		// record as the customer having edited the field by hand — and drops the settlement
+		// record, so the next address search leaves without `within`. It only takes a
+		// different SPELLING of the same locality: the carrier answers «Москва» where the
+		// provider said «Moscow» under an English account locale. The announcement lets the
+		// cascade re-seed first; `dispatchEvent()` runs its listeners inline, so the re-seed
+		// is complete before the `change` events below are fired. A page with no cascade on
+		// it has no listener and this is an inert no-op.
+		fireDocumentEvent( 'woodev_pickup_address_replacing', { fields: fields, fieldId: config.fieldId } );
 
 		writeAndFireChange( target + '_address_1', address );
 		writeAndFireChange( target + '_city', locality, locality );


### PR DESCRIPTION
Closes #339.

## Что было

Выбор ПВЗ пишет адрес пункта в родные адресные поля WooCommerce. Этими полями владеет `location-cascade.js`, и по собственному правилу он читает значение, не совпадающее с подтверждённой записью, как ручную правку — поэтому сбрасывал запись НП, и следующий поиск адреса уходил **без `within`**, по всей стране, хотя город покупатель выбирал.

Хватает одного символа. На риге локаль аккаунта транслитерирует, поэтому провайдер говорит «Moscow», а карьер отвечает «Москва»; в любой локали то же делают «Санкт-Петербург» против «Санкт Петербург».

## Что сделано

`pickup-mount.js` файрит `woodev_pickup_address_replacing` — седьмое событие семейства `woodev_pickup_*` — **непосредственно перед** записью, со всеми полями, которые собирается заполнить. `location-cascade.js` слушает и пересеивает `entry.resolved` своим же `writeSilently()`, поэтому пришедший следом `change` опознаётся как собственный. `dispatchEvent()` выполняет слушателей инлайн, так что пересев завершается до записи — не нужен ни флаг порядка, ни окно подавления.

**Пересев, а не подавление — намеренно.** Пункт может законно стоять в СОСЕДНЕМ населённом пункте (для Новой Москвы это обычное дело), а именно эти поля уезжают в заказ. Записать туда город покупателя значило бы починить скоуп поиска ценой адреса доставки.

## Предложение оператора проверено замером и отклонено

Идея прогонять адрес пункта через `Location_Provider::normalize()`, чтобы обе стороны совпали байт в байт, замерена на риге до принятия решения — полностью в [#339](https://github.com/kalbac/woodev-plugin-framework/issues/339#issuecomment-5307370992). Кратко:

- **ключ приходит не тот** — `normalize()` строит его из `fias_id` самого глубокого распознанного объекта: дом (`fias_level` 8), улица (7), микрорайон (65), но не населённый пункт. Вызов со `scope=settlement` меняет только метку `level`, ключ остаётся домовым — запись начинает врать о своём уровне;
- для **Москвы и СПб** компоненты НП в ответе нет вовсе (это регионы);
- на строке в форме карьера может **тихо подменить адрес**: `Москва Внуково Центральная 6` → `г Москва, ул Центральная, д 6`, `qc=3` («есть альтернативные варианты, нужна ручная проверка»);
- **платно и без кэша** — три одинаковых вызова подряд 133/89/103 мс;
- capability **опциональная**, и при её отсутствии `Abstract_Location_Provider::normalize()` **бросает исключение**, а не возвращает `null`.

## Проверка на риге (гость, живой Яндекс, с контролем в том же прогоне)

| Проверка | Результат |
|---|---|
| объявление файрится | `announced: 1`, в detail поля пункта |
| запись НП после выбора ПВЗ | **не сброшена** |
| поля после выбора | город «Москва», адрес «Москва Новокосинская 17 к6», индекс 111673 — адрес **пункта** |
| следующий поиск адреса | `within=dadata:0c5b2444-…` — скоуп на месте |
| **контроль:** правка города рукой сразу после | сброс **есть**, `within` пропал — правило каскада живо |
| после перезагрузки | запись НП жива, пункт сохранён |

Оформление заказа целиком пройти не удалось: упирается в обязательное `billing_city` — select2 старого демо §8, чей источник на риге не отдаёт результатов. К этой правке отношения не имеет; адрес доставки в полях проверен напрямую.

## Тесты

- **jest 1126** (+9): 6 в `location-cascade.test.js`, 3 в `pickup-mount.test.js`
- Обе половины шва **проверены мутацией**: снятие слушателя роняет тест каскада, снятие объявления — тест порядка в pickup-mount
- Отдельный тест на то, что объявление **не глушит** следующую настоящую ручную правку — фикс, тихо оглушивший каскад, прошёл бы все тесты про сам баг
- `composer check`: 2272 unit / 5632 ассертов, phpcs и phpstan чисто

## Доки

Готча `a-module-that-writes-into-another-modules-field-must-announce-it` — обобщение: модуль, пишущий в чужое поле, обязан объявлять запись, иначе владелец прочтёт её как пользовательскую.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD