### PR TITLE
fix(location): keep a foreign-provider address out of the customer chain (#352)

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -155,8 +155,8 @@ function locationField( level, section = 'billing' ) {
  * (`Checkout_Config::build_location_block()`).
  *
  * @param {{region?: boolean, settlement?: boolean, address?: boolean, section?: string,
- *          levels?: Object, countries?: string[], current?: Object|null, chain?: Object,
- *          implicit?: boolean, defaultCountry?: string}} opts
+ *          levels?: Object, owners?: Object, countries?: string[], current?: Object|null,
+ *          chain?: Object, implicit?: boolean, defaultCountry?: string}} opts
  * @returns {Object}
  */
 function buildConfig( opts ) {
@@ -189,6 +189,13 @@ function buildConfig( opts ) {
 			// coverage is per country (street data for RU/BY/KZ/UZ, city-only elsewhere), so
 			// a flat per-level map cannot describe it without lying.
 			levels: o.levels || { RU: { region: true, settlement: true, address: true } },
+			// Issue #352: keyed BY COUNTRY, same shape as `levels`, but each leaf is a
+			// provider id (or `''`) rather than a bool — omitted entirely (not merely
+			// `undefined`) unless a test opts in, so "no `owners` key at all" (an older
+			// server, or a plugin that builds the location block itself) is exercised as
+			// its own real case by every OTHER test in this file, mirroring the `chain`
+			// convention just below.
+			...( o.owners !== undefined ? { owners: o.owners } : {} ),
 			current: o.current !== undefined ? o.current : null,
 			// Issue #330 (spec §7): `{ level: { key, level } }`, alongside `current` — omitted
 			// entirely (not merely `undefined`) unless a test opts in, so "no `chain` key at
@@ -1131,6 +1138,239 @@ describe( 'backwards fill', () => {
 		// Exactly one new fetch: the /select persist call — no extra GET suggest lookups.
 		expect( global.fetch.mock.calls.length ).toBe( fetchCallCountBefore + 1 );
 		expect( fetchCalls[ fetchCalls.length - 1 ].url ).toBe( SELECT_URL );
+	} );
+
+	/**
+	 * Issue #352 (Variant A) — the measured bug's field-text half: a mixed provider chain
+	 * (the active provider owning `region`/`settlement`, the bundled DaData fallback owning
+	 * `address` alone) used to let picking an address overwrite the settlement/region text a
+	 * DIFFERENT provider had already written, with that OTHER provider's own — possibly
+	 * differently-spelled — component. A level with NO known owner still fills exactly as
+	 * before this fix: nobody owns it, so nothing is being clobbered.
+	 */
+	it( 'skips a foreign-owned ancestor while still filling an unowned one', () => {
+		boot( {
+			region: true, settlement: true, address: true,
+			// region is owned by the (different) active provider; settlement has no known
+			// owner in this fixture at all.
+			owners: { RU: { region: 'test-cdek', settlement: '', address: 'dadata' } },
+		} );
+
+		// The customer's own settlement pick, in the active provider's own Cyrillic spelling —
+		// this must survive untouched.
+		document.getElementById( 'billing_state' ).value = 'Московская область';
+
+		const addressCall = callFor( 'billing_address_1' );
+		const item = {
+			key: 'dadata:addr1', label: 'Moscow, Tverskaya st, 1', level: 'address',
+			record: {
+				key: 'dadata:addr1', provider_id: 'dadata', level: 'address', country: 'RU',
+				// DaData's OWN region component, under an English-locale account — exactly the
+				// spelling that must never overwrite the field above.
+				region: { name: 'Moscow Oblast', type: '' },
+				settlement: { name: 'Moscow', type: '' },
+				postcode: '101000',
+				label: 'Moscow, Tverskaya st, 1',
+			},
+		};
+
+		selectViaFake( addressCall, item );
+
+		// region is owned by 'test-cdek' ≠ the record's own 'dadata' — left untouched.
+		expect( document.getElementById( 'billing_state' ).value ).toBe( 'Московская область' );
+		// settlement has NO known owner — still filled from the record, unchanged behaviour.
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Moscow' );
+		// postcode is never gated by ownership — it is not a chain level.
+		expect( document.getElementById( 'billing_postcode' ).value ).toBe( '101000' );
+	} );
+
+	/**
+	 * Issue #352's LITERAL reported defect, under the REAL rig owner map (the active
+	 * `test-cdek` provider owning `region`+`settlement`, the bundled DaData fallback owning
+	 * `address` alone). The operator measured `city = "Москва"` becoming `city = "Moscow"` and
+	 * `state = "Москва"` becoming `state = "Moscow"` the moment an address suggestion was
+	 * picked: the rig account's locale is English, so DaData answers transliterated while the
+	 * carrier answers Cyrillic (gotcha `a-locality-display-name-is-not-an-identifier`).
+	 *
+	 * The test above pins the UNOWNED half (a level nobody owns still fills). This one pins the
+	 * OWNED half, which is the half that was actually broken — without it the suite passes with
+	 * `settlement` left writable by any provider.
+	 */
+	it( 'leaves a foreign-owned settlement AND region untouched — the measured «Москва» → «Moscow» defect', () => {
+		boot( {
+			region: true, settlement: true, address: true,
+			owners: { RU: { region: 'test-cdek', settlement: 'test-cdek', address: 'dadata' } },
+		} );
+
+		// What the customer picked from the CDEK-backed provider, in its own Cyrillic spelling.
+		document.getElementById( 'billing_state' ).value = 'Москва';
+		document.getElementById( 'billing_city' ).value = 'Москва';
+
+		selectViaFake( callFor( 'billing_address_1' ), {
+			key: 'dadata:addr1', label: 'Moscow, Tverskaya st, 1', level: 'address',
+			record: {
+				key: 'dadata:addr1', provider_id: 'dadata', level: 'address', country: 'RU',
+				region: { name: 'Moscow', type: '' },
+				settlement: { name: 'Moscow', type: '' },
+				postcode: '101000',
+				label: 'Moscow, Tverskaya st, 1',
+			},
+		} );
+
+		expect( document.getElementById( 'billing_state' ).value ).toBe( 'Москва' );
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Москва' );
+		// Still filled: postcode is not a chain level and is never gated by ownership.
+		expect( document.getElementById( 'billing_postcode' ).value ).toBe( '101000' );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// Issue #352 — mixed-provider chain: a foreign-provider record never enters the
+// SERVER-SIDE chain via /select (Variant A). See `class-checkout-config.php
+// ::build_location_block()`'s own `owners` docblock and `location-cascade.js`'s own
+// `mayEnterChain()` docblock for the full reasoning.
+// -----------------------------------------------------------------------
+
+describe( 'issue #352 — refusing to post a foreign-provider record into the server chain', () => {
+	const OWNERS_MIXED_CHAIN = { RU: { region: 'test-cdek', settlement: 'test-cdek', address: 'dadata' } };
+
+	function foreignAddressItem() {
+		return {
+			key: 'dadata:addr1', label: 'ул Тверская, 1', level: 'address',
+			record: {
+				key: 'dadata:addr1', provider_id: 'dadata', level: 'address', country: 'RU',
+				label: 'ул Тверская, 1',
+			},
+		};
+	}
+
+	it( 'does not POST /select for a record DEEPER than settlement whose provider does not own the settlement level', () => {
+		boot( { region: true, settlement: true, address: true, owners: OWNERS_MIXED_CHAIN } );
+
+		const fetchCallCountBefore = global.fetch.mock.calls.length;
+
+		selectViaFake( callFor( 'billing_address_1' ), foreignAddressItem() );
+
+		// No new fetch AT ALL — the /select POST never happened.
+		expect( global.fetch.mock.calls.length ).toBe( fetchCallCountBefore );
+	} );
+
+	it( 'still POSTs /select when the SAME provider owns the settlement level (single-provider chain)', () => {
+		boot( {
+			region: true, settlement: true, address: true,
+			owners: { RU: { region: 'dadata', settlement: 'dadata', address: 'dadata' } },
+		} );
+
+		const fetchCallCountBefore = global.fetch.mock.calls.length;
+
+		selectViaFake( callFor( 'billing_address_1' ), foreignAddressItem() );
+
+		expect( global.fetch.mock.calls.length ).toBe( fetchCallCountBefore + 1 );
+		expect( fetchCalls[ fetchCalls.length - 1 ].url ).toBe( SELECT_URL );
+	} );
+
+	/**
+	 * THE RULE MUST NOT BE RE-BROADENED — this is the adversarial critic's counter-example
+	 * (Codex/GPT-5.5, s78), and it is a REGRESSION GUARD, not a nicety.
+	 *
+	 * A first draft of `mayEnterChain()` refused a record unless its provider owned every served
+	 * level from the shallowest down to its own. Under a store whose active provider serves ONLY
+	 * `region`, with the bundled DaData fallback serving `settlement` and `address`, that draft
+	 * refused the SETTLEMENT pick because `region` had a foreign owner. The settlement record
+	 * then never reached the server at all, `Provider_Selection_Scope::current_locality()` kept
+	 * answering `''`, and the customer's pickup point could never be filed or restored — strictly
+	 * WORSE than the unfixed code, which posts the settlement, lets `rebuild_chain()` drop the
+	 * unprovable region, and ends with a usable `{ settlement: … }` chain.
+	 *
+	 * The settlement level is the anchor. Nothing at or above it is ever refused.
+	 */
+	it( 'still POSTs a settlement pick even when a SHALLOWER level is foreign-owned (the anchor is never refused)', () => {
+		boot( {
+			region: true, settlement: true, address: true,
+			owners: { RU: { region: 'city-dict', settlement: 'dadata', address: 'dadata' } },
+		} );
+
+		const fetchCallCountBefore = global.fetch.mock.calls.length;
+
+		selectViaFake( callFor( 'billing_city' ), {
+			key: 'dadata:city1', label: 'г Москва', level: 'settlement',
+			record: {
+				key: 'dadata:city1', provider_id: 'dadata', level: 'settlement', country: 'RU',
+				label: 'г Москва',
+			},
+		} );
+
+		expect( global.fetch.mock.calls.length ).toBe( fetchCallCountBefore + 1 );
+		expect( fetchCalls[ fetchCalls.length - 1 ].url ).toBe( SELECT_URL );
+	} );
+
+	it( 'still POSTs /select exactly as before this fix when the config carries no `owners` map at all', () => {
+		// No `owners` key in the config at all — an older cached config, or a plugin/test
+		// harness building the location block itself. Must degrade to EXACTLY the pre-#352
+		// behaviour: every pick reaches /select, regardless of provider.
+		boot( { region: true, settlement: true, address: true } );
+
+		const fetchCallCountBefore = global.fetch.mock.calls.length;
+
+		selectViaFake( callFor( 'billing_address_1' ), foreignAddressItem() );
+
+		expect( global.fetch.mock.calls.length ).toBe( fetchCallCountBefore + 1 );
+		expect( fetchCalls[ fetchCalls.length - 1 ].url ).toBe( SELECT_URL );
+	} );
+
+	/**
+	 * The coordinator's own measurement: WooCommerce's classic checkout does not reliably fire
+	 * `update_checkout` off an address change on its own (gotcha
+	 * `wc-does-not-save-the-address-until-every-required-text-field-is-filled`), and
+	 * `backwardsFill()`'s silent writes dispatch no event of their own — so a foreign record
+	 * that skips /select must still trigger `update_checkout` itself, or the address/postcode
+	 * it just wrote into the DOM never reaches WooCommerce's own pricing at all.
+	 */
+	it( 'foreign record: no /select POST, but update_checkout still fires', () => {
+		boot( { region: true, settlement: true, address: true, owners: OWNERS_MIXED_CHAIN } );
+
+		const triggerSpy = jest.spyOn( window.jQuery.fn, 'trigger' );
+		const fetchCallCountBefore = global.fetch.mock.calls.length;
+
+		selectViaFake( callFor( 'billing_address_1' ), foreignAddressItem() );
+
+		expect( global.fetch.mock.calls.length ).toBe( fetchCallCountBefore );
+		expect( triggerSpy.mock.calls.some( ( args ) => args[ 0 ] === 'update_checkout' ) ).toBe( true );
+
+		triggerSpy.mockRestore();
+	} );
+
+	it( 'does not fire woodev_location_applied for a foreign-provider record', () => {
+		boot( { region: true, settlement: true, address: true, owners: OWNERS_MIXED_CHAIN } );
+
+		const seen = [];
+		document.body.addEventListener( 'woodev_location_applied', ( event ) => seen.push( event.detail ) );
+
+		selectViaFake( callFor( 'billing_address_1' ), foreignAddressItem() );
+
+		expect( seen ).toHaveLength( 0 );
+	} );
+
+	it( 'the LOCAL record and the address lock still update for a refused, foreign-provider pick', () => {
+		boot( { region: true, settlement: true, address: true, owners: OWNERS_MIXED_CHAIN } );
+
+		// The address field starts locked (issue #337: a settlement/address chain with the
+		// address level served and no settlement confirmed yet).
+		expect( document.getElementById( 'billing_address_1' ).disabled ).toBe( true );
+
+		// Confirm a settlement first — through the OWNING provider, so /select DOES fire and
+		// unlocks the address field, exactly like the real mixed-chain flow.
+		selectViaFake( callFor( 'billing_city' ), {
+			key: 'test-cdek:msk', label: 'г Москва', level: 'settlement',
+			record: { key: 'test-cdek:msk', provider_id: 'test-cdek', level: 'settlement', country: 'RU', label: 'г Москва' },
+		} );
+		expect( document.getElementById( 'billing_address_1' ).disabled ).toBe( false );
+
+		selectViaFake( callFor( 'billing_address_1' ), foreignAddressItem() );
+
+		// Still unlocked — refusing the /select POST does not re-lock a field the customer can
+		// already see is confirmed and editable.
+		expect( document.getElementById( 'billing_address_1' ).disabled ).toBe( false );
 	} );
 } );
 

--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -651,9 +651,146 @@ class CheckoutConfigTest extends TestCase {
 		sort( $countries );
 		$this->assertSame( [ 'BY', 'RU' ], $countries );
 
-		$serialized = (string) json_encode( $config );
-		$this->assertStringNotContainsString( 'city-dict', $serialized, 'the chosen provider id must never leak' );
-		$this->assertStringNotContainsString( 'dadata', $serialized, 'the fallback provider id must never leak' );
+		// Issue #352 (Variant A): `owners` is spec D15's one DELIBERATE exception — it names
+		// providers on purpose, so the client can refuse a foreign-provider record before ever
+		// posting it (see `class-checkout-config.php::build_location_block()`'s own `owners`
+		// docblock). Every OTHER key must still honour the non-leak guarantee, so the check
+		// below runs against the config WITH `owners` stripped out first.
+		$without_owners = $config;
+		unset( $without_owners['location']['owners'] );
+		$serialized = (string) json_encode( $without_owners );
+		$this->assertStringNotContainsString( 'city-dict', $serialized, 'the chosen provider id must never leak outside owners' );
+		$this->assertStringNotContainsString( 'dadata', $serialized, 'the fallback provider id must never leak outside owners' );
+
+		// The other half of the same fact: `owners` DOES legitimately carry both ids for the
+		// levels each provider actually resolves — RU's region/settlement (the chosen provider)
+		// and BY's address (the fallback), proving this is a real publication, not an accident.
+		$this->assertSame( 'city-dict', $config['location']['owners']['RU']['region'] );
+		$this->assertSame( 'dadata', $config['location']['owners']['BY']['address'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// owners — issue #352's mixed-provider-chain fix (Variant A): per-level provider
+	// ownership, byte-consistent with `levels` (owners[c][l] === '' EXACTLY when
+	// levels[c][l] === false, for the SAME country/level).
+	// -------------------------------------------------------------------------
+
+	public function test_owners_reports_empty_string_for_a_level_no_provider_serves(): void {
+		$service = new Checkout_Config_Fake_Location_Service(
+			true,
+			[ 'region' => true, 'settlement' => true, 'address' => false ],
+			null,
+			[ 'RU' ]
+		);
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertFalse( $config['location']['levels']['RU']['address'] );
+		$this->assertSame( '', $config['location']['owners']['RU']['address'] );
+		// The SERVED levels carry the real (fake, here) provider id.
+		$this->assertSame( 'fake-provider-should-never-leak', $config['location']['owners']['RU']['region'] );
+		$this->assertSame( 'fake-provider-should-never-leak', $config['location']['owners']['RU']['settlement'] );
+	}
+
+	/**
+	 * The #294 arbitration must apply to BOTH maps together (this method's own docblock's
+	 * byte-consistency promise): a country whose region is stood down because WooCommerce
+	 * already renders a native `<select>` there must report `owners[c].region === ''` too,
+	 * even though the D15 chain itself DOES resolve a provider for that level — otherwise the
+	 * client could see a non-empty `owners[c].region` for a level `levels[c].region === false`
+	 * already told it is not a typeahead target, which `mayEnterChain()` client-side would then
+	 * read as "this provider owns region" for a field WooCommerce, not this layer, actually
+	 * renders.
+	 */
+	public function test_owners_region_is_forced_empty_by_the_294_arbitration_together_with_levels(): void {
+		Functions\expect( '_doing_it_wrong' )->once();
+
+		$service = new Checkout_Config_Fake_Location_Service( true, [ 'region' => true, 'settlement' => true, 'address' => true ], null, [ 'BY' ] );
+		$config  = $this->config_with_states( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'BY' ], $service, [ 'BY' => [ 'MIN' => 'Минск' ] ] )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertFalse( $config['location']['levels']['BY']['region'] );
+		$this->assertSame( '', $config['location']['owners']['BY']['region'], 'owners must agree with levels — never name an owner for a level WC already renders natively' );
+		// Only `region` is affected — settlement stays the fake provider's, untouched by the
+		// arbitration (which is region-specific).
+		$this->assertSame( 'fake-provider-should-never-leak', $config['location']['owners']['BY']['settlement'] );
+	}
+
+	/**
+	 * The mixed-chain case issue #352 exists for, end-to-end through the REAL
+	 * {@see Location_Service} + provider registry (not the simplified fake above, which
+	 * cannot model two DIFFERENTLY-countried providers along the chain — same reasoning as
+	 * {@see self::test_location_countries_is_the_union_across_the_d15_chain_not_just_the_active_provider()}):
+	 * the chosen provider owns region/settlement, the bundled DaData fallback owns address
+	 * alone, for the SAME country. `owners['RU']` must name the RIGHT provider PER LEVEL.
+	 */
+	public function test_owners_names_different_providers_per_level_in_a_mixed_chain(): void {
+		Location_Provider_Registry::instance()->reset_for_tests();
+		Settings_Page_Registry::instance()->reset_for_tests();
+
+		$chosen = new class() extends Abstract_Location_Provider {
+			public function get_id(): string {
+				return 'city-dict';
+			}
+
+			public function get_name(): string {
+				return 'City Dict';
+			}
+
+			public function get_countries(): array {
+				return [ 'RU' ];
+			}
+
+			protected function declare_suggest_levels(): array {
+				return [ Location_Record::LEVEL_REGION, Location_Record::LEVEL_SETTLEMENT ];
+			}
+
+			public function suggest( string $query, Location_Scope $scope ): array {
+				return [];
+			}
+		};
+
+		Functions\when( 'add_action' )->justReturn( true );
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+		Functions\when( 'is_user_logged_in' )->justReturn( false );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $tag, $default = null ) use ( $chosen ) {
+				return Location_Provider_Registry::FILTER_PROVIDERS === $tag ? [ $chosen ] : $default;
+			}
+		);
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				if ( 'woodev_location_active_provider' === $name ) {
+					return 'city-dict';
+				}
+				if ( 'woodev_location_token' === $name ) {
+					return 'tok'; // configures the bundled fallback.
+				}
+
+				return $default;
+			}
+		);
+		Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'RU', 'state' => '' ] );
+
+		$registry = Location_Provider_Registry::instance();
+		$registry->declare_needed();
+		$registry->collect();
+
+		$service = new Location_Service( $registry );
+		$this->assertTrue( $service->is_active() );
+
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], $service ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame(
+			[ 'region' => 'city-dict', 'settlement' => 'city-dict', 'address' => 'dadata' ],
+			$config['location']['owners']['RU']
+		);
 	}
 
 	// -------------------------------------------------------------------------
@@ -808,9 +945,21 @@ class CheckoutConfigTest extends TestCase {
 		// The fake provider's own id is a distinctive string chosen specifically so
 		// this assertion is meaningful, not merely "matches by accident". Only the
 		// customer record's own persisted key (which the client already round-tripped
-		// itself via /select) may legitimately carry a provider prefix.
-		$serialized = (string) json_encode( $config );
+		// itself via /select) may legitimately carry a provider prefix — and, since
+		// issue #352, `owners`, spec D15's one deliberate exception (see
+		// `class-checkout-config.php::build_location_block()`'s own `owners` docblock),
+		// so THAT key is stripped before this check runs.
+		$without_owners = $config;
+		unset( $without_owners['location']['owners'] );
+		$serialized = (string) json_encode( $without_owners );
 		$this->assertStringNotContainsString( 'fake-provider-should-never-leak', $serialized );
+
+		// The other half: `owners` DOES legitimately name it, for every level this fake
+		// reports as served.
+		$this->assertSame(
+			[ 'region' => 'fake-provider-should-never-leak', 'settlement' => 'fake-provider-should-never-leak', 'address' => 'fake-provider-should-never-leak' ],
+			$config['location']['owners']['RU']
+		);
 	}
 
 	// -------------------------------------------------------------------------
@@ -877,8 +1026,18 @@ class CheckoutConfigTest extends TestCase {
 		$serialized = (string) json_encode( $config );
 		$this->assertStringNotContainsString( $token, $serialized );
 		$this->assertStringNotContainsString( $secret, $serialized );
-		// D15: the client learns WHICH LEVELS are served, never WHICH provider.
-		$this->assertStringNotContainsString( 'dadata', $serialized );
+
+		// D15: `levels`/`countries`/`mode`/etc. still learn only WHICH LEVELS are served,
+		// never WHICH provider — `owners` is the one deliberate exception (issue #352; see
+		// `class-checkout-config.php::build_location_block()`'s own `owners` docblock), so
+		// it is stripped before this specific check runs.
+		$without_owners = $config;
+		unset( $without_owners['location']['owners'] );
+		$this->assertStringNotContainsString( 'dadata', (string) json_encode( $without_owners ) );
+
+		// The other half: with only ONE provider active (the bundled DaData fallback,
+		// nothing else configured), `owners` legitimately names it for every level RU serves.
+		$this->assertSame( 'dadata', $config['location']['owners']['RU']['region'] );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -1231,6 +1231,81 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		}
 
 		// -------------------------------------------------------------------
+		// get_level_owners_for_country(): issue #352's mixed-provider-chain fix
+		// (Variant A) — the sibling of get_levels_for_country() above that
+		// deliberately DOES reveal which provider serves each level, so the
+		// client can refuse to post a foreign-provider record into the
+		// server-side chain (Customer_Location_Store::rebuild_chain()'s
+		// is_within() check, issue #334, cannot prove cross-provider kinship).
+		// -------------------------------------------------------------------
+
+		public function test_get_level_owners_for_country_names_dadata_for_every_level_it_serves_in_ru(): void {
+			$this->stub_dadata_token( 'tok' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			$this->assertSame(
+				[ 'region' => 'dadata', 'settlement' => 'dadata', 'address' => 'dadata' ],
+				$service->get_level_owners_for_country( 'RU' )
+			);
+		}
+
+		public function test_get_level_owners_for_country_reports_empty_string_for_an_unserved_level(): void {
+			$this->stub_dadata_token( 'tok' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			// AM is GeoNames-tier — DaData serves region/settlement there, never address.
+			$this->assertSame(
+				[ 'region' => 'dadata', 'settlement' => 'dadata', 'address' => '' ],
+				$service->get_level_owners_for_country( 'AM' )
+			);
+		}
+
+		public function test_get_level_owners_for_country_reports_empty_string_for_every_level_when_the_layer_has_no_active_provider(): void {
+			$service = new Location_Service( Location_Provider_Registry::instance() );
+
+			$this->assertSame(
+				[ 'region' => '', 'settlement' => '', 'address' => '' ],
+				$service->get_level_owners_for_country( 'RU' )
+			);
+		}
+
+		/**
+		 * The mixed-chain case issue #352 exists for: a chosen provider owning
+		 * region/settlement, the bundled DaData fallback owning address alone —
+		 * `get_level_owners_for_country()` must name the RIGHT provider PER
+		 * LEVEL, never collapse to one id for the whole country. Same fixture
+		 * shape as {@see self::test_chain_city_only_chosen_with_configured_fallback_address_served_by_fallback()}.
+		 */
+		public function test_get_level_owners_for_country_names_different_providers_per_level_in_a_mixed_chain(): void {
+			$chosen = new Location_Service_Fake_Provider( 'city-dict', [ Location_Record::LEVEL_REGION, Location_Record::LEVEL_SETTLEMENT ], true );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $chosen ] );
+			$this->stub_dadata_token( 'tok' ); // the real bundled fallback must be configured to serve as fallback.
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$service = new Location_Service( $registry );
+
+			$this->assertSame(
+				[ 'region' => 'city-dict', 'settlement' => 'city-dict', 'address' => 'dadata' ],
+				$service->get_level_owners_for_country( 'RU' )
+			);
+		}
+
+		// -------------------------------------------------------------------
 		// Degradation: no active provider -> every read-side method answers
 		// safely, nothing fatals
 		// -------------------------------------------------------------------

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -366,6 +366,45 @@
 		return ( entry.location && entry.location.defaultCountry ) || '';
 	}
 
+
+	/**
+	 * The country whose owner map governs an ownership decision about `record` (issue #352
+	 * follow-up, post-review finding P1) — `record`'s OWN `country` field when it carries one,
+	 * falling back to {@see countryFor}'s live-field read only for the defensive case of a
+	 * record with none.
+	 *
+	 * WHY THE RECORD'S OWN COUNTRY, NOT THE LIVE FIELD: {@see mayEnterChain} and
+	 * {@see backwardsFill} both ask "who owns this level in the country THIS RECORD belongs
+	 * to" — resolving that via the live country `<select>` instead answers the WRONG owner map
+	 * when the country changed between the moment the suggestion was fetched and the moment it
+	 * was clicked (a real, if narrow, window: typeahead results are already in flight before a
+	 * click). Every record that reaches this module already passed through
+	 * `Location_Record::from_array()` server-side, which REQUIRES `country` and upper-cases it
+	 * (that method's own docblock: "Required: … `country` … case-normalized to upper-case on
+	 * the way in") — so the fallback below is defensive only, never observed to actually fire.
+	 * `owners` is keyed by the SAME upper-case WC country codes `class-checkout-config.php`
+	 * iterates to build it, so no case normalization is needed at the {@see levelOwner} lookup
+	 * either; verified against both sources rather than assumed.
+	 *
+	 * NOT A FIX FOR A STALE CROSS-COUNTRY RECORD: a record fetched for one country and clicked
+	 * after the customer already switched the country field to another is issue #346, and is
+	 * deliberately left alone here — this function only makes sure the OWNERSHIP CHECK itself
+	 * consults the right country while the record is still live, not whether the record itself
+	 * is still valid to apply at all.
+	 *
+	 * @param {Object} entry
+	 * @param {{section?: string}} node
+	 * @param {Object} record
+	 * @returns {string}
+	 */
+	function countryForRecord( entry, node, record ) {
+		if ( record && 'string' === typeof record.country && record.country ) {
+			return record.country;
+		}
+
+		return countryFor( entry, node );
+	}
+
 	/**
 	 * Whether the live "ship to a different address" checkbox is checked — read by its stable
 	 * `name` attribute, the SAME selector `pickup-mount.js`'s own `resolveAddressTarget()`
@@ -843,29 +882,66 @@
 	 * address-level record's OWN embedded components — no second lookup. Only levels STRICTLY
 	 * BEFORE the selected one are filled (selecting a settlement never touches address).
 	 *
+	 * SKIPS A FOREIGN-OWNED ANCESTOR (issue #352, Variant A): an ancestor level with a KNOWN
+	 * owner ({@see levelOwner}) that DIFFERS from `record.provider_id` is left untouched — this
+	 * is the measured bug's field-text half. A mixed provider chain (e.g. the active provider
+	 * serving `region`/`settlement`, the bundled DaData fallback serving `address`) used to let
+	 * the customer pick their settlement from one provider («Москва», Cyrillic) and their street
+	 * from the other, whose OWN record for that same locality carries a different spelling under
+	 * a different account locale («Moscow» — gotcha `a-locality-display-name-is-not-an-identifier`)
+	 * — this function would then overwrite the settlement field's correct text with the address
+	 * provider's own, wrong one. An ancestor level with NO known owner (`''` — unserved, or an
+	 * older config carrying no `owners` map at all) still fills exactly as before this fix:
+	 * nobody owns it, so nothing is being clobbered by writing there.
+	 *
+	 * `record.postcode` is NEVER gated by ownership — postcode is not a chain LEVEL (it has no
+	 * entry in {@see LEVELS}/`owners`), and a foreign provider's postcode for the customer's own
+	 * street is correct data the order wants regardless of which provider resolved the settlement
+	 * above it.
+	 *
+	 * OWNERSHIP IS JUDGED BY THE RECORD'S OWN COUNTRY (issue #352 follow-up, P1), via
+	 * {@see countryForRecord} — not the live country field {@see countryFor} alone would read —
+	 * so a country change between fetching the suggestion and clicking it cannot make this
+	 * function consult the wrong country's owner map. See {@see countryForRecord}'s own
+	 * docblock for the full reasoning and what this deliberately does NOT fix (issue #346).
+	 *
 	 * @param {Object} entry
-	 * @param {string} level  The level that was just selected.
+	 * @param {{level: string, section?: string}} node   The node that was just selected — its
+	 *                                                    `level` is the level just selected;
+	 *                                                    its `section` is used only as
+	 *                                                    {@see countryForRecord}'s fallback when
+	 *                                                    `record` carries no `country` of its own.
 	 * @param {Object} record The selected record.
 	 * @returns {void}
 	 */
-	function backwardsFill( entry, level, record ) {
+	function backwardsFill( entry, node, record ) {
+		var level = node.level;
 		var idx = LEVELS.indexOf( level );
+		// Issue #352 follow-up (P1): the RECORD's own country, not the live field — see
+		// {@see countryForRecord}'s own docblock for why.
+		var country = countryForRecord( entry, node, record );
 
 		LEVELS.forEach( function( ancestorLevel, i ) {
 			if ( i >= idx ) {
 				return;
 			}
 
-			var node = chainNodeForLevel( entry, ancestorLevel );
+			var ancestorNode = chainNodeForLevel( entry, ancestorLevel );
 			var component = record[ ancestorLevel ];
 
-			if ( ! node || ! component ) {
+			if ( ! ancestorNode || ! component ) {
+				return;
+			}
+
+			var owner = levelOwner( entry, country, ancestorLevel );
+
+			if ( owner && owner !== record.provider_id ) {
 				return;
 			}
 
 			// Same derivation a direct pick at that level gets ({@see fieldValueFor}) — a
 			// backwards-filled field and a directly picked one must not read differently.
-			writeSilently( entry, node.fieldId, fieldValueFor( record, ancestorLevel ) );
+			writeSilently( entry, ancestorNode.fieldId, fieldValueFor( record, ancestorLevel ) );
 		} );
 
 		if ( record.postcode && entry.postcodeFieldId ) {
@@ -1031,6 +1107,28 @@
 	}
 
 	/**
+	 * Fires WooCommerce's own `update_checkout` — the ONE place this module fires it itself,
+	 * because WooCommerce's OWN client-side gate does not reliably fire it off an address change
+	 * on its own (gotcha `wc-does-not-save-the-address-until-every-required-text-field-is-filled`
+	 * — `checkout.js`'s `maybe_update_checkout()` withholds it while ANY required TEXT field in
+	 * the same block is still empty; see the file docblock's own D8/PERSIST THEN TRIGGER
+	 * section). Two call sites share this exact trigger (issue #352): the ordinary
+	 * persisted-`/select` path ({@see settleSelect}), and the foreign-provider-record path
+	 * ({@see onSelectFor}, gated by {@see mayEnterChain}) — a record `mayEnterChain()` refuses
+	 * never reaches `/select` at all, but {@see backwardsFill}'s SILENT writes (never dispatching
+	 * an `input`/`change` event of their own — see {@see writeSilently}) may still have changed
+	 * the address WooCommerce needs to re-price, so the checkout must still refresh even though
+	 * nothing was persisted server-side for this pick.
+	 *
+	 * @returns {void}
+	 */
+	function triggerCheckoutUpdate() {
+		if ( window.jQuery ) {
+			window.jQuery( document.body ).trigger( 'update_checkout' );
+		}
+	}
+
+	/**
 	 * Frees the single-flight slot for `entry` and either forwards to the next queued
 	 * selection (a newer one arrived while this request was in flight — this response is
 	 * stale by construction, so it never fires the trigger NOR shows a notice for it) or,
@@ -1094,10 +1192,7 @@
 			// D11) — `implicit` is unconditionally `false` here, regardless of what the
 			// PREVIOUS state (boot's own fire, see {@see prefill}) said.
 			fireLocationApplied( entry, record, false );
-
-			if ( window.jQuery ) {
-				window.jQuery( document.body ).trigger( 'update_checkout' );
-			}
+			triggerCheckoutUpdate();
 
 			return;
 		}
@@ -1273,6 +1368,20 @@
 	 * later — only the SERVER round trip (and, with it, the `woodev_location_applied` event
 	 * and `update_checkout` trigger) is gated on {@see isActiveAddressSection}.
 	 *
+	 * ONLY ENTERS THE SERVER-SIDE CHAIN WHEN {@see mayEnterChain} SAYS SO (issue #352, Variant
+	 * A): a record DEEPER than `settlement` whose own provider is not the one that owns the
+	 * `settlement` level never reaches `/select` at all — posting it would let the server's
+	 * `is_within()` ancestor-kinship check (issue #334, unchanged) amputate the settlement record
+	 * a DIFFERENT provider persisted, and that record is the one thing
+	 * `Provider_Selection_Scope::current_locality()` reads. See {@see mayEnterChain}'s own
+	 * docblock for why the rule stops at `settlement` and must not be broadened to every
+	 * shallower level. The LOCAL state (`entry.records[node.level]`,
+	 * {@see backwardsFill}, {@see refreshAddressLock}) still updates regardless — only the round
+	 * trip is refused. {@see triggerCheckoutUpdate} still fires for a refused pick (see that
+	 * function's own docblock for why WooCommerce needs the nudge even with nothing persisted),
+	 * but neither `/select` nor `woodev_location_applied` do — see {@see mayEnterChain}'s own
+	 * docblock for what a refusal deliberately leaves alone.
+	 *
 	 * @param {Object} entry
 	 * @param {{level: string, fieldId: string, section?: string}} node
 	 * @returns {function(Object): void}
@@ -1291,7 +1400,7 @@
 			// entry-level, not node-level, concept.
 			entry.lastSelectedFieldId = node.fieldId;
 
-			backwardsFill( entry, node.level, record );
+			backwardsFill( entry, node, record );
 
 			// Issue #337: a settlement pick unlocks the address field on the SPOT, off the
 			// optimistic record above — never only once `/select` comes back. Waiting for the
@@ -1300,7 +1409,17 @@
 			refreshAddressLock( entry );
 
 			if ( isActiveAddressSection( node.section ) ) {
-				enqueueSelect( entry, record );
+				if ( mayEnterChain( entry, node, record ) ) {
+					enqueueSelect( entry, record );
+				} else {
+					// Issue #352: a foreign-provider record never reaches /select, so
+					// nothing downstream of it (update_checkout, the "not saved" notice)
+					// fires on ITS behalf either — but backwardsFill()'s silent writes above
+					// may still have changed the address WooCommerce needs to re-price, and
+					// nothing else will ever ask it to. See triggerCheckoutUpdate()'s own
+					// docblock.
+					triggerCheckoutUpdate();
+				}
 			}
 		};
 	}
@@ -1342,6 +1461,102 @@
 		}
 
 		return !! byCountry[ country ][ level ];
+	}
+
+	/**
+	 * The id of the provider that owns `level` for `country` (issue #352, Variant A) — `''`
+	 * (never throws, never `undefined`) when unknown/unserved OR when `entry.location.owners`
+	 * is absent entirely (an older cached config, a plugin/test harness that builds the location
+	 * block itself without this key, or a config predating this fix) — an ABSENT map degrades to
+	 * EXACTLY today's behaviour, never a hard failure: every caller below treats `''` as "nobody
+	 * to conflict with", which is precisely the single-provider-chain answer this module already
+	 * gave before `owners` existed.
+	 *
+	 * Mirrors {@see isLevelServed}'s own shape exactly (same `byCountry`/`country`/`level`
+	 * lookup), reading `entry.location.owners` — the sibling map
+	 * `class-checkout-config.php::build_location_block()` populates from
+	 * `Location_Service::get_level_owners_for_country()`, `owners[c][l] === ''` EXACTLY when
+	 * `levels[c][l] === false` for the same country/level (that method's own docblock).
+	 *
+	 * @param {Object} entry
+	 * @param {string} country ISO-3166 alpha-2.
+	 * @param {string} level
+	 * @returns {string}
+	 */
+	function levelOwner( entry, country, level ) {
+		var byCountry = entry.location && entry.location.owners;
+
+		if ( ! byCountry || ! country || ! byCountry[ country ] ) {
+			return '';
+		}
+
+		var owner = byCountry[ country ][ level ];
+
+		return 'string' === typeof owner ? owner : '';
+	}
+
+	/**
+	 * Whether `record` may enter the SERVER-SIDE location chain via `/select` (issue #352,
+	 * operator decision "Variant A") — the fix for the mixed-provider-chain bug: a store can run
+	 * an active provider (e.g. a CDEK-backed one) for `region`/`settlement` and the bundled
+	 * DaData fallback for `address` alone (the exact rig configuration the bug was found on).
+	 * `Customer_Location_Store::rebuild_chain()` keeps a shallower STORED record only when the
+	 * new one can PROVE kinship with it (`Location_Record::is_within()`, which requires every
+	 * ancestor to share the SAME provider — issue #334, deliberately kept UNCHANGED by this fix:
+	 * a Moscow settlement must not survive a Saint-Petersburg address, and that rule cannot tell
+	 * "different provider" apart from "different place"). A DaData address record posted on top
+	 * of a CDEK settlement can therefore never prove kinship — posting it anyway silently
+	 * amputates the settlement (and, with it, the pickup layer's own locality key) the instant
+	 * the server applies that rule. See `class-checkout-config.php::build_location_block()`'s own
+	 * `owners` docblock for the server-side half of this reasoning.
+	 *
+	 * THE RULE IS NARROWER THAN "owns every served level down to `node.level`" — IT ONLY LOOKS
+	 * AT `settlement` (operator decision, #352 rescope, post-review). An EARLIER version of this
+	 * function refused a record unless its provider owned every served level from the shallowest
+	 * one down to and including `node.level`. That was an over-generalization of the operator's
+	 * actual words — «чужая АДРЕСНАЯ запись в цепочку не попадает вовсе — адрес от провайдера,
+	 * который не владеет уровнем НП, живёт только как ТЕКСТ полей» — and it caused a REGRESSION
+	 * an adversarial review caught: a store whose active provider serves only `region`, with the
+	 * bundled DaData fallback serving `settlement`/`address`, refused the customer's OWN
+	 * settlement pick (foreign `region` owner) exactly as it refused a genuinely foreign one. The
+	 * settlement record then never posted, {@see \Woodev\Framework\Shipping\Pickup\Provider_Selection_Scope::current_locality()}
+	 * (`class-provider-selection-scope.php`) kept answering `''` because it reads the SETTLEMENT
+	 * record STRICTLY and refuses when there is none, and the customer's pickup point could never
+	 * be filed or restored — strictly WORSE than the unfixed #352 bug, which at least posted the
+	 * settlement and let `rebuild_chain()` drop only the unprovable region.
+	 *
+	 * `settlement` is the anchor for exactly that reason: it is the ONE level a live consumer
+	 * reads strictly and breaks without. `record` may enter the chain when EITHER (a) its own
+	 * `node.level` sits at `settlement` or shallower (`region`/`settlement` never conflict with a
+	 * shallower foreign owner — there is nothing shallower than `region` to protect, and a
+	 * `settlement` pick is itself the thing being protected), OR (b) `settlement`'s KNOWN owner
+	 * ({@see levelOwner} — `''` means unserved, or an absent `owners` map; either way, nobody to
+	 * conflict with) equals `record.provider_id`. Do NOT re-broaden this to every served level —
+	 * that is the exact change that regressed.
+	 *
+	 * WHAT THIS DOES NOT GATE (see {@see onSelectFor}'s own call site): `entry.records[node.level]`
+	 * (the LOCAL record the address widget/map read) and {@see refreshAddressLock} both still run
+	 * regardless of this predicate's answer, and {@see backwardsFill} makes its OWN,
+	 * per-ancestor-level ownership decision — only the `/select` POST into the server chain is
+	 * gated here.
+	 *
+	 * @param {Object} entry
+	 * @param {{level: string, section?: string}} node
+	 * @param {Object} record
+	 * @returns {boolean}
+	 */
+	function mayEnterChain( entry, node, record ) {
+		var idx = LEVELS.indexOf( node.level );
+		var settlementIdx = LEVELS.indexOf( 'settlement' );
+
+		if ( idx <= settlementIdx ) {
+			return true;
+		}
+
+		var country = countryForRecord( entry, node, record );
+		var owner = levelOwner( entry, country, 'settlement' );
+
+		return ! owner || owner === record.provider_id;
 	}
 
 	/**

--- a/woodev/shipping-method/checkout/class-checkout-config.php
+++ b/woodev/shipping-method/checkout/class-checkout-config.php
@@ -48,6 +48,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 	 *     'countries' => string[],
 	 *     'mode'      => string, // 'typeahead' | 'related-list' | 'ajax-select2' (Task 13; spec D7)
 	 *     'levels'    => [ country_code => [ 'region' => bool, 'settlement' => bool, 'address' => bool ] ],
+	 *     'owners'    => [ country_code => [ 'region' => string, 'settlement' => string, 'address' => string ] ], // issue #352: provider id or '' — see build_location_block()'s own docblock
 	 *     'current'   => [ 'key' => string, 'level' => string ]|null,
 	 *     'chain'     => [ level => [ 'key' => string, 'level' => string ] ], // issue #330: every level in the customer's saved chain; [] when there is no customer record at all
 	 *     'implicit'  => bool,
@@ -204,6 +205,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *         countries: string[],
 		 *         mode: string,
 		 *         levels: array<string, array{region: bool, settlement: bool, address: bool}>,
+		 *         owners: array<string, array{region: string, settlement: string, address: string}>,
 		 *         current: array{key: string, level: string}|null,
 		 *         chain: array<string, array{key: string, level: string}>,
 		 *         implicit: bool
@@ -382,10 +384,39 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *   to refresh it. Each per-country entry answers whether the D15
 		 *   provider-fallback chain
 		 *   ({@see \Woodev\Framework\Shipping\Location\Location_Service::get_levels_for_country()})
-		 *   resolves ANY provider for that level IN that country. The client
-		 *   learns only this — NEVER which provider serves a level (spec D15) —
-		 *   because neither this method nor `get_levels_for_country()` ever reads
+		 *   resolves ANY provider for that level IN that country. This is the
+		 *   ONLY thing `levels` answers — WHICH provider serves a level is
+		 *   `owners`' job, below (spec D15's original single-answer intent, kept
+		 *   for this key specifically) — because neither this method nor
+		 *   `get_levels_for_country()` ever reads
 		 *   {@see \Woodev\Framework\Shipping\Location\Location_Provider::get_id()}.
+		 * - `owners` — a MAP with the SAME shape as `levels`
+		 *   (`{ [country]: { region, settlement, address } }`), but each leaf is
+		 *   the id of the provider the D15 chain resolves for that (level,
+		 *   country) rather than a bool — `''` (never `null`) when no provider
+		 *   serves it there, from
+		 *   {@see \Woodev\Framework\Shipping\Location\Location_Service::get_level_owners_for_country()}.
+		 *   Issue #352: this is spec D15's one deliberate, documented exception —
+		 *   nothing NEW leaks by publishing it, because every persisted
+		 *   {@see \Woodev\Framework\Shipping\Location\Location_Record::to_array()}
+		 *   already carries `provider_id`, and `key()` is literally
+		 *   `provider_id:native_id`; what changes is that the CLIENT can now act
+		 *   on ownership BEFORE posting a record, not only after. A store running
+		 *   a mixed provider chain (e.g. the active provider serving
+		 *   `region`/`settlement`, the bundled fallback serving `address`) can
+		 *   never prove cross-provider kinship for
+		 *   {@see \Woodev\Framework\Shipping\Location\Customer_Location_Store::rebuild_chain()}'s
+		 *   `is_within()` check (issue #334, deliberately UNCHANGED — a Moscow
+		 *   settlement must not survive a Saint-Petersburg address, and that rule
+		 *   cannot distinguish "different provider" from "different place"); a
+		 *   client that posted a foreign-provider address anyway would silently
+		 *   amputate every shallower level of the customer's chain the instant the
+		 *   server applied that rule. `owners` lets `location-cascade.js`'s
+		 *   `mayEnterChain()` refuse to post a foreign-owned pick in the first
+		 *   place, keeping the address as local field TEXT only (Variant A). `owners[c][l] === ''`
+		 *   EXACTLY when `levels[c][l] === false`, for the same country and
+		 *   level — including the `region` #294 arbitration below, which this
+		 *   method applies to BOTH maps together so they can never disagree.
 		 *
 		 *   **`levels[country]['region']` — issue #294 arbitration (Task 13).**
 		 *   The D15 chain's own opinion ("some provider could suggest a region")
@@ -525,6 +556,11 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 * @since 2.0.2 Gained `chain` — every level in the customer's saved chain
 		 *              (location-chain design §8; issue #330), via
 		 *              {@see \Woodev\Framework\Shipping\Location\Location_Service::get_customer_chain()}.
+		 * @since 2.0.2 Gained `owners` — issue #352's mixed-provider-chain fix
+		 *              (Variant A): per-level provider ownership, so the client
+		 *              can refuse to post a foreign-provider record into the
+		 *              server-side chain, via
+		 *              {@see \Woodev\Framework\Shipping\Location\Location_Service::get_level_owners_for_country()}.
 		 *
 		 * @param \Woodev\Framework\Shipping\Location\Location_Service $service The active, already-confirmed facade.
 		 *
@@ -534,6 +570,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *     countries: string[],
 		 *     mode: string,
 		 *     levels: array<string, array{region: bool, settlement: bool, address: bool}>,
+		 *     owners: array<string, array{region: string, settlement: string, address: string}>,
 		 *     current: array{key: string, level: string}|null,
 		 *     chain: array<string, array{key: string, level: string}>,
 		 *     implicit: bool,
@@ -552,10 +589,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 			}
 
 			$levels                    = [];
+			$owners                    = [];
 			$region_conflict_countries = [];
 
 			foreach ( $countries as $code ) {
 				$country_levels = $service->get_levels_for_country( $code );
+				$country_owners = $service->get_level_owners_for_country( $code );
 
 				// #294 arbitration: the authority is the FINAL woocommerce_states
 				// result, read AFTER every filter (native WC, §8 carrier takeover,
@@ -572,7 +611,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 
 				$country_levels['region'] = $country_levels['region'] && ! $states_present;
 
+				// `owners` MUST honour the SAME final answer as `levels` (issue #352):
+				// a provider that technically resolves for "region" is not the owner
+				// of a field the #294 arbitration just stood this layer down from —
+				// otherwise the client could see `levels[c].region === false` (native
+				// WC select) alongside a non-empty `owners[c].region` (a typeahead
+				// owner) for the same level, which is incoherent.
+				if ( ! $country_levels['region'] ) {
+					$country_owners['region'] = '';
+				}
+
 				$levels[ $code ] = $country_levels;
+				$owners[ $code ] = $country_owners;
 			}
 
 			if ( [] !== $region_conflict_countries ) {
@@ -674,6 +724,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 				'countries'      => array_values( $countries ),
 				'mode'           => $service->get_field_mode(),
 				'levels'         => $levels,
+				'owners'         => $owners,
 				'current'        => $current,
 				'chain'          => $chain,
 				'implicit'       => $implicit,

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -1043,6 +1043,56 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		}
 
 		/**
+		 * Which PROVIDER owns each suggest LEVEL for ONE specific country —
+		 * `region`/`settlement`/`address` => the id of the provider the D15
+		 * chain resolves for that level in that country, or `''` (never
+		 * `null`) when no provider serves it there.
+		 *
+		 * This is the D15 spec's one deliberate exception (issue #352): the
+		 * sibling {@see self::get_levels_for_country()} exists specifically so
+		 * the client never learns WHICH provider serves a level, only WHETHER
+		 * one does — but nothing NEW leaks by adding this method. The provider
+		 * id is ALREADY visible to the client on every persisted record
+		 * ({@see Location_Record::to_array()} includes `provider_id`, and
+		 * {@see Location_Record::key()} is literally `provider_id:native_id`),
+		 * so this method only republishes, ahead of a pick, information the
+		 * client already receives the moment it makes one. What genuinely
+		 * changes is that the client can now act on ownership BEFORE posting a
+		 * record — see below.
+		 *
+		 * The reason this is needed at all: a store can run a mixed provider
+		 * chain, e.g. the active provider serving `region`/`settlement` and
+		 * the bundled fallback serving `address`. {@see \Woodev\Framework\Shipping\Location\Customer_Location_Store::rebuild_chain()}
+		 * only keeps a shallower stored record when the new one can PROVE
+		 * kinship with it ({@see Location_Record::is_within()}, which requires
+		 * every ancestor to share the SAME provider — issue #334, deliberately
+		 * NOT weakened here: a Moscow settlement must not survive a
+		 * Saint-Petersburg address, and cross-provider kinship cannot be
+		 * proven in principle). Without knowing which provider owns which
+		 * level, the client cannot tell a same-provider pick (safe to enter
+		 * the chain) from a foreign one (would silently amputate every
+		 * shallower level once posted) — it would have to post first and find
+		 * out never. `location-cascade.js`'s `mayEnterChain()` is the
+		 * consumer this method exists for.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $country ISO-3166 alpha-2 country code, any case/whitespace.
+		 *
+		 * @return array{region: string, settlement: string, address: string}
+		 */
+		public function get_level_owners_for_country( string $country ): array {
+			$owners = [];
+
+			foreach ( Location_Record::LEVELS as $level ) {
+				$provider          = $this->provider_for_level( $level, $country );
+				$owners[ $level ] = null !== $provider ? $provider->get_id() : '';
+			}
+
+			return $owners;
+		}
+
+		/**
 		 * Walks the D15 provider chain for one suggest LEVEL: the active
 		 * provider first, when it is configured and declares the level in
 		 * {@see Location_Provider::get_suggest_levels()}; otherwise the


### PR DESCRIPTION
Closes #352

## Проблема

На риге активен `test-cdek` (регион + НП), адрес отдаёт бандленная DaData. Выбор адресной подсказки уничтожал запись НП: `Customer_Location_Store::rebuild_chain()` сохраняет более мелкий уровень только когда новая запись ДОКАЗАЛА родство (`is_within`), а `Location_Record::parse_ancestors()` требует, чтобы каждый ancestor принадлежал тому же провайдеру. Кросс-провайдерное родство недоказуемо в принципе, поэтому запись НП отбрасывалась всегда. Терялся ключ НП, а с ним скоуп следующего поиска и привязка выбранного ПВЗ. Видимая часть — тексты НП/региона перезаписывались транслитом DaData.

Правило #334 верное и **не ослаблено**: внутри одного провайдера `is_within` по-прежнему требует доказанного родства.

## Решение — вариант A (решение оператора)

Чужая адресная запись в цепочку не попадает; адрес живёт только как ТЕКСТ полей.

- `Location_Service::get_level_owners_for_country()` отдаёт владельца каждого уровня; `Checkout_Config` публикует это как `config.location.owners`, выводя карту ПОСЛЕ арбитража #294, чтобы она не могла разойтись с `levels`.
- `backwardsFill()` не пишет уровень, которым владеет другой провайдер.
- `mayEnterChain()` не отправляет в `/select` запись ГЛУБЖЕ уровня НП, если уровнем НП владеет другой провайдер.

**Почему правило останавливается на НП.** Первая редакция отклоняла запись, если её провайдер не владеет всеми уровнями выше. Adversarial-критик (Codex) нашёл регрессию: при конфигурации «активный провайдер отдаёт только регион, DaData отдаёт НП и адрес» отклонялся сам ВЫБОР НП, запись НП не сохранялась вообще, и ПВЗ переставал привязываться — хуже, чем без правки. НП — якорь, его не отклоняем никогда: `Provider_Selection_Scope::current_locality()` читает строго его. На повторное расширение правила стоит регрессионный тест.

Отклонённая запись всё равно вызывает `update_checkout` (больше ничто не обновляет чекаут после выбора адреса), но НЕ вызывает `woodev_location_applied` — иначе карта ПВЗ переадресовалась бы на адрес вместо НП.

Отсутствие `owners` в конфиге деградирует ровно к поведению до правки.

## Проверка

Тесты: **2299 unit / 5690 ассертов** (было 2292/5672), **1154 jest** (было 1145), phpcs 210/210 и phpstan чисто.

Новые тесты проверены мутациями: снятие проверки владения в `backwardsFill` роняет 2 теста, `mayEnterChain` всегда-«да» роняет 2, возврат отклонённого широкого правила роняет 1.

**Риг, с контролем в том же прогоне.**

Контроль (код без правки):
```
после выбора адреса:  state = "Moscow"  city = "Moscow"
после перезагрузки:   current = { key: "dadata:0ecde158-…", level: "address" }
                      chain   = { address: … }
```

С правкой (чистая гостевая сессия):
```
после выбора адреса:  state = "Москва"  city = "Москва"  addr = "ulitsa Tverskaya, 1"  postcode = 125009
после перезагрузки:   current = { key: "test-cdek:44", level: "settlement" }
                      chain   = { settlement: test-cdek:44 }
                      ПВЗ     = "Москва Новокосинская 17 к6"
```

## Связано

- #353 — проверка при регистрации, что провайдер отдаёт уровень НП (заведена в ходе этой работы)
- #334 — правило доказанного родства, не тронуто

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD