### PR TITLE
fix(location): блокировать поле адреса, пока не выбран НП (#337)

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -2903,3 +2903,160 @@ describe( 'a pickup point address replacement must not read as a manual edit (#3
 		} ).not.toThrow();
 	} );
 } );
+
+// -----------------------------------------------------------------------
+// Address lock (#337)
+// -----------------------------------------------------------------------
+
+describe( 'the address field is locked until a settlement is picked (#337)', () => {
+	const SETTLEMENT_ITEM = {
+		key: 'dadata:0c5b2444', label: 'Москва', level: 'settlement',
+		record: {
+			key: 'dadata:0c5b2444', provider_id: 'dadata', level: 'settlement',
+			country: 'RU', settlement: { name: 'Москва', type: 'г' }, label: 'г Москва',
+		},
+	};
+
+	function addressField() {
+		return document.getElementById( 'billing_address_1' );
+	}
+
+	it( 'locks it on boot when settlement and address are linked and the provider serves address', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		expect( addressField().disabled ).toBe( true );
+	} );
+
+	it( 'leaves it an ORDINARY input when the chain carries no settlement field', () => {
+		// Nothing to wait for: with no settlement field, the address level is scoped
+		// country-wide by construction (scopeKeyFor()), so a lock would never lift.
+		boot( { region: true, address: true } );
+
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 'leaves it an ORDINARY input when the provider does not serve the address level', () => {
+		// The operator's second condition, read PER LEVEL: no address suggestions means the
+		// customer free-types a street, and needs no settlement to do it.
+		boot( {
+			region: true, settlement: true, address: true,
+			levels: { RU: { region: true, settlement: true, address: false } },
+		} );
+
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 'unlocks on the settlement pick ITSELF, before /select has answered', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+
+		// The /select round trip is still in flight — the customer must be able to type now.
+		expect( fetchCalls[ fetchCalls.length - 1 ].url ).toContain( SELECT_URL );
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 're-locks when the settlement text is edited without picking a suggestion', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+		expect( addressField().disabled ).toBe( false );
+
+		const city = document.getElementById( 'billing_city' );
+
+		city.value = 'Тверь';
+		city.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		// The record no longer matches the text, so the address is unscoped again.
+		expect( addressField().disabled ).toBe( true );
+	} );
+
+	it( 'is ALREADY unlocked on boot when the server restored a settlement record', () => {
+		// "Active immediately after a reload, not after some first event nudges it."
+		boot( {
+			region: true, settlement: true, address: true,
+			current: { key: 'dadata:0c5b2444', level: 'settlement' },
+		} );
+
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 'stays locked when the restored record is an ADDRESS with no settlement behind it', () => {
+		// The pre-#337 state itself: an address picked while no settlement ever was. The chain
+		// the server restores names no settlement, so there is still nothing keying the pickup
+		// selection — the lock is exactly what stops this state being created again.
+		boot( {
+			region: true, settlement: true, address: true,
+			current: { key: 'dadata:c0e3b087', level: 'address' },
+			chain: { address: { key: 'dadata:c0e3b087', level: 'address' } },
+		} );
+
+		expect( addressField().disabled ).toBe( true );
+	} );
+
+	it( 'becomes an ORDINARY input when the country changes to one with no address coverage', () => {
+		boot( {
+			region: true, settlement: true, address: true,
+			countries: [ 'RU', 'AM' ],
+			levels: {
+				RU: { region: true, settlement: true, address: true },
+				AM: { region: true, settlement: true, address: false },
+			},
+		} );
+
+		expect( addressField().disabled ).toBe( true );
+
+		const country = document.getElementById( 'billing_country' );
+
+		country.innerHTML += '<option value="AM">Армения</option>';
+		country.value = 'AM';
+		country.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 're-locks after a country change wipes a settlement that HAD been picked', () => {
+		boot( { region: true, settlement: true, address: true, countries: [ 'RU', 'US' ], levels: {
+			RU: { region: true, settlement: true, address: true },
+			US: { region: true, settlement: true, address: true },
+		} } );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+		expect( addressField().disabled ).toBe( false );
+
+		const country = document.getElementById( 'billing_country' );
+
+		country.value = 'US';
+		country.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( addressField().disabled ).toBe( true );
+	} );
+
+	it( 're-applies the lock to the FRESH node after a checkout re-render', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		// WooCommerce replaces the address fragment: a fresh node carrying the server's markup
+		// and none of the lock this module put on the one it replaced.
+		const fresh = document.createElement( 'input' );
+		fresh.type = 'text';
+		fresh.id = 'billing_address_1';
+		fresh.name = 'billing_address_1';
+		addressField().replaceWith( fresh );
+
+		expect( fresh.disabled ).toBe( false );
+
+		window.jQuery( document.body ).trigger( 'updated_checkout' );
+
+		expect( fresh.disabled ).toBe( true );
+	} );
+
+	it( 'does not lock a shipping-section field while "ship to a different address" is unchecked', () => {
+		// A field hidden behind the toggle is not in play at all — isNodeActive()'s own rule.
+		boot( {
+			region: true, settlement: true, address: true,
+			section: 'shipping', shipToDifferentAddress: false,
+		} );
+
+		expect( document.getElementById( 'shipping_address_1' ).disabled ).toBe( false );
+	} );
+} );

--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -2927,6 +2927,29 @@ describe( 'the address field is locked until a settlement is picked (#337)', () 
 		expect( addressField().disabled ).toBe( true );
 	} );
 
+	it( 'marks the locked field for the stylesheet, and unmarks it again', () => {
+		// `disabled` alone is invisible — the theme's own `input` rule overrides the browser's
+		// greying (measured on the rig), so the class is what location.css can actually see.
+		boot( { region: true, settlement: true, address: true } );
+
+		expect( addressField().classList.contains( 'woodev-location-locked' ) ).toBe( true );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+
+		expect( addressField().classList.contains( 'woodev-location-locked' ) ).toBe( false );
+	} );
+
+	it( 'says nothing about the lock — no title, no aria description', () => {
+		// Standing operator rule (#274): a blocked control is blocked, and that is all it says.
+		boot( { region: true, settlement: true, address: true } );
+
+		const el = addressField();
+
+		expect( el.getAttribute( 'title' ) ).toBeNull();
+		expect( el.getAttribute( 'aria-describedby' ) ).toBeNull();
+		expect( el.getAttribute( 'aria-disabled' ) ).toBeNull();
+	} );
+
 	it( 'leaves it an ORDINARY input when the chain carries no settlement field', () => {
 		// Nothing to wait for: with no settlement field, the address level is scoped
 		// country-wide by construction (scopeKeyFor()), so a lock would never lift.

--- a/woodev/shipping-method/assets/css/frontend/location.css
+++ b/woodev/shipping-method/assets/css/frontend/location.css
@@ -9,7 +9,9 @@
  * rendered the suggestion list as a plain bulleted, link-coloured list instead of a dropdown panel —
  * this file is that gap closed.
  *
- * THE INPUT ITSELF IS NEVER STYLED HERE. `attachTypeahead()` enhances WooCommerce's own native
+ * THE INPUT ITSELF IS NEVER STYLED HERE — with ONE deliberate exception, the locked address field
+ * (issue #337) at the very bottom of this file, where the whole point is that the input must stop
+ * looking like every other one. `attachTypeahead()` enhances WooCommerce's own native
  * checkout `<input>` in place (role/aria attributes only — see that file's PROGRESSIVE ENHANCEMENT
  * note); it must keep looking like every other checkout field. Only the listbox this module OWNS is
  * ours to style — this is a customer-facing checkout, and matching the platform's own visual
@@ -417,4 +419,32 @@
 	.woodev-location-listbox {
 		max-height: 200px;
 	}
+}
+
+/* -------------------------------------------------------------------------
+ * THE LOCKED ADDRESS INPUT (issue #337) — the ONE deliberate exception to this file's own "the
+ * input itself is never styled here" rule at the top. That rule exists so the field keeps looking
+ * like every other checkout field; a locked field is precisely the state where it must NOT, or the
+ * customer is left with a field that looks ordinary and silently refuses to type. `disabled` alone
+ * does not carry that: measured on the rig, the theme's own `input` rule (its own background,
+ * border and colour) overrides the browser's default greying entirely, so the attribute was
+ * invisible.
+ *
+ * NOTHING HERE EXPLAINS THE LOCK — no generated content, no message, no tooltip (standing operator
+ * rule: a blocked control is blocked, and that is all it says). Only the two signals a disabled
+ * control conventionally carries: it is dimmed, and the pointer says it cannot be used.
+ *
+ * `opacity` rather than a colour of our own, on purpose: it composes with WHATEVER background,
+ * border and text colour the theme already gave the field — light or dark, ours or theirs — so this
+ * rule needs no palette, no custom property threaded through from PHP, and cannot clash with a
+ * theme the way a hardcoded grey would. Specificity stays flat (one class) exactly like everything
+ * else in this file, so a theme that wants a stronger treatment can still take it.
+ *
+ * `location-cascade.js` toggles the class ({@see refreshAddressLock}); it is never rendered
+ * server-side.
+ * ---------------------------------------------------------------------- */
+
+.woodev-location-locked {
+	cursor: not-allowed;
+	opacity: 0.55;
 }

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -166,6 +166,9 @@
 	/** @type {Object.<string, string>} WC-convention field-id suffix per level, for postcode derivation. */
 	var LEVEL_SUFFIX = { region: 'state', settlement: 'city', address: 'address_1' };
 
+	/** @type {string} marks the address input while it is locked (issue #337) — see {@see refreshAddressLock}. */
+	var LOCKED_CLASS = 'woodev-location-locked';
+
 	var factory = window.WoodevCheckoutFieldStore;
 
 	if ( ! factory || 'function' !== typeof factory.createStore ) {
@@ -1570,9 +1573,13 @@
 	 * NOTHING EXPLAINS THE LOCK. No `title`, no `aria-*` description, no message beside the
 	 * field — the same standing operator rule that removed the inline "fill this in" text from
 	 * the A2 gate in `checkout-field-classic.js` (#274): a blocked control is blocked, and that
-	 * is all it says. `disabled` is therefore the WHOLE mechanism: the browser greys the input
-	 * itself in any theme, so `location.css` keeps its own stated rule of never styling the
-	 * checkout input, and nothing has to be threaded through PHP for the presentation.
+	 * is all it says. But blocked must still LOOK blocked: `disabled` on its own is not a visual
+	 * signal — measured on the rig, the theme's own `input` rule overrides the browser's default
+	 * greying completely, leaving a field that looks exactly like its editable neighbour and just
+	 * refuses to type, which reads as broken rather than as blocked. Hence the {@see LOCKED_CLASS}
+	 * marker and the ONE rule `location.css` carries for it — deliberately the single exception to
+	 * that file's own "never style the checkout input" discipline, because a locked field is the
+	 * one state where the input must NOT look like every other one.
 	 *
 	 * CLIENT-SIDE ONLY, LIKE EVERY OTHER GATE IN THIS LAYER (`refreshGate()`'s own rule in
 	 * `checkout-field-classic.js`): the server stays the authority. Rendering the attribute
@@ -1602,7 +1609,17 @@
 			return;
 		}
 
-		el.disabled = isAddressLocked( entry, node );
+		var locked = isAddressLocked( entry, node );
+
+		el.disabled = locked;
+		// The class is what location.css can see — `disabled` alone is NOT a visual signal:
+		// measured on the rig, the theme's own `input` rule (its own background/border/colour)
+		// overrides the browser's default greying entirely, leaving a field that looks ordinary
+		// and merely refuses to type. That reads as broken, which is a different thing from
+		// blocked. See `location.css`'s own rule for this class.
+		if ( el.classList ) {
+			el.classList.toggle( LOCKED_CLASS, locked );
+		}
 	}
 
 	/**

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -69,6 +69,14 @@
  * new value against `resolved[fieldId]` — genuinely unchanged is always a no-op, by
  * construction, regardless of how many times or through which world the event arrives.
  *
+ * ADDRESS LOCK (issue #337): when — and ONLY when — this entry's chain carries BOTH a
+ * settlement and an address field AND the provider serves the `address` level for that field's
+ * own country, the address input is `disabled` until a settlement record is actually confirmed.
+ * It is a UX gate, client-side only, with nothing explaining it; the full reasoning, including
+ * why the settlement is not simply derived out of the address record instead, lives on
+ * {@see isAddressLocked} and {@see refreshAddressLock}. Every state transition that can change
+ * the answer re-applies it — see those two functions' own call sites.
+ *
  * BOTH EVENT WORLDS (gotcha `jquery-trigger-change-fires-no-native-event`): a jQuery
  * `.trigger('change')` (how select2/selectWoo and much of WooCommerce's own churn report a
  * change) dispatches NO native DOM event, so a delegated `addEventListener('change')` alone
@@ -999,6 +1007,11 @@
 				// can run against records this adoption was about to overwrite anyway.
 				adoptChain( entry, body && body.chain );
 
+				// Issue #337: the server's own chain is authoritative ({@see adoptChain}), so a
+				// repair that DROPPED the settlement level must re-lock the address field the
+				// optimistic pick above already unlocked.
+				refreshAddressLock( entry );
+
 				settleSelect( entry, persisted, ! persisted, record );
 			},
 			function( error ) {
@@ -1277,6 +1290,12 @@
 
 			backwardsFill( entry, node.level, record );
 
+			// Issue #337: a settlement pick unlocks the address field on the SPOT, off the
+			// optimistic record above — never only once `/select` comes back. Waiting for the
+			// round trip would leave the customer looking at a field that stays blocked for as
+			// long as the network takes, right after doing the one thing that unblocks it.
+			refreshAddressLock( entry );
+
 			if ( isActiveAddressSection( node.section ) ) {
 				enqueueSelect( entry, record );
 			}
@@ -1485,6 +1504,116 @@
 			} else if ( ! attached && active ) {
 				attachOne( entry, node );
 			}
+		} );
+	}
+
+	// -------------------------------------------------------------------------
+	// Address lock (issue #337)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Whether the address field must currently be LOCKED — the customer cannot type into it
+	 * until they have actually PICKED a settlement (issue #337, operator decision 16.08.2026).
+	 *
+	 * WHY A LOCK, AND NOT A DERIVED SETTLEMENT: the pickup layer keys the customer's chosen
+	 * point off the SETTLEMENT record ({@see \Woodev\Framework\Shipping\Pickup\
+	 * Provider_Selection_Scope::current_locality()}), so an address picked with no settlement
+	 * ever chosen produces a chain with no settlement record at all — the pickup choice is then
+	 * never written and does not survive a reload (measured on the rig, issue #337). Deriving
+	 * the settlement back out of the address record was considered and REJECTED: an address row
+	 * carries TWO candidate ancestors (`city_fias_id` / `settlement_fias_id`) and only the
+	 * customer knows which one is theirs (gotcha
+	 * `a-derived-ancestor-is-not-the-one-the-customer-picked`; #339 measured the same thing from
+	 * the other end). The lock removes the state BY CONSTRUCTION instead of guessing a way out
+	 * of it afterwards.
+	 *
+	 * BOTH CONDITIONS MUST HOLD — in every other case the address field stays an ORDINARY input
+	 * and is never locked (the operator's own narrowing of the rule):
+	 *
+	 * 1. SETTLEMENT AND ADDRESS ARE LINKED — both levels are present in THIS entry's own chain.
+	 *    This is the level-driven equivalent of a §8 `depends_on`: a location-kind field carries
+	 *    no `depends_on` at all (see the file docblock's CHAIN ASSEMBLY section), and the chain
+	 *    is exactly what {@see scopeKeyFor} already reads to decide whether the address level is
+	 *    scoped BY the settlement one — so "linked" and "scoped by" are one and the same fact
+	 *    here. An entry with no settlement field has nothing to wait for, and locking it would
+	 *    be a dead end rather than a gate.
+	 * 2. THE PROVIDER SERVES `address` FOR THIS NODE'S OWN COUNTRY — read PER LEVEL out of
+	 *    `config.location.levels[country]` (D15), never from the fact that a provider is active
+	 *    at all: a provider with no address suggestions leaves the customer free-typing a
+	 *    street, and no settlement is needed for that. {@see isNodeActive} is consulted rather
+	 *    than {@see isLevelServed} directly, because it carries that per-level check TOGETHER
+	 *    with the country/section gates the very same field is attached under — so the lock and
+	 *    the widget can never disagree about which country's coverage applies, or lock a
+	 *    shipping-section field the customer has not even opted into.
+	 *
+	 * The lock is then ON exactly while no settlement record is confirmed — {@see scopeKeyFor},
+	 * the SAME answer that decides whether an address `/suggest` may carry a `within`. A field
+	 * locked here is precisely a field whose suggestions would otherwise search country-wide.
+	 *
+	 * @param {Object} entry
+	 * @param {{level: string, fieldId: string, section?: string}} node The address chain node.
+	 * @returns {boolean}
+	 */
+	function isAddressLocked( entry, node ) {
+		if ( ! chainNodeForLevel( entry, 'settlement' ) || ! isNodeActive( entry, node ) ) {
+			return false;
+		}
+
+		return null === scopeKeyFor( entry, 'address' );
+	}
+
+	/**
+	 * Applies {@see isAddressLocked} to whichever element currently carries the address field —
+	 * read from the live document every time, never a captured node, since WooCommerce replaces
+	 * the address fragment wholesale on `updated_checkout` ({@see reconcileAfterCheckoutUpdate}).
+	 *
+	 * NOTHING EXPLAINS THE LOCK. No `title`, no `aria-*` description, no message beside the
+	 * field — the same standing operator rule that removed the inline "fill this in" text from
+	 * the A2 gate in `checkout-field-classic.js` (#274): a blocked control is blocked, and that
+	 * is all it says. `disabled` is therefore the WHOLE mechanism: the browser greys the input
+	 * itself in any theme, so `location.css` keeps its own stated rule of never styling the
+	 * checkout input, and nothing has to be threaded through PHP for the presentation.
+	 *
+	 * CLIENT-SIDE ONLY, LIKE EVERY OTHER GATE IN THIS LAYER (`refreshGate()`'s own rule in
+	 * `checkout-field-classic.js`): the server stays the authority. Rendering the attribute
+	 * server-side would additionally make a JS failure permanent — an address field nothing
+	 * could ever unlock.
+	 *
+	 * A disabled input is not serialized into WooCommerce's `update_checkout` POST or the order
+	 * submission. That takes nothing away in-session: every path that drops the settlement
+	 * record also clears the address VALUE ({@see clearDescendants}, {@see clearCountryScope}),
+	 * so a locked field is an empty field. The one state where it is not is a session created
+	 * BEFORE this rule existed (an address picked while no settlement ever was — exactly what
+	 * #337 is about): there the restored value is greyed out and left behind on submit, and the
+	 * recovery is the one the rule asks for anyway — picking the settlement, which clears the
+	 * descendants and unlocks the field for a fresh pick. The announced pickup-address write
+	 * ({@see handlePickupAddressReplacing}) is not a counter-example either: it only ever
+	 * follows a pickup SELECTION, which the pickup layer refuses to persist without a settlement
+	 * key at all (gotcha `an-empty-domain-key-is-not-a-key`) — i.e. only ever while unlocked.
+	 *
+	 * @param {Object} entry
+	 * @returns {void}
+	 */
+	function refreshAddressLock( entry ) {
+		var node = chainNodeForLevel( entry, 'address' );
+		var el = node ? document.getElementById( node.fieldId ) : null;
+
+		if ( ! el ) {
+			return;
+		}
+
+		el.disabled = isAddressLocked( entry, node );
+	}
+
+	/**
+	 * {@see refreshAddressLock} for every entry — the shape the global (entry-agnostic) event
+	 * handlers use.
+	 *
+	 * @returns {void}
+	 */
+	function refreshAddressLocks() {
+		entries.forEach( function( entry ) {
+			refreshAddressLock( entry );
 		} );
 	}
 
@@ -1839,6 +1968,12 @@
 
 			clearDescendants( entry, info.index );
 		} );
+
+		// Issue #337. Fired for EVERY entry, not only those that matched a node above: a
+		// settlement record can be dropped by this handler (a text edit without a pick) and the
+		// address field must go back to locked in the same pass, while a field this entry does
+		// not own leaves {@see refreshAddressLock} a no-op anyway.
+		refreshAddressLocks();
 	}
 
 	/**
@@ -1859,6 +1994,11 @@
 		entries.forEach( function( entry ) {
 			applyCountryArbitration( entry );
 		} );
+
+		// Issue #337: the address level's own coverage is per COUNTRY (D15) and the section
+		// gate moves with the "ship to a different address" toggle, so both of this function's
+		// triggers can flip the lock's own preconditions, not just which widgets are attached.
+		refreshAddressLocks();
 	}
 
 	/** @type {{native: boolean, jquery: boolean}} which event worlds are currently bound. */
@@ -1933,6 +2073,10 @@
 				live.value = stored;
 			}
 		} );
+
+		// Issue #337: a re-render hands back a FRESH element, carrying the server's markup and
+		// none of the lock this module applied to the node it replaced.
+		refreshAddressLock( entry );
 	}
 
 	function handleCheckoutUpdated() {
@@ -2116,6 +2260,10 @@
 		entries.forEach( function( entry ) {
 			prefill( entry );
 			attachAll( entry ); // per-node gated internally via isNodeActive()
+			// Issue #337: the lock's state is decided HERE, on the records {@see prefill} just
+			// restored — a customer who already picked a settlement must find the address field
+			// live immediately after a reload, never only after some first event nudges it.
+			refreshAddressLock( entry );
 		} );
 
 		suppressWcAddressAutocomplete();


### PR DESCRIPTION
Closes #337.

## Что сделано

Поле адреса блокируется, пока покупатель не **выбрал** населённый пункт. Только блокировка — обратный матчинг НП из адреса не делаем (решение оператора 16.08.2026; рассуждение осталось в карточке).

Правило ровно в той форме, в какой оператор его сузил. Блокировка включается, только когда выполнены **оба** условия:

1. **НП и адрес связаны** — оба уровня присутствуют в цепочке этой записи. Это и есть уровневый эквивалент `depends_on`: location-поле не несёт `depends_on` вовсе (цепочка собирается по `location_level`), а «связаны» и «адрес скоупится по НП» — здесь один и тот же факт, который уже читает `scopeKeyFor()`.
2. **Провайдер даёт подсказки уровня `address`** для страны этого поля — поуровнево из `config.location.levels[country]` (D15), а не из факта «провайдер активен». Проверяется через `isNodeActive()`, чтобы блокировка и виджет не могли разойтись в том, чью страну считать.

Во всех прочих случаях поле адреса — **обычный инпут**. На риге это живой случай: AM/AZ/KG/TJ/TM отдают `address: false`.

Блокировку **ничем не поясняем** — ни `title`, ни aria, ни подписи (стоячее правило, то же, что убрало текст из A2-гейта в #274). Гейт клиентский, сервер остаётся авторитетом.

Пересчёт на каждом переходе, который может изменить ответ: загрузка, сам выбор НП (оптимистично, не дожидаясь `/select`), починка цепочки сервером, правка текста НП без выбора, арбитраж страны/секции, перерисовка чекаута.

## Второй коммит: блокировка должна быть ВИДНА

`disabled` сам по себе сигналом не является — замерено на риге: правило `input` темы полностью перекрывает дефолтное серение браузера, и поле выглядело как обычное, просто не принимало ввод. Это читается как «сломано», а не как «заблокировано». Добавлен класс `woodev-location-locked` и одно плоское правило в `location.css`: приглушение + `cursor: not-allowed`, больше ничего. `opacity`, а не свой цвет — чтобы складывалось с любой темой.

Это единственное сознательное исключение из правила самого файла «сам инпут здесь не стилизуем», и оба докблока теперь об этом говорят.

## Проверка

Риг, `:8973`, `/classic-checkout/`, чистая изолированная гостевая сессия — весь цикл в одном прогоне с контролем:

- свежий гость → `shipping_address_1` заблокирован, приглушён, `cursor: not-allowed`;
- выбираем НП «Russia, Moscow city» → разблокирован **сразу**, класс снят, `/select` ещё в полёте;
- перезагрузка с восстановленной записью НП → поле активно **сразу**, а не после первого события;
- правка текста НП руками без выбора подсказки → снова заблокировано;
- переключение страны на AM (без адресного уровня) → обычный инпут, хотя НП не выбран.

Тесты: **+13 jest (1139)**. Оба перехода запинены — предикат мутировался в обе стороны (6 и 8 падений соответственно).

`composer test:unit` 2272/5632 · phpcs чисто · phpstan без ошибок.

## Нужна ручная проверка оператора

Визуальная сила сигнала — вкусовая развилка: сейчас приглушение 0.55. Если хочется заметнее — скажи, добавлю фон.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD
