### PR TITLE
fix(location): adopt or report a settlement typed without picking (#350)

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -225,7 +225,10 @@ function fakeTypeahead() {
 	attachCalls = [];
 	window.WoodevLocationTypeahead = jest.fn( ( el, opts ) => {
 		const detach = jest.fn();
-		const call = { el, fetch: opts.fetch, onSelect: opts.onSelect, emptyText: opts.emptyText, detach };
+		const call = {
+			el, fetch: opts.fetch, onSelect: opts.onSelect, onAbandon: opts.onAbandon,
+			emptyText: opts.emptyText, detach,
+		};
 
 		attachCalls.push( call );
 
@@ -281,6 +284,27 @@ function selectViaFake( call, item, viaJquery = false ) {
 	}
 
 	call.onSelect( item );
+}
+
+/**
+ * Simulates a customer typing `query` into the field behind `call` and abandoning it — leaving
+ * WITHOUT ever picking a suggestion, with a COMPLETED search that resolved to zero results
+ * (issue #350). Reproduces the real timing this module's own `handleFieldChanged()` docblock and
+ * `location-typeahead.js`'s own ABANDON section both rely on: a real browser fires the native
+ * `change` a text edit produces BEFORE the widget's own `blur`-driven decision runs, so the
+ * "typed but not picked" clearing this module already does for ANY unpicked edit always happens
+ * FIRST, and the widget's `onAbandon()` call (never a value write — unlike
+ * {@see selectViaFake}) always lands strictly after it.
+ *
+ * @param {Object} call
+ * @param {string} query
+ * @returns {void}
+ */
+function abandonViaFake( call, query ) {
+	call.el.value = query;
+	call.el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+	call.onAbandon( { query, resolved: true } );
 }
 
 function callFor( fieldId ) {
@@ -3321,5 +3345,195 @@ describe( 'the address field is locked until a settlement is picked (#337)', () 
 		} );
 
 		expect( document.getElementById( 'shipping_address_1' ).disabled ).toBe( false );
+	} );
+
+	// -----------------------------------------------------------------------
+	// #350 amendment: a settlement the provider will never suggest stands the lock down
+	// -----------------------------------------------------------------------
+
+	it( 'is NOT locked after an abandon-with-zero-results at settlement level (#350)', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		expect( addressField().disabled ).toBe( true );
+
+		abandonViaFake( callFor( 'billing_city' ), 'Тьмутаракань' );
+
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 'is NOT locked after a below-minChars abandon at settlement level — #350 follow-up (17.08.2026)', () => {
+		// A settlement name genuinely shorter than the widget's own minChars used to be a dead
+		// end: no fetch ever ran, so onAbandon() never fired and the lock had no exit at all.
+		// location-typeahead.js's handleBlur() now reports `resolved: false` for this case —
+		// this cascade must unlock on it exactly like the zero-results `resolved: true` case,
+		// since onAbandonFor() treats both identically (see that function's own docblock for why).
+		boot( { region: true, settlement: true, address: true } );
+
+		expect( addressField().disabled ).toBe( true );
+
+		const call = callFor( 'billing_city' );
+
+		call.el.value = 'Ку';
+		call.el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		call.onAbandon( { query: 'Ку', resolved: false } );
+
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 're-locks once the abandoned settlement text is edited to something else (#350)', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		abandonViaFake( callFor( 'billing_city' ), 'Тьмутаракань' );
+		expect( addressField().disabled ).toBe( false );
+
+		const city = document.getElementById( 'billing_city' );
+
+		// Still no pick — but the text itself changed, so the #350 marker no longer describes it.
+		city.value = 'Тьмутаракань-2';
+		city.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( addressField().disabled ).toBe( true );
+	} );
+
+	it( 'a plain "typed but not picked" edit that never went through onAbandon still locks — #337 itself is unweakened (#350)', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		const city = document.getElementById( 'billing_city' );
+
+		// Simulates a customer still mid-search (or one whose search simply never completed) —
+		// NOT the #350 zero-results report, which only ever arrives via onAbandon().
+		city.value = 'Москва';
+		city.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( addressField().disabled ).toBe( true );
+	} );
+
+	it( 'never clears a field VALUE and never touches the region field on an abandon (#350, operator point 3)', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		const region = document.getElementById( 'billing_state' );
+
+		region.value = 'Московская область';
+		region.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		abandonViaFake( callFor( 'billing_city' ), 'Кокошкино' );
+
+		expect( region.value ).toBe( 'Московская область' ); // a parent — never in scope for this.
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Кокошкино' ); // the typed text survives.
+		expect( addressField().value ).toBe( '' ); // had nothing to begin with — still nothing, not "wiped".
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	// -----------------------------------------------------------------------
+	// #350 follow-up (operator decision, 17.08.2026): the customer keeps their downstream
+	// TEXT on an abandon — only the IDENTITY (the record) is dropped, because it belonged to
+	// the settlement they just abandoned. clearDescendants() itself is UNCHANGED and still
+	// unconditionally wipes on every text edit (the ORDINARY path — adopting a different
+	// settlement still has to clear the old address); a snapshot-and-restore step downstream
+	// of it (restoreClearedDescendants(), reached only via onAbandonFor()) puts the TEXT back
+	// when the edit turns out to be an abandon rather than a pick.
+	// -----------------------------------------------------------------------
+
+	const ADDRESS_ITEM = {
+		key: 'dadata:addr1', label: 'ул Тверская, 1', level: 'address',
+		record: {
+			key: 'dadata:addr1', provider_id: 'dadata', level: 'address', country: 'RU',
+			settlement: { name: 'Москва', type: 'г' },
+			street: { name: 'Тверская', type: 'ул' }, house: '1', label: 'ул Тверская, 1',
+		},
+	};
+
+	it( 'restores the address TEXT (never the record) after a zero-results settlement abandon (#350 follow-up)', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		const region = document.getElementById( 'billing_state' );
+
+		region.value = 'Московская область';
+		region.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+		selectViaFake( callFor( 'billing_address_1' ), ADDRESS_ITEM );
+
+		expect( addressField().value ).toBe( 'ул Тверская, 1' );
+
+		abandonViaFake( callFor( 'billing_city' ), 'Тьмутаракань' );
+
+		// region: untouched (a parent, never in scope). settlement: the customer's own typed
+		// text. address: the TEXT is back, even though clearDescendants() already wiped it the
+		// instant the settlement field's `change` fired — but the RECORD is genuinely gone and
+		// the field is unlocked, exactly like the plain #350 zero-results case.
+		expect( region.value ).toBe( 'Московская область' );
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Тьмутаракань' );
+		expect( addressField().value ).toBe( 'ул Тверская, 1' );
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 'restores the address TEXT after a below-minChars settlement abandon too', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+		selectViaFake( callFor( 'billing_address_1' ), ADDRESS_ITEM );
+
+		const call = callFor( 'billing_city' );
+
+		call.el.value = 'Ку';
+		call.el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		call.onAbandon( { query: 'Ку', resolved: false } );
+
+		expect( addressField().value ).toBe( 'ул Тверская, 1' );
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 'never overwrites address text the customer typed themselves while the abandon was resolving', () => {
+		boot( { region: true, settlement: true, address: true } );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+		selectViaFake( callFor( 'billing_address_1' ), ADDRESS_ITEM );
+
+		const settlementCall = callFor( 'billing_city' );
+
+		// The settlement `change` fires first (clearDescendants() wipes+snapshots the address),
+		// mirroring the real timing onAbandon's own docblock relies on — but this time the
+		// customer types their OWN new address into the now-empty field BEFORE the abandon
+		// report itself arrives.
+		settlementCall.el.value = 'Тьмутаракань';
+		settlementCall.el.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+		expect( addressField().value ).toBe( '' ); // clearDescendants() already ran.
+
+		addressField().value = 'ул Новая, 5';
+
+		settlementCall.onAbandon( { query: 'Тьмутаракань', resolved: true } );
+
+		// Their own text wins — never clobbered by a restore of the OLD address.
+		expect( addressField().value ).toBe( 'ул Новая, 5' );
+		expect( addressField().disabled ).toBe( false );
+	} );
+
+	it( 'does NOT restore the old address after the settlement is re-typed and then a REAL suggestion is adopted', () => {
+		// The regression guard: the snapshot must never leak into the ordinary cascade path.
+		boot( { region: true, settlement: true, address: true } );
+
+		selectViaFake( callFor( 'billing_city' ), SETTLEMENT_ITEM );
+		selectViaFake( callFor( 'billing_address_1' ), ADDRESS_ITEM );
+
+		expect( addressField().value ).toBe( 'ул Тверская, 1' );
+
+		const OTHER_SETTLEMENT_ITEM = {
+			key: 'dadata:other', label: 'Тверь', level: 'settlement',
+			record: {
+				key: 'dadata:other', provider_id: 'dadata', level: 'settlement',
+				country: 'RU', settlement: { name: 'Тверь', type: 'г' }, label: 'г Тверь',
+			},
+		};
+
+		// A genuine pick at settlement — never onAbandon.
+		selectViaFake( callFor( 'billing_city' ), OTHER_SETTLEMENT_ITEM );
+
+		expect( document.getElementById( 'billing_city' ).value ).toBe( 'Тверь' );
+		// The address stays cleared — clearDescendants() wiped it, and nothing restores it for
+		// an ordinary pick; adopting a different settlement really must not keep the old street.
+		expect( addressField().value ).toBe( '' );
+		expect( addressField().disabled ).toBe( false ); // unlocked by the pick itself.
 	} );
 } );

--- a/tests/js/location-typeahead.test.js
+++ b/tests/js/location-typeahead.test.js
@@ -851,3 +851,430 @@ test( 'without emptyText the listbox still hides silently — the old contract i
 	expect( emptyRowOf() ).toBeNull();
 	expect( input.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
 } );
+
+// -----------------------------------------------------------------------
+// ABANDON — adopt or report on blur (issue #350)
+// -----------------------------------------------------------------------
+//
+// A customer who types a locality and tabs away without ever clicking a suggestion used to
+// leave `location-cascade.js` with typed TEXT but no confirmed RECORD — harmless for most
+// fields, but a dead end for the settlement level (issue #337's address lock has no exit for a
+// town the provider genuinely does not carry). `options.onAbandon` is the fix: adopt the first
+// suggestion when the query actually resolved to one or more, report zero via
+// `onAbandon({ resolved: true })` when a completed search resolved to none, report
+// `onAbandon({ resolved: false })` (FIX 1, 17.08.2026) when the text never reached `minChars`
+// at all — never adopting either way — and report NOTHING at all for a blank/escaped/
+// already-committed blur. See the file's own ABANDON docblock section for the full contract.
+
+describe( 'ABANDON — adopt or report on blur (issue #350)', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	test( 'blur with >= 1 completed result adopts item 0', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [ { label: 'Жуковский' }, { label: 'Жуков' } ] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 );
+		await flushMicrotasks();
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( input.value ).toBe( 'Жуковский' );
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onSelect ).toHaveBeenCalledWith( { label: 'Жуковский' } );
+		expect( onAbandon ).not.toHaveBeenCalled();
+		expect( listboxOf().hidden ).toBe( true );
+	} );
+
+	test( 'blur with 0 results calls onAbandon, never onSelect, and leaves the typed text alone', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'Тьмутаракань';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 );
+		await flushMicrotasks();
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onAbandon ).toHaveBeenCalledTimes( 1 );
+		expect( onAbandon ).toHaveBeenCalledWith( { query: 'Тьмутаракань', resolved: true } );
+		expect( input.value ).toBe( 'Тьмутаракань' ); // never overwritten — nothing to adopt.
+	} );
+
+	test( 'Escape then blur adopts nothing', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [ { label: 'Жуковский' } ] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 );
+		await flushMicrotasks(); // a real completed result set now exists for 'жук'.
+
+		input.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ) );
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onAbandon ).not.toHaveBeenCalled();
+		expect( input.value ).toBe( 'жук' ); // an explicit cancel, never silently overridden.
+	} );
+
+	test( 'blur immediately after a real pick adopts nothing', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [ { label: 'Жуковский' }, { label: 'Жуков' } ] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 );
+		await flushMicrotasks();
+
+		input.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } ) );
+		input.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } ) ); // a real pick.
+
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( onSelect ).toHaveBeenCalledTimes( 1 ); // still one — blur decided there was nothing left to do.
+		expect( onAbandon ).not.toHaveBeenCalled();
+		expect( input.value ).toBe( 'Жуковский' );
+	} );
+
+	test( 'blur while the debounce is still pending flushes it and then adopts', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [ { label: 'Жуковский' } ] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+
+		// Tabs away inside the 250ms debounce window — the commonest real trigger for this bug
+		// (operator's own framing): nothing has fired yet, so a strict "already completed" check
+		// with no flush would adopt nothing and the bug would survive unfixed.
+		expect( fetchMock ).not.toHaveBeenCalled();
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( fetchMock ).toHaveBeenCalledWith( 'жук' );
+		expect( onSelect ).toHaveBeenCalledWith( { label: 'Жуковский' } );
+		expect( input.value ).toBe( 'Жуковский' );
+
+		// The debounce timer must actually have been cancelled, not merely raced — advancing
+		// past its original window fires nothing a second time.
+		jest.advanceTimersByTime( 250 );
+		await flushMicrotasks();
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'blur while a fetch is already in flight (debounce already fired) chains onto it', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const pending = deferred();
+		const fetchMock = jest.fn( () => pending.promise );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 ); // the debounce fires — fetch is now in flight, unresolved.
+
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+
+		pending.resolve( [ { label: 'Жуковский' } ] );
+		await flushMicrotasks();
+
+		// Chained onto the SAME in-flight fetch — never a redundant second call.
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( onSelect ).toHaveBeenCalledWith( { label: 'Жуковский' } );
+		expect( input.value ).toBe( 'Жуковский' );
+	} );
+
+	test( 'a blank input never adopts or abandons', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = '';
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onAbandon ).not.toHaveBeenCalled();
+	} );
+
+	test( 'text below minChars never ADOPTS, even if it exactly matches a previously completed query — but it DOES report (FIX 1)', async () => {
+		// Superseded 17.08.2026 (FIX 1): a below-minChars blur used to report nothing at all,
+		// which was itself the dead end — a customer whose real settlement name is shorter than
+		// minChars had no fetch to ever complete, so no way to ever clear #337's address lock.
+		// It still never ADOPTS (nothing was ever asked), but it now DOES report resolved: false.
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [] ) );
+
+		// minChars defaults to 2 — a single character is never eligible for a search at all.
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon, minChars: 2 } );
+
+		input.value = 'ж';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( fetchMock ).not.toHaveBeenCalled();
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onAbandon ).toHaveBeenCalledTimes( 1 );
+		expect( onAbandon ).toHaveBeenCalledWith( { query: 'ж', resolved: false } );
+	} );
+
+	test( 'no onAbandon option supplied — behaviour is byte-identical to today: blur just closes', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		// Note: NO onAbandon in the options object below.
+		const fetchMock = jest.fn( () => Promise.resolve( [] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect } );
+
+		input.value = 'Тьмутаракань';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 );
+		await flushMicrotasks();
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( listboxOf().hidden ).toBe( true );
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( input.value ).toBe( 'Тьмутаракань' ); // untouched — no auto-adopt logic ever ran.
+	} );
+
+	// -----------------------------------------------------------------------
+	// FIX 1 (P0, #350 follow-up): below-minChars is no longer a dead end
+	// -----------------------------------------------------------------------
+	//
+	// A below-minChars blur used to just closeListbox() and stop — no fetch ever ran, so
+	// onAbandon() never fired and a customer whose real settlement name is shorter than
+	// minChars had no way to ever clear #337's address lock. It must now still REPORT
+	// (resolved: false — nothing was ever asked), while still never ADOPTING (there is
+	// nothing to adopt).
+
+	test( 'a below-minChars, non-blank blur reports onAbandon with resolved: false, never onSelect', async () => {
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [ { label: 'should never be called' } ] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon, minChars: 3 } );
+
+		input.value = 'жк'; // 2 chars, below minChars: 3
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( fetchMock ).not.toHaveBeenCalled();
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onAbandon ).toHaveBeenCalledTimes( 1 );
+		expect( onAbandon ).toHaveBeenCalledWith( { query: 'жк', resolved: false } );
+		expect( input.value ).toBe( 'жк' ); // never overwritten
+		expect( listboxOf().hidden ).toBe( true );
+	} );
+
+	test( 'a blank blur still reports nothing at all, even below minChars', async () => {
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [] ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon, minChars: 3 } );
+
+		input.value = '';
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		expect( onSelect ).not.toHaveBeenCalled();
+		expect( onAbandon ).not.toHaveBeenCalled();
+	} );
+
+	// -----------------------------------------------------------------------
+	// FIX 2 (P1): ensureCompletedResults() must not chain onto the WRONG in-flight fetch
+	// -----------------------------------------------------------------------
+	//
+	// `inFlight` names the most RECENTLY ISSUED fetch, which is not necessarily one for the
+	// CURRENT text — the DOM value can change with no `input` event of this module's own (a
+	// silent programmatic write). Chaining onto a stale in-flight fetch there used to make
+	// the widget go silent (no adopt, no onAbandon) for the query the customer actually blurs
+	// on. A blur must resolve the CURRENT text, never fall silent.
+
+	test( 'blur resolves the CURRENT text when an OLDER query is still in flight and no debounce is live', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const older = deferred();
+		const newer = deferred();
+		const fetchMock = jest.fn()
+			.mockImplementationOnce( () => older.promise )
+			.mockImplementationOnce( () => newer.promise );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		// The older query's debounce fires — its fetch is now in flight, unresolved.
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 );
+		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		expect( fetchMock ).toHaveBeenNthCalledWith( 1, 'жук' );
+
+		// The DOM value now holds newer text, but WITHOUT dispatching this module's own
+		// `input` event — mirrors location-cascade.js's writeSilently() (backwards fill /
+		// the pickup-address-replacing announcement), which is exactly how this state arises
+		// for real. No debounce is live for this newer text at all.
+		input.value = 'жуковский';
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		// A SECOND, explicit fetch for the CURRENT text — never chained onto the stale one.
+		expect( fetchMock ).toHaveBeenCalledTimes( 2 );
+		expect( fetchMock ).toHaveBeenNthCalledWith( 2, 'жуковский' );
+
+		newer.resolve( [ { label: 'Жуковский' } ] );
+		await flushMicrotasks();
+
+		expect( onSelect ).toHaveBeenCalledWith( { label: 'Жуковский' } );
+		expect( input.value ).toBe( 'Жуковский' );
+
+		// The stale older fetch finishing afterwards changes nothing further.
+		older.resolve( [ { label: 'stale, never adopted' } ] );
+		await flushMicrotasks();
+
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onAbandon ).not.toHaveBeenCalled();
+	} );
+
+	// Note: the matching-in-flight-query case (`inFlight.query === query`, still chained onto
+	// rather than re-fetched) is already covered by the pre-existing 'blur while a fetch is
+	// already in flight (debounce already fired) chains onto it' test above — FIX 2 narrows
+	// that same branch's condition without changing its outcome, so no separate case is added
+	// here for it.
+
+	// -----------------------------------------------------------------------
+	// FIX 3 (P2): a guard re-runs AFTER the blur continuation's async gap
+	// -----------------------------------------------------------------------
+	//
+	// ensureCompletedResults() deliberately does not closeListbox() before chaining/flushing
+	// (that would bump generation and orphan the very fetch it wants to chain onto), so the
+	// listbox can stay visibly open through the whole await. If something else — a real pick
+	// through that still-open listbox — resolves DURING the gap, the continuation must not
+	// then double-act on top of it.
+
+	test( 'a real pick that lands before the (still-pending) blur continuation resolves is never overwritten', async () => {
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const pending = deferred();
+		const fetchMock = jest.fn( () => pending.promise );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 ); // fetch in flight, unresolved — ensureCompletedResults() will chain onto it.
+
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+
+		// Resolve the in-flight fetch. This settles in TWO microtask steps: (1) runFetch()'s
+		// own success handler renders the listbox and records lastCompletedQuery/Items, which
+		// (2) then resolves ensureCompletedResults()'s own promise, only AFTER which the blur
+		// continuation's `.then()` is even scheduled. One `await` tick lands exactly between
+		// (1) and (2) — the listbox is populated, but the blur continuation has not run yet.
+		pending.resolve( [ { label: 'Жуковский' }, { label: 'Жуков' } ] );
+		await Promise.resolve();
+
+		expect( listboxOf().children.length ).toBe( 2 ); // renderItems() already ran.
+
+		// A real mouse pick on the SECOND option happens NOW — strictly before the blur
+		// continuation (still queued, not yet run) gets to auto-adopt item 0.
+		listboxOf().children[ 1 ].dispatchEvent( new MouseEvent( 'mousedown', { bubbles: true } ) );
+
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onSelect ).toHaveBeenCalledWith( { label: 'Жуков' } );
+		expect( input.value ).toBe( 'Жуков' );
+
+		await flushMicrotasks(); // now let the blur continuation itself run.
+
+		// The blur continuation must find `input.value !== query` ('Жуков' !== 'жук') and do
+		// nothing at all — never overwriting the real pick with its own auto-adopt of item 0.
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onAbandon ).not.toHaveBeenCalled();
+		expect( input.value ).toBe( 'Жуков' );
+	} );
+
+	test( 'an async adopt landing after a consumer already reacted to the abandoned text supersedes it harmlessly', async () => {
+		// Documents the ordering the file docblock relies on: a real browser fires a native
+		// `change` on blur BEFORE this module's own `blur` listener runs, so an outside consumer
+		// (location-cascade.js's handleFieldChanged()) already sees the raw, unresolved text by
+		// the time this module's async adopt decision even starts. The LATER selectItem() this
+		// module runs on adopt supersedes that first, premature read exactly like a slightly
+		// slower human click would — same write, same input/change dispatch. If this stops being
+		// true (e.g. a future change makes the adopt run BEFORE the consumer's own `change`
+		// handling), this test starts failing and should be looked at.
+		jest.useFakeTimers();
+		const onSelect = jest.fn();
+		const onAbandon = jest.fn();
+		const fetchMock = jest.fn( () => Promise.resolve( [ { label: 'Жуковский' } ] ) );
+		const seenAtChange = [];
+
+		input.addEventListener( 'change', () => seenAtChange.push( input.value ) );
+
+		attachTypeahead( input, { fetch: fetchMock, onSelect, onAbandon } );
+
+		input.value = 'жук';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		jest.advanceTimersByTime( 250 );
+		await flushMicrotasks();
+
+		// Mirrors what a real browser (and this module's own blur handler) does: the native
+		// `change` a text edit produces fires BEFORE `blur`.
+		input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		input.dispatchEvent( new Event( 'blur', { bubbles: true } ) );
+		await flushMicrotasks();
+
+		// First `change` seen was the customer's own raw, unresolved text — exactly what a
+		// consumer's own "typed but not picked" handling reacts to. The second is this module's
+		// OWN synthetic dispatch from selectItem(), carrying the adopted value — the correction.
+		expect( seenAtChange ).toEqual( [ 'жук', 'Жуковский' ] );
+		expect( input.value ).toBe( 'Жуковский' );
+	} );
+} );

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -77,6 +77,11 @@
  * {@see isAddressLocked} and {@see refreshAddressLock}. Every state transition that can change
  * the answer re-applies it — see those two functions' own call sites.
  *
+ * ISSUE #350 AMENDS #337 rather than replacing it: a settlement the provider will never suggest
+ * — the customer typed a real but uncarried town and a completed search proved it, never merely
+ * abandoned mid-search — stands down the lock instead of leaving it on forever with no exit. See
+ * {@see isAddressLocked}'s own amendment section and {@see onAbandonFor} for the mechanism.
+ *
  * BOTH EVENT WORLDS (gotcha `jquery-trigger-change-fires-no-native-event`): a jQuery
  * `.trigger('change')` (how select2/selectWoo and much of WooCommerce's own churn report a
  * change) dispatches NO native DOM event, so a delegated `addEventListener('change')` alone
@@ -734,6 +739,22 @@
 			resolved: {},
 			// Per-LEVEL confirmed record (only chain levels; postcode never has one of its own).
 			records: {},
+			// Per-LEVEL text a COMPLETED search already proved the provider has nothing for
+			// (issue #350) — `{ [level]: string|null }`, written by {@see onAbandonFor}, cleared
+			// by a successful pick at that level ({@see onSelectFor}) or by the field's own text
+			// changing to something else ({@see handleFieldChanged}). See {@see isAddressLocked}'s
+			// own #350 amendment, its only consumer.
+			unresolved: {},
+			// Per-LEVEL snapshot of what {@see clearDescendants} most recently wiped as a DIRECT
+			// result of editing THAT level's own field — `{ [level]: {fieldId: previousValue}|null }`
+			// (issue #350 follow-up, operator decision 17.08.2026: the customer keeps their
+			// downstream TEXT when the edit above it turns out unresolvable — only the IDENTITY,
+			// `records[level]`, is genuinely gone). Written by {@see clearDescendants} itself
+			// (never anywhere else), consumed and cleared by {@see restoreClearedDescendants}
+			// (called from {@see onAbandonFor}), and discarded early by a successful pick at that
+			// level ({@see onSelectFor}) so a stale snapshot from BEFORE the pick can never be
+			// restored against some later, unrelated abandon.
+			clearedByEdit: {},
 			// fieldId -> { el, api } for every CURRENTLY attached widget (typeahead OR one of
 			// Task 13's mode-specific renderers — see attachOne()/resolveModeRenderer()).
 			widgets: {},
@@ -1399,6 +1420,17 @@
 			// notice to — see showNotPersistedNotice()'s own docblock for why this is an
 			// entry-level, not node-level, concept.
 			entry.lastSelectedFieldId = node.fieldId;
+			// Issue #350: a real pick proves the CURRENT text is no longer "known unresolved" —
+			// see {@see onAbandonFor}'s own docblock for what this flag means and why it must not
+			// survive past the pick that disproves it.
+			entry.unresolved[ node.level ] = null;
+			// Issue #350 follow-up: the SAME native `change` that just ran ahead of this callback
+			// already had {@see clearDescendants} snapshot whatever it wiped below this level, in
+			// case an abandon needed to restore it. A real pick is not an abandon — the address
+			// staying cleared for a genuinely NEW settlement is correct, ordinary behaviour — so
+			// that snapshot is discarded here, never restored. See {@see restoreClearedDescendants}'s
+			// own docblock for why this mirrors that function's own discard on the abandon path.
+			entry.clearedByEdit[ node.level ] = null;
 
 			backwardsFill( entry, node, record );
 
@@ -1421,6 +1453,73 @@
 					triggerCheckoutUpdate();
 				}
 			}
+		};
+	}
+
+	/**
+	 * Builds the `onAbandon({ query, resolved })` callback handed to the Task 10 widget for one
+	 * chain node (issue #350) — the widget's own file docblock explains WHEN this runs: a blur
+	 * that leaves the query resolved to exactly zero suggestions (`resolved: true`), after
+	 * flushing/chaining onto whatever fetch was pending or in flight, OR a blur whose text never
+	 * reached `minChars` at all (`resolved: false`) — the widget never even ASKED the provider
+	 * about it, so there is nothing "completed" to report, but the customer is left in the exact
+	 * same dead end either way (17.08.2026 follow-up: a settlement name genuinely shorter than
+	 * `minChars` used to have no exit from #337's lock at all, because it could never produce a
+	 * completed zero-result search to begin with).
+	 *
+	 * THE BUG THIS CLOSES: `handleFieldChanged()` already drops `entry.records[level]` for a
+	 * typed-but-never-picked edit (see that function's own docblock) — for the settlement level
+	 * that alone re-locks the address field via issue #337's rule, and #337 has no exit for a
+	 * town the provider genuinely does not carry: such a town will never produce a suggestion to
+	 * click, so the lock would stay on forever and the order could never be completed (operator
+	 * decision, 17.08.2026). This callback records the ONE fact {@see isAddressLocked}'s own
+	 * amendment needs to recognise that dead end and stand down: "the provider has nothing to
+	 * offer for this EXACT text" — whether that was proven by a completed search or by the text
+	 * never being eligible for one.
+	 *
+	 * `detail.resolved` IS DELIBERATELY READ NO FURTHER THAN THIS DOCBLOCK — informational only,
+	 * on purpose, not an oversight: this callback stores the SAME marker (`entry.unresolved[level]`)
+	 * for BOTH `true` and `false`, and {@see isAddressLocked}'s own amendment reads that marker
+	 * without ever asking which one produced it. That is the right call, not a shortcut, because
+	 * the amendment's own question — "can this exact typed text ever produce a suggestion to
+	 * click?" — has the same answer, no, in both cases: `resolved: true` means the provider was
+	 * asked and had nothing; `resolved: false` means the widget never even got to ask, but a
+	 * customer cannot click a suggestion that was never requested either. Distinguishing the two
+	 * here would gate the SAME lock on HOW the dead end was discovered rather than on whether one
+	 * exists — a distinction with no customer-visible difference to make. A future caller that
+	 * genuinely needs the distinction (e.g. different messaging for "try a longer name" vs "we
+	 * don't carry this") can still read `detail.resolved` itself; nothing here prevents that.
+	 *
+	 * NEVER CLEARS A FIELD VALUE ITSELF, AND RESTORES WHAT ANOTHER FUNCTION ALREADY DID (operator's
+	 * own point 3: "a customer left without city, region and address cannot place an order",
+	 * sharpened 17.08.2026 into "keeps the TEXT, only the IDENTITY is gone"). `handleFieldChanged()`'s
+	 * `clearDescendants()` call already did whatever record/descendant-value clearing a typed edit
+	 * ever does — this function runs strictly AFTER that (blur fires after the native `change` a
+	 * text edit already triggered) and never repeats or reaches around it. What it adds is
+	 * {@see restoreClearedDescendants}, which puts back ONLY the TEXT that same clear wiped for
+	 * THIS level, never the record ({@see clearDescendants} already, correctly, nulled it, and
+	 * this never un-nulls it) — see that function's own docblock for the full contract, including
+	 * why a field the customer has since typed into themselves is never overwritten. The region
+	 * field is a PARENT of settlement and nothing in this path — old or new — ever touches it.
+	 *
+	 * @param {Object} entry
+	 * @param {{level: string, fieldId: string, section?: string}} node
+	 * @returns {function({query: string, resolved: boolean}): void}
+	 */
+	function onAbandonFor( entry, node ) {
+		return function( detail ) {
+			entry.unresolved[ node.level ] = detail && 'string' === typeof detail.query ? detail.query : '';
+
+			// Issue #350 follow-up (operator decision 17.08.2026): the customer keeps their
+			// DOWNSTREAM TEXT — only the identity clearDescendants() already dropped for this
+			// level stays dropped. See {@see restoreClearedDescendants}'s own docblock for the
+			// full contract (text-only, never a field already holding the customer's OWN newer
+			// text, snapshot consumed either way).
+			restoreClearedDescendants( entry, node.level );
+
+			// Same rule as a direct pick (issue #337): every state transition that can change
+			// the lock's own answer re-applies it on the spot, never only on some later event.
+			refreshAddressLocks();
 		};
 	}
 
@@ -1599,6 +1698,10 @@
 		var options = {
 			fetch: fetchFor( entry, node ),
 			onSelect: onSelectFor( entry, node ),
+			// Issue #350: OPTIONAL for the widget (a mode-specific Task 13 renderer is free to
+			// ignore it, same as every other primitive here) — see {@see onAbandonFor}'s own
+			// docblock.
+			onAbandon: onAbandonFor( entry, node ),
 			// Server-supplied (translated, filterable via `woodev_location_i18n`) — never a
 			// literal here: this string reaches the customer, so it follows the same route
 			// every other user-facing string in this layer takes.
@@ -1768,6 +1871,29 @@
 	 * the SAME answer that decides whether an address `/suggest` may carry a `within`. A field
 	 * locked here is precisely a field whose suggestions would otherwise search country-wide.
 	 *
+	 * ISSUE #350 AMENDMENT (operator decision, 17.08.2026) — ONE EXCEPTION, NARROWER THAN IT
+	 * LOOKS: the rule above assumes a customer who has not picked a settlement yet still CAN —
+	 * eventually typing enough of a real locality's name produces a suggestion to click. That
+	 * assumption fails for a town the active provider does not carry at all: no suggestion for it
+	 * will ever exist, so the lock this function returns would never lift and the order could
+	 * never be completed — a customer typing a real address in a real, unlisted village is not a
+	 * mistake to be blocked, it is the ordinary case the lock was never meant to catch. So: when
+	 * the settlement field's CURRENT text exactly matches `entry.unresolved.settlement` — a
+	 * COMPLETED search ({@see onAbandonFor}) already proved the provider has nothing for this
+	 * exact string — the address field stays unlocked despite no settlement record existing.
+	 * `entry.unresolved.settlement` is cleared on the two events that can PROVE it stale — a real
+	 * pick ({@see onSelectFor}), or {@see handleFieldChanged} observing the field's own text
+	 * actually change — never "the instant" the text stops matching in some more general sense: a
+	 * purely PROGRAMMATIC value change that dispatches no event of its own (e.g.
+	 * {@see writeSilently}, used for backwards fill and the pickup-address-replacing
+	 * announcement) touches neither path, and could in principle leave the marker stale. What
+	 * actually keeps that safe is the comparison itself being read off the LIVE DOM element rather
+	 * than a captured value (same reason {@see refreshAddressLock} always re-reads too): a stale
+	 * marker only ever matters if the live text still equals it, and a silent write that changes
+	 * the text without dispatching an event makes them differ on the spot —
+	 * {@see settlementTextIsKnownUnresolved} already stops matching before the marker is ever
+	 * cleared.
+	 *
 	 * @param {Object} entry
 	 * @param {{level: string, fieldId: string, section?: string}} node The address chain node.
 	 * @returns {boolean}
@@ -1777,7 +1903,28 @@
 			return false;
 		}
 
-		return null === scopeKeyFor( entry, 'address' );
+		if ( null === scopeKeyFor( entry, 'address' ) ) {
+			return ! settlementTextIsKnownUnresolved( entry );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the settlement field's CURRENT live text is exactly the string a completed search
+	 * already proved the provider has nothing for (issue #350) — {@see isAddressLocked}'s own
+	 * amendment, its only caller. `''` never counts, even if `entry.unresolved.settlement` were
+	 * somehow also `''` — an empty field is simply "nothing typed yet", not a proven dead end.
+	 *
+	 * @param {Object} entry
+	 * @returns {boolean}
+	 */
+	function settlementTextIsKnownUnresolved( entry ) {
+		var node = chainNodeForLevel( entry, 'settlement' );
+		var el = node ? document.getElementById( node.fieldId ) : null;
+		var text = el ? el.value : '';
+
+		return !! text && text === entry.unresolved.settlement;
 	}
 
 	/**
@@ -1998,13 +2145,42 @@
 	 * (mirrors `checkout-field-classic.js`'s own `cascadeChild()` — a destructive clear must
 	 * not itself cascade further).
 	 *
+	 * THIS ALWAYS RUNS — issue #350 follow-up (operator decision 17.08.2026) does NOT weaken this
+	 * function or its call site: it runs synchronously off the native `change` a text edit fires,
+	 * long before any provider answer exists, and it must keep unconditionally clearing on the
+	 * ORDINARY path — adopting a different settlement has to wipe the old address, or the customer
+	 * ends up with a Tverskaya street address filed under a village they just typed over it. What
+	 * changes instead is a SEPARATE snapshot-and-restore step downstream of here
+	 * ({@see restoreClearedDescendants}, called only from {@see onAbandonFor}): when `fromIndex`
+	 * names a CHAIN level (one that can itself carry a widget an abandon can fire from —
+	 * `entry.allNodes[fromIndex].level` is non-null; a postcode-only edit has no such level and no
+	 * `onAbandon` to ever ask for a restore), the pre-clear value of every node this call is about
+	 * to blank is captured into `entry.clearedByEdit[editedLevel]` FIRST, so a later abandon that
+	 * proves the edit unresolvable can put the customer's downstream TEXT back — never the record
+	 * this function correctly nulled two lines below, which stays gone regardless (the identity
+	 * belonged to the settlement the customer just abandoned, not to whatever settlement comes
+	 * next). Overwrites whatever this same level's OWN previous snapshot held — see
+	 * {@see restoreClearedDescendants}'s own docblock for why an overwrite, never an accumulation,
+	 * is the right rule here.
+	 *
 	 * @param {Object} entry
 	 * @param {number} fromIndex
 	 * @returns {void}
 	 */
 	function clearDescendants( entry, fromIndex ) {
+		var editedNode = entry.allNodes[ fromIndex ];
+		var editedLevel = editedNode ? editedNode.level : null;
+		var snapshot = editedLevel ? {} : null;
+
 		for ( var i = fromIndex + 1; i < entry.allNodes.length; i++ ) {
 			var node = entry.allNodes[ i ];
+			var el = document.getElementById( node.fieldId );
+
+			if ( snapshot ) {
+				// Captured BEFORE the clear below, off the live DOM — the text the customer
+				// actually saw, not whatever the store happens to mirror.
+				snapshot[ node.fieldId ] = el ? el.value : '';
+			}
 
 			if ( node.level ) {
 				entry.records[ node.level ] = null;
@@ -2013,12 +2189,70 @@
 			entry.store.setValue( node.fieldId, '' );
 			entry.resolved[ node.fieldId ] = '';
 
-			var el = document.getElementById( node.fieldId );
-
 			if ( el ) {
 				el.value = '';
 			}
 		}
+
+		if ( editedLevel ) {
+			entry.clearedByEdit[ editedLevel ] = snapshot;
+		}
+	}
+
+	/**
+	 * Restores whatever {@see clearDescendants} most recently wiped as a direct result of editing
+	 * `level`'s own field — issue #350 follow-up (operator decision 17.08.2026), called only from
+	 * {@see onAbandonFor} once a search for that edit's exact text (or a below-`minChars` text too
+	 * short to search at all) has proved it unresolvable. TEXT ONLY, never identity:
+	 * `entry.records[...]` for those descendant levels was already set `null` by
+	 * {@see clearDescendants} and stays that way here — the record belonged to the settlement the
+	 * customer just abandoned, and nothing about a downstream field's text coming back re-confirms
+	 * it for whatever settlement comes next.
+	 *
+	 * A FIELD ALREADY HOLDING NEW TEXT IS LEFT ALONE — read live off the DOM, never a captured
+	 * value, so a customer who typed their own address WHILE the abandon was still resolving (the
+	 * whole point of this flow is that it runs after an async round trip) is never overwritten:
+	 * their text always wins over a restore of the OLD one.
+	 *
+	 * THE SNAPSHOT IS CONSUMED, NOT REUSABLE — cleared to `null` unconditionally before this
+	 * function returns, whether or not anything existed to restore. {@see clearDescendants} is the
+	 * only writer, and it already overwrites the same key on every subsequent edit at this level,
+	 * so an explicit clear here exists only to close the one gap that overwrite cannot: a snapshot
+	 * left behind by an edit that a REAL PICK resolved (never reaching this function at all) must
+	 * not survive to be replayed against some later, unrelated abandon — {@see onSelectFor} already
+	 * discards it for that reason on its own path; this one discards it on the abandon path itself,
+	 * so neither leaves a stale snapshot for the other to trip over.
+	 *
+	 * @param {Object} entry
+	 * @param {string} level
+	 * @returns {void}
+	 */
+	function restoreClearedDescendants( entry, level ) {
+		var snapshot = entry.clearedByEdit[ level ];
+
+		entry.clearedByEdit[ level ] = null;
+
+		if ( ! snapshot ) {
+			return;
+		}
+
+		Object.keys( snapshot ).forEach( function( fieldId ) {
+			var previousValue = snapshot[ fieldId ];
+
+			if ( ! previousValue ) {
+				return; // nothing was actually wiped for this field — nothing to restore.
+			}
+
+			var el = document.getElementById( fieldId );
+
+			if ( el && el.value ) {
+				return; // the customer already typed something of their own here — theirs wins.
+			}
+
+			// Silent, like clearDescendants() itself — a restore must not look like a fresh
+			// customer edit and re-trigger this same module's own change-gate.
+			writeSilently( entry, fieldId, previousValue );
+		} );
 	}
 
 	/**
@@ -2185,6 +2419,13 @@
 
 			if ( info.level ) {
 				entry.records[ info.level ] = null; // the field's own record no longer matches its text.
+				// Issue #350: whatever the text was before, this IS a real transition (the
+				// `entry.resolved[id] === newValue` guard above already ruled out a no-op) — so
+				// the field no longer carries the exact string a completed search once proved
+				// unresolved, even if the customer typed right back to nothing in particular.
+				// {@see onAbandonFor} re-sets this for the NEW text, if and when its own search
+				// completes and again finds nothing.
+				entry.unresolved[ info.level ] = null;
 
 				var level = info.level;
 				var section = entry.allNodes[ info.index ].section;

--- a/woodev/shipping-method/assets/js/frontend/location-typeahead.js
+++ b/woodev/shipping-method/assets/js/frontend/location-typeahead.js
@@ -100,6 +100,87 @@
  * With no `emptyText` supplied the old behaviour stands (listbox hidden, no
  * chrome), so a caller that wants silence still gets it.
  *
+ * ABANDON — adopting or reporting a typed-but-never-picked query (issue #350): this module has
+ * no "commit" concept of its own — {@see handleBlur} used to be one line, `closeListbox()`, and
+ * a customer who typed a locality and tabbed away without ever clicking a suggestion left the
+ * cascade layer with typed TEXT but no confirmed RECORD. For most fields that is harmless (the
+ * next `/select` from another field still works); for the settlement level it is not — issue
+ * #337's address lock has no exit for a town the provider genuinely does not carry, because
+ * such a town will never produce a suggestion to click. The operator's fix (17.08.2026) is
+ * `options.onAbandon`, an OPTIONAL third callback alongside `fetch`/`onSelect`:
+ *
+ * - a blur that leaves the query resolved to >= 1 suggestion ADOPTS the first one — the same
+ *   `selectItem()` a click or Enter would run, never a hand-rolled write/dispatch/close/onSelect
+ *   sequence of its own (the ordering in {@see selectItem} is load-bearing — see its own
+ *   docblock);
+ * - a blur that leaves the query resolved to exactly ZERO suggestions calls
+ *   `onAbandon({ query, resolved: true })` instead, so the caller can decide what "the provider
+ *   has nothing for this text" means for ITS OWN fields (`location-cascade.js` uses this to stop
+ *   locking the address field for a settlement the provider will never suggest — see that file's
+ *   `isAddressLocked()`);
+ * - a blur whose text is shorter than `minChars` — this module never even ASKED the provider
+ *   about it, so there is no completed search to report zero results for — calls
+ *   `onAbandon({ query, resolved: false })` instead: never adopts (there is nothing to adopt),
+ *   but still reports, because a query the widget REFUSED TO ASK is, from the customer's own
+ *   side, indistinguishable from one it asked and got nothing for — both leave them with typed
+ *   text and no suggestion they could ever click. A short-but-real settlement name is the
+ *   concrete case this closes (issue #350 follow-up, operator decision): without it, a customer
+ *   whose locality name is shorter than `minChars` had no way to ever clear #337's address lock.
+ *   `resolved` carries the true/false distinction so a caller that wants to tell "asked, got
+ *   nothing" apart from "never asked" still can; see `location-cascade.js`'s own docblock for
+ *   why its current consumer treats the two identically on purpose.
+ *
+ * "Resolved" is deliberately not "whatever `items` currently holds" — {@see closeListbox} (run
+ * on every prior close: a keystroke dropping below `minChars`, a completed pick, Escape, an
+ * outside click) empties `items` unconditionally, and on a MOUSE click-away
+ * {@see handleDocumentMousedown} closes at `mousedown`, strictly BEFORE the `blur` this logic
+ * runs on. Two pieces of state survive `closeListbox()` on purpose so this decision can still be
+ * made afterwards: `lastCompletedQuery`/`lastCompletedItems`, the last fetch that actually
+ * FINISHED (written only inside {@see runFetch}'s success branch, gated on its own generation
+ * still being current — a stale/discarded response can never masquerade as a real answer here
+ * either). Blur additionally FLUSHES a still-pending debounce or CHAINS onto a still-in-flight
+ * fetch ({@see ensureCompletedResults}) before deciding — the ordinary abandon (customer types
+ * the last few characters and tabs straight out) lands inside the 250ms debounce window far more
+ * often than after it, and without this flush the widget would see no completed query for the
+ * current text and adopt nothing, i.e. the bug this whole mechanism exists to close would
+ * survive unfixed for the single most common trigger.
+ *
+ * NEVER REPORTS ANYTHING AT ALL (no adopt, no `onAbandon`) ON: a blank input (there is no typed
+ * settlement to be unresolved about), an `Escape` since the last keystroke (`escaped`, an
+ * explicit customer cancel — never silently overridden by an auto-adopt or a report), or a blur
+ * whose value is exactly what {@see selectItem} itself just wrote (`committedValue` — a blur
+ * firing right after a genuine pick must not re-decide anything). A rejected fetch, or the widget
+ * detaching while the flush/chain above is still pending, also does nothing at all — see
+ * {@see handleBlur}'s own body. A query shorter than `minChars` is DIFFERENT from all of these —
+ * see the bullet list above: it never adopts, but it does report, `resolved: false`.
+ *
+ * A GUARD RE-RUNS AFTER THE ASYNC GAP {@see ensureCompletedResults} OPENS, right before adopting
+ * or reporting: `detached`, `input.value !== query` (the text changed under us — a fresh
+ * keystroke `handleInput()` already reacted to on its own terms), and `query === committedValue`
+ * (something committed this exact value WHILE the await was pending — most concretely, the
+ * listbox staying open through the gap on purpose, see {@see ensureCompletedResults}'s own
+ * docblock, and the customer clicking one of ITS options mid-await). Any of these three means
+ * this continuation no longer owns the decision and does nothing at all — never even
+ * `closeListbox()`, which the action that already ran (a pick closes it itself) or will still run
+ * (a fresh keystroke's own debounce) already owns.
+ *
+ * A LATE ADOPT RACING `location-cascade.js`'s OWN "typed but not picked" HANDLING IS SAFE AND
+ * DELIBERATELY UNGUARDED: a real browser already fires a native `change` on blur before this
+ * module's own `blur` listener runs, so by the time an async adopt here resolves,
+ * `handleFieldChanged()` has typically already read the abandoned text, dropped the field's
+ * record, and fired a spurious empty-key `woodev_location_applied`. The later `selectItem()` this
+ * module then runs supersedes it exactly the same way a slightly slower human click would — same
+ * write, same `input`/`change` dispatch, same `onSelect()` — so nothing extra is needed to
+ * suppress or reorder it.
+ *
+ * With no `onAbandon` supplied, `handleBlur()` is EXTERNALLY EQUIVALENT to before this feature
+ * existed — `closeListbox()` and nothing else, the same DOM/ARIA/focus outcome a caller could
+ * observe either way. It is not literally unchanged internally: every piece of new state above
+ * (`committedValue`, `inFlight`, `lastCompletedQuery`/`lastCompletedItems`) is still maintained
+ * by {@see selectItem}/{@see runFetch} regardless of whether `onAbandon` was supplied (there is
+ * no branch cheap enough to justify skipping it) — a caller with no `onAbandon` simply never
+ * reads any of it.
+ *
  * UMD-ish dual export (matches pickup-datasource.js): the module IS the
  * factory function.
  *   - Browser global: window.WoodevLocationTypeahead = attachTypeahead
@@ -206,6 +287,17 @@
 	 * @param {Function}         options.fetch    `function( query: string ): Promise<Array>`.
 	 * @param {Function}         options.onSelect `function( item: Object ): void`, called with the
 	 *                                             raw selected suggestion object.
+	 * @param {Function}         [options.onAbandon] `function( { query: string, resolved: boolean } ): void`
+	 *                                                — see the file docblock's ABANDON section.
+	 *                                                Called on blur, in place of an auto-adopt,
+	 *                                                when a completed search resolved to zero
+	 *                                                suggestions (`resolved: true`) OR when the
+	 *                                                query was too short to search at all
+	 *                                                (`resolved: false`). Omitted entirely:
+	 *                                                `handleBlur()` is externally equivalent to
+	 *                                                how it behaved before this option existed —
+	 *                                                see the file docblock's own note on what
+	 *                                                that equivalence does and does not cover.
 	 * @param {number}           [options.minChars] Minimum input length before a search fires.
 	 *                                               Defaults to {@see DEFAULT_MIN_CHARS}.
 	 * @param {string}           [options.emptyText] Message shown in the listbox when a completed
@@ -220,6 +312,7 @@
 			return Promise.resolve( [] );
 		};
 		var onSelectFn = 'function' === typeof opts.onSelect ? opts.onSelect : function() {};
+		var onAbandonFn = 'function' === typeof opts.onAbandon ? opts.onAbandon : null;
 		var minChars = 'number' === typeof opts.minChars && opts.minChars >= 0 ? opts.minChars : DEFAULT_MIN_CHARS;
 
 		var existing = instances.get( input );
@@ -278,6 +371,40 @@
 
 		/** @type {boolean} true once detach() has run — guards a second detach() call. */
 		var detached = false;
+
+		/**
+		 * ABANDON state — see the file docblock's own section. Unlike `items`/`activeIndex`,
+		 * NONE of the below is touched by {@see closeListbox}: it must all still answer correctly
+		 * for a blur that runs strictly after the listbox has already closed (a mouse click-away
+		 * closes at `mousedown`, well before its own `blur`).
+		 */
+
+		/** @type {string|null} the query the last COMPLETED fetch ran for — {@see runFetch}. */
+		var lastCompletedQuery = null;
+
+		/** @type {Array} that completed fetch's own result array. */
+		var lastCompletedItems = [];
+
+		/**
+		 * @type {boolean} true from an Escape keypress until the next `input` event — an explicit
+		 * cancel that {@see handleBlur} must never second-guess with an auto-adopt.
+		 */
+		var escaped = false;
+
+		/**
+		 * @type {string|null} the value {@see selectItem} last wrote into the input — a blur
+		 * landing right after a genuine pick (`input.value === committedValue`) has nothing left
+		 * to decide.
+		 */
+		var committedValue = null;
+
+		/**
+		 * @type {{generation: number, query: string, promise: Promise}|null} the most recently
+		 * ISSUED fetch's own bookkeeping, kept until a NEWER {@see runFetch} call overwrites it —
+		 * lets {@see ensureCompletedResults} chain onto a fetch that is still in flight at blur
+		 * time instead of starting a redundant second one.
+		 */
+		var inFlight = null;
 
 		/**
 		 * Shows or hides the busy indicator — see the file docblock's BUSY STATE
@@ -453,6 +580,10 @@
 			var value = item && 'string' === typeof item.value ? item.value : label;
 
 			input.value = value;
+			// See the file docblock's ABANDON section: a blur immediately after THIS write must
+			// find nothing left to decide, whether the pick came from a click/Enter or from
+			// handleBlur()'s own auto-adopt.
+			committedValue = value;
 			input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 			input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
 
@@ -466,8 +597,16 @@
 		 * the result (success or failure) only if that generation is still
 		 * current when it settles — see the file docblock.
 		 *
+		 * ALSO records `inFlight` (for {@see ensureCompletedResults} to chain onto) and, on a
+		 * generation-current success, `lastCompletedQuery`/`lastCompletedItems` (the file
+		 * docblock's ABANDON state) — both are plain bookkeeping side effects of the SAME
+		 * generation-gated success branch every caller already relies on for `renderItems()`,
+		 * never a second, differently-gated decision. Returns the settling promise so
+		 * {@see ensureCompletedResults} can await it; every other existing caller ignores the
+		 * return value, so this is not a behaviour change for them.
+		 *
 		 * @param {string} query
-		 * @returns {void}
+		 * @returns {Promise}
 		 */
 		function runFetch( query ) {
 			generation += 1;
@@ -481,10 +620,10 @@
 				// to show — and nothing still outstanding, so the search is over.
 				setBusy( false );
 
-				return;
+				return Promise.resolve();
 			}
 
-			Promise.resolve( result ).then(
+			var settled = Promise.resolve( result ).then(
 				function( results ) {
 					// A response whose generation is stale must not clear the busy state
 					// either: a NEWER search owns it now, and this one losing the race is
@@ -494,6 +633,14 @@
 					}
 
 					setBusy( false );
+
+					// See the file docblock's ABANDON section — written ONLY here, inside the
+					// same "this response is still current" guard renderItems() already relies
+					// on, so a stale/discarded response can never masquerade as a real answer
+					// for a query the customer has since moved on from.
+					lastCompletedQuery = query;
+					lastCompletedItems = Array.isArray( results ) ? results : [];
+
 					renderItems( results );
 				},
 				function() {
@@ -501,10 +648,18 @@
 						return;
 					}
 
-					// `closeListbox()` clears the busy state itself.
+					// `closeListbox()` clears the busy state itself. Deliberately does NOT touch
+					// `lastCompletedQuery`/`lastCompletedItems` — a rejection leaves whatever the
+					// PREVIOUS completed fetch left there, which is exactly what makes those two
+					// read as stale-for-this-query rather than "resolved to zero" (see
+					// {@see handleBlur}: it only trusts them when `lastCompletedQuery === query`).
 					closeListbox();
 				}
 			);
+
+			inFlight = { generation: myGeneration, query: query, promise: settled };
+
+			return settled;
 		}
 
 		/**
@@ -519,6 +674,10 @@
 		 */
 		function handleInput() {
 			var query = input.value;
+
+			// See the file docblock's ABANDON section: Escape is an explicit cancel, but only
+			// until the customer actually types again — a fresh keystroke re-arms the auto-adopt.
+			escaped = false;
 
 			if ( null !== debounceTimer ) {
 				clearTimeout( debounceTimer );
@@ -586,6 +745,9 @@
 
 			if ( 'Escape' === event.key ) {
 				event.preventDefault();
+				// See the file docblock's ABANDON section — an explicit cancel {@see handleBlur}
+				// must never override with an auto-adopt, until the customer types again.
+				escaped = true;
 				closeListbox();
 			}
 		}
@@ -640,14 +802,139 @@
 		}
 
 		/**
+		 * Ensures a completed result set exists for exactly `query` before {@see handleBlur}
+		 * decides anything — see the file docblock's own reasoning for why this flush/chain step
+		 * is required, not optional: the ordinary abandon (typing the last characters and tabbing
+		 * straight out) lands INSIDE the 250ms debounce window far more often than after it.
+		 *
+		 * A pending debounce timer is cancelled and its fetch run immediately. Otherwise, a fetch
+		 * already in flight is chained onto via `inFlight.promise` — but ONLY when it is in flight
+		 * FOR `query` ITSELF (`inFlight.query === query`); `inFlight` always names the most
+		 * RECENTLY ISSUED fetch, which is not necessarily one for the CURRENT text — the DOM value
+		 * can change with no `input` event of this module's own in between (e.g.
+		 * `location-cascade.js`'s `writeSilently()`, used for backwards fill and the pickup-
+		 * address-replacing announcement, writes `el.value` directly). Chaining onto a stale
+		 * in-flight fetch there would let its resolution decide {@see handleBlur} for text it was
+		 * never asked about — `lastCompletedQuery` would then read as the OLD query, the
+		 * `lastCompletedQuery !== query` guard in {@see handleBlur} would find no usable answer for
+		 * the CURRENT text, and the customer would get silence: no adopt, no `onAbandon`, the exact
+		 * no-exit shape this whole mechanism exists to close. A query already answered by an
+		 * EARLIER completed fetch (`lastCompletedQuery === query`, nothing pending or in flight for
+		 * it) needs no fetch of its own either — the promise resolves on the very next microtask,
+		 * and the caller finds `lastCompletedQuery` already equal to `query`. Every other case runs
+		 * a fresh fetch for `query` explicitly (the same call the debounce-flush branch above
+		 * makes) — never a duplicate of one already outstanding for that exact text, since the
+		 * matching-`inFlight` branch above already claimed that case.
+		 *
+		 * @param {string} query
+		 * @returns {Promise}
+		 */
+		function ensureCompletedResults( query ) {
+			if ( null !== debounceTimer ) {
+				clearTimeout( debounceTimer );
+				debounceTimer = null;
+
+				return runFetch( query );
+			}
+
+			if ( inFlight && inFlight.query === query ) {
+				return inFlight.promise;
+			}
+
+			if ( lastCompletedQuery === query ) {
+				return Promise.resolve();
+			}
+
+			return runFetch( query );
+		}
+
+		/**
 		 * `blur` handler: the listbox is only ever relevant while the input is
 		 * focused (e.g. Tab away without any mouse click at all, which the
 		 * document mousedown listener would never see).
 		 *
+		 * WITHOUT `options.onAbandon` this is the original one-liner — `closeListbox()` and
+		 * nothing else (externally equivalent to before this option existed — see the file
+		 * docblock's own note on that). WITH it, see the file docblock's own ABANDON section for
+		 * the full contract; in short:
+		 *
+		 * - a blank input, an Escape since the last keystroke, or a value already matching
+		 *   {@see selectItem}'s last write reports NOTHING at all — just `closeListbox()`;
+		 * - a query shorter than `minChars` reports `onAbandon( { query, resolved: false } )` —
+		 *   never adopts (nothing was ever asked), but DOES report, since a query this module
+		 *   refused to ask about is, from the customer's own side, indistinguishable from one it
+		 *   asked and got nothing for;
+		 * - otherwise, flush/chain onto a completed fetch for the current text
+		 *   ({@see ensureCompletedResults}), RE-CHECK the guards below (the await it returns is an
+		 *   async gap something else may have already acted inside), and either adopt the first
+		 *   result, report `onAbandon( { query, resolved: true } )` for zero, or — if the guards
+		 *   below now say this continuation no longer owns the decision — do nothing at all.
+		 *
 		 * @returns {void}
 		 */
 		function handleBlur() {
-			closeListbox();
+			if ( ! onAbandonFn ) {
+				closeListbox();
+
+				return;
+			}
+
+			var query = input.value;
+
+			if ( '' === query || escaped || query === committedValue ) {
+				closeListbox();
+
+				return;
+			}
+
+			if ( query.length < minChars ) {
+				// See the file docblock's ABANDON section: this module never even asked the
+				// provider about a query this short, so there is no completed search to report
+				// zero results for — but a customer whose real settlement name is shorter than
+				// `minChars` still has no suggestion to click, exactly the dead end #350 exists to
+				// close. Reported, never adopted (there is nothing to adopt).
+				closeListbox();
+				onAbandonFn( { query: query, resolved: false } );
+
+				return;
+			}
+
+			ensureCompletedResults( query ).then( function() {
+				if ( detached ) {
+					return;
+				}
+
+				// The await above is a real async gap — something else may already have acted
+				// inside it. See the file docblock's own note on this guard for both cases:
+				// `input.value !== query` (the text changed under us — a fresh keystroke
+				// `handleInput()` already reacted to on its own terms) and `query === committedValue`
+				// (a real pick landed while this was pending — most concretely a click on the
+				// listbox {@see ensureCompletedResults} deliberately leaves open through the await).
+				// Either way this continuation no longer owns the decision — not even
+				// `closeListbox()`, which whatever already ran either already called itself (a pick)
+				// or will still call on its own terms (a fresh keystroke's own debounce/close path).
+				if ( input.value !== query || query === committedValue ) {
+					return;
+				}
+
+				if ( lastCompletedQuery !== query ) {
+					// Nothing usable for THIS exact text — the fetch for it rejected, or (a
+					// defensive case the invariants above should prevent) never ran at all. See
+					// the file docblock: silence, not a false "resolved to zero" report.
+					closeListbox();
+
+					return;
+				}
+
+				if ( lastCompletedItems.length >= 1 ) {
+					selectItem( lastCompletedItems[ 0 ] ); // closes the listbox itself.
+
+					return;
+				}
+
+				closeListbox();
+				onAbandonFn( { query: query, resolved: true } );
+			} );
 		}
 
 		input.addEventListener( 'input', handleInput );


### PR DESCRIPTION
Closes #350

## Проблема

Покупатель печатает НП и уходит, не выбрав подсказку. Записи уровня НП нет → по правилу #337 адрес блокируется. Для города, которого нет в базе провайдера, у этой блокировки **нет выхода**: подсказок не будет по условию, значит выбрать нечего, значит заказ не оформить.

## Решение (оператор, 17.08.2026)

Подставлять первую подсказку, если список вернул хотя бы один результат. Если результатов нет — оставлять введённый текст и **не блокировать** адрес (согласованная правка #337). Регион не трогаем: он выбран раньше и отдельно, неизвестный НП его не опровергает.

## Почему это не однострочник

В виджете **не было понятия «коммит»**: `handleBlur()` состоял из одного `closeListbox()`. И **не было состояния**, отличающего «запрос завершился и вернул ноль» от «запрос ещё летит / не запускался» — `items === []` означало всё сразу, а `closeListbox()` затирал его раньше, чем blur успевал прочитать. При клике мимо список закрывается на `mousedown`, то есть до `change` и `blur`. Оба механизма пришлось построить.

- `location-typeahead.js` хранит `lastCompletedQuery`/`lastCompletedItems` через закрытие списка, отслеживает летящий запрос, помнит, что подставил `selectItem()` и был ли отменён ввод по Escape. На blur дожимает отложенный дебаунс (или пристраивается к летящему запросу **того же** текста) и только потом решает — иначе уход по Tab внутри 250 мс дебаунса ничего бы не подставил и баг пережил бы правку. Подстановка идёт через настоящий `selectItem()`: порядок «значение → input → change → закрыть → onSelect» несущий. Escape, пустое поле и уже подставленное значение не подставляют ничего.
- `location-cascade.js` запоминает неразрешённый текст по уровню и снимает блокировку, пока поле НП держит ровно его. Текст короче `minChars` тоже отчитывается: провайдера не спрашивали вовсе, значит выхода из блокировки тем более нет.
- `clearDescendants()` снимает слепок значений, которые стирает, а отказной путь их возвращает — **только в поля, оставшиеся пустыми**, чтобы текст, введённый покупателем за время ожидания, всегда побеждал. Идентичности при этом остаются сброшенными: возвращается только текст. Настоящий выбор подсказки слепок выбрасывает, поэтому смена города по-прежнему чистит старый адрес.

## Что нашёл adversarial-критик (Codex) и что исправлено

- **P0:** выход по `minChars` сохранял тот же тупик для коротких названий НП.
- **P1:** `ensureCompletedResults()` мог ждать **чужой** летящий запрос (не сверялся `inFlight.query`), после чего молча закрывался — ни подстановки, ни отказа.
- **P2:** не было проверки после `await` — покупатель мог за это время уйти или выбрать сам.
- **P2:** докблоки обещали больше, чем код делает.

## Проверка

**1177 jest** (было 1154), **2299 unit / 5690 ассертов**, phpcs 210/210, phpstan чисто.

Каждое новое поведение проверено мутацией с подтверждением, что мутация применилась. Честно отмечено: одна защитная строка (сброс слепка при выборе) не убивает ни одного теста — при текущем графе вызовов она недостижима, оставлена намеренно.

**Риг (пара СДЭК + DaData):**

| Сценарий | До | После |
|---|---|---|
| Печатает «Москва», уходит без выбора | адрес заблокирован | подставилась первая подсказка, `chain = { settlement: test-cdek:44 }`, адрес открыт |
| Печатает несуществующий НП с чистого листа | адрес заблокирован | текст остался, адрес разблокирован |
| НП и адрес заполнены, НП переписан на несуществующий | — | регион «Москва», адрес `ulitsa Tverskaya, 1` и индекс `125009` целы, адрес открыт |

## Связано

- #337 — правило блокировки, здесь согласованно смягчено
- #352 — смежная правка того же слоя, уже в `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD