### PR TITLE
test(rig): живой провайдер СДЭК на риге — второй провайдер для проверки многопровайдерности (#343)

### DIFF
--- a/tests/_fixtures/woodev-test-shipping-method/class-test-cdek-location-provider.php
+++ b/tests/_fixtures/woodev-test-shipping-method/class-test-cdek-location-provider.php
@@ -1,0 +1,771 @@
+<?php
+/**
+ * Woodev_Test_Cdek_Location_Provider — the rig's SECOND live location provider (issue #343).
+ *
+ * WHY THIS EXISTS. The rig has exactly one live provider (DaData) and it serves every level,
+ * so nothing multi-provider is observable there: per-level arbitration, cross-provider `within`
+ * and key namespacing are all exercised only against fixtures that were written from the same
+ * assumptions as the code under test (gotcha
+ * `an-invented-fixture-tests-your-assumptions-not-the-carrier`). CDEK is the honest counterpart:
+ * a real carrier dictionary with regions and settlements and — measured, see below — NO street
+ * data at all.
+ *
+ * WHAT WAS MEASURED (test contour, 16.08.2026). The Locations API has exactly three endpoints,
+ * and this was read off CDEK's own documentation inventory rather than inferred from silence:
+ *
+ * | endpoint                        | what it answers                                        |
+ * |---------------------------------|--------------------------------------------------------|
+ * | `GET /v2/location/regions`      | the whole region dictionary; `region_code` is identity  |
+ * | `GET /v2/location/cities`       | settlements, filterable by `region_code`/`code`/`city`  |
+ * | `GET /v2/location/suggest/cities` | settlement suggestions by `name`                      |
+ *
+ * There is no address/street suggestion endpoint. That is not a gap in this fixture — it is the
+ * whole point of issue #343's scenario A: a live provider for which the `address` level must
+ * stay a plain input, exactly as the #337 lock rule requires.
+ *
+ * IDENTITY. CDEK's own identifiers are its dictionary codes — `region_code` for a region,
+ * `code` for a settlement — never FIAS. `GET /location/cities` DOES also carry `fias_guid`, and
+ * Moscow's is byte-for-byte the guid DaData answers with (`0c5b2444-…`, measured), but this
+ * provider deliberately keys off the CDEK code anyway: a {@see \Woodev\Framework\Shipping\Location\Locality_Key}
+ * is `provider_id:native_id`, and borrowing another provider's identifier space would hide the
+ * very cross-provider seam this fixture exists to expose. The guid rides along under `raw`.
+ *
+ * SUGGESTION COMPONENTS ARE PARSED FROM `full_name`. `/location/suggest/cities` returns only
+ * `code`, `city_uuid`, `full_name` and `country_code` — no components, no `region_code` — while
+ * a {@see \Woodev\Framework\Shipping\Location\Location_Record} needs them for backwards fill.
+ * `full_name` is CDEK's own composite ("Москва, Россия"; "Московский, Московская область,
+ * Россия"; "Московская, Афанасьевский район, Кировская область, Россия"), so it is split on
+ * commas: first part is the settlement, last is the country, the last of what remains is the
+ * region and anything between it and the settlement is the district. The parse only ever
+ * produces DISPLAY components — identity stays the `code` — so a mis-split degrades the label,
+ * never the key (gotcha `a-locality-display-name-is-not-an-identifier`). The region name is
+ * then looked up in the cached region dictionary to recover `region_code`, which is what lets a
+ * suggestion carry a real ancestor key rather than a dangling one.
+ *
+ * COUNTRIES ARE NARROWED ON PURPOSE. CDEK's dictionary spans ~95 countries (measured). This
+ * fixture declares the SAME nine the rig's DaData provider covers, so the two are directly
+ * comparable on the same checkout — the point is arbitration between them, not coverage.
+ *
+ * CREDENTIALS ARE NEVER COMMITTED. CDEK publishes shared test-contour keys (they appear in
+ * their own official WooCommerce plugin as `Cdek\Config::TEST_CLIENT_ID` /
+ * `TEST_CLIENT_SECRET`), and orders placed with them are never processed — but this repository
+ * is public and the rule does not bend for a credential that happens to be public elsewhere
+ * (gotcha `public-repo-third-party-credentials`). They are read from the rig's own wp-config
+ * constants and bridged into the store options by {@see \Woodev_Test_Credential_Seeder}, the
+ * same idiom `WOODEV_TEST_DADATA_TOKEN` already uses.
+ *
+ * Required/declared inside the plugin's own init callback, never at file top level — gotcha
+ * `fixture-classes-must-live-inside-plugin-init`.
+ *
+ * @package Woodev_Test_Shipping_Method
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Woodev_Test_Cdek_Location_Provider' ) ) {
+
+	/**
+	 * Class Woodev_Test_Cdek_Location_Provider
+	 */
+	class Woodev_Test_Cdek_Location_Provider extends \Woodev\Framework\Shipping\Location\Abstract_Location_Provider {
+
+		/**
+		 * Provider id — the {@see \Woodev\Framework\Shipping\Location\Locality_Key}
+		 * namespace prefix every record this provider produces carries.
+		 *
+		 * Prefixed `test-` like every other fixture here: this is a rig provider built to
+		 * exercise the multi-provider seams, NOT a shipped CDEK integration, and a stored
+		 * key must never be mistaken for one written by such an integration later.
+		 *
+		 * @var string
+		 */
+		public const PROVIDER_ID = 'test-cdek';
+
+		/**
+		 * Settings field id: OAuth client id.
+		 *
+		 * @var string
+		 */
+		public const FIELD_CLIENT_ID = 'cdek_client_id';
+
+		/**
+		 * Settings field id: OAuth client secret.
+		 *
+		 * @var string
+		 */
+		public const FIELD_CLIENT_SECRET = 'cdek_client_secret';
+
+		/**
+		 * CDEK's TEST contour. Production (`https://api.cdek.ru/v2`) is deliberately not
+		 * reachable from this fixture at all — a rig provider has no business being one
+		 * setting away from a live carrier account.
+		 *
+		 * @var string
+		 */
+		public const API_BASE = 'https://api.edu.cdek.ru/v2';
+
+		/**
+		 * Transient holding the OAuth bearer token.
+		 *
+		 * @var string
+		 */
+		private const TOKEN_TRANSIENT = 'woodev_test_cdek_token';
+
+		/**
+		 * Transient prefix for the per-country region dictionary.
+		 *
+		 * @var string
+		 */
+		private const REGIONS_TRANSIENT_PREFIX = 'woodev_test_cdek_regions_';
+
+		/**
+		 * Region dictionary TTL. A carrier's region list changes on the order of years;
+		 * a day is already generous for a rig.
+		 *
+		 * @var int
+		 */
+		private const REGIONS_TTL = DAY_IN_SECONDS;
+
+		/**
+		 * Request timeout, seconds — the same value the rig's live Yandex source uses.
+		 *
+		 * @var int
+		 */
+		private const REQUEST_TIMEOUT = 15;
+
+		/**
+		 * How many settlements {@see self::list_localities()} enumerates per region.
+		 * CDEK's own default is 1000; a region's full settlement list is what the
+		 * `related-list`/`ajax-select2` modes render, so the cap is a real one.
+		 *
+		 * @var int
+		 */
+		private const LIST_PAGE_SIZE = 500;
+
+		/**
+		 * The countries this fixture claims — see the file docblock on why this is
+		 * narrower than CDEK's real coverage.
+		 *
+		 * @var string[]
+		 */
+		private const COUNTRIES = [ 'AM', 'AZ', 'BY', 'KZ', 'KG', 'RU', 'TJ', 'TM', 'UZ' ];
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function get_id(): string {
+			return self::PROVIDER_ID;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function get_name(): string {
+			return __( 'СДЭК — тестовый контур (только для рига)', 'woodev-plugin-framework' );
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function get_countries(): array {
+			return self::COUNTRIES;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * REGION AND SETTLEMENT, NEVER ADDRESS — the measured shape of CDEK's Locations
+		 * API (see the file docblock), and the reason this fixture exists: it is the live
+		 * case for #337's rule that the address field stays an ordinary input when the
+		 * provider serves no address suggestions.
+		 */
+		protected function declare_suggest_levels(): array {
+			return [
+				\Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION,
+				\Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT,
+			];
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Both credentials, both sensitive. `required` on both: unlike DaData's optional
+		 * Clean secret, CDEK issues no token at all without the pair.
+		 */
+		public function get_settings_fields(): array {
+			return [
+				self::FIELD_CLIENT_ID     => [
+					'name'        => __( 'Client ID СДЭК', 'woodev-plugin-framework' ),
+					'type'        => \Woodev_Setting::TYPE_STRING,
+					'description' => __( 'Идентификатор приложения для Integration API 2.0 (тестовый контур api.edu.cdek.ru).', 'woodev-plugin-framework' ),
+					'default'     => '',
+					'required'    => true,
+					'sensitive'   => true,
+				],
+				self::FIELD_CLIENT_SECRET => [
+					'name'        => __( 'Client Secret СДЭК', 'woodev-plugin-framework' ),
+					'type'        => \Woodev_Setting::TYPE_STRING,
+					'description' => __( 'Секрет приложения для Integration API 2.0 (тестовый контур api.edu.cdek.ru).', 'woodev-plugin-framework' ),
+					'default'     => '',
+					'required'    => true,
+					'sensitive'   => true,
+				],
+			];
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * The provider's own honest answer, as the contract requires: BOTH halves of the
+		 * credential pair must actually be stored. The abstract default can only see that
+		 * the fields were declared, never that a value was saved.
+		 */
+		public function is_configured(): bool {
+			return '' !== $this->credential( self::FIELD_CLIENT_ID ) && '' !== $this->credential( self::FIELD_CLIENT_SECRET );
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Region level: a substring match over the cached region dictionary — CDEK has no
+		 * region suggest endpoint, and the dictionary is small enough (tens of rows per
+		 * country) that filtering it locally is both cheaper and more predictable than any
+		 * remote alternative would be.
+		 *
+		 * Settlement level: `GET /location/suggest/cities`, then — when the scope names a
+		 * parent region — filtered to the suggestions whose parsed region matches it. CDEK's
+		 * suggest endpoint takes no region parameter (measured), so the narrowing has to
+		 * happen here; a caller's `within` is therefore honoured even though the carrier
+		 * cannot honour it itself.
+		 *
+		 * A transport or payload failure returns `[]` rather than throwing: a suggestion
+		 * list that cannot be fetched is an empty list to the customer, and the checkout
+		 * must not fatal because a carrier dictionary is briefly unreachable.
+		 */
+		public function suggest( string $query, \Woodev\Framework\Shipping\Location\Location_Scope $scope ): array {
+			$needle = mb_strtolower( trim( $query ) );
+
+			if ( '' === $needle ) {
+				return [];
+			}
+
+			if ( \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION === $scope->level() ) {
+				return $this->match_regions( $needle, $scope->country() );
+			}
+
+			if ( \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT === $scope->level() ) {
+				return $this->suggest_settlements( $query, $scope );
+			}
+
+			// `address` — never served (see declare_suggest_levels()). The framework's own
+			// D15 chain walk is what keeps this branch unreached; answering [] rather than
+			// throwing keeps a mis-wired caller harmless.
+			return [];
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Overriding this method is what DECLARES {@see \Woodev\Framework\Shipping\Location\Location_Provider::CAPABILITY_LIST}
+		 * — the abstract base reflects capabilities off the declaring class rather than
+		 * asking for a list, so there is nothing else to register.
+		 *
+		 * This is the capability DaData structurally cannot have (a query-driven API cannot
+		 * enumerate), and a carrier dictionary structurally can.
+		 */
+		public function list_localities( \Woodev\Framework\Shipping\Location\Location_Scope $scope ): array {
+			if ( \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION === $scope->level() ) {
+				return $this->match_regions( '', $scope->country() );
+			}
+
+			if ( \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT !== $scope->level() ) {
+				return [];
+			}
+
+			$region_code = $this->region_code_from_scope( $scope );
+
+			if ( null === $region_code ) {
+				// Enumerating every settlement of a country is not a list anyone can render,
+				// and CDEK would page it into the tens of thousands. An unnarrowed settlement
+				// scope gets nothing, deliberately.
+				return [];
+			}
+
+			$rows = $this->request(
+				'/location/cities',
+				[
+					'region_code'   => $region_code,
+					'country_codes' => $scope->country(),
+					'size'          => self::LIST_PAGE_SIZE,
+				]
+			);
+
+			$records = [];
+
+			foreach ( $rows as $row ) {
+				$record = $this->record_from_city_row( $row );
+
+				if ( null !== $record ) {
+					$records[] = $record;
+				}
+			}
+
+			return $records;
+		}
+
+		// -----------------------------------------------------------------
+		// Suggestion building
+		// -----------------------------------------------------------------
+
+		/**
+		 * Region records whose name contains `$needle` — every region of the country when
+		 * `$needle` is empty, which is what {@see self::list_localities()} enumerates.
+		 *
+		 * @param string $needle Lower-cased search term, or `''` for "all".
+		 * @param string $country ISO-3166 alpha-2.
+		 *
+		 * @return \Woodev\Framework\Shipping\Location\Location_Record[]
+		 */
+		private function match_regions( string $needle, string $country ): array {
+			$records = [];
+
+			foreach ( $this->regions( $country ) as $region_code => $name ) {
+				if ( '' !== $needle && false === mb_strpos( mb_strtolower( $name ), $needle ) ) {
+					continue;
+				}
+
+				$records[] = $this->record_from_region( (int) $region_code, $name, $country );
+			}
+
+			return $records;
+		}
+
+		/**
+		 * Settlement suggestions for `$query`, narrowed to the scope's parent region when it
+		 * names one.
+		 *
+		 * @param string                                            $query Raw search term.
+		 * @param \Woodev\Framework\Shipping\Location\Location_Scope $scope Settlement-level scope.
+		 *
+		 * @return \Woodev\Framework\Shipping\Location\Location_Record[]
+		 */
+		private function suggest_settlements( string $query, \Woodev\Framework\Shipping\Location\Location_Scope $scope ): array {
+			$country     = $scope->country();
+			$rows        = $this->request( '/location/suggest/cities', [ 'name' => $query, 'country_code' => $country ] );
+			$region_code = $this->region_code_from_scope( $scope );
+			$records     = [];
+
+			foreach ( $rows as $row ) {
+				$record = $this->record_from_suggest_row( $row, $country );
+
+				if ( null === $record ) {
+					continue;
+				}
+
+				// The `within` narrowing CDEK's own endpoint cannot do. Compared on the
+				// ancestor KEY, never on the region's display name — the name is what the
+				// parse produced, the key is what the dictionary lookup confirmed.
+				if ( null !== $region_code && ! in_array( self::PROVIDER_ID . ':r' . $region_code, $record->ancestors(), true ) ) {
+					continue;
+				}
+
+				$records[] = $record;
+			}
+
+			return $records;
+		}
+
+		/**
+		 * Builds a region record.
+		 *
+		 * Native id is prefixed `r` so a region code and a settlement code — both plain
+		 * integers out of two different CDEK dictionaries — can never collide inside one
+		 * provider's key namespace.
+		 *
+		 * @param int    $region_code CDEK region code.
+		 * @param string $name        Region name.
+		 * @param string $country     ISO-3166 alpha-2.
+		 *
+		 * @return \Woodev\Framework\Shipping\Location\Location_Record
+		 */
+		private function record_from_region( int $region_code, string $name, string $country ): \Woodev\Framework\Shipping\Location\Location_Record {
+			return \Woodev\Framework\Shipping\Location\Location_Record::from_array(
+				[
+					'key'         => self::PROVIDER_ID . ':r' . $region_code,
+					'provider_id' => self::PROVIDER_ID,
+					'level'       => \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_REGION,
+					'country'     => $country,
+					'region'      => [ 'name' => $name ],
+					'label'       => $name,
+					'raw'         => [ 'region_code' => $region_code ],
+				]
+			);
+		}
+
+		/**
+		 * Builds a settlement record from a `/location/suggest/cities` row, or `null` when
+		 * the row carries no usable code.
+		 *
+		 * @param mixed  $row     One decoded suggestion row.
+		 * @param string $country ISO-3166 alpha-2 the search ran under.
+		 *
+		 * @return \Woodev\Framework\Shipping\Location\Location_Record|null
+		 */
+		private function record_from_suggest_row( $row, string $country ): ?\Woodev\Framework\Shipping\Location\Location_Record {
+			if ( ! is_array( $row ) || empty( $row['code'] ) ) {
+				return null;
+			}
+
+			$parts       = self::split_full_name( (string) ( $row['full_name'] ?? '' ) );
+			$region_name = $parts['region'];
+
+			// A FEDERAL CITY is its own region, and `full_name` says so by omission: Moscow
+			// comes back as plain "Москва, Россия", with no region part to parse at all. The
+			// region is not GUESSED from that — it is CONFIRMED, by looking the settlement's
+			// own name up in CDEK's region dictionary and only accepting an exact hit. CDEK's
+			// own `/location/cities` reports the same pairing for both such cities (measured:
+			// code 44 → region "Москва"/81, code 137 → "Санкт-Петербург"/82), so this
+			// reproduces the carrier's own answer rather than inventing an ancestor the way
+			// gotcha `a-derived-ancestor-is-not-the-one-the-customer-picked` warns against.
+			// A two-part row whose settlement name is NOT in the dictionary keeps no region,
+			// exactly as before.
+			if ( '' === $region_name && '' !== $parts['settlement'] && null !== $this->region_code_for_name( $parts['settlement'], $country ) ) {
+				$region_name = $parts['settlement'];
+			}
+
+			$region_code = '' === $region_name ? null : $this->region_code_for_name( $region_name, $country );
+
+			return \Woodev\Framework\Shipping\Location\Location_Record::from_array(
+				array_filter(
+					[
+						'key'         => self::PROVIDER_ID . ':' . (int) $row['code'],
+						'provider_id' => self::PROVIDER_ID,
+						'level'       => \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT,
+						'country'     => is_string( $row['country_code'] ?? null ) && '' !== $row['country_code'] ? $row['country_code'] : $country,
+						'settlement'  => [ 'name' => $parts['settlement'] ],
+						'region'      => '' === $region_name ? null : [ 'name' => $region_name ],
+						'district'    => '' === $parts['district'] ? null : [ 'name' => $parts['district'] ],
+						'label'       => (string) ( $row['full_name'] ?? $parts['settlement'] ),
+						'raw'         => $row,
+						'ancestors'   => null === $region_code ? null : [ self::PROVIDER_ID . ':r' . $region_code ],
+					],
+					static function ( $value ) {
+						return null !== $value;
+					}
+				)
+			);
+		}
+
+		/**
+		 * Builds a settlement record from a `/location/cities` row — the richer payload:
+		 * real components, coordinates and `fias_guid`, no parsing needed.
+		 *
+		 * @param mixed $row One decoded city row.
+		 *
+		 * @return \Woodev\Framework\Shipping\Location\Location_Record|null
+		 */
+		private function record_from_city_row( $row ): ?\Woodev\Framework\Shipping\Location\Location_Record {
+			if ( ! is_array( $row ) || empty( $row['code'] ) || empty( $row['country_code'] ) ) {
+				return null;
+			}
+
+			$region_code = isset( $row['region_code'] ) ? (int) $row['region_code'] : 0;
+
+			return \Woodev\Framework\Shipping\Location\Location_Record::from_array(
+				array_filter(
+					[
+						'key'         => self::PROVIDER_ID . ':' . (int) $row['code'],
+						'provider_id' => self::PROVIDER_ID,
+						'level'       => \Woodev\Framework\Shipping\Location\Location_Record::LEVEL_SETTLEMENT,
+						'country'     => (string) $row['country_code'],
+						'settlement'  => [ 'name' => (string) ( $row['city'] ?? '' ) ],
+						'region'      => empty( $row['region'] ) ? null : [ 'name' => (string) $row['region'] ],
+						'district'    => empty( $row['sub_region'] ) ? null : [ 'name' => (string) $row['sub_region'] ],
+						'lat'         => isset( $row['latitude'] ) ? (float) $row['latitude'] : null,
+						'lon'         => isset( $row['longitude'] ) ? (float) $row['longitude'] : null,
+						'label'       => (string) ( $row['city'] ?? '' ),
+						'raw'         => $row,
+						'ancestors'   => 0 === $region_code ? null : [ self::PROVIDER_ID . ':r' . $region_code ],
+					],
+					static function ( $value ) {
+						return null !== $value;
+					}
+				)
+			);
+		}
+
+		/**
+		 * Splits CDEK's `full_name` composite into display components.
+		 *
+		 * The shape, measured: `settlement[, district…], region, country` — with the region
+		 * absent for a federal city ("Москва, Россия"). So: drop the last part (country),
+		 * take the first as the settlement, the last of the remainder as the region, and
+		 * join anything still in between as the district.
+		 *
+		 * PUBLIC AND STATIC because it is PURE — no WordPress calls, no network — which is
+		 * what makes this one derived rule directly unit-testable without standing a whole
+		 * provider (and a carrier) up behind it. Same "pure half extracted so the rule can be
+		 * pinned on its own" reasoning {@see \Woodev_Test_Credential_Seeder::should_seed()}
+		 * states for its own decision.
+		 *
+		 * @param string $full_name CDEK's own composite label.
+		 *
+		 * @return array{settlement: string, district: string, region: string}
+		 */
+		public static function split_full_name( string $full_name ): array {
+			$parts = array_values(
+				array_filter(
+					array_map( 'trim', explode( ',', $full_name ) ),
+					static function ( string $part ): bool {
+						return '' !== $part;
+					}
+				)
+			);
+
+			$settlement = array_shift( $parts ) ?? '';
+
+			// The country tail. Absent only for a malformed row, which then simply yields no
+			// region rather than treating the country as one.
+			array_pop( $parts );
+
+			$region   = (string) array_pop( $parts );
+			$district = implode( ', ', $parts );
+
+			return [
+				'settlement' => (string) $settlement,
+				'district'   => $district,
+				'region'     => $region,
+			];
+		}
+
+		// -----------------------------------------------------------------
+		// Region dictionary
+		// -----------------------------------------------------------------
+
+		/**
+		 * The region dictionary for one country, `region_code => name`, from a transient
+		 * when fresh.
+		 *
+		 * Only a NON-EMPTY answer is cached — an outage must be retried on the next request
+		 * rather than remembered as "this country has no regions" for a day (the same rule
+		 * the rig's live Yandex source states for its own cache).
+		 *
+		 * @param string $country ISO-3166 alpha-2.
+		 *
+		 * @return array<int, string>
+		 */
+		private function regions( string $country ): array {
+			$transient_key = self::REGIONS_TRANSIENT_PREFIX . strtolower( $country );
+			$cached        = get_transient( $transient_key );
+
+			if ( is_array( $cached ) && [] !== $cached ) {
+				return $cached;
+			}
+
+			$regions = [];
+
+			foreach ( $this->request( '/location/regions', [ 'country_codes' => $country, 'size' => 1000 ] ) as $row ) {
+				if ( is_array( $row ) && ! empty( $row['region_code'] ) && ! empty( $row['region'] ) ) {
+					$regions[ (int) $row['region_code'] ] = (string) $row['region'];
+				}
+			}
+
+			if ( [] !== $regions ) {
+				set_transient( $transient_key, $regions, self::REGIONS_TTL );
+			}
+
+			return $regions;
+		}
+
+		/**
+		 * The CDEK region code whose name equals `$name`, or `null`.
+		 *
+		 * Exact, case-insensitive match: this resolves a name CDEK itself just produced
+		 * against CDEK's own dictionary, so a fuzzy match would only ever paper over a
+		 * parse that already went wrong.
+		 *
+		 * @param string $name    Region name as parsed out of `full_name`.
+		 * @param string $country ISO-3166 alpha-2.
+		 *
+		 * @return int|null
+		 */
+		private function region_code_for_name( string $name, string $country ): ?int {
+			$needle = mb_strtolower( $name );
+
+			foreach ( $this->regions( $country ) as $region_code => $region_name ) {
+				if ( mb_strtolower( $region_name ) === $needle ) {
+					return (int) $region_code;
+				}
+			}
+
+			return null;
+		}
+
+		/**
+		 * The CDEK region code a settlement-level scope is narrowed to — from the parent
+		 * record's own key when the caller supplied a record, else from its `region.name`
+		 * components. `null` when the scope has no parent, or names one that is not this
+		 * provider's.
+		 *
+		 * A parent key belonging to ANOTHER provider yields `null`, not a guess: a
+		 * `Locality_Key` carries its `provider_id` precisely so a foreign key can be
+		 * recognised as foreign instead of being read as an opaque string.
+		 *
+		 * @param \Woodev\Framework\Shipping\Location\Location_Scope $scope Settlement-level scope.
+		 *
+		 * @return int|null
+		 */
+		private function region_code_from_scope( \Woodev\Framework\Shipping\Location\Location_Scope $scope ): ?int {
+			$parent_record = $scope->parent_record();
+
+			if ( null !== $parent_record ) {
+				[ $provider_id, $native_id ] = \Woodev\Framework\Shipping\Location\Locality_Key::parse( $parent_record->key() );
+
+				if ( self::PROVIDER_ID !== $provider_id || 'r' !== substr( $native_id, 0, 1 ) ) {
+					return null;
+				}
+
+				return (int) substr( $native_id, 1 );
+			}
+
+			$components  = $scope->parent_components();
+			$region_name = $components['region']['name'] ?? null;
+
+			return is_string( $region_name ) && '' !== $region_name
+				? $this->region_code_for_name( $region_name, $scope->country() )
+				: null;
+		}
+
+		// -----------------------------------------------------------------
+		// Transport
+		// -----------------------------------------------------------------
+
+		/**
+		 * Performs one authenticated GET against the test contour and returns the decoded
+		 * LIST body, or `[]` on any failure.
+		 *
+		 * Never throws. Every caller here is on the suggestion path, where the honest
+		 * degradation is an empty list — and where an exception would surface as a broken
+		 * checkout rather than as a carrier that had nothing to say.
+		 *
+		 * @param string               $path   Endpoint path, leading slash.
+		 * @param array<string, mixed> $params Query parameters.
+		 *
+		 * @return array<int, mixed>
+		 */
+		private function request( string $path, array $params ): array {
+			$token = $this->token();
+
+			if ( '' === $token ) {
+				return [];
+			}
+
+			$response = wp_safe_remote_get(
+				add_query_arg( array_map( 'rawurlencode', array_map( 'strval', $params ) ), self::API_BASE . $path ),
+				[
+					'timeout' => self::REQUEST_TIMEOUT,
+					'headers' => [
+						'Authorization' => 'Bearer ' . $token,
+						'Accept'        => 'application/json',
+					],
+				]
+			);
+
+			if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+				$this->log( sprintf( 'GET %s failed', $path ), $response );
+
+				return [];
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			return is_array( $body ) ? $body : [];
+		}
+
+		/**
+		 * The OAuth bearer token, from a transient when fresh.
+		 *
+		 * Cached for the lifetime CDEK itself reports, less a minute of slack so a token
+		 * cannot expire between being read here and arriving there.
+		 *
+		 * @return string Empty when unconfigured or the exchange failed.
+		 */
+		private function token(): string {
+			$cached = get_transient( self::TOKEN_TRANSIENT );
+
+			if ( is_string( $cached ) && '' !== $cached ) {
+				return $cached;
+			}
+
+			if ( ! $this->is_configured() ) {
+				return '';
+			}
+
+			$response = wp_safe_remote_post(
+				self::API_BASE . '/oauth/token',
+				[
+					'timeout' => self::REQUEST_TIMEOUT,
+					'headers' => [ 'Content-Type' => 'application/x-www-form-urlencoded' ],
+					'body'    => [
+						'grant_type'    => 'client_credentials',
+						'client_id'     => $this->credential( self::FIELD_CLIENT_ID ),
+						'client_secret' => $this->credential( self::FIELD_CLIENT_SECRET ),
+					],
+				]
+			);
+
+			if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+				$this->log( 'OAuth token exchange failed', $response );
+
+				return '';
+			}
+
+			$body  = json_decode( wp_remote_retrieve_body( $response ), true );
+			$token = is_array( $body ) && is_string( $body['access_token'] ?? null ) ? $body['access_token'] : '';
+
+			if ( '' === $token ) {
+				return '';
+			}
+
+			$ttl = isset( $body['expires_in'] ) ? max( 60, (int) $body['expires_in'] - 60 ) : 5 * MINUTE_IN_SECONDS;
+
+			set_transient( self::TOKEN_TRANSIENT, $token, $ttl );
+
+			return $token;
+		}
+
+		/**
+		 * Reads one stored credential.
+		 *
+		 * `woodev_location_{field_id}` — the option naming the bundled DaData provider uses
+		 * for its own fields, from the registry's `location` settings service id.
+		 *
+		 * @param string $field_id One of the FIELD_* constants.
+		 *
+		 * @return string
+		 */
+		private function credential( string $field_id ): string {
+			return trim( (string) get_option( 'woodev_location_' . $field_id, '' ) );
+		}
+
+		/**
+		 * Logs a failure, when the rig is running with debug logging on.
+		 *
+		 * @param string $message  What failed.
+		 * @param mixed  $response The `wp_remote_*` response or WP_Error behind it.
+		 *
+		 * @return void
+		 */
+		private function log( string $message, $response ): void {
+			if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+				return;
+			}
+
+			$detail = is_wp_error( $response )
+				? $response->get_error_message()
+				: sprintf( 'HTTP %d', (int) wp_remote_retrieve_response_code( $response ) );
+
+			error_log( sprintf( '[%s] %s: %s', self::PROVIDER_ID, $message, $detail ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		}
+	}
+}

--- a/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
+++ b/tests/_fixtures/woodev-test-shipping-method/woodev-test-shipping-method.php
@@ -319,17 +319,26 @@ function woodev_test_shipping_method_plugin_init(): void {
 	// reasoning as the two requires just above.
 	require_once __DIR__ . '/class-test-list-location-provider.php';
 
-	// Registers the fixture provider alongside the bundled DaData one — NOT made active
-	// by default (the store's `active_provider` setting still defaults to `dadata`), an
-	// operator opts in explicitly on the "Локация" settings page to see `related-list`/
-	// `ajax-select2` on the rig. Safe to register the closure here regardless of the
-	// bootstrap's own loading stage (see the `woodev_shipping_pickup_point_selection`
-	// filter registration further down in this file for the identical reasoning:
-	// registering a callback does not INVOKE it).
+	// Issue #343: the rig's SECOND LIVE provider — CDEK's test contour. Where the fixture
+	// above is static data shaped like a carrier dictionary, this one IS a carrier
+	// dictionary: real regions, real settlements, and — measured against CDEK's own API —
+	// no address level at all, which is what makes scenario A of #343 (and with it the
+	// #337 lock rule) observable on a live provider instead of on our own assumptions.
+	// Required unconditionally, same reasoning as the requires just above.
+	require_once __DIR__ . '/class-test-cdek-location-provider.php';
+
+	// Registers the fixture providers alongside the bundled DaData one — NEITHER made
+	// active by default (the store's `active_provider` setting still defaults to
+	// `dadata`), an operator opts in explicitly on the "Локация" settings page to see
+	// `related-list`/`ajax-select2`, or the CDEK dictionary, on the rig. Safe to register
+	// the closure here regardless of the bootstrap's own loading stage (see the
+	// `woodev_shipping_pickup_point_selection` filter registration further down in this
+	// file for the identical reasoning: registering a callback does not INVOKE it).
 	add_filter(
 		\Woodev\Framework\Shipping\Location\Location_Provider_Registry::FILTER_PROVIDERS,
 		static function ( array $providers ): array {
 			$providers[] = new Woodev_Test_List_Location_Provider();
+			$providers[] = new Woodev_Test_Cdek_Location_Provider();
 
 			return $providers;
 		}
@@ -753,9 +762,9 @@ function woodev_test_shipping_method_plugin_init(): void {
 
 				// Location Provider layer, block PR-C rig-visibility pull-forward: bridge the
 				// rig's own DaData credential constants into the store option BEFORE anything
-				// reads it this request — see maybe_seed_dadata_credentials_from_rig_constants()'s
+				// reads it this request — see maybe_seed_location_credentials_from_rig_constants()'s
 				// own docblock.
-				$this->maybe_seed_dadata_credentials_from_rig_constants();
+				$this->maybe_seed_location_credentials_from_rig_constants();
 			}
 
 			/**
@@ -947,19 +956,38 @@ function woodev_test_shipping_method_plugin_init(): void {
 			}
 
 			/**
-			 * Bridges the rig's own `WOODEV_TEST_DADATA_TOKEN`/`WOODEV_TEST_DADATA_SECRET`
-			 * wp-config constants into the DaData provider's store-level settings options
-			 * (`woodev_location_token`/`woodev_location_clean_secret`) via
+			 * Bridges the rig's own wp-config credential constants into the location
+			 * providers' store-level settings options via
 			 * {@see \Woodev_Test_Credential_Seeder::maybe_seed()} — see that class's own
-			 * docblock for the full rationale and the idempotent/non-destructive rule.
+			 * docblock for the full rationale and the idempotent/non-destructive rule:
+			 * `WOODEV_TEST_DADATA_TOKEN`/`WOODEV_TEST_DADATA_SECRET` for the bundled DaData
+			 * provider, and (issue #343) `WOODEV_TEST_CDEK_CLIENT_ID`/
+			 * `WOODEV_TEST_CDEK_CLIENT_SECRET` for the CDEK test-contour fixture provider.
 			 *
 			 * @since 2.0.2
+			 * @since 2.0.2 Also seeds the CDEK credentials (issue #343); renamed from
+			 *              `maybe_seed_dadata_credentials_from_rig_constants()`, which no
+			 *              longer described what it does.
 			 *
 			 * @return void
 			 */
-			private function maybe_seed_dadata_credentials_from_rig_constants(): void {
+			private function maybe_seed_location_credentials_from_rig_constants(): void {
 				\Woodev_Test_Credential_Seeder::maybe_seed( 'woodev_location_token', 'WOODEV_TEST_DADATA_TOKEN' );
 				\Woodev_Test_Credential_Seeder::maybe_seed( 'woodev_location_clean_secret', 'WOODEV_TEST_DADATA_SECRET' );
+
+				// Issue #343: the same bridge for the CDEK test-contour credentials. CDEK
+				// publishes shared test keys, but a credential that is public elsewhere is
+				// still not ours to commit here (gotcha
+				// `public-repo-third-party-credentials`) — so they live in the rig's own
+				// wp-config exactly like the DaData token does, and never in this repo.
+				\Woodev_Test_Credential_Seeder::maybe_seed(
+					'woodev_location_' . \Woodev_Test_Cdek_Location_Provider::FIELD_CLIENT_ID,
+					'WOODEV_TEST_CDEK_CLIENT_ID'
+				);
+				\Woodev_Test_Credential_Seeder::maybe_seed(
+					'woodev_location_' . \Woodev_Test_Cdek_Location_Provider::FIELD_CLIENT_SECRET,
+					'WOODEV_TEST_CDEK_CLIENT_SECRET'
+				);
 			}
 
 			// -----------------------------------------------------------------

--- a/tests/unit/Shipping/Location/CdekFixtureProviderTest.php
+++ b/tests/unit/Shipping/Location/CdekFixtureProviderTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Unit tests for the rig's CDEK fixture provider (issue #343).
+ *
+ * Covers the two things about it that are decided in OUR code rather than by the carrier,
+ * and are therefore ours to keep from regressing:
+ *
+ * 1. The SHAPE it declares — region and settlement, never `address`, and the `list`
+ *    capability. That shape is the whole reason the fixture exists (it is what makes #337's
+ *    "no address suggestions ⇒ no lock" rule observable against a live provider), and it is
+ *    exactly the kind of thing a well-meaning later edit widens by accident.
+ * 2. The ONE derived rule in it — splitting CDEK's `full_name` composite into display
+ *    components. The strings below are verbatim captures from the live test contour
+ *    (16.08.2026), all three shapes it actually produces.
+ *
+ * Nothing here touches the network: both are answerable without a token, which is why the
+ * parse was extracted as a pure static in the first place.
+ *
+ * @package Woodev\Tests\Unit\Shipping\Location
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Location;
+
+use Woodev\Framework\Shipping\Location\Location_Provider;
+use Woodev\Framework\Shipping\Location\Location_Record;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-locality-key.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-record.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/class-location-scope.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/interface-location-provider.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/abstract-location-provider.php';
+require_once dirname( __DIR__, 3 ) . '/_fixtures/woodev-test-shipping-method/class-test-cdek-location-provider.php';
+
+/**
+ * Class CdekFixtureProviderTest
+ */
+class CdekFixtureProviderTest extends TestCase {
+
+	/**
+	 * The declared levels are region and settlement — and `address` is NOT among them.
+	 *
+	 * Asserted as an explicit absence, not merely as an expected pair: this is the
+	 * property #343's scenario A and #337's lock rule both hang off, and it deserves to
+	 * fail with a message that says which one broke.
+	 */
+	public function test_it_declares_region_and_settlement_but_never_address(): void {
+		$provider = new \Woodev_Test_Cdek_Location_Provider();
+
+		$this->assertSame(
+			[ Location_Record::LEVEL_REGION, Location_Record::LEVEL_SETTLEMENT ],
+			$provider->get_suggest_levels()
+		);
+		$this->assertNotContains(
+			Location_Record::LEVEL_ADDRESS,
+			$provider->get_suggest_levels(),
+			'CDEK has no street data — a fixture claiming the address level would stop being the live case #343 needs.'
+		);
+	}
+
+	/**
+	 * The per-country answer does not widen the unnarrowed one — CDEK's dictionary has no
+	 * street data anywhere, so no country may report an address level.
+	 */
+	public function test_no_country_reports_an_address_level(): void {
+		$provider = new \Woodev_Test_Cdek_Location_Provider();
+
+		foreach ( $provider->get_countries() as $country ) {
+			$this->assertNotContains(
+				Location_Record::LEVEL_ADDRESS,
+				$provider->get_suggest_levels( $country ),
+				sprintf( 'Country %s must not report an address level.', $country )
+			);
+		}
+	}
+
+	/**
+	 * The `list` capability is declared (by overriding `list_localities()`), and the two
+	 * capabilities this provider does NOT implement are not.
+	 */
+	public function test_it_declares_only_the_list_capability(): void {
+		$provider = new \Woodev_Test_Cdek_Location_Provider();
+
+		$this->assertSame( [ Location_Provider::CAPABILITY_LIST ], $provider->get_capabilities() );
+	}
+
+	/**
+	 * A three-part `full_name`: settlement, region, country.
+	 */
+	public function test_it_splits_a_settlement_with_a_region(): void {
+		$this->assertSame(
+			[
+				'settlement' => 'Московский',
+				'district'   => '',
+				'region'     => 'Московская область',
+			],
+			\Woodev_Test_Cdek_Location_Provider::split_full_name( 'Московский, Московская область, Россия' )
+		);
+	}
+
+	/**
+	 * A four-part `full_name`: settlement, district, region, country.
+	 */
+	public function test_it_splits_a_settlement_with_a_district(): void {
+		$this->assertSame(
+			[
+				'settlement' => 'Московская',
+				'district'   => 'Афанасьевский район',
+				'region'     => 'Кировская область',
+			],
+			\Woodev_Test_Cdek_Location_Provider::split_full_name( 'Московская, Афанасьевский район, Кировская область, Россия' )
+		);
+	}
+
+	/**
+	 * A FEDERAL CITY carries no region part at all — the parse must leave the region empty
+	 * rather than promoting the country into it. (Recovering the region for this case is a
+	 * separate, dictionary-confirmed step in the provider itself, deliberately not part of
+	 * the parse.)
+	 */
+	public function test_it_leaves_a_federal_city_without_a_region(): void {
+		$this->assertSame(
+			[
+				'settlement' => 'Москва',
+				'district'   => '',
+				'region'     => '',
+			],
+			\Woodev_Test_Cdek_Location_Provider::split_full_name( 'Москва, Россия' )
+		);
+	}
+
+	/**
+	 * Degenerate input never throws and never invents a component: an empty string yields
+	 * an empty settlement, and a single part is a settlement with nothing above it.
+	 */
+	public function test_it_survives_degenerate_input(): void {
+		$this->assertSame(
+			[
+				'settlement' => '',
+				'district'   => '',
+				'region'     => '',
+			],
+			\Woodev_Test_Cdek_Location_Provider::split_full_name( '' )
+		);
+
+		$this->assertSame(
+			[
+				'settlement' => 'Одинокое',
+				'district'   => '',
+				'region'     => '',
+			],
+			\Woodev_Test_Cdek_Location_Provider::split_full_name( 'Одинокое' )
+		);
+	}
+
+	/**
+	 * Whitespace and empty segments are cleaned rather than carried into a component —
+	 * CDEK's own strings are tidy, but a component with a stray leading space is exactly
+	 * the kind of thing that later reads as a different locality name.
+	 */
+	public function test_it_trims_and_drops_empty_segments(): void {
+		$this->assertSame(
+			[
+				'settlement' => 'Пушкино',
+				'district'   => 'Пушкинский городской округ',
+				'region'     => 'Московская область',
+			],
+			\Woodev_Test_Cdek_Location_Provider::split_full_name( ' Пушкино ,, Пушкинский городской округ ,  Московская область , Россия ' )
+		);
+	}
+}


### PR DESCRIPTION
Closes #343.

## Зачем

На риге был ровно один живой провайдер, и он умеет всё. Поэтому многопровайдерность была непроверяема вживую: поуровневый арбитраж, кросс-провайдерный `within` и разделение ключей проверялись только против самодельных фикстур, написанных из тех же допущений, что и проверяемый код (готча `an-invented-fixture-tests-your-assumptions-not-the-carrier`).

СДЭК — честный контрагент: настоящий справочник перевозчика, живой тестовый контур `api.edu.cdek.ru`, регионы и населённые пункты — и **никаких улиц**.

## Что замерено по документации ДО реализации

Инвентарь Locations API у СДЭК — ровно три эндпойнта (прочитано в их собственной документации через Context7, а не выведено из молчания):

| эндпойнт | что отдаёт |
|---|---|
| `GET /v2/location/regions` | весь справочник регионов; идентичность — `region_code` |
| `GET /v2/location/cities` | НП, фильтруется по `region_code`/`code`/`city`; несёт `fias_guid`, координаты |
| `GET /v2/location/suggest/cities` | подсказки НП по `name` |

**Адресных подсказок нет вообще.** Это не пробел фикстуры — это ровно сценарий А из карточки.

## Идентичность

Ключи — собственные коды справочника СДЭК (`region_code`, `code`), никогда не ФИАС. Хотя у Москвы `fias_guid` **байт в байт** совпадает с тем, что отдаёт DaData (`0c5b2444-…`, замерено) — брать чужое пространство идентификаторов значило бы спрятать ровно тот шов, ради которого фикстура и делается. ФИАС едет пассажиром в `raw`.

Единственное выводимое правило — разбор композитной строки `full_name` на отображаемые компоненты; идентичность от него не зависит никогда. У города федерального значения региональной части в строке нет вовсе, и регион восстанавливается **поиском имени в справочнике регионов СДЭК с точным совпадением** — подтверждение, а не догадка: их же `/location/cities` даёт ту же пару (код 44 → «Москва»/81, 137 → «Санкт-Петербург»/82).

## Проверка на риге

**Сценарий А — СДЭК активен, DaData не сконфигурирована** (токен временно снят, потом возвращён):

```
levels.RU            -> { region: true, settlement: true, address: false }
shipping_address_1   -> disabled: false, класса блокировки нет, role: null  (обычный инпут, виджет не навешен)
shipping_city        -> role: combobox                                       (подсказки СДЭК живые)
```

Дальше весь путь: выбран НП «Москва, Россия» → `city`/`state` заполнены обратным заполнением из компонентов СДЭК → адрес введён свободным текстом → выбран метод Woodev Test Shipping → открыт список ПВЗ (300 точек) → пункт подтверждён. После **перезагрузки**:

```
current              -> { key: "test-cdek:44", level: "settlement" }
chain                -> { settlement: { key: "test-cdek:44" } }
carrier_pickup_point -> 019373a0ecd97151922149c5094feaf6      <- выбор ПВЗ пережил перезагрузку
```

То есть на живом провайдере без адресного уровня каскад цел, ПВЗ выбирается и запись НП сохраняется.

**Сценарий Б — СДЭК держит НП, DaData отдаёт только адрес** (оба сконфигурированы, активен СДЭК):

```
/location/suggest?q=Тверская&level=address&country=RU&within=test-cdek%3A44
-> 10 подсказок dadata:…, метки уже относительные («ulitsa Tverskaya», а не «Russia, Moscow city, ulitsa Tverskaya»)
```

Кросс-провайдерный `within` **работает, и вот почему**: `Location_Controller::build_scope()` резолвит `within` не как строку, а против цепочки покупателя — находит РЕАЛЬНУЮ запись СДЭК и передаёт `Location_Scope::within( $record, $level )`, а DaData строит свой constraint из `parent_components()`, то есть из имён компонентов. Передача между провайдерами идёт через компоненты, а не через идентификаторы. Ключи при этом не смешиваются: НП остаётся `test-cdek:44`, адресные подсказки — `dadata:…`.

Побочно подтвердилось: СДЭК отдаёт «Москва» кириллицей, аккаунт DaData на риге — английский, и ограничение по кириллическому имени отработало корректно.

## Секреты

СДЭК публикует общие тестовые ключи (они лежат в их же официальном плагине для WooCommerce как `Cdek\Config::TEST_CLIENT_ID`/`TEST_CLIENT_SECRET`), заказы с ними не обрабатываются. Но правило не гнётся из-за того, что ключ публичен где-то ещё (готча `public-repo-third-party-credentials`) — они едут тем же мостом через константы wp-config, что и `WOODEV_TEST_DADATA_TOKEN`, и в репозиторий не попадают.

Как поднять у себя:

```bash
wp config set WOODEV_TEST_CDEK_CLIENT_ID <id> --type=constant
wp config set WOODEV_TEST_CDEK_CLIENT_SECRET <secret> --type=constant
wp option update woodev_location_active_provider test-cdek   # вернуть: dadata
```

Риг сейчас возвращён в исходное состояние: активен `dadata`, токен на месте.

## Тесты

`+8` unit (**2280**), 110 интеграционных зелёные, phpcs и phpstan чисто. Юнит-тесты закрывают то, что решаем МЫ, а не перевозчик: объявленная форма (region+settlement, `address` — никогда; capability `list`) и разбор `full_name` на всех трёх реальных формах строки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD
