### PR TITLE
feat(checkout): односоставность §8 как следствие конфигурации, а не зашитое допущение (#325)

### DIFF
--- a/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerValidateTest.php
@@ -603,6 +603,142 @@ class CheckoutHandlerValidateTest extends TestCase {
 			$handler->process( [ 'pvz' => '', 'shipping_method' => [ 'flat_rate:2' ], 'billing_country' => 'RU' ], 0 )
 		);
 	}
+
+	// -----------------------------------------------------------------------
+	// Part F — the backstop enforces EVERY declared pickup slot (#325)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Builds a two-slot field set. One slot is what every plugin declares today; two is
+	 * what the layer must not silently mis-handle, since the client has always mounted a
+	 * trigger per declared slot.
+	 *
+	 * Bare `mark_pickup_slot()` fields, NOT the `Pickup_Field` preset: the preset also
+	 * carries a condition-spec `required`, which makes the per-field loop block on its own
+	 * and would mask whatever the backstop did or did not do. These tests are about the
+	 * backstop alone, so the only thing that may block here is the backstop.
+	 *
+	 * @return Checkout_Fields
+	 */
+	private static function two_pickup_slots(): Checkout_Fields {
+		return Checkout_Fields::from_array(
+			[
+				Field::create( 'carrier_pickup_point' )->mark_pickup_slot()->to_array(),
+				Field::create( 'carrier_pickup_point_2' )->mark_pickup_slot()->to_array(),
+			]
+		);
+	}
+
+	/**
+	 * THE REGRESSION #325 IS ABOUT: with the FIRST slot filled and a second one blank, the
+	 * backstop used to take the first slot, find it filled, and pass — so a second declared
+	 * slot was mounted client-side and then never validated at all.
+	 */
+	public function test_backstop_blocks_when_a_LATER_pickup_slot_is_blank(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )->atLeast()->once();
+
+		$handler = new Checkout_Handler( self::two_pickup_slots(), 'carrier' );
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+
+		$this->assertFalse(
+			$handler->validate(
+				[ 'carrier_pickup_point' => 'PVZ-1', 'carrier_pickup_point_2' => '' ],
+				[ 'chosen_shipping_method' => 'carrier_pickup' ]
+			)
+		);
+	}
+
+	/**
+	 * Both slots filled — the backstop stays silent, so the extra enforcement never turns
+	 * into a checkout nobody can complete.
+	 */
+	public function test_backstop_passes_when_every_pickup_slot_is_filled(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )->never();
+
+		$handler = new Checkout_Handler( self::two_pickup_slots(), 'carrier' );
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+
+		$this->assertTrue(
+			$handler->validate(
+				[ 'carrier_pickup_point' => 'PVZ-1', 'carrier_pickup_point_2' => 'PVZ-2' ],
+				[ 'chosen_shipping_method' => 'carrier_pickup' ]
+			)
+		);
+	}
+
+	/**
+	 * The boundary seam: a domain narrowing the enforced set through
+	 * `woodev_checkout_pickup_slot_fields` is honoured — the filter exists precisely so a
+	 * plugin can decide which of several slots this checkout actually requires.
+	 */
+	public function test_filter_can_narrow_the_enforced_slot_set(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )->never();
+		\Brain\Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value ) {
+				return 'woodev_checkout_pickup_slot_fields' === $hook ? [] : $value;
+			}
+		);
+
+		$handler = new Checkout_Handler( self::two_pickup_slots(), 'carrier' );
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+
+		$this->assertTrue(
+			$handler->validate(
+				[ 'carrier_pickup_point' => '', 'carrier_pickup_point_2' => '' ],
+				[ 'chosen_shipping_method' => 'carrier_pickup' ]
+			)
+		);
+	}
+
+	/**
+	 * A filter returning something unusable must NOT be the reason a checkout stops being
+	 * blocked: the framework's own answer stands. Two shapes at once — a non-array return,
+	 * and a list whose entries carry no id to dereference.
+	 */
+	public function test_a_malformed_filter_return_leaves_the_backstop_standing(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )->atLeast()->once();
+		\Brain\Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value ) {
+				return 'woodev_checkout_pickup_slot_fields' === $hook ? 'not an array at all' : $value;
+			}
+		);
+
+		$handler = new Checkout_Handler( self::two_pickup_slots(), 'carrier' );
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+
+		$this->assertFalse(
+			$handler->validate(
+				[ 'carrier_pickup_point' => '', 'carrier_pickup_point_2' => '' ],
+				[ 'chosen_shipping_method' => 'carrier_pickup' ]
+			)
+		);
+	}
+
+	/**
+	 * Entries the backstop could not dereference are dropped rather than warned about
+	 * mid-validation — a half-built descriptor from a filter must not surface as a PHP
+	 * notice on a customer's checkout.
+	 */
+	public function test_filter_entries_without_an_id_are_dropped(): void {
+		\Brain\Monkey\Functions\expect( 'wc_add_notice' )->never();
+		\Brain\Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $value ) {
+				return 'woodev_checkout_pickup_slot_fields' === $hook
+					? [ [ 'label' => 'no id here' ], 'a bare string' ]
+					: $value;
+			}
+		);
+
+		$handler = new Checkout_Handler( self::two_pickup_slots(), 'carrier' );
+		$handler->set_requires_pickup_methods( [ 'carrier_pickup' ] );
+
+		$this->assertTrue(
+			$handler->validate(
+				[ 'carrier_pickup_point' => '', 'carrier_pickup_point_2' => '' ],
+				[ 'chosen_shipping_method' => 'carrier_pickup' ]
+			)
+		);
+	}
 }
 
 /**

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -1125,8 +1125,11 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 *
 		 * After the per-field loop an independent pickup backstop runs when
 		 * {@see set_requires_pickup_methods()} has been called: if the chosen method is one of
-		 * the declared pickup methods AND the `is_pickup_slot` field value is blank, checkout is
-		 * blocked regardless of that field's condition-spec.
+		 * the declared pickup methods AND a pickup-slot field's value is blank, checkout is
+		 * blocked regardless of that field's condition-spec. EVERY declared slot is checked,
+		 * not just the first one found ({@see self::pickup_slot_fields()}, issue #325) — see
+		 * that method for what in this layer is still single-package on purpose, and where a
+		 * package dimension would go.
 		 *
 		 * The backstop skips its OWN notice when the per-field loop already added a
 		 * required-field error for that exact pickup field id (measured duplication, #299/#134:
@@ -1152,6 +1155,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 		 * @since 2.0.2 Added independent pickup backstop guard.
 		 * @since 2.0.2 Backstop notice suppressed when the per-field loop already reported the
 		 *              same field id blank-and-required (#299, #134).
+		 * @since 2.0.2 Backstop enforces EVERY declared pickup slot instead of only the first
+		 *              one found (#325).
 		 *
 		 * @param array<string, mixed> $values clean values keyed by field id
 		 * @param array<string, mixed> $state  flat checkout-state map, e.g.
@@ -1194,50 +1199,117 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 				$chosen = (string) ( $state['chosen_shipping_method'] ?? '' );
 
 				if ( self::chosen_method_matches( $chosen, $this->requires_pickup_methods ) ) {
-					$pickup_field = null;
-
-					foreach ( $this->fields->get_fields() as $field ) {
-						if ( ! empty( $field['is_pickup_slot'] ) ) {
-							$pickup_field = $field;
-							break;
-						}
-					}
-
-					if ( null !== $pickup_field ) {
+					foreach ( $this->pickup_slot_fields() as $pickup_field ) {
 						$pickup_value = $values[ $pickup_field['id'] ] ?? '';
 
-						if ( self::is_blank( $pickup_value ) ) {
-							$valid = false;
+						if ( ! self::is_blank( $pickup_value ) ) {
+							continue;
+						}
 
-							// Already reported by the per-field loop above — do not repeat the same
-							// failure as a second notice (measured duplication, see method docblock).
-							if ( ! isset( $blank_required_ids[ $pickup_field['id'] ] ) ) {
-								$supplied = self::supplied_required_message( $pickup_field );
+						$valid = false;
 
-								/*
-								 * Its OWN wording, deliberately not the per-field message (#327):
-								 * this branch fires precisely when the field's own condition-spec
-								 * did NOT match the chosen method, so it is the one that can say
-								 * why a point is needed at all. Both dropped «значение поля» —
-								 * the control here is a button, and there is no field to fill in.
-								 * A plugin-supplied message still wins, because it is a statement
-								 * about the field rather than about this code path.
-								 */
-								$this->add_error(
-									'' !== $supplied
-										? $supplied
-										: __(
-											'Для этого способа доставки нужно выбрать пункт выдачи заказов.',
-											'woodev-plugin-framework'
-										)
-								);
-							}
+						// Already reported by the per-field loop above — do not repeat the same
+						// failure as a second notice (measured duplication, see method docblock).
+						if ( ! isset( $blank_required_ids[ $pickup_field['id'] ] ) ) {
+							$supplied = self::supplied_required_message( $pickup_field );
+
+							/*
+							 * Its OWN wording, deliberately not the per-field message (#327):
+							 * this branch fires precisely when the field's own condition-spec
+							 * did NOT match the chosen method, so it is the one that can say
+							 * why a point is needed at all. Both dropped «значение поля» —
+							 * the control here is a button, and there is no field to fill in.
+							 * A plugin-supplied message still wins, because it is a statement
+							 * about the field rather than about this code path.
+							 */
+							$this->add_error(
+								'' !== $supplied
+									? $supplied
+									: __(
+										'Для этого способа доставки нужно выбрать пункт выдачи заказов.',
+										'woodev-plugin-framework'
+									)
+							);
 						}
 					}
 				}
 			}
 
 			return $valid;
+		}
+
+		/**
+		 * Every field declared as a pickup slot ({@see Field::pickup_slot()}), in declaration
+		 * order.
+		 *
+		 * ONE SLOT IS A CONFIGURATION OUTCOME HERE, NOT AN ASSUMPTION (issue #325). Every
+		 * plugin in production today declares exactly one, so this list has exactly one entry
+		 * — but nothing in this method, in {@see validate()}'s backstop above, or in
+		 * `checkout-field-classic.js`'s own `placeSlots()` (which has always mounted a trigger
+		 * per declared slot) depends on that. Until #325 the backstop took the FIRST slot and
+		 * stopped: a second declared slot was mounted client-side and then silently never
+		 * validated, which is the exact shape of a hidden "one" the issue asks to remove.
+		 *
+		 * WHAT IS STILL SINGLE, DELIBERATELY, AND WHERE IT WOULD BE EXTENDED. A multi-package
+		 * cart is NOT built (operator decision, 16.08.2026 — YAGNI, no consumer), and two
+		 * places genuinely still carry one package's worth of state. Both are named here so
+		 * the next reader recognises an accepted limit rather than an oversight to "fix":
+		 *
+		 * - {@see \Woodev\Framework\Shipping\Pickup\Pickup_Handler} persists ONE point to the
+		 *   order, through the single logical field id the plugin wired. A package dimension
+		 *   would be an addition to that key map, not a change to this layer.
+		 * - {@see \Woodev\Framework\Shipping\Pickup\Pickup_Selection}'s session map is keyed
+		 *   `[locality][type]`, which is already parameterised and already holds many entries
+		 *   at once; a package would be a third key there, and the eviction cap it already
+		 *   applies would carry over unchanged.
+		 *
+		 * The filter below is the boundary seam the issue asks for — a domain can add, remove
+		 * or reorder the slots this backstop enforces without touching the field declarations
+		 * themselves. Left in place with no consumer on purpose: an extension point is not
+		 * gated on someone already using it.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<int, array<string, mixed>> Normalized descriptors, list-indexed.
+		 */
+		private function pickup_slot_fields(): array {
+			$slots = [];
+
+			foreach ( $this->fields->get_fields() as $field ) {
+				if ( ! empty( $field['is_pickup_slot'] ) ) {
+					$slots[] = $field;
+				}
+			}
+
+			/**
+			 * Filters the pickup-slot fields the checkout backstop enforces.
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param array<int, array<string, mixed>> $slots  Normalized field descriptors, in
+			 *                                                 declaration order.
+			 * @param array<string, array<string, mixed>> $fields Every normalized field descriptor,
+			 *                                                    keyed by id.
+			 */
+			$filtered = apply_filters( 'woodev_checkout_pickup_slot_fields', $slots, $this->fields->get_fields() );
+
+			// A filter that returns something unusable leaves the framework's own answer
+			// standing — the backstop exists to BLOCK a checkout, and a malformed filter
+			// return must never be the reason it silently stops doing that. Entries are
+			// checked for the ONE key this backstop actually dereferences, so a half-built
+			// descriptor is dropped rather than warned about mid-validation.
+			if ( ! is_array( $filtered ) ) {
+				return $slots;
+			}
+
+			return array_values(
+				array_filter(
+					$filtered,
+					static function ( $slot ): bool {
+						return is_array( $slot ) && isset( $slot['id'] ) && '' !== (string) $slot['id'];
+					}
+				)
+			);
 		}
 
 		/**

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -155,6 +155,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 * the full point under, or null when the plugin has not wired full-point
 		 * persistence.
 		 *
+		 * ONE LOGICAL FIELD MEANS ONE POINT PER ORDER, AND THAT IS AN ACCEPTED LIMIT (issue
+		 * #325, operator decision 16.08.2026): a multi-package cart is not built while
+		 * nothing consumes it. This is the narrowest place where that shows, and the place
+		 * a package dimension would be added — as a further entry in the plugin's own
+		 * logical→real key map on {@see Shipping_Order_Handler}, which is already the only
+		 * sanctioned destination for an installed-site order-meta key. Nothing else in the
+		 * layer would have to move: the selection map is keyed (locality, type) and already
+		 * holds many entries ({@see Pickup_Selection}), and the checkout backstop already
+		 * enforces every declared slot rather than the first
+		 * ({@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::pickup_slot_fields()}).
+		 * Read this as a decision, not as an unfinished case.
+		 *
 		 * @since 2.0.2
 		 * @var string|null
 		 */

--- a/woodev/shipping-method/pickup/class-pickup-selection.php
+++ b/woodev/shipping-method/pickup/class-pickup-selection.php
@@ -28,6 +28,16 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Selection' )
 	 * [ <locality> => [ <type code> => [ 'id' => <point id>, 'seq' => <int> ] ] ]
 	 * ```
 	 *
+	 * ONE PACKAGE PER CART IS AN ACCEPTED LIMIT, NOT A FORGOTTEN CASE (issue #325, operator
+	 * decision 16.08.2026 — a multi-package cart is YAGNI while nothing consumes it). Note
+	 * what this map is NOT: it is not "the customer's chosen point", it is a map keyed by
+	 * (locality, type) that already holds many entries at once and evicts by `seq` under its
+	 * own cap. A package dimension would therefore be a THIRD key here — an addition, not a
+	 * rewrite — and everything else in this class (eviction, recency, the "opaque strings
+	 * only" discipline) carries over untouched. The parts of the layer that genuinely do
+	 * assume one package are named in
+	 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::pickup_slot_fields()}.
+	 *
 	 * `seq` is a monotonic sequence number stamped on every write, INCLUDING an
 	 * overwrite of an existing `(locality, type)` entry. This is deliberate, not
 	 * incidental: a PHP array does not track insertion order across a re-assignment —


### PR DESCRIPTION
Closes #325.

## Решение

Полноценную мультипакетную корзину **не строим** — YAGNI, потребителей нет (решение оператора 16.08.2026). Карточка сводится к тому, чтобы односоставность была следствием конфигурации, а не скрытым допущением: тогда мультипакетность позже — расширение, а не переписывание.

## Где «один» действительно был зашит — ровно одно место

`Checkout_Handler::validate()`, независимый пикап-бэкстоп: брал **первое** поле с `is_pickup_slot` и `break`. При этом `placeSlots()` в `checkout-field-classic.js` всегда монтировал триггер на **каждое объявленное** поле-слот. То есть плагин, объявивший два слота, получал два триггера на клиенте и валидацию ровно одного из них — молча. Теперь бэкстоп проверяет все объявленные слоты.

Для сегодняшних плагинов не меняется ничего: все объявляют ровно один.

## Что уже было параметризовано (и достаточно задокументировать)

- `Field::mark_pickup_slot()` — пофайловое объявление, слотов может быть сколько угодно;
- `Pickup_Selection` — карта в сессии ключуется `[locality][type]`, уже держит много записей одновременно и вытесняет по `seq` под собственной крышкой. Пакет был бы **третьим ключом**, а не переделкой: вытеснение, свежесть и дисциплина «только непрозрачные строки» переносятся без изменений.

## Что осталось односоставным СОЗНАТЕЛЬНО

Записано в докблоках именно как принятое ограничение с названной точкой расширения — чтобы следующий агент прочитал это как решение, а не как недоделку:

- `Pickup_Handler::$point_field_logical` — одно логическое поле, значит **один пункт на заказ**. Пакет добавлялся бы записью в собственную карту логических→реальных ключей плагина на `Shipping_Order_Handler`, то есть в единственное санкционированное место для ключа заказ-меты.
- Отсутствие измерения «пакет» в ключе карты выбора (см. выше).

## Шов на границе

`woodev_checkout_pickup_slot_fields` — фильтр над набором слотов, которые бэкстоп принуждает. Домен может добавить, убрать или переупорядочить их, не трогая объявления полей. Потребителя нет **намеренно**: точка расширения не обусловлена тем, что ей уже кто-то пользуется.

Некорректный возврат фильтра (не массив, записи без `id`) оставляет собственный ответ фреймворка в силе — бэкстоп существует, чтобы БЛОКИРОВАТЬ оформление, и кривой фильтр не должен быть причиной, по которой он молча перестаёт это делать.

## Тесты

`+5` unit (**2277**), 110 интеграционных зелёные, phpcs и phpstan чисто.

Регрессионный тест проверен против старого поведения: возвращаю `break` — падает ровно он и ничего больше. Тесты берут голые `mark_pickup_slot()`-поля, а не пресет `Pickup_Field`: у пресета есть свой condition-spec `required`, из-за которого блокирует уже пофайловый цикл, и он маскировал бы то, что делает (или не делает) бэкстоп.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD
