### PR TITLE
fix(pickup): возврат к прежнему НП снова показывает выбранный там пункт (#349)

### DIFF
--- a/tests/js/pickup-mount.test.js
+++ b/tests/js/pickup-mount.test.js
@@ -641,6 +641,10 @@ function makeConfig( overrides ) {
 		// `Pickup_Handler::resolve_chosen_address()` returns `''` in that case, never `undefined`.
 		// Tests exercising the restore path override this explicitly.
 		chosenAddress: '',
+		// The PRODUCTION default for a page with nothing remembered anywhere (issue #349) —
+		// `Pickup_Handler::resolve_remembered_selections()` returns `[]`, which arrives here as
+		// an empty object. Tests exercising the locality-restore path override it explicitly.
+		selections: {},
 		mapConfig: { center: [ 55.75, 37.61 ] },
 		replaceAddress: { enabled: true, billingOnly: false },
 		// TOP-LEVEL keys `Pickup_Handler::get_js_config()` really emits and the map provider
@@ -6961,4 +6965,167 @@ test( 'no announcement when replaceAddress is disabled — nothing is written, s
 	await selectAndConfirm( StubProvider.instances[ 0 ], point() );
 
 	expect( seen ).toEqual( [] );
+} );
+
+// -----------------------------------------------------------------------
+// Returning to a locality restores the point chosen there (#349)
+// -----------------------------------------------------------------------
+
+/**
+ * #176's agreed behaviour, stated in `handleLocalityChanged()`'s own docblock: the remembered
+ * point in the session is deliberately NOT dropped when the customer changes locality, because
+ * "returning to the previous locality restores the point chosen there". Until #349 only the
+ * CLEARING half existed client-side — the restore happened solely through a full page render,
+ * so switching city and back left the picker empty until a reload (operator, rig, 17.08.2026).
+ *
+ * The restore hangs off `woodev_location_applied`, NOT off the city field's `change`, and that
+ * is load-bearing: `handleLocalityChanged()` runs on the `change`, which fires BEFORE the
+ * cascade's `/select` round trip, so at that moment the new locality's KEY is still the old one.
+ */
+describe( 'restores the point remembered for a locality (#349)', () => {
+	function fireLocationApplied( key ) {
+		document.body.dispatchEvent(
+			new CustomEvent( 'woodev_location_applied', {
+				detail: { key, level: 'settlement', settlementKey: key },
+				bubbles: true,
+			} )
+		);
+	}
+
+	function mountField( fieldId, overrides ) {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div data-woodev-pickup-slot="' + fieldId + '"></div>' +
+			'<input id="' + fieldId + '" type="hidden" value="" />'
+		);
+
+		// A §8 store that OWNS this field id: `writeAndFireChange()` warns when no store does,
+		// and the WP jest preset turns a warning into a failure. Production always has one.
+		createStore( { fields: { [ fieldId ]: { id: fieldId }, billing_city: { id: 'billing_city' } } } );
+
+		setConfig( makeConfig( Object.assign( {
+			fieldId,
+			strategy: 'bulk',
+			location: { current: { key: 'dadata:msk' } },
+		}, overrides ) ) );
+
+		mountAll();
+
+		return document.getElementById( fieldId );
+	}
+
+	it( 'restores the id and its address when the customer returns to a remembered locality', () => {
+		const field = mountField( 'restore_known_locality_349', {
+			selections: {
+				'dadata:msk': { id: 'PVZ-MSK', address: 'Москва, Новокосинская 17' },
+			},
+		} );
+
+		// Away: the cascade clears the applied value on the locality change itself.
+		field.value = '';
+		fireLocationApplied( 'dadata:tver' );
+		expect( field.value ).toBe( '' );
+
+		// …and back.
+		fireLocationApplied( 'dadata:msk' );
+
+		expect( field.value ).toBe( 'PVZ-MSK' );
+		expect( document.querySelector( '.woodev-pickup-chosen-address strong' ).textContent )
+			.toBe( 'Москва, Новокосинская 17' );
+	} );
+
+	it( 'restores nothing for a locality with no remembered point, leaving the field cleared', () => {
+		// The half that must NOT happen: re-applying the point belonging to the locality the
+		// customer just left would be worse than the bug it replaces.
+		const field = mountField( 'restore_unknown_locality_349', {
+			selections: { 'dadata:msk': { id: 'PVZ-MSK', address: 'Москва' } },
+		} );
+
+		field.value = '';
+		fireLocationApplied( 'dadata:nowhere' );
+
+		expect( field.value ).toBe( '' );
+	} );
+
+	it( 'does not re-write the field when it already holds the remembered id', () => {
+		// The ordinary first event after a reload: the server already restored both the value
+		// and the label. Re-writing would fire a redundant `change`, and with it an
+		// `update_checkout`, on every single page load.
+		const fieldId = 'restore_noop_when_same_349';
+		const field = mountField( fieldId, {
+			selections: { 'dadata:msk': { id: 'PVZ-MSK', address: 'Москва' } },
+		} );
+
+		field.value = 'PVZ-MSK';
+
+		const changes = [];
+		field.addEventListener( 'change', () => changes.push( field.value ) );
+
+		fireLocationApplied( 'dadata:msk' );
+
+		expect( field.value ).toBe( 'PVZ-MSK' );
+		expect( changes ).toEqual( [] );
+	} );
+
+	it( 'ignores a field with no config.location (a plugin outside the layer)', () => {
+		const fieldId = 'restore_no_location_block_349';
+
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div data-woodev-pickup-slot="' + fieldId + '"></div>' +
+			'<input id="' + fieldId + '" type="hidden" value="" />'
+		);
+
+		setConfig( makeConfig( {
+			fieldId,
+			strategy: 'bulk',
+			selections: { 'dadata:msk': { id: 'PVZ-MSK', address: 'Москва' } },
+		} ) );
+		mountAll();
+
+		fireLocationApplied( 'dadata:msk' );
+
+		expect( document.getElementById( fieldId ).value ).toBe( '' );
+	} );
+
+	it( 'drops a malformed entry instead of restoring an empty selection', () => {
+		// An entry with no usable id would "restore" as a blank value — indistinguishable from
+		// clearing one, i.e. it would look exactly like the bug this fixes.
+		const field = mountField( 'restore_malformed_entry_349', {
+			selections: { 'dadata:msk': { address: 'Москва, без id' } },
+		} );
+
+		field.value = '';
+		fireLocationApplied( 'dadata:msk' );
+
+		expect( field.value ).toBe( '' );
+	} );
+
+	it( 'restores a point chosen on THIS page, with nothing seeded from the server', async () => {
+		// The operator's own reproduction, and the half a server-rendered seed cannot cover:
+		// pick a point, switch city, switch back — all within one page load.
+		const picker = openPicker( {
+			location: { current: { key: 'dadata:msk' } },
+			selections: {},
+		} );
+
+		// PIN the locality key explicitly rather than leaning on `config.location.current`:
+		// `resolvedLocalityKey` is MODULE state this file never resets between tests, and an
+		// earlier test in this file may already have seeded it for this shared field id. Firing
+		// the event first makes the key this test's own, whatever ran before it.
+		fireLocationApplied( 'dadata:msk' );
+
+		picker.emitSelect( { id: 'PVZ-LOCAL', short_address: 'Москва, Ленина 5' } );
+		await picker.resolveSelect( { allowed: true, reason: null, close: null, refresh_checkout: null } );
+
+		expect( picker.field.value ).toBe( 'PVZ-LOCAL' );
+
+		picker.field.value = '';
+		fireLocationApplied( 'dadata:tver' );
+		expect( picker.field.value ).toBe( '' );
+
+		fireLocationApplied( 'dadata:msk' );
+
+		expect( picker.field.value ).toBe( 'PVZ-LOCAL' );
+	} );
 } );

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -2202,6 +2202,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 					'nonceNodeId',
 					'i18n',
 					'chosenAddress',
+					'selections',
 					'defaultLocation',
 					'pointIcons',
 					'pointGlyphs',

--- a/tests/unit/Shipping/Pickup/PickupSelectionTest.php
+++ b/tests/unit/Shipping/Pickup/PickupSelectionTest.php
@@ -724,6 +724,97 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 		 *
 		 * @return int
 		 */
+		// -------------------------------------------------------------------------
+		// recall_all() — the bulk read the browser restores from (#349)
+		// -------------------------------------------------------------------------
+
+		public function test_recall_all_returns_every_locality_remembered_for_that_type(): void {
+			$selection = $this->probe( new Pickup_Selection_Fake_Session() );
+
+			$selection->remember( 'msk', 'pvz', 'P1', 'Тверская, 1' );
+			$selection->remember( 'tver', 'pvz', 'P2', 'Советская, 2' );
+
+			$this->assertSame(
+				[
+					'msk'  => [ 'id' => 'P1', 'address' => 'Тверская, 1' ],
+					'tver' => [ 'id' => 'P2', 'address' => 'Советская, 2' ],
+				],
+				$selection->recall_all( 'pvz' )
+			);
+		}
+
+		/**
+		 * The bulk read must answer with the SAME id the single lookup answers with — a locality
+		 * that has an entry for another type only is absent here, exactly as `recall()` returns
+		 * null for it. A bulk view that quietly widened the type would restore a point the
+		 * checkout itself would not.
+		 */
+		public function test_recall_all_omits_a_locality_that_has_nothing_for_that_type(): void {
+			$selection = $this->probe( new Pickup_Selection_Fake_Session() );
+
+			$selection->remember( 'msk', 'pvz', 'P1' );
+			$selection->remember( 'tver', 'postamat', 'P2' );
+
+			$this->assertSame( [ 'msk' => [ 'id' => 'P1', 'address' => '' ] ], $selection->recall_all( 'pvz' ) );
+			$this->assertNull( $selection->recall( 'tver', 'pvz' ), 'the single lookup agrees' );
+		}
+
+		/**
+		 * `TYPE_ANY` resolves per locality exactly like {@see Pickup_Selection::recall_latest()}:
+		 * the most recently WRITTEN entry, by `seq` — never array order.
+		 */
+		public function test_recall_all_for_type_any_takes_the_latest_entry_per_locality(): void {
+			$selection = $this->probe( new Pickup_Selection_Fake_Session() );
+
+			$selection->remember( 'msk', 'pvz', 'P1', 'первый' );
+			$selection->remember( 'msk', 'postamat', 'P2', 'второй' );
+			$selection->remember( 'tver', 'pvz', 'P3', 'третий' );
+
+			$this->assertSame(
+				[
+					'msk'  => [ 'id' => 'P2', 'address' => 'второй' ],
+					'tver' => [ 'id' => 'P3', 'address' => 'третий' ],
+				],
+				$selection->recall_all( Selection_Scope::TYPE_ANY )
+			);
+		}
+
+		/**
+		 * A legacy (pre-#274) id-only entry restores its id with an empty address rather than
+		 * being dropped — the id is what actually re-applies the selection; the address only
+		 * labels it.
+		 */
+		public function test_recall_all_keeps_a_legacy_id_only_entry_with_an_empty_address(): void {
+			$session = new Pickup_Selection_Fake_Session();
+
+			$session->set( 'woodev_test_selection_map', [ 'msk' => [ 'pvz' => [ 'id' => 'P1', 'seq' => 1 ] ] ] );
+
+			$this->assertSame(
+				[ 'msk' => [ 'id' => 'P1', 'address' => '' ] ],
+				$this->probe( $session )->recall_all( 'pvz' )
+			);
+		}
+
+		public function test_recall_all_is_empty_when_nothing_is_remembered(): void {
+			$this->assertSame( [], $this->probe( new Pickup_Selection_Fake_Session() )->recall_all( 'pvz' ) );
+		}
+
+		/**
+		 * No session (no WooCommerce, or none started yet) degrades to an empty map, never a
+		 * fatal — the same rule every other read in this class follows.
+		 */
+		public function test_recall_all_degrades_to_empty_without_a_session(): void {
+			$this->assertSame( [], $this->probe( null )->recall_all( 'pvz' ) );
+		}
+
+		public function test_recall_all_rejects_an_unusable_type(): void {
+			$selection = $this->probe( new Pickup_Selection_Fake_Session() );
+
+			$selection->remember( 'msk', 'pvz', 'P1' );
+
+			$this->assertSame( [], $selection->recall_all( '' ) );
+		}
+
 		private function count_entries( Pickup_Selection_Fake_Session $session, string $key ): int {
 			$map = $session->raw( $key );
 

--- a/woodev/shipping-method/assets/js/frontend/pickup-mount.js
+++ b/woodev/shipping-method/assets/js/frontend/pickup-mount.js
@@ -859,6 +859,138 @@
 	}
 
 	/**
+	 * The remembered pickup selection per LOCALITY KEY, per field id (issue #349) —
+	 * `{ fieldId: { localityKey: { id, address } } }`.
+	 *
+	 * Seeded from `config.selections` (`Pickup_Handler::resolve_remembered_selections()`, the
+	 * same session-backed `[locality][type]` map `chosenAddress` and the restored field value
+	 * come out of) and kept current by {@see rememberSelectionLocally} on every confirmed pick.
+	 * Both halves are needed and neither is redundant: the seed covers localities chosen BEFORE
+	 * this page loaded, the local mirror covers the ones chosen since.
+	 *
+	 * @type {Object.<string, Object.<string, {id: string, address: string}>>}
+	 */
+	var rememberedSelections = {};
+
+	/**
+	 * Seeds {@see rememberedSelections} for one field id from `config.selections` — guarded to
+	 * run once per field id, exactly like {@see seedChosenAddress}, so a later mount pass never
+	 * discards what this page has since remembered locally.
+	 *
+	 * Shape-guarded entry by entry rather than trusted wholesale: this is server-rendered JSON,
+	 * but an entry with no usable id would later be "restored" as an empty selection, which is
+	 * indistinguishable from clearing one — the failure would look like the very bug this fixes.
+	 *
+	 * @param {Object} config
+	 * @returns {void}
+	 */
+	function seedRememberedSelections( config ) {
+		if ( Object.prototype.hasOwnProperty.call( rememberedSelections, config.fieldId ) ) {
+			return;
+		}
+
+		var seeded = {};
+		var source = config && config.selections;
+
+		if ( source && 'object' === typeof source ) {
+			Object.keys( source ).forEach( function( localityKey ) {
+				var entry = source[ localityKey ];
+
+				if ( ! localityKey || ! entry || 'string' !== typeof entry.id || ! entry.id ) {
+					return;
+				}
+
+				seeded[ localityKey ] = {
+					id: entry.id,
+					address: 'string' === typeof entry.address ? entry.address : '',
+				};
+			} );
+		}
+
+		rememberedSelections[ config.fieldId ] = seeded;
+	}
+
+	/**
+	 * Mirrors a just-confirmed selection into {@see rememberedSelections} under the locality key
+	 * it was filed against — see {@see applySelection}'s own call site.
+	 *
+	 * Keyed on {@see resolveLocalityKey}, which is what the server's own
+	 * `Provider_Selection_Scope::current_locality()` files under for a plugin inside the
+	 * Location Provider layer. A plugin OUTSIDE that layer gets `resolveLocality()`'s DOM read
+	 * here, which its own `Selection_Scope` may or may not agree with — a mismatch simply means
+	 * nothing is ever found to restore, i.e. exactly today's behaviour, never a wrong point.
+	 *
+	 * @param {Object} config
+	 * @param {string} pointId
+	 * @param {string} address
+	 * @returns {void}
+	 */
+	function rememberSelectionLocally( config, pointId, address ) {
+		if ( ! pointId ) {
+			return;
+		}
+
+		var localityKey = resolveLocalityKey( config );
+
+		if ( ! localityKey ) {
+			return;
+		}
+
+		// Seeded HERE and in {@see restoreRememberedSelection} rather than at mount time, on
+		// purpose: `woodev_location_applied` can reach this module before `mountAll()` has run
+		// for a given config (script order is not ours to assume), and a restore that ran
+		// against an unseeded map would silently find nothing. The guard inside makes it
+		// idempotent, so calling it from both entry points costs nothing.
+		seedRememberedSelections( config );
+
+		if ( ! rememberedSelections[ config.fieldId ] ) {
+			rememberedSelections[ config.fieldId ] = {};
+		}
+
+		rememberedSelections[ config.fieldId ][ localityKey ] = {
+			id: pointId,
+			address: 'string' === typeof address ? address : '',
+		};
+	}
+
+	/**
+	 * Restores the point remembered for `localityKey`, if any — #176's own agreed behaviour,
+	 * stated on {@see handleLocalityChanged} ("returning to the previous locality restores the
+	 * point chosen there") and, until issue #349, implemented only by a full page render.
+	 *
+	 * A no-op when nothing is remembered for that locality: the clearing
+	 * {@see handleLocalityChanged} already did is then the correct final state, and this must
+	 * NOT re-apply a point belonging to the locality the customer just left.
+	 *
+	 * Also a no-op when the field already holds that exact id — the ordinary case on the very
+	 * first `woodev_location_applied` after a reload, where the server already restored both the
+	 * value and the label. Re-writing it would fire a redundant `change` (and with it an
+	 * `update_checkout`) on every single page load.
+	 *
+	 * @param {Object} config
+	 * @param {string} localityKey
+	 * @returns {void}
+	 */
+	function restoreRememberedSelection( config, localityKey ) {
+		if ( ! localityKey || applyingSelection[ config.fieldId ] ) {
+			return;
+		}
+
+		seedRememberedSelections( config );
+
+		var remembered = ( rememberedSelections[ config.fieldId ] || {} )[ localityKey ];
+
+		if ( ! remembered || ! remembered.id || fieldValue( config.fieldId ) === remembered.id ) {
+			return;
+		}
+
+		chosenAddress[ config.fieldId ] = remembered.address;
+
+		writeAndFireChange( config.fieldId, remembered.id );
+		syncTriggerLabel( config );
+	}
+
+	/**
 	 * The `aria-label` context {@see syncTriggerLabel} appends to a trigger button's visible
 	 * text, keyed by the slot's own `data-woodev-pickup-placement` (issue #308 item 4 —
 	 * adversarial review of #274 item 3: two identically-labelled buttons for the same
@@ -1332,6 +1464,15 @@
 		collectConfigs().forEach( function( config ) {
 			if ( config.location ) {
 				resolvedLocalityKey[ config.fieldId ] = key;
+
+				// Issue #349. THIS is where a selection can be restored, and the only place it
+				// can: {@see handleLocalityChanged} runs off a `change` on the city field, which
+				// fires BEFORE the cascade's `/select` round trip — so at that moment the new
+				// locality's KEY is still the old one, and a lookup there would either miss or,
+				// worse, restore the point belonging to the locality just left. This event is
+				// fired precisely once the new record is persisted, i.e. once the identity of
+				// the locality now on screen is settled and agreed with the server.
+				restoreRememberedSelection( config, key );
 			}
 		} );
 	}
@@ -1476,6 +1617,14 @@
 		var shortAddress = point && 'string' === typeof point.short_address ? point.short_address : '';
 
 		chosenAddress[ config.fieldId ] = addressEscaped ? decodeEscapedAddress( shortAddress ) : shortAddress;
+
+		// Issue #349: keep this page's own copy of the remembered map in step with the server's.
+		// The server filed this point under the customer's CURRENT locality a moment ago (the
+		// `/select` endpoint's own `Pickup_Selection::remember()`), and without mirroring it here
+		// the restore below would only ever know about selections made before this page loaded —
+		// so "pick a point, switch locality, switch back" would still come up empty until a
+		// reload, which is the exact half of #176 that was missing.
+		rememberSelectionLocally( config, pointId, chosenAddress[ config.fieldId ] );
 	}
 
 	/**

--- a/woodev/shipping-method/pickup/class-pickup-handler.php
+++ b/woodev/shipping-method/pickup/class-pickup-handler.php
@@ -1396,6 +1396,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 				// mount script degrades to the label alone in every one of those cases.
 				'chosenAddress' => $this->resolve_chosen_address(),
 
+				// Every locality this customer has a remembered point for, keyed by the SAME
+				// locality key {@see Provider_Selection_Scope::current_locality()} files them
+				// under (issue #349). `chosenAddress` above answers "what is applied right now";
+				// this answers "what would be applied if the customer went back to locality X",
+				// which is the question the browser could not previously ask at all — it dropped
+				// the applied selection on a locality change and had no way to restore it
+				// without a full page render, even though #176's agreed behaviour (stated on
+				// `pickup-mount.js`'s own `handleLocalityChanged()`) is that returning restores.
+				// Empty when no scope is wired or nothing is remembered.
+				'selections' => $this->resolve_remembered_selections(),
+
 				'defaultLocation' => $this->default_location,
 				'pointIcons'      => $this->normalized_point_icons(),
 
@@ -2752,6 +2763,46 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Handler' ) )
 		 *                remembered address does not belong to the posted id, or selection
 		 *                persistence is not wired for this handler).
 		 */
+		/**
+		 * The whole remembered-selection map for the CURRENTLY chosen shipping method, as
+		 * `locality => [ 'id' => …, 'address' => … ]` (issue #349).
+		 *
+		 * Resolved through the same {@see self::current_selection_pair()} gate
+		 * {@see self::restore_selection()} and {@see self::resolve_chosen_address()} use — only
+		 * its TYPE half, since the locality half is exactly what this method varies. So an entry
+		 * here answers with the same id those two would answer with, were the customer standing
+		 * in that locality; the browser can therefore restore a selection without the page
+		 * having to be rendered again for it.
+		 *
+		 * `$_POST` is deliberately NOT consulted, unlike {@see self::resolve_chosen_address()}:
+		 * that method describes what WooCommerce is about to SHOW for the current locality and
+		 * must agree with the posted id, while this one describes what is REMEMBERED for
+		 * localities the customer is not currently in — a posted id says nothing about those.
+		 *
+		 * Empty array when no selection scope is wired, or no shipping method with a pickup type
+		 * is chosen: both mean there is nothing this handler could restore, and the browser then
+		 * keeps its existing "clear on locality change" behaviour unchanged.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, array{id: string, address: string}>
+		 */
+		protected function resolve_remembered_selections(): array {
+			$selection = $this->selection();
+
+			if ( null === $selection ) {
+				return [];
+			}
+
+			$pair = $this->current_selection_pair();
+
+			if ( null === $pair ) {
+				return [];
+			}
+
+			return $selection->recall_all( $pair['type'] );
+		}
+
 		protected function resolve_chosen_address(): string {
 			$selection = $this->selection();
 

--- a/woodev/shipping-method/pickup/class-pickup-selection.php
+++ b/woodev/shipping-method/pickup/class-pickup-selection.php
@@ -225,6 +225,68 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Pickup\\Pickup_Selection' )
 		}
 
 		/**
+		 * Every locality that has something remembered for `$type`, as
+		 * `locality => [ 'id' => …, 'address' => … ]` (issue #349).
+		 *
+		 * The SAME resolution {@see self::recall()}/{@see self::recall_address()} apply for an
+		 * exact type, and {@see self::recall_latest()}/{@see self::recall_latest_address()} for
+		 * {@see Selection_Scope::TYPE_ANY} — applied here to every locality at once instead of
+		 * one. Reusing those four methods rather than re-walking the map is the point: this is a
+		 * BULK read of the same answer, and a second implementation of "the entry for this pair"
+		 * is exactly how a bulk view and a single lookup drift apart.
+		 *
+		 * WHY A BULK READ EXISTS AT ALL. The browser drops the applied selection when the
+		 * customer changes locality, and #176's agreed behaviour is that returning to the
+		 * previous locality restores the point chosen there — but the browser had no way to know
+		 * what was remembered for a locality it is only now arriving at, so "restore" only ever
+		 * happened through a full page render. This hands the page the whole (small, capped)
+		 * picture up front, so the restore needs no round trip and cannot race a fast sequence of
+		 * locality changes.
+		 *
+		 * Localities whose entry carries no usable id are omitted rather than returned empty —
+		 * the caller reads presence as "there is something to restore here".
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $type Opaque type code from {@see Selection_Scope}, or
+		 *                     {@see Selection_Scope::TYPE_ANY}.
+		 *
+		 * @return array<string, array{id: string, address: string}>
+		 */
+		public function recall_all( string $type ): array {
+			$is_any = Selection_Scope::TYPE_ANY === $type;
+
+			if ( ! $is_any && ! self::is_usable_key( $type ) ) {
+				return [];
+			}
+
+			$out = [];
+
+			foreach ( array_keys( $this->read_map( $this->session() ) ) as $locality ) {
+				$locality = (string) $locality;
+
+				if ( ! self::is_usable_key( $locality ) ) {
+					continue;
+				}
+
+				$id = $is_any ? $this->recall_latest( $locality ) : $this->recall( $locality, $type );
+
+				if ( null === $id ) {
+					continue;
+				}
+
+				$address = $is_any ? $this->recall_latest_address( $locality ) : $this->recall_address( $locality, $type );
+
+				$out[ $locality ] = [
+					'id'      => $id,
+					'address' => null !== $address ? $address : '',
+				];
+			}
+
+			return $out;
+		}
+
+		/**
 		 * Clears the whole map — every locality, every type.
 		 *
 		 * Called once an order is created; see


### PR DESCRIPTION
Closes #349.

## Что было

`handleLocalityChanged()` умел только **очищать** применённый выбор при смене НП, хотя его же докблок обещает обратное — согласованное в #176 поведение «возврат к прежней локальности восстанавливает выбранный там пункт». Восстановление жило исключительно в серверном рендере (`restore_selection()` / `resolve_chosen_address()`), поэтому появлялось только после перезагрузки. Готча `built-on-both-sides-with-no-caller-in-the-middle` буквально: память на сервере есть, очистка на клиенте есть, «спросить при возврате» никто не позвал.

Вторая половина: транзиция определяется по **тексту** города из DOM, а сервер помнит по **ключу** локальности. По тексту восстанавливать нечего.

## Что сделано

Сервер отдаёт в конфиг страницы `selections` — карту `ключ локальности → { id, address }`, собранную тем же гейтом `current_selection_pair()` и тем же правилом `recall`/`recall_latest`, каким пользуется одиночный поиск. Массовое чтение не может ответить иначе, чем точечное: это принципиально, второй реализации «что такое запись для этой пары» не появилось.

Клиент восстанавливает на `woodev_location_applied`, **не** на `change` поля города. Это несущее решение: `change` летит ДО круга `/select`, и в тот момент ключ новой локальности ещё старый — восстановление там подставило бы пункт только что покинутого города. Событие же приходит ровно тогда, когда личность города подтверждена сервером.

Плюс клиент зеркалит собственные подтверждения, поэтому «выбрал → ушёл → вернулся» работает внутри одной загрузки, а серверный сид закрывает «ушёл → перезагрузился → вернулся».

## Проверка на риге, с контролем в том же прогоне

| сценарий | результат |
|---|---|
| Москва → ПВЗ → Тверь → Москва, без перезагрузки | восстановился |
| перезагрузка в Твери → возврат в Москву (клиентская память пуста) | восстановился вместе с адресом |
| **контроль:** вызов восстановления отключён | пусто и через 15 секунд |

Кто именно восстанавливает — снято по времени:

```
t=189715  location_applied  key=dadata:0c5b2444…(Москва)  field=""
t=189717  update_checkout(start)                          field=019373a0…   ← +2 мс
```

`update_checkout` ушёл уже с заполненным полем — то есть это не серверный рендер, а обработчик. Гипотеза, что восстанавливает перерисовка по `updated_checkout`, проверена мутацией и **опровергнута**.

Видимая задержка — ожидание `/select` (2.5–9 с на живой DaData), то есть время до подтверждения личности города. Сократить её нельзя, не угадывая, в какой город попал покупатель.

## Тесты

`+7` unit, `+6` jest → **2292 / 1145**. phpcs, phpstan и 110 интеграционных зелёные.

Тест-аллоулист верхнеуровневых ключей конфига (`PickupHandlerTest`) сработал как задумано и потребовал явного добавления `selections` — ровно тот гейт, ради которого он написан.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD
