### PR TITLE
fix(location): read a stale customer record as absent (#346, #333)

### DIFF
--- a/docs-internal/GOTCHAS.md
+++ b/docs-internal/GOTCHAS.md
@@ -1,6 +1,6 @@
 # Gotchas — Woodev Plugin Framework
 
-> **Index only.** 162 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
+> **Index only.** 163 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
 > recognise, and a link to the file that holds the detail. Never paste the detail here — a second
 > copy drifts from the first, and this file is read at the start of every session.
 > **Adding one:** create `gotchas/{slug}.md` (format: `DOCS-SCHEMA.md`), then add one line below
@@ -119,6 +119,7 @@
 - [testing/integration] **A fixture class that implements a framework interface must be declared inside the plugin's init callback.** → [fixture-classes-must-live-inside-plugin-init](gotchas/fixture-classes-must-live-inside-plugin-init.md) (s46)
 - [testing/integration] **integration tests — don't fire global admin hooks; `$menu`/`$submenu` accumulate across tests.** → [integration-test-global-admin-hooks-output-and-submenu-accumulation](gotchas/integration-test-global-admin-hooks-output-and-submenu-accumulation.md) (s34)
 - [testing/integration] **A stale `.phpunit.result.cache` hides cross-test state leaks CI cannot avoid.** → [phpunit-defects-cache-hides-cross-test-session-leaks](gotchas/phpunit-defects-cache-hides-cross-test-session-leaks.md) (s71)
+- [testing/integration] **A fresh guest's shipping country resolves through geolocation (hardcoded `US` fallback), not the store default.** → [wc-customer-default-location-geolocation-fallback](gotchas/wc-customer-default-location-geolocation-fallback.md) (s78)
 - [testing/integration] **`WP_UnitTestCase` restores the hook table after every test — an identity-based `reset_for_tests()` cannot remove what comes back.** → [hook-snapshot-restore-defeats-an-identity-based-reset](gotchas/hook-snapshot-restore-defeats-an-identity-based-reset.md) (s70)
 
 - [testing/unit] **A mutation sweep over branch conditions reads as complete and is not.** → [mutation-sweep-branch-only-false-confidence](gotchas/mutation-sweep-branch-only-false-confidence.md) (s45)

--- a/docs-internal/GOTCHAS.md
+++ b/docs-internal/GOTCHAS.md
@@ -1,6 +1,6 @@
 # Gotchas — Woodev Plugin Framework
 
-> **Index only.** 159 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
+> **Index only.** 162 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
 > recognise, and a link to the file that holds the detail. Never paste the detail here — a second
 > copy drifts from the first, and this file is read at the start of every session.
 > **Adding one:** create `gotchas/{slug}.md` (format: `DOCS-SCHEMA.md`), then add one line below
@@ -79,6 +79,7 @@
 - [woocommerce/address-autocomplete] **Wrapping `window.wc.addressAutocomplete.providers` touches a namespace, not a contract — and two implementation traps along the way.** → [wc-address-autocomplete-registry-wrap-is-not-a-documented-contract](gotchas/wc-address-autocomplete-registry-wrap-is-not-a-documented-contract.md) (s69)
 
 ### [shipping/location] — Location provider layer
+- [shipping/location] **`within_applied` reports what the scope BUILDER decided, not what the provider honoured — the one field that could detect a dropped scope cannot.** → [within-applied-reports-the-scope-builder-not-the-provider](gotchas/within-applied-reports-the-scope-builder-not-the-provider.md) (s78)
 - [shipping/location] **A served level can come from the FALLBACK provider, not the active one — "the active provider lacks X" and "X is unserved" are different statements.** → [a-level-served-can-come-from-the-fallback-not-the-active-provider](gotchas/a-level-served-can-come-from-the-fallback-not-the-active-provider.md) (s76)
 - [shipping/location] **One identity, two roles: one must refuse, the other must fall back.** → [one-identity-two-roles-one-must-refuse-the-other-must-fall-back](gotchas/one-identity-two-roles-one-must-refuse-the-other-must-fall-back.md) (s74)
 - [shipping/location] **A derived ancestor is not the one the customer picked.** → [a-derived-ancestor-is-not-the-one-the-customer-picked](gotchas/a-derived-ancestor-is-not-the-one-the-customer-picked.md) (s74)
@@ -96,6 +97,8 @@
 - [framework/wiring] **A feature built on both sides, with nothing calling it in the middle.** → [built-on-both-sides-with-no-caller-in-the-middle](gotchas/built-on-both-sides-with-no-caller-in-the-middle.md) (s56, extended s59)
 
 ### [testing/*] — Testing patterns
+- [testing/*] **Measure a gate only where the gate can actually fire — an AND-ed precondition you did not control answers for you.** → [measure-a-gate-where-the-gate-can-actually-fire](gotchas/measure-a-gate-where-the-gate-can-actually-fire.md) (s78)
+- [testing/*] **A `perl -0pi` mutation with `\n` silently misses every CRLF file, and the green run reads as proof.** → [perl-multiline-mutation-silently-misses-crlf-files](gotchas/perl-multiline-mutation-silently-misses-crlf-files.md) (s78)
 - [testing/*] **A probe that uses the production accessor creates the state it measures.** → [a-probe-that-uses-the-production-accessor-creates-the-state-it-measures](gotchas/a-probe-that-uses-the-production-accessor-creates-the-state-it-measures.md) (s74)
 - [testing/*] **A mutation you did not confirm APPLIED proves nothing — a silently-missed edit reads as "the test survives it".** → [a-mutation-you-did-not-confirm-applied-proves-nothing](gotchas/a-mutation-you-did-not-confirm-applied-proves-nothing.md) (s73)
 - [testing/unit] **`Functions\expect( 'f' )->once()->with( X )` does NOT reject a second call with different arguments.** → [brain-monkey-expect-with-does-not-reject-extra-calls](gotchas/brain-monkey-expect-with-does-not-reject-extra-calls.md) (s72)

--- a/docs-internal/gotchas/codex-shell-sandbox-broken-windows.md
+++ b/docs-internal/gotchas/codex-shell-sandbox-broken-windows.md
@@ -109,8 +109,14 @@ Note this does NOT contradict step 3 above — that recipe pipes via **stdin** (
 which is safe. Argument interpolation is what breaks.
 
 **Fix — use a transport that cannot reinterpret quoting, in this order:**
-1. `--prompt-file <path>` (verified working s61, invoked from **Bash**, not PowerShell)
-2. stdin pipe from Bash (`cat bundle.md | codex exec … -`) — the step-3 recipe
+1. ~~`--prompt-file <path>`~~ — **GONE as of codex-cli 0.147.0** (s78). The flag no longer
+   exists; the CLI answers `error: unexpected argument '--prompt-file' found / tip: a similar
+   argument exists: '--profile'` and **exits 0**, so a background run looks like it succeeded
+   and simply writes no output file. If your critic produced no `-o` file, check for this
+   before assuming the model failed.
+2. **stdin pipe from Bash** (`cat bundle.md | codex exec … -`) — the step-3 recipe. **This is now
+   the primary transport** (verified working s78 on 0.147.0, two clean critic runs with the
+   canary echoed back quote-for-quote).
 3. a Bash heredoc
 
 **Always verify the round trip before accepting any finding.** Prepend to the bundle:

--- a/docs-internal/gotchas/measure-a-gate-where-the-gate-can-actually-fire.md
+++ b/docs-internal/gotchas/measure-a-gate-where-the-gate-can-actually-fire.md
@@ -1,0 +1,65 @@
+# Gotcha: [testing/*] — Measure a gate only where the gate can actually fire, or you prove someone else's point
+> Tags: rig, measurement, control, location | Session: s78
+
+## What happens
+
+Issue #346 claims a stale customer record UNLOCKS the address field: the layer thinks a
+settlement is chosen, so rule #337 stands down.
+
+The obvious rig pass: pick a settlement in RU, switch the country, reload, read
+`shipping_address_1.disabled`. Done on **AM**, it returned `disabled: false` — the claim
+apparently confirmed.
+
+It proved nothing. `levels.AM.address === false` — the layer does not serve the address level in
+Armenia at all, so `isAddressLocked()` returns `false` at its `isNodeActive()` guard long before
+it ever looks at the settlement record. The field would read `disabled: false` with no stored
+record, no country change, and no bug. The measurement could not have come out any other way.
+
+Re-run on **BY** (`levels.BY.address === true`), the claim is genuinely confirmed: country BY,
+settlement field EMPTY, address field open, `current = { key: "test-cdek:44" }` — a Russian
+settlement.
+
+## Root cause
+
+A gate with several AND-ed preconditions can be satisfied by ANY of them. Reading the output
+tells you the gate is open; it does not tell you WHICH condition opened it. Pick an environment
+where the conditions you are not testing are all satisfied, or the one you are testing never gets
+a vote.
+
+Here `isAddressLocked()` reads:
+
+```js
+if ( ! chainNodeForLevel( entry, 'settlement' ) || ! isNodeActive( entry, node ) ) {
+    return false;                       // <- AM exits here, every time
+}
+return null === scopeKeyFor( entry, 'address' );   // <- the condition under test
+```
+
+## Fix
+
+❌ Wrong — one country, one reading, conclusion drawn:
+
+```
+country = AM → address disabled: false → "the stale record unlocks the address" ✓
+```
+
+✅ Correct — choose the environment so the untested preconditions hold, and say why:
+
+```
+levels.AM.address === false  → AM cannot test this gate at all, the early return wins
+levels.BY.address === true   → BY can
+country = BY → address disabled: false, city EMPTY, current = test-cdek:44  → claim confirmed
+```
+
+General rule for this rig: before measuring anything gated per level, read
+`config.location.levels[country]` and pick a country where the level under test is served.
+`RU`, `BY`, `KZ` and `UZ` serve `address`; `AM`, `AZ`, `KG`, `TJ` and `TM` do not.
+
+## Related
+
+- [a-restore-tied-to-a-server-confirmation-looks-like-a-render-artefact](a-restore-tied-to-a-server-confirmation-looks-like-a-render-artefact.md)
+  — the same failure from the other side: settle "who did this" with a control, never by watching
+- [a-probe-that-uses-the-production-accessor-creates-the-state-it-measures](a-probe-that-uses-the-production-accessor-creates-the-state-it-measures.md)
+  — another way a rig probe answers a question you did not ask
+- [a-level-served-can-come-from-the-fallback-not-the-active-provider](a-level-served-can-come-from-the-fallback-not-the-active-provider.md)
+  — where the per-country `levels` map comes from

--- a/docs-internal/gotchas/perl-multiline-mutation-silently-misses-crlf-files.md
+++ b/docs-internal/gotchas/perl-multiline-mutation-silently-misses-crlf-files.md
@@ -1,0 +1,61 @@
+# Gotcha: [testing/*] — A `perl -0pi` mutation with `\n` silently misses every CRLF file, and the green run reads as proof
+> Tags: mutation-testing, windows, crlf, verification | Session: s78
+
+## What happens
+
+Standard practice here: after adding a test, mutate the implementation and confirm the test
+FAILS — a test that passes both ways proves nothing.
+
+The mutation is applied with a one-liner:
+
+```bash
+perl -0pi -e "s/\tif \( owner && owner !== record\.provider_id \) \{\n\t\t\treturn;\n\t\t\}/\tif ( false ) {\n\t\t\treturn;\n\t\t}/" file.js
+```
+
+The suite is re-run and comes back **fully green**. Read at face value, that says the new tests
+are vacuous. Read the other way round — "my fix is not covered" — and you would go rewrite
+working tests.
+
+Both readings are wrong. `perl` exited 0, changed nothing, and said nothing. The working tree on
+this box holds **CRLF**, so `\n` in the pattern never matched the `\r\n` in the file. The mutation
+was never applied, so of course nothing failed.
+
+This is the exact shape of gotcha `a-mutation-you-did-not-confirm-applied-proves-nothing`, with
+a Windows-specific cause: the tool that reports success is not the tool that had to match.
+
+## Root cause
+
+Files in this repo are CRLF in the working tree (`.gitattributes` normalises to LF on commit —
+hence the routine `warning: CRLF will be replaced by LF` on every `git diff`). A multi-line
+`perl` pattern written with `\n` therefore matches nothing, and a non-matching `s///` is not an
+error. `git diff --stat` afterwards still shows the file as modified — from the REAL edits made
+earlier — so even the diff looks plausible.
+
+## Fix
+
+❌ Wrong — mutate and trust the exit code:
+
+```bash
+perl -0pi -e "s/old\nlines/new\nlines/" file.js
+npm run test:js -- --roots "<rootDir>/tests/js"      # green => "the test is vacuous"
+```
+
+✅ Correct — use the `Edit` tool for the mutation (it matches the file as it really is), then
+**grep the mutated line back before running anything**:
+
+```bash
+grep -n "if ( false &&" file.js     # no output => the mutation did NOT apply, stop
+npm run test:js -- --roots "<rootDir>/tests/js"
+```
+
+Only a mutation you have SEEN in the file makes the following test run meaningful. If you must
+use `perl`, match `\r?\n` — but prefer `Edit`.
+
+## Related
+
+- [a-mutation-you-did-not-confirm-applied-proves-nothing](a-mutation-you-did-not-confirm-applied-proves-nothing.md)
+  — the general rule this is a Windows-flavoured instance of
+- [serena-replace-content-eol-flip](serena-replace-content-eol-flip.md) — the other CRLF trap on
+  this box, from the opposite direction (an edit that rewrites the WHOLE file)
+- [git-add-all-sweeps-crlf-normalisation-in-a-fresh-worktree](git-add-all-sweeps-crlf-normalisation-in-a-fresh-worktree.md)
+  — the same line-ending split biting the commit instead of the edit

--- a/docs-internal/gotchas/wc-customer-default-location-geolocation-fallback.md
+++ b/docs-internal/gotchas/wc-customer-default-location-geolocation-fallback.md
@@ -1,0 +1,60 @@
+# Gotcha: [testing/integration] — a fresh guest's shipping country resolves through geolocation, not the store default
+> Tags: testing, integration, woocommerce, customer, shipping-country | Session: s78
+
+## What happens
+
+A test that constructs a fresh guest `WC()->customer` and expects `get_shipping_country()` to
+answer the store's `woocommerce_default_country` setting (or an empty string) is wrong. It answers
+`US` instead — even on a store whose default country is `RU` and whose `woocommerce_default_customer_address`
+is left at its own default.
+
+Reached in this codebase via `Location_Service::customer_shipping_country()`
+(`woodev/shipping-method/location/class-location-service.php`), which is the country authority
+`is_customer_record_stale()`'s rule (b) checks a stored record against (#346). Two integration
+tests had to call `WC()->customer->set_shipping_country( 'RU' )` explicitly before asserting
+anything about staleness, or the ambient customer answered `US` and every `RU` fixture record
+read as stale for the wrong reason.
+
+## Root cause
+
+`WC_Customer::get_shipping_country()` for a customer with no explicitly-set shipping country falls
+back to `wc_get_customer_default_location()`. That function's own default,
+`woocommerce_default_customer_address`, is `'geolocation'` (WooCommerce's own out-of-the-box
+setting — not something this project configures) — which resolves the country through
+`WC_Geolocation::geolocate_ip()`. In a test/CI environment the request IP is not a routable public
+address, so the MaxMind/API lookup fails, and `WC_Geolocation` falls back to a **hardcoded `'US'`**
+— entirely bypassing `woocommerce_default_country`, the setting a developer would reasonably
+expect to be consulted.
+
+So "the store's own configured default country" and "what a fresh guest's `WC()->customer` actually
+reports" are two different chains that happen to share a name (`default`) but not a value.
+
+## Fix
+
+❌ Wrong — assuming an unconfigured guest customer reflects the store setting:
+
+```php
+// Store default is RU, so a fresh guest customer should read RU too... right?
+$customer = new \WC_Customer( 0, true );
+$this->assertSame( 'RU', $customer->get_shipping_country() ); // fails: reads 'US'
+```
+
+✅ Correct — seed the field explicitly whenever a test's assertion depends on a specific shipping
+country, rather than relying on WooCommerce's own default chain:
+
+```php
+WC()->customer->set_shipping_country( 'RU' );
+```
+
+✅ Also correct — when writing a country-authority accessor that must never disagree with a
+caller's own already-resolved country (e.g. a REST request's own `country` param), give it an
+explicit override rather than only reading the ambient customer object — see
+`Location_Service::is_customer_record_stale()`'s optional `$for_country` parameter (#350/#352
+follow-up): a call site with a stronger authority than the ambient customer can supply it directly
+instead of fighting this fallback chain.
+
+## Related
+
+- [the-integration-suite-has-a-wc-session-a-rest-request-does-not](the-integration-suite-has-a-wc-session-a-rest-request-does-not.md) — another place the integration harness's ambient WooCommerce state does not match a real request
+- [guest-session-write-needs-the-cart-cookie](guest-session-write-needs-the-cart-cookie.md) — a sibling guest/session surprise in the same location layer
+- [within-applied-reports-the-scope-builder-not-the-provider](within-applied-reports-the-scope-builder-not-the-provider.md) — another `Location_Service`/`Location_Controller` seam where an ambient signal reads as an authority it is not

--- a/docs-internal/gotchas/within-applied-reports-the-scope-builder-not-the-provider.md
+++ b/docs-internal/gotchas/within-applied-reports-the-scope-builder-not-the-provider.md
@@ -1,0 +1,70 @@
+# Gotcha: [shipping/location] — `within_applied` reports what the scope BUILDER decided, not what the provider honoured
+> Tags: location, suggest, scope, observability | Session: s78
+
+## What happens
+
+`GET /location/suggest` answers with `within_applied`. It reads as "the search was narrowed to
+the parent you asked for". It is not that. It is `true` whenever `build_scope()` managed to turn
+the `within` key into a `Location_Scope` — regardless of whether the provider then used it,
+partially degraded it, or discarded it outright.
+
+Measured on the rig (s78), a chain record from an inactive provider (`test-cdek:44`) handed to
+DaData: the response reported `within_applied: true` while DaData had silently dropped the
+record's key and `raw` payload and fallen back to a plain TEXT constraint on the region/city
+names. In the CDEK fixture's `suggest_settlements()` the same shape reports `within_applied:
+true` while the search runs country-wide, completely unnarrowed.
+
+So the one field an integrator would reach for to detect "my scope was ignored" is exactly the
+field that cannot detect it.
+
+## Root cause
+
+```php
+// class-location-controller.php — perform_suggest()
+'within_applied' => $scope->has_parent(),
+```
+
+`$scope` is the object `build_scope()` returned. `has_parent()` answers "does this scope carry a
+parent record", which is a fact about the CONTROLLER's own work. Honouring the scope happens
+later and elsewhere — inside the provider, which is free to use the parent, degrade it, or
+ignore it, and reports nothing either way:
+
+- `Dadata_Provider::build_locations_constraint()` uses `raw()` FIAS ids only when
+  `self::PROVIDER_ID === $parent->provider_id()`; a foreign parent silently degrades to
+  `region`/`city` name text.
+- The CDEK fixture's `region_code_from_scope()` returns `null` on a foreign prefix; `list_localities()`
+  then returns `[]`, but `suggest_settlements()` simply SKIPS its filter and answers country-wide.
+
+The two honest states — "narrowed" and "asked to narrow but could not" — are collapsed into one.
+
+## Fix
+
+❌ Wrong — treating the flag as a provider verdict:
+
+```php
+// "the provider scoped my search"  — it says no such thing
+if ( $body['within_applied'] ) { /* trust the results are inside the parent */ }
+```
+
+✅ Correct — until the contract is fixed, the flag answers only the controller's half; prove
+narrowing by MEASURING against a control in the same run:
+
+```
+GET /location/suggest?level=address&country=RU&q=Тверская&within=<key>   -> 8 results
+GET /location/suggest?level=address&country=RU&q=Тверская                -> 10 results   (CONTROL)
+```
+
+A differing result set is evidence of narrowing. An identical one means the scope was dropped —
+whatever `within_applied` claims.
+
+The real repair is for the provider seam to report back what it did with the parent, so
+"narrowed" and "could not narrow" stop sharing a value. Tracked with #333.
+
+## Related
+
+- [an-empty-domain-key-is-not-a-key](an-empty-domain-key-is-not-a-key.md) — the same discipline
+  from the other end: refusing to answer beats a plausible wrong answer
+- [a-cross-provider-within-is-handed-over-as-components](a-cross-provider-within-is-handed-over-as-components.md)
+  — why a foreign parent works at all, and why it works only by accident of the handover shape
+- [a-level-served-can-come-from-the-fallback-not-the-active-provider](a-level-served-can-come-from-the-fallback-not-the-active-provider.md)
+  — the other place where "who actually answered" is invisible from the outside

--- a/tests/integration/Shipping/LocationRouteTest.php
+++ b/tests/integration/Shipping/LocationRouteTest.php
@@ -57,6 +57,17 @@ class LocationRouteTest extends TestCase {
 	 */
 	private $original_dadata_token;
 
+	/**
+	 * `woocommerce_default_country` as found at the start of THIS test — same
+	 * save/restore discipline as {@see self::$original_dadata_token}. Restored
+	 * mainly for hygiene; see {@see self::setUp()}'s own comment for why the
+	 * ACTUAL fix for #346/#333 in this file is the direct
+	 * `WC()->customer->set_shipping_country()` seed below, not this option.
+	 *
+	 * @var string|false
+	 */
+	private $original_default_country;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -64,6 +75,9 @@ class LocationRouteTest extends TestCase {
 		// and a prior test (or another declaring plugin loaded in wp-env) may
 		// already have opened it; reset so this test controls the gate itself.
 		Location_Provider_Registry::instance()->reset_for_tests();
+
+		$this->original_default_country = get_option( 'woocommerce_default_country', false );
+		update_option( 'woocommerce_default_country', 'RU' );
 
 		// The rig environment may carry `woodev_location_token` already seeded
 		// by `Woodev_Test_Credential_Seeder` (tests/_fixtures/woodev-test-shipping-method/
@@ -86,6 +100,12 @@ class LocationRouteTest extends TestCase {
 			delete_option( self::OPTION_DADATA_TOKEN );
 		} else {
 			update_option( self::OPTION_DADATA_TOKEN, $this->original_dadata_token );
+		}
+
+		if ( false === $this->original_default_country ) {
+			delete_option( 'woocommerce_default_country' );
+		} else {
+			update_option( 'woocommerce_default_country', $this->original_default_country );
 		}
 
 		Location_Provider_Registry::instance()->reset_for_tests();
@@ -123,6 +143,32 @@ class LocationRouteTest extends TestCase {
 		}
 
 		WC()->session->set( self::CUSTOMER_LOCATION_SESSION_KEY, null );
+	}
+
+	/**
+	 * Seeds `WC()->customer`'s LIVE shipping-country field (#346/#333) — the
+	 * seam {@see \Woodev\Framework\Shipping\Location\Location_Service::customer_shipping_country()}
+	 * reads FIRST, before falling through to
+	 * {@see \Woodev\Framework\Shipping\Location\Location_Service::resolve_default_country()}'s
+	 * store-setting floor. On a brand-new `WP_UnitTestCase` guest,
+	 * `WC()->customer->get_shipping_country()` answers from
+	 * `wc_get_customer_default_location()` (`woocommerce_default_customer_address`
+	 * defaults to `geolocation`), which resolves to a hardcoded `US` fallback
+	 * for the container's own non-routable IP — measured (s79), and NOT
+	 * something `update_option( 'woocommerce_default_country', ... )` alone
+	 * reaches, since the geolocation branch never consults that option at
+	 * all. Every fixture record in this file is `country: RU`; called AFTER
+	 * `wp_set_current_user( 0 )` in each test that needs it, since switching
+	 * the current user can reload `WC()->customer`. Mirrors what a real
+	 * checkout's own `update_checkout` AJAX would already have done by the
+	 * time a customer reaches the location picker.
+	 *
+	 * @param string $country ISO-3166 alpha-2 country code.
+	 *
+	 * @return void
+	 */
+	private function seed_customer_shipping_country( string $country = 'RU' ): void {
+		WC()->customer->set_shipping_country( $country );
 	}
 
 	/**
@@ -237,7 +283,7 @@ class LocationRouteTest extends TestCase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false ], $response->get_data() );
+		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false, 'within_status' => 'not_requested' ], $response->get_data() );
 	}
 
 	/**
@@ -360,6 +406,7 @@ class LocationRouteTest extends TestCase {
 		$this->make_location_layer_active();
 
 		wp_set_current_user( 0 );
+		$this->seed_customer_shipping_country();
 
 		$request = new WP_REST_Request( 'POST', '/woodev/v1/location/select' );
 		$request->set_param(
@@ -411,6 +458,7 @@ class LocationRouteTest extends TestCase {
 		$this->make_location_layer_active();
 
 		wp_set_current_user( 0 );
+		$this->seed_customer_shipping_country();
 
 		$settlement_request = new WP_REST_Request( 'POST', '/woodev/v1/location/select' );
 		$settlement_request->set_param(

--- a/tests/integration/Shipping/ProviderSelectionScopeAgreementTest.php
+++ b/tests/integration/Shipping/ProviderSelectionScopeAgreementTest.php
@@ -115,6 +115,19 @@ class ProviderSelectionScopeAgreementTest extends TestCase {
 	private $original_ambient_point_source;
 
 	/**
+	 * `woocommerce_default_country` as found at the start of THIS test — same
+	 * save/restore discipline as {@see self::$original_dadata_token}, and the
+	 * same reason as {@see \Woodev\Tests\Integration\Shipping\LocationRouteTest::$original_default_country}'s
+	 * own docblock: #346/#333's staleness gate compares every stored `RU`
+	 * fixture record's country against the store's OWN default when no live
+	 * `WC()->customer` shipping field is set, and this rig's WP test site
+	 * carries WooCommerce's factory default (`US:CA`).
+	 *
+	 * @var string|false
+	 */
+	private $original_default_country;
+
+	/**
 	 * @return void
 	 */
 	protected function setUp(): void {
@@ -137,6 +150,9 @@ class ProviderSelectionScopeAgreementTest extends TestCase {
 		// depends on an explicit token must never rely on ambient DB state.
 		$this->original_dadata_token = get_option( self::OPTION_DADATA_TOKEN, false );
 		delete_option( self::OPTION_DADATA_TOKEN );
+
+		$this->original_default_country = get_option( 'woocommerce_default_country', false );
+		update_option( 'woocommerce_default_country', 'RU' );
 	}
 
 	/**
@@ -147,6 +163,12 @@ class ProviderSelectionScopeAgreementTest extends TestCase {
 			delete_option( self::OPTION_DADATA_TOKEN );
 		} else {
 			update_option( self::OPTION_DADATA_TOKEN, $this->original_dadata_token );
+		}
+
+		if ( false === $this->original_default_country ) {
+			delete_option( 'woocommerce_default_country' );
+		} else {
+			update_option( 'woocommerce_default_country', $this->original_default_country );
 		}
 
 		Location_Provider_Registry::instance()->reset_for_tests();
@@ -221,6 +243,21 @@ class ProviderSelectionScopeAgreementTest extends TestCase {
 	}
 
 	/**
+	 * Seeds `WC()->customer`'s LIVE shipping-country field (#346/#333) — see
+	 * {@see \Woodev\Tests\Integration\Shipping\LocationRouteTest::seed_customer_shipping_country()}'s
+	 * own docblock for the full reasoning (measured s79: a brand-new guest's
+	 * `WC()->customer->get_shipping_country()` resolves via WooCommerce's own
+	 * GeoIP default-location fallback to a hardcoded `US`, unrelated to
+	 * `woocommerce_default_country`). Every fixture record in this file is
+	 * `country: RU`; called AFTER `wp_set_current_user( 0 )`.
+	 *
+	 * @return void
+	 */
+	private function seed_customer_shipping_country(): void {
+		WC()->customer->set_shipping_country( 'RU' );
+	}
+
+	/**
 	 * Proves `Woodev_Test_Provider_Selection_Scope::locality_for_point()` and
 	 * `current_locality()` speak the same vocabulary end to end, through the
 	 * REAL production write/read paths — not by asserting on the scope
@@ -252,6 +289,7 @@ class ProviderSelectionScopeAgreementTest extends TestCase {
 		$this->open_location_gate_and_boot_routes();
 
 		wp_set_current_user( 0 );
+		$this->seed_customer_shipping_country();
 
 		$select_locality = new WP_REST_Request( 'POST', '/woodev/v1/location/select' );
 		$select_locality->set_param(
@@ -335,6 +373,7 @@ class ProviderSelectionScopeAgreementTest extends TestCase {
 		$this->open_location_gate_and_boot_routes();
 
 		wp_set_current_user( 0 );
+		$this->seed_customer_shipping_country();
 
 		update_option( self::OPTION_DADATA_TOKEN, 'test-integration-token' );
 

--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -154,7 +154,7 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 		return $this->default_country;
 	}
 
-	public function get_customer_record(): ?array {
+	public function get_customer_record( ?string $for_country = null ): ?array {
 		return $this->customer;
 	}
 
@@ -168,7 +168,7 @@ final class Checkout_Config_Fake_Location_Service extends Location_Service {
 	 *
 	 * @return array{records: array<string, Location_Record>, current: string, implicit: bool, saved_at: int}|null
 	 */
-	public function get_customer_chain(): ?array {
+	public function get_customer_chain( ?string $for_country = null ): ?array {
 		if ( null !== $this->chain_records ) {
 			return [
 				'records'  => $this->chain_records,

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
@@ -70,7 +70,7 @@ final class Checkout_Handler_Fake_Location_Service extends Location_Service {
 		return $this->active;
 	}
 
-	public function get_customer_record(): ?array {
+	public function get_customer_record( ?string $for_country = null ): ?array {
 		return null;
 	}
 

--- a/tests/unit/Shipping/Location/LocationServiceDefaultTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceDefaultTest.php
@@ -212,6 +212,12 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			);
 			Functions\when( 'apply_filters' )->returnArg( 2 );
 			Functions\when( 'is_user_logged_in' )->justReturn( false );
+			// Location_Service::is_customer_record_stale()'s rule (b) (#346) now
+			// calls customer_shipping_country() -> resolve_default_country() ->
+			// wc_get_base_location() on every stored-record read (including a
+			// record resolve_default() itself just wrote) — 'RU' matches every
+			// fixture in this file.
+			Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'RU', 'state' => '' ] );
 
 			Location_Provider_Registry::instance()->reset_for_tests();
 			Settings_Page_Registry::instance()->reset_for_tests();

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -1049,6 +1049,15 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			};
 
 			$reflection = new \ReflectionProperty( Location_Service::class, 'unpersisted_default' );
+
+			// Required on PHP < 8.1, a deprecated no-op from 8.5 — guard it, never call it
+			// unconditionally (gotcha `reflection-setaccessible-version-guard`). Without the
+			// guard this test passes on 8.1-8.3 and errors on 7.4/8.0 with
+			// "Cannot access non-public member", which is exactly how CI caught it.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$reflection->setAccessible( true );
+			}
+
 			$reflection->setValue(
 				$service,
 				Location_Record::from_array(

--- a/tests/unit/Shipping/Location/LocationServiceTest.php
+++ b/tests/unit/Shipping/Location/LocationServiceTest.php
@@ -323,6 +323,15 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			// Customer_Location_Store::get()/set() checks this on every call —
 			// every fixture here is a guest unless a test says otherwise.
 			Functions\when( 'is_user_logged_in' )->justReturn( false );
+			// Location_Service::is_customer_record_stale()'s rule (b) (#346) now
+			// calls customer_shipping_country() -> resolve_default_country() ->
+			// wc_get_base_location() on EVERY stored-record read, not only the
+			// resolve_default_country()-specific tests below (which re-stub this
+			// per scenario, overriding this default) — 'RU' matches this file's
+			// own fixture convention (record()'s default country), so it is the
+			// one value that keeps every OTHER test in this file from having to
+			// know about a WooCommerce function it is not about.
+			Functions\when( 'wc_get_base_location' )->justReturn( [ 'country' => 'RU', 'state' => '' ] );
 
 			Location_Provider_Registry::instance()->reset_for_tests();
 			Settings_Page_Registry::instance()->reset_for_tests();
@@ -370,6 +379,39 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$registry = Location_Provider_Registry::instance();
 			$registry->declare_needed();
 			$registry->collect();
+		}
+
+		/**
+		 * Registers `$provider` and makes it the shop's ACTIVE provider (D15
+		 * chain, chosen slot) — #346/#333: {@see Location_Service::get_customer_record()}
+		 * / {@see Location_Service::get_customer_chain()} now run every stored
+		 * record through {@see Location_Service::provider_for_level()} (the
+		 * staleness gate), so a fixture record built via {@see self::record()}
+		 * needs a REAL registered owning provider or the gate drops it as
+		 * stale — this is the one place that boilerplate lives for every test
+		 * below that stores a record and reads it back.
+		 *
+		 * `Location_Provider_Registry::DEFAULT_PROVIDER_ID` ('dadata') is
+		 * NOT reusable here as a fixture id: {@see Location_Provider_Registry::collect()}
+		 * unconditionally registers the REAL bundled `Dadata_Provider` under
+		 * that id first, and a duplicate id registration is rejected —
+		 * `$provider` must use its OWN, different id (this file's established
+		 * `'svc-fixture'` convention, e.g. {@see self::test_is_active_true_when_gate_open_provider_active_and_configured()}).
+		 *
+		 * @param Location_Service_Fake_Provider $provider Provider to activate.
+		 *
+		 * @return Location_Provider_Registry
+		 */
+		private function activate_owning_provider( Location_Service_Fake_Provider $provider ): Location_Provider_Registry {
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $provider ] );
+			Functions\when( 'get_option' )->justReturn( $provider->get_id() );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			return $registry;
 		}
 
 		private function record( string $key = 'dadata:fias-1' ): Location_Record {
@@ -469,10 +511,11 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		}
 
 		public function test_set_then_get_round_trips_through_the_store_including_the_implicit_flag(): void {
-			$store   = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+			$service  = new Location_Service( $registry, $store );
 
-			$record = $this->record();
+			$record = $this->record( 'svc-fixture:fias-1' );
 			$ok     = $service->set_customer_record( $record, true );
 
 			$this->assertTrue( $ok );
@@ -485,10 +528,11 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		}
 
 		public function test_an_explicit_set_reports_implicit_false_on_read(): void {
-			$store   = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+			$service  = new Location_Service( $registry, $store );
 
-			$service->set_customer_record( $this->record(), false );
+			$service->set_customer_record( $this->record( 'svc-fixture:fias-1' ), false );
 
 			$this->assertFalse( $service->get_customer_record()['implicit'] );
 		}
@@ -528,11 +572,12 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		}
 
 		public function test_get_customer_chain_reflects_every_level_the_customer_picked(): void {
-			$store   = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+			$service  = new Location_Service( $registry, $store );
 
-			$settlement = $this->record( 'dadata:settlement-1' );
-			$address    = $this->record_with_ancestors( 'dadata:address-1', Location_Record::LEVEL_ADDRESS, [ 'dadata:settlement-1' ] );
+			$settlement = $this->record( 'svc-fixture:settlement-1' );
+			$address    = $this->record_with_ancestors( 'svc-fixture:address-1', Location_Record::LEVEL_ADDRESS, [ 'svc-fixture:settlement-1' ] );
 
 			$service->set_customer_record( $settlement );
 			$service->set_customer_record( $address );
@@ -548,11 +593,12 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		}
 
 		public function test_get_customer_record_at_returns_the_record_for_a_present_level(): void {
-			$store   = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+			$service  = new Location_Service( $registry, $store );
 
-			$settlement = $this->record( 'dadata:settlement-1' );
-			$address    = $this->record_with_ancestors( 'dadata:address-1', Location_Record::LEVEL_ADDRESS, [ 'dadata:settlement-1' ] );
+			$settlement = $this->record( 'svc-fixture:settlement-1' );
+			$address    = $this->record_with_ancestors( 'svc-fixture:address-1', Location_Record::LEVEL_ADDRESS, [ 'svc-fixture:settlement-1' ] );
 
 			$service->set_customer_record( $settlement );
 			$service->set_customer_record( $address );
@@ -561,9 +607,9 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$at_address    = $service->get_customer_record_at( Location_Record::LEVEL_ADDRESS );
 
 			$this->assertNotNull( $at_settlement );
-			$this->assertSame( 'dadata:settlement-1', $at_settlement->key() );
+			$this->assertSame( 'svc-fixture:settlement-1', $at_settlement->key() );
 			$this->assertNotNull( $at_address );
-			$this->assertSame( 'dadata:address-1', $at_address->key() );
+			$this->assertSame( 'svc-fixture:address-1', $at_address->key() );
 		}
 
 		public function test_get_customer_record_at_returns_null_for_an_absent_level(): void {
@@ -622,6 +668,18 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 						]
 					);
 				}
+
+				// This test is not ABOUT staleness (FIX 1's own gate on the
+				// resolved default) — it is about the get_customer_record()
+				// <-> get_customer_chain() handoff for an unpersisted default
+				// (review finding F1). The registry above is deliberately
+				// left unactivated, so a REAL gate would reject this fixture
+				// for having no owning provider at all; bypass it via the
+				// same test seam is_customer_record_stale()'s own docblock
+				// documents for exactly this situation.
+				protected function is_customer_record_stale( Location_Record $record, ?string $for_country = null ): bool {
+					return false;
+				}
 			};
 
 			$first = $service->get_customer_record();
@@ -638,6 +696,405 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 			$at_level = $service->get_customer_record_at( Location_Record::LEVEL_SETTLEMENT );
 			$this->assertNotNull( $at_level );
 			$this->assertSame( 'dadata:geo-default', $at_level->key() );
+		}
+
+		// -------------------------------------------------------------------
+		// #346/#333 — the staleness gate: a stored record whose owning provider
+		// or country has moved out from under it is read as ABSENT, never
+		// re-resolved. See Location_Service::gate_chain() /
+		// Location_Service::is_customer_record_stale() for the two rules this
+		// exercises.
+		// -------------------------------------------------------------------
+
+		public function test_gate_drops_a_record_whose_provider_no_longer_owns_its_level(): void {
+			// Gate never opened at all (registry not activated) — nobody
+			// resolves for "settlement", so the 'svc-fixture'-owned record this
+			// test wrote earlier is no longer owned by anyone.
+			$store = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$store->set( $this->record( 'svc-fixture:fias-1' ) );
+
+			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+
+			$this->assertNull( $service->get_customer_record(), 'a record whose owning provider no longer resolves for its level must read as absent' );
+		}
+
+		public function test_gate_keeps_a_record_from_the_bundled_fallback_provider_still_resolved_as_owner(): void {
+			// Regression guard against OVER-dropping: the chosen provider serves
+			// REGION only, so the D15 chain falls through to the BUNDLED
+			// Dadata_Provider for "settlement" — and that fallback is STILL the
+			// resolved owner, so a 'dadata'-provider record must survive even
+			// though the shop's ACTIVE provider is a different one entirely.
+			$store  = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$chosen = new Location_Service_Fake_Provider( 'city-dict', [ Location_Record::LEVEL_REGION ], true );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $chosen ] );
+			$this->stub_dadata_token( 'tok' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$store->set( $this->record( 'dadata:settlement-1' ) );
+
+			$service = new Location_Service( $registry, $store );
+
+			// Sanity: the D15 chain really did fall through to the bundled
+			// provider for this level, not the (region-only) chosen one.
+			$this->assertInstanceOf( Dadata_Provider::class, $service->provider_for_level( Location_Record::LEVEL_SETTLEMENT ) );
+
+			$fetched = $service->get_customer_record();
+
+			$this->assertNotNull( $fetched, 'a record from the BUNDLED fallback provider must survive when that provider is still the resolved owner' );
+			$this->assertSame( 'dadata:settlement-1', $fetched['record']->key() );
+		}
+
+		public function test_gate_drops_a_record_when_provider_for_level_resolves_to_null(): void {
+			// The gate IS open, but nobody resolves for "settlement": the chosen
+			// provider only serves region, and the bundled fallback is left
+			// unconfigured (no token) — distinct from the "gate never opened"
+			// case above, same null outcome.
+			$store  = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$chosen = new Location_Service_Fake_Provider( 'city-dict', [ Location_Record::LEVEL_REGION ], true );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $chosen ] );
+			$this->stub_dadata_token( '' );
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$store->set( $this->record( 'dadata:settlement-1' ) );
+
+			$service = new Location_Service( $registry, $store );
+
+			$this->assertNull( $service->provider_for_level( Location_Record::LEVEL_SETTLEMENT, 'RU' ), 'sanity: nobody resolves for this level' );
+			$this->assertNull( $service->get_customer_record(), 'provider_for_level() answering null must drop the record as stale' );
+		}
+
+		public function test_gate_drops_a_record_whose_country_differs_from_the_customer_shipping_country(): void {
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+
+			$store->set( $this->record( 'svc-fixture:fias-1' ) ); // country RU
+
+			// The customer switched the checkout country (#346's own rig
+			// measurement) — the record's provider ownership is fine, only the
+			// country moved.
+			$service = new class( $registry, $store ) extends Location_Service {
+				protected function customer_shipping_country(): string {
+					return 'BY';
+				}
+			};
+
+			$this->assertNull( $service->get_customer_record(), 'a record whose country no longer matches the customer LIVE shipping country must read as absent' );
+		}
+
+		public function test_gate_compares_against_ru_when_no_live_field_and_no_store_country_are_set(): void {
+			// Operator correction (s79): "unknown country" is not a reachable
+			// state — customer_shipping_country() always resolves through the
+			// SAME checkout-field -> store-setting -> RU chain
+			// resolve_default_country() embodies. This pins that floor
+			// specifically: no live WC()->customer stub at all (so step 1
+			// answers nothing), and the store's OWN base location is also
+			// empty (so step 2 answers nothing either) — the gate must still
+			// land on 'RU' and match an 'RU' fixture record.
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+
+			Functions\when( 'wc_get_base_location' )->justReturn( [] ); // step 2 answers nothing either.
+
+			$store->set( $this->record( 'svc-fixture:fias-1' ) ); // country RU
+
+			$service = new Location_Service( $registry, $store );
+
+			$this->assertNotNull(
+				$service->get_customer_record(),
+				'with no live field and no store country, the gate must fall back to the RU floor and match an RU fixture'
+			);
+		}
+
+		public function test_gate_drops_a_record_when_the_ru_floor_does_not_match_it(): void {
+			// The mirror of the test above: the SAME empty-field/empty-store
+			// state, but the stored record is NOT 'RU' — the RU floor must
+			// still apply and drop it, proving this is a real comparison, not
+			// an accidental always-match.
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'BY' ] ) );
+
+			Functions\when( 'wc_get_base_location' )->justReturn( [] );
+
+			$store->set(
+				Location_Record::from_array(
+					[
+						'key'         => 'svc-fixture:fias-by',
+						'provider_id' => 'svc-fixture',
+						'level'       => Location_Record::LEVEL_SETTLEMENT,
+						'country'     => 'BY',
+					]
+				)
+			);
+
+			$service = new Location_Service( $registry, $store );
+
+			$this->assertNull( $service->get_customer_record(), 'the RU floor must drop a record from a different country, not silently match everything' );
+		}
+
+		public function test_gate_partial_chain_keeps_the_surviving_region_and_recomputes_current(): void {
+			// 'svc-fixture' serves REGION only, so a settlement stored under the
+			// SAME provider id is stale (nobody resolves it) while the region
+			// survives — the chain must report ONLY the survivor, with `current`
+			// recomputed to it rather than left pointing at the dropped level.
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', [ Location_Record::LEVEL_REGION ], true, [ 'RU' ] ) );
+
+			$region     = Location_Record::from_array(
+				[
+					'key'         => 'svc-fixture:region-1',
+					'provider_id' => 'svc-fixture',
+					'level'       => Location_Record::LEVEL_REGION,
+					'country'     => 'RU',
+				]
+			);
+			$settlement = $this->record_with_ancestors( 'svc-fixture:settlement-1', Location_Record::LEVEL_SETTLEMENT, [ 'svc-fixture:region-1' ] );
+
+			$store->set( $region );
+			$store->set( $settlement );
+
+			$service = new Location_Service( $registry, $store );
+
+			$chain = $service->get_customer_chain();
+
+			$this->assertNotNull( $chain );
+			$this->assertSame(
+				[ Location_Record::LEVEL_REGION ],
+				array_keys( $chain['records'] ),
+				'the stale settlement must be dropped, the surviving region kept'
+			);
+			$this->assertSame( Location_Record::LEVEL_REGION, $chain['current'], 'current must be recomputed to the deepest SURVIVING level' );
+		}
+
+		public function test_gate_nothing_survives_triggers_the_lazy_default_exactly_like_an_empty_store(): void {
+			$store = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$store->set( $this->record( 'unregistered-provider:fias-1' ) ); // nobody owns this — fully stale.
+
+			$service = new class( Location_Provider_Registry::instance(), $store ) extends Location_Service {
+				public function resolve_default(): ?Location_Record {
+					return Location_Record::from_array(
+						[
+							'key'         => 'dadata:geo-default',
+							'provider_id' => 'dadata',
+							'level'       => Location_Record::LEVEL_SETTLEMENT,
+							'country'     => 'RU',
+						]
+					);
+				}
+
+				// This test needs the STORED fixture to stay genuinely stale
+				// (that is the whole scenario under test — a fully-stale
+				// chain must let the lazy trigger run), while the FRESHLY
+				// RESOLVED default above must pass FIX 1's own pre-check —
+				// so, unlike the sibling test above, this seam discriminates
+				// by key rather than bypassing the gate unconditionally.
+				protected function is_customer_record_stale( Location_Record $record, ?string $for_country = null ): bool {
+					return 'dadata:geo-default' !== $record->key();
+				}
+			};
+
+			$fetched = $service->get_customer_record();
+
+			$this->assertNotNull( $fetched, 'a fully-stale chain must let the lazy default trigger run, exactly as an empty store does' );
+			$this->assertSame( 'dadata:geo-default', $fetched['record']->key() );
+		}
+
+		public function test_gate_never_writes_back_to_the_store(): void {
+			$store = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$store->set( $this->record( 'unregistered-provider:fias-1' ) );
+
+			// Gate closed (registry never activated) -> get_default_locality_policy()
+			// answers 'off' -> resolve_default() answers null with no further
+			// calls, so there is nothing to fall back to either.
+			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+
+			$this->assertNull( $service->get_customer_record() );
+
+			$raw = $store->get_chain();
+			$this->assertNotNull( $raw, 'the stale blob must still be on disk — the gate re-applies per read, it never forgets' );
+			$this->assertSame(
+				'unregistered-provider:fias-1',
+				$raw['records'][ Location_Record::LEVEL_SETTLEMENT ]->key(),
+				'the gate must never write anything back to the store'
+			);
+		}
+
+		public function test_gate_drops_every_descendant_of_a_dropped_ancestor_even_when_individually_valid(): void {
+			// Adversarial review finding, s78 (FIX 2): gate_chain() used to
+			// filter each level INDEPENDENTLY — a stale settlement dropped
+			// while a deeper address (individually still valid) survived,
+			// producing {address: ...} with current = address: an address
+			// with no settlement above it, a shape
+			// Customer_Location_Store::rebuild_chain() would never itself
+			// build and the region > settlement > address cascade does not
+			// permit. Gating must instead propagate in CASCADE ORDER: once an
+			// ancestor is dropped, every deeper level goes with it.
+			$store  = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$chosen = new Location_Service_Fake_Provider( 'city-dict', [ Location_Record::LEVEL_ADDRESS ], true );
+
+			Functions\when( 'add_action' )->justReturn( true );
+			$this->stub_providers_filter( [ $chosen ] );
+			$this->stub_dadata_token( '' ); // bundled fallback stays unconfigured -> nobody owns SETTLEMENT.
+
+			$registry = Location_Provider_Registry::instance();
+			$registry->declare_needed();
+			$registry->collect();
+
+			$settlement = Location_Record::from_array(
+				[
+					'key'         => 'city-dict:settlement-1',
+					'provider_id' => 'city-dict',
+					'level'       => Location_Record::LEVEL_SETTLEMENT,
+					'country'     => 'RU',
+				]
+			);
+			$address = Location_Record::from_array(
+				[
+					'key'         => 'city-dict:address-1',
+					'provider_id' => 'city-dict',
+					'level'       => Location_Record::LEVEL_ADDRESS,
+					'country'     => 'RU',
+					'ancestors'   => [ 'city-dict:settlement-1' ],
+				]
+			);
+
+			$store->set( $settlement );
+			$store->set( $address );
+
+			$service = new Location_Service( $registry, $store );
+
+			// Sanity: settlement has no owner at all (stale, rule a), while
+			// address's OWN level is still owned by 'city-dict' — proving
+			// this test would have kept address under the OLD, per-level
+			// independent gate.
+			$this->assertNull( $service->provider_for_level( Location_Record::LEVEL_SETTLEMENT, 'RU' ), 'sanity: nobody owns SETTLEMENT' );
+			$address_owner = $service->provider_for_level( Location_Record::LEVEL_ADDRESS, 'RU' );
+			$this->assertNotNull( $address_owner, 'sanity: city-dict still owns ADDRESS individually' );
+			$this->assertSame( 'city-dict', $address_owner->get_id() );
+
+			$this->assertNull(
+				$service->get_customer_chain(),
+				'a deeper record must be dropped along with a stale ancestor, even when it would individually still pass the gate'
+			);
+		}
+
+		// -------------------------------------------------------------------
+		// #346/#333 FIX 1 (adversarial review, s78): the LAZY DEFAULT must
+		// pass the SAME gate a stored record has to pass. resolve_default()
+		// resolves against the store-setting/RU floor, while the gate's rule
+		// (b) compares against the LIVE customer_shipping_country() — a
+		// freshly-resolved default that fails that comparison must never be
+		// served ungated, and get_customer_record()/get_customer_chain() must
+		// never disagree about whether the customer has a location.
+		// -------------------------------------------------------------------
+
+		public function test_get_customer_record_and_chain_agree_when_the_lazy_default_fails_its_own_gate(): void {
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+
+			// resolve_default() answers an RU default (e.g. what a `fixed`/
+			// `geoip` policy resolved against the store-setting/RU floor),
+			// but the customer's LIVE shipping country is BY — the same
+			// mismatch #346/#333 already gate STORED records against.
+			// Before FIX 1, get_customer_record() served this default
+			// UNGATED while get_customer_chain() answered null for the exact
+			// same state.
+			$service = new class( $registry, $store ) extends Location_Service {
+				public function resolve_default(): ?Location_Record {
+					return Location_Record::from_array(
+						[
+							'key'         => 'svc-fixture:ru-default',
+							'provider_id' => 'svc-fixture',
+							'level'       => Location_Record::LEVEL_SETTLEMENT,
+							'country'     => 'RU',
+						]
+					);
+				}
+
+				protected function customer_shipping_country(): string {
+					return 'BY';
+				}
+			};
+
+			$record = $service->get_customer_record();
+			$chain  = $service->get_customer_chain();
+
+			$this->assertNull( $record, 'a default that cannot pass its own gate must answer null, not an ungated record' );
+			$this->assertNull( $chain, 'get_customer_record() and get_customer_chain() must agree — both empty for the same state' );
+		}
+
+		public function test_cached_unpersisted_default_is_re_gated_not_served_blindly(): void {
+			// The critic's own follow-up on FIX 1: "$this->unpersisted_default
+			// branch a few lines above returns ungated too — check it." Seeds
+			// the cache directly (bypassing resolve_default()) with a value
+			// that fails the SAME gate a stored record must pass, pinning
+			// that the early-return branch re-checks it rather than trusting
+			// whatever got cached there.
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+
+			$service = new class( $registry, $store ) extends Location_Service {
+				protected function customer_shipping_country(): string {
+					return 'BY';
+				}
+			};
+
+			$reflection = new \ReflectionProperty( Location_Service::class, 'unpersisted_default' );
+			$reflection->setValue(
+				$service,
+				Location_Record::from_array(
+					[
+						'key'         => 'svc-fixture:cached-ru',
+						'provider_id' => 'svc-fixture',
+						'level'       => Location_Record::LEVEL_SETTLEMENT,
+						'country'     => 'RU',
+					]
+				)
+			);
+
+			$this->assertNull( $service->get_customer_record(), 'a cached unpersisted default that fails the gate must not be served ungated' );
+		}
+
+		// -------------------------------------------------------------------
+		// #350/#352 follow-up (FIX 3): the optional $for_country parameter —
+		// when given, rule (b) compares against IT instead of the ambient
+		// customer_shipping_country(), so a REST read that already carries
+		// its own normalized `country` param is no longer forced through the
+		// ambient WooCommerce customer (which can disagree with it — gotcha
+		// wc-customer-default-location-geolocation-fallback).
+		// -------------------------------------------------------------------
+
+		public function test_get_customer_chain_uses_for_country_instead_of_the_ambient_customer_country_when_given(): void {
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+
+			$store->set( $this->record( 'svc-fixture:fias-1' ) ); // country RU
+
+			// Ambient customer disagrees — e.g. a REST request whose own
+			// normalized `country` param is RU, while WooCommerce's ambient
+			// customer object answers something else for the SAME request
+			// (measured, s79: a fresh guest's shipping country resolves
+			// through geolocation, independent of the request at hand).
+			$service = new class( $registry, $store ) extends Location_Service {
+				protected function customer_shipping_country(): string {
+					return 'BY';
+				}
+			};
+
+			$this->assertNull( $service->get_customer_chain(), 'sanity: without $for_country, the ambient mismatch drops the record' );
+			$this->assertNotNull(
+				$service->get_customer_chain( 'RU' ),
+				'$for_country, when given, must be used INSTEAD of the ambient customer country'
+			);
 		}
 
 		// -------------------------------------------------------------------
@@ -660,10 +1117,11 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		public function test_resolve_for_delegates_to_the_resolution_cache_with_the_current_record(): void {
 			$store        = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
 			$spy_cache    = new Location_Service_Spy_Resolution_Cache( 'city-code-42' );
-			$service      = new Location_Service( Location_Provider_Registry::instance(), $store, $spy_cache );
+			$registry     = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+			$service      = new Location_Service( $registry, $store, $spy_cache );
 			$plugin       = $this->plugin();
 
-			$service->set_customer_record( $this->record() );
+			$service->set_customer_record( $this->record( 'svc-fixture:fias-1' ) );
 
 			$result = $service->resolve_for( $plugin );
 
@@ -709,22 +1167,24 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 		public function test_resolve_for_defaults_to_the_current_record_when_no_record_is_passed(): void {
 			$store     = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
 			$spy_cache = new Location_Service_Spy_Resolution_Cache( 'city-code-42' );
-			$service   = new Location_Service( Location_Provider_Registry::instance(), $store, $spy_cache );
+			$registry  = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+			$service   = new Location_Service( $registry, $store, $spy_cache );
 			$plugin    = $this->plugin();
 
-			$service->set_customer_record( $this->record( 'dadata:fias-1' ) );
+			$service->set_customer_record( $this->record( 'svc-fixture:fias-1' ) );
 
 			$result = $service->resolve_for( $plugin, null );
 
 			$this->assertSame( 'city-code-42', $result );
 			$this->assertNotNull( $spy_cache->last_record );
-			$this->assertSame( 'dadata:fias-1', $spy_cache->last_record->key() );
+			$this->assertSame( 'svc-fixture:fias-1', $spy_cache->last_record->key() );
 		}
 
 		public function test_resolve_for_uses_the_real_resolution_cache_end_to_end(): void {
-			$store   = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
-			$cache   = new Location_Service_Resolution_Cache_Probe( new Location_Service_Fake_Session() );
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store, $cache );
+			$store    = new Location_Service_Customer_Store_Probe( new Location_Service_Fake_Session() );
+			$cache    = new Location_Service_Resolution_Cache_Probe( new Location_Service_Fake_Session() );
+			$registry = $this->activate_owning_provider( new Location_Service_Fake_Provider( 'svc-fixture', Location_Record::LEVELS, true, [ 'RU' ] ) );
+			$service  = new Location_Service( $registry, $store, $cache );
 
 			$adapter = new class implements Location_Adapter {
 				public int $calls = 0;
@@ -748,13 +1208,13 @@ namespace Woodev\Tests\Unit\Shipping\Location {
 				}
 			};
 
-			$service->set_customer_record( $this->record( 'dadata:fias-9' ) );
+			$service->set_customer_record( $this->record( 'svc-fixture:fias-9' ) );
 
 			$first  = $service->resolve_for( $plugin );
 			$second = $service->resolve_for( $plugin );
 
-			$this->assertSame( 'resolved-dadata:fias-9', $first );
-			$this->assertSame( 'resolved-dadata:fias-9', $second );
+			$this->assertSame( 'resolved-svc-fixture:fias-9', $first );
+			$this->assertSame( 'resolved-svc-fixture:fias-9', $second );
 			$this->assertSame( 1, $adapter->calls, 'the adapter must be cached across two resolve_for() calls through the façade' );
 		}
 

--- a/tests/unit/Shipping/LocationDefaultCountrySeamTest.php
+++ b/tests/unit/Shipping/LocationDefaultCountrySeamTest.php
@@ -101,7 +101,7 @@ namespace Woodev\Tests\Unit\Shipping {
 			return true;
 		}
 
-		public function get_customer_record(): ?array {
+		public function get_customer_record( ?string $for_country = null ): ?array {
 			return null;
 		}
 

--- a/tests/unit/Shipping/Pickup/PickupHandlerTest.php
+++ b/tests/unit/Shipping/Pickup/PickupHandlerTest.php
@@ -47,10 +47,13 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 
 	use Brain\Monkey\Filters;
 	use Brain\Monkey\Functions;
+	use Woodev\Framework\Shipping\Location\Abstract_Location_Provider;
 	use Woodev\Framework\Shipping\Location\Customer_Location_Store;
 	use Woodev\Framework\Shipping\Location\Location_Adapter;
+	use Woodev\Framework\Shipping\Location\Location_Provider;
 	use Woodev\Framework\Shipping\Location\Location_Provider_Registry;
 	use Woodev\Framework\Shipping\Location\Location_Record;
+	use Woodev\Framework\Shipping\Location\Location_Scope;
 	use Woodev\Framework\Shipping\Location\Location_Service;
 	use Woodev\Framework\Shipping\Map\Map_Provider;
 	use Woodev\Framework\Shipping\Order\Shipping_Order_Handler;
@@ -193,6 +196,43 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 	}
 
 	/**
+	 * A minimal `dadata`-id fixture provider claiming EVERY level in `RU` — the owning
+	 * provider {@see Pickup_Handler_Location_Service_Active_Probe::provider_for_level()}
+	 * always hands back, so #346/#333's staleness gate
+	 * ({@see Location_Service::is_customer_record_stale()}) never drops this file's own
+	 * `dadata:...` fixture records (see {@see PickupHandlerTest::location_record()} /
+	 * {@see PickupHandlerTest::address_record()}) — this file is about `Pickup_Handler`
+	 * downstream of a VALID record, not about the gate itself (that is
+	 * `LocationServiceTest`'s job).
+	 */
+	final class Pickup_Handler_Test_Owning_Provider extends Abstract_Location_Provider {
+
+		public function get_id(): string {
+			return 'dadata';
+		}
+
+		public function get_name(): string {
+			return 'dadata';
+		}
+
+		public function get_countries(): array {
+			return [ 'RU' ];
+		}
+
+		public function is_configured(): bool {
+			return true;
+		}
+
+		protected function declare_suggest_levels(): array {
+			return Location_Record::LEVELS;
+		}
+
+		public function suggest( string $query, Location_Scope $scope ): array {
+			return [];
+		}
+	}
+
+	/**
 	 * A {@see Location_Service} whose {@see Location_Service::is_active()} answers a FIXED
 	 * value the test controls directly (review finding F1, rig-verified) — bypassing the
 	 * registry/active-provider/`is_configured()` machinery `LocationServiceTest.php`
@@ -201,6 +241,14 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 	 * PLUGIN WIRED BUT NEVER CONFIGURED (`is_active() === false`) is exactly the
 	 * review-finding scenario — {@see Pickup_Handler::location_config_block()} used to gate
 	 * on `$plugin` alone and leaked the block through anyway.
+	 *
+	 * Also overrides {@see Location_Service::provider_for_level()} (#346/#333) — same
+	 * "bypass the registry machinery, this file needs only the outcome" reasoning as
+	 * `is_active()` above: every stored record this file builds
+	 * ({@see PickupHandlerTest::location_record()}, {@see PickupHandlerTest::address_record()})
+	 * is `dadata`-owned, so this always hands back {@see Pickup_Handler_Test_Owning_Provider}
+	 * rather than requiring every one of this file's dozens of fixtures to also open the
+	 * real provider-registry gate.
 	 */
 	final class Pickup_Handler_Location_Service_Active_Probe extends Location_Service {
 
@@ -213,6 +261,24 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 
 		public function is_active(): bool {
 			return $this->active;
+		}
+
+		public function provider_for_level( string $level, ?string $country = null ): ?Location_Provider {
+			return new Pickup_Handler_Test_Owning_Provider();
+		}
+
+		/**
+		 * #346/#333, rule (b) — the real implementation now falls through to
+		 * {@see Location_Service::resolve_default_country()}, which calls
+		 * `wc_get_base_location()`, unstubbed anywhere in this file (this file
+		 * is about `Pickup_Handler` downstream of a valid record, not the
+		 * gate's own country chain — that is `LocationServiceTest`'s job).
+		 * Fixed to `'RU'`, matching every `dadata:...` fixture this file
+		 * builds ({@see PickupHandlerTest::location_record()},
+		 * {@see PickupHandlerTest::address_record()}).
+		 */
+		protected function customer_shipping_country(): string {
+			return 'RU';
 		}
 	}
 

--- a/tests/unit/Shipping/Pickup/ProviderSelectionScopeTest.php
+++ b/tests/unit/Shipping/Pickup/ProviderSelectionScopeTest.php
@@ -116,6 +116,25 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 	}
 
 	/**
+	 * A {@see Location_Service} that never treats a stored record as STALE
+	 * (#346/#333) — this file's own fixtures deliberately switch a record's
+	 * `provider_id` mid-test (`dadata:X` -> `cdek:Y`, spec D5's provider-switch
+	 * MISS) to prove `current_locality()` tracks whichever record is CURRENTLY
+	 * stored; none of that is about whether a record's OWNING provider still
+	 * resolves to it, which is `LocationServiceTest`'s own job. Overriding
+	 * {@see Location_Service::is_customer_record_stale()} (a `protected` test
+	 * seam for exactly this) is simpler here than registering a real owning
+	 * provider per record, because a single record's `provider_id` in this
+	 * file is not fixed the way it is in `PickupHandlerTest`'s own fixtures.
+	 */
+	final class Provider_Selection_Scope_Location_Service_Probe extends Location_Service {
+
+		protected function is_customer_record_stale( Location_Record $record, ?string $for_country = null ): bool {
+			return false;
+		}
+	}
+
+	/**
 	 * A minimal, concrete {@see Provider_Selection_Scope} — `current_locality()` is
 	 * inherited (`final`, cannot be overridden); the other three methods are the plugin's
 	 * own domain knowledge, exactly as {@see Provider_Selection_Scope}'s own docblock
@@ -191,7 +210,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 
 		public function test_current_locality_is_empty_when_the_customer_has_no_record_yet(): void {
 			$store = new Provider_Selection_Scope_Customer_Store_Probe( new Provider_Selection_Scope_Fake_Session() );
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope   = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$this->assertSame( '', $scope->current_locality() );
@@ -201,7 +220,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$store = new Provider_Selection_Scope_Customer_Store_Probe( new Provider_Selection_Scope_Fake_Session() );
 			$store->set( $this->record( 'dadata:fias-1' ) );
 
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope   = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$this->assertSame( 'dadata:fias-1', $scope->current_locality() );
@@ -212,7 +231,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			// never a value cached at construction time — a provider switch (or simply the
 			// customer choosing a new locality) must be visible on the very next call.
 			$store   = new Provider_Selection_Scope_Customer_Store_Probe( new Provider_Selection_Scope_Fake_Session() );
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope   = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$this->assertSame( '', $scope->current_locality() );
@@ -263,7 +282,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$store->set( $this->record( 'dadata:fias-1' ) );
 			$store->set( $this->address_record( 'dadata:fias-1' ) );
 
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope   = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$this->assertSame(
@@ -283,7 +302,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$store = new Provider_Selection_Scope_Customer_Store_Probe( new Provider_Selection_Scope_Fake_Session() );
 			$store->set( $this->address_record( 'dadata:fias-1' ) );
 
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope   = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$this->assertSame( '', $scope->current_locality() );
@@ -305,7 +324,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 				)
 			);
 
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope   = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$this->assertSame( '', $scope->current_locality() );
@@ -319,7 +338,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 			$store->set( $this->address_record( 'dadata:fias-1' ) );
 			$store->set( $this->record( 'dadata:fias-2' ) );
 
-			$service = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope   = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$this->assertSame( 'dadata:fias-2', $scope->current_locality() );
@@ -332,7 +351,7 @@ namespace Woodev\Tests\Unit\Shipping\Pickup {
 		public function test_a_point_remembered_under_one_provider_key_is_not_offered_under_a_different_one(): void {
 			$customer_session = new Provider_Selection_Scope_Fake_Session();
 			$store            = new Provider_Selection_Scope_Customer_Store_Probe( $customer_session );
-			$service          = new Location_Service( Location_Provider_Registry::instance(), $store );
+			$service          = new Provider_Selection_Scope_Location_Service_Probe( Location_Provider_Registry::instance(), $store );
 			$scope            = new Provider_Selection_Scope_Test_Scope( $service );
 
 			$pickup_session = new Provider_Selection_Scope_Fake_Session();

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -224,9 +224,28 @@ final class Location_Controller_Fake_Service extends Location_Service {
 	}
 
 	/**
+	 * `$for_country` (#350/#352 follow-up, FIX 3): this fake never gates
+	 * anything by country at all — it exists purely as a recording spy so a
+	 * controller-level test can assert `build_scope()` actually PASSES its
+	 * own already-normalized `$country` through here, rather than letting
+	 * the read fall back to the ambient customer country. The deeper
+	 * behavioural proof (that `Location_Service::get_customer_chain()`
+	 * itself USES `$for_country` instead of the ambient
+	 * `customer_shipping_country()`) lives in `LocationServiceTest` against
+	 * the REAL method, not this fake.
+	 *
+	 * @var array<int, string|null>
+	 */
+	public array $get_customer_chain_calls = [];
+
+	/**
+	 * @param string|null $for_country See {@see self::$get_customer_chain_calls}.
+	 *
 	 * @return array{records: array<string, Location_Record>, current: string, implicit: bool, saved_at: int}|null
 	 */
-	public function get_customer_chain(): ?array {
+	public function get_customer_chain( ?string $for_country = null ): ?array {
+		$this->get_customer_chain_calls[] = $for_country;
+
 		if ( null !== $this->chain_records ) {
 			return [
 				'records'  => $this->chain_records,
@@ -278,7 +297,7 @@ final class Location_Controller_Fake_Service extends Location_Service {
 		return $this->provider;
 	}
 
-	public function get_customer_record(): ?array {
+	public function get_customer_record( ?string $for_country = null ): ?array {
 		return $this->customer_record;
 	}
 
@@ -574,7 +593,7 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_suggest_request( $request );
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false ], $result );
+		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false, 'within_status' => 'not_requested' ], $result );
 	}
 
 	public function test_suggest_accepts_a_query_exactly_at_the_maximum(): void {
@@ -682,7 +701,7 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_suggest_request( $request );
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false ], $result );
+		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false, 'within_status' => 'not_requested' ], $result );
 	}
 
 	public function test_suggest_inactive_layer_returns_empty_200_not_404(): void {
@@ -696,7 +715,7 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_suggest_request( $request );
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false ], $result );
+		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false, 'within_status' => 'not_requested' ], $result );
 	}
 
 	/**
@@ -716,7 +735,7 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_suggest_request( $request );
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false ], $result );
+		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false, 'within_status' => 'not_requested' ], $result );
 		$this->assertCount( 0, $provider->suggest_calls, 'an unsupported country must never reach the provider' );
 	}
 
@@ -895,7 +914,7 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_suggest_request( $request );
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false ], $result );
+		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false, 'within_status' => 'not_requested' ], $result );
 		$this->assertCount( 0, $fallback->suggest_calls, 'a country the resolved provider does not cover must never reach it' );
 		$this->assertCount( 0, $chosen->suggest_calls, 'the active provider is never the one dispatched to for this level' );
 	}
@@ -1010,6 +1029,7 @@ final class LocationControllerTest extends TestCase {
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
 		$this->assertFalse( $captured->has_parent() );
+		$this->assertSame( 'bad_level', $result['within_status'], '#333: a level-ordering mismatch reports bad_level, not just a swallowed within_applied' );
 	}
 
 	// -------------------------------------------------------------------
@@ -1065,6 +1085,41 @@ final class LocationControllerTest extends TestCase {
 		$this->assertSame( $settlement, $captured->parent_record() );
 	}
 
+	/**
+	 * #350/#352 follow-up (FIX 3): `build_scope()` must pass ITS OWN
+	 * already-normalized `$country` through to
+	 * `Location_Service::get_customer_chain()` as `$for_country`, rather
+	 * than letting that read fall back to whatever the ambient WooCommerce
+	 * customer answers — a `/suggest` request's own `country` param is the
+	 * stronger authority for THIS request (see gotcha
+	 * `wc-customer-default-location-geolocation-fallback` for why the
+	 * ambient customer can disagree with it even on a freshly-booted guest).
+	 * `LocationServiceTest` proves the deeper mechanism (that
+	 * `get_customer_chain( $for_country )` actually USES it instead of the
+	 * ambient country); this test proves the CONTROLLER wiring — that
+	 * `build_scope()` actually passes it.
+	 */
+	public function test_suggest_passes_its_own_normalized_country_into_get_customer_chain(): void {
+		$provider = new Location_Controller_Fake_Provider( static fn() => [] );
+		$service  = new Location_Controller_Fake_Service( true, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		// get_customer_chain() is only reached when build_scope() has a
+		// `within` key to resolve at all (see build_scope()'s own early
+		// return for '' === $within_key) — a real, non-empty value is
+		// load-bearing here, not incidental.
+		$request = new WP_REST_Request(
+			[ 'q' => 'Мос', 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'within' => 'dadata:region-1' ]
+		);
+		$ctrl->handle_suggest_request( $request );
+
+		$this->assertSame(
+			[ 'RU' ],
+			$service->get_customer_chain_calls,
+			'build_scope() must thread its own normalized country into get_customer_chain() as $for_country'
+		);
+	}
+
 	public function test_suggest_within_naming_a_chain_record_from_another_country_is_refused(): void {
 		// Adversarial review: Location_Scope::within() takes the scope's COUNTRY FROM
 		// THE PARENT — there is deliberately no $country argument there — so honouring a
@@ -1116,6 +1171,7 @@ final class LocationControllerTest extends TestCase {
 		$this->assertFalse( $captured->has_parent(), 'a parent from another country must not constrain the search' );
 		$this->assertSame( 'UZ', $captured->country(), 'and the search must stay in the country the customer asked for' );
 		$this->assertFalse( $result['within_applied'] );
+		$this->assertSame( 'cross_country', $result['within_status'], '#333: a cross-country parent is named explicitly, not merely swallowed' );
 	}
 
 	public function test_suggest_within_still_resolves_when_the_requested_country_is_lower_case(): void {
@@ -1173,6 +1229,7 @@ final class LocationControllerTest extends TestCase {
 		$result = $ctrl->handle_suggest_request( $request );
 
 		$this->assertTrue( $result['within_applied'] );
+		$this->assertSame( 'applied', $result['within_status'] );
 	}
 
 	public function test_suggest_within_applied_is_false_when_an_unknown_within_falls_through(): void {
@@ -1186,6 +1243,7 @@ final class LocationControllerTest extends TestCase {
 		$result = $ctrl->handle_suggest_request( $request );
 
 		$this->assertFalse( $result['within_applied'] );
+		$this->assertSame( 'unknown_key', $result['within_status'] );
 	}
 
 	/**
@@ -1203,6 +1261,7 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_suggest_request( $request );
 
 		$this->assertFalse( $result['within_applied'] );
+		$this->assertSame( 'not_requested', $result['within_status'] );
 	}
 
 	public function test_suggest_within_applied_is_false_when_no_provider_serves_the_level(): void {
@@ -1213,6 +1272,32 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_suggest_request( $request );
 
 		$this->assertFalse( $result['within_applied'] );
+		// The client DID send a `within` here, and this branch never builds a
+		// scope at all (see perform_suggest()'s own comment on this exact
+		// branch) — but `within_status` must NOT claim `not_requested`
+		// (adversarial review finding, s78 — FIX 4): that constant's own
+		// docblock promises "no `within` param was sent at all", which is
+		// false here. `unserved_level` is the honest answer: a `within` was
+		// sent, but there was nothing to resolve it against.
+		$this->assertSame( 'unserved_level', $result['within_status'] );
+	}
+
+	/**
+	 * The mirror of the test above (adversarial review finding, s78 — FIX 4):
+	 * the SAME no-provider branch, but the client sent NO `within` at all —
+	 * `within_status` must still answer `not_requested` here, exactly as
+	 * before this fix, since that value's own promise ("no `within` param
+	 * was sent at all") is actually true on THIS branch.
+	 */
+	public function test_suggest_within_status_is_not_requested_when_no_provider_serves_the_level_and_no_within_was_sent(): void {
+		$service = new Location_Controller_Fake_Service( true, null ); // no provider for this level
+		$ctrl    = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request( [ 'q' => 'Мос', 'level' => Location_Record::LEVEL_ADDRESS, 'country' => 'RU' ] );
+		$result  = $ctrl->handle_suggest_request( $request );
+
+		$this->assertFalse( $result['within_applied'] );
+		$this->assertSame( 'not_requested', $result['within_status'] );
 	}
 
 	public function test_suggest_within_applied_reflects_the_scope_in_the_unsupported_country_branch(): void {
@@ -1240,6 +1325,7 @@ final class LocationControllerTest extends TestCase {
 
 		$this->assertSame( [], $result['suggestions'] );
 		$this->assertTrue( $result['within_applied'], 'the scope was still built (and had a parent) before the unsupported-country check ran' );
+		$this->assertSame( 'applied', $result['within_status'] );
 	}
 
 	// -------------------------------------------------------------------
@@ -1575,6 +1661,7 @@ final class LocationControllerTest extends TestCase {
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
 		$this->assertCount( 1, $result['localities'] );
 		$this->assertFalse( $result['truncated'] );
+		$this->assertSame( 'not_requested', $result['within_status'], '#333: /list carries within_status too, not only /suggest' );
 
 		$locality = $result['localities'][0];
 		$this->assertSame( 'fake-list:mo', $locality['key'] );
@@ -1780,11 +1867,41 @@ final class LocationControllerTest extends TestCase {
 		$request = new WP_REST_Request(
 			[ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'within' => 'dadata:region-1' ]
 		);
-		$ctrl->handle_list_request( $request );
+		$result = $ctrl->handle_list_request( $request );
 
 		$this->assertNotNull( $captured );
 		$this->assertTrue( $captured->has_parent() );
 		$this->assertSame( $parent, $captured->parent_record() );
+		$this->assertSame( 'applied', $result['within_status'] );
+	}
+
+	public function test_list_within_status_is_unknown_key_when_within_matches_nothing(): void {
+		$provider = new Location_Controller_Fake_List_Provider( static fn() => [] );
+		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request(
+			[ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'within' => 'dadata:some-stale-key' ]
+		);
+		$result = $ctrl->handle_list_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'unknown_key', $result['within_status'] );
+	}
+
+	public function test_list_within_status_is_cross_country_when_the_parent_is_in_another_country(): void {
+		$region_ru = $this->region_record( 'dadata:region-1' );
+		$provider  = new Location_Controller_Fake_List_Provider( static fn() => [] );
+		$service   = new Location_Controller_Fake_Service( true, null, [ 'record' => $region_ru, 'implicit' => false, 'saved_at' => 0 ], true, true, null, null, $provider );
+		$ctrl      = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request(
+			[ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'UZ', 'within' => 'dadata:region-1' ]
+		);
+		$result = $ctrl->handle_list_request( $request );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'cross_country', $result['within_status'] );
 	}
 
 	// -------------------------------------------------------------------
@@ -1862,7 +1979,7 @@ final class LocationControllerTest extends TestCase {
 		$result  = $ctrl->handle_admin_suggest_request( $request );
 
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false ], $result );
+		$this->assertSame( [ 'suggestions' => [], 'within_applied' => false, 'within_status' => 'not_requested' ], $result );
 	}
 
 	// -------------------------------------------------------------------

--- a/woodev/shipping-method/location/class-location-service.php
+++ b/woodev/shipping-method/location/class-location-service.php
@@ -182,6 +182,44 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * same request, or a later request once the write above landed, finds
 		 * `$current` non-null and returns immediately).
 		 *
+		 * A STORED record no longer counts as "having one" once
+		 * {@see self::gated_current_entry()} drops it as STALE (#346/#333) —
+		 * see that method and {@see self::is_customer_record_stale()} for the
+		 * two staleness rules. A stale-only store therefore behaves EXACTLY
+		 * like an empty one: the lazy default trigger below runs for it too,
+		 * on every read, since nothing is ever written back for a stale
+		 * record (the blob itself is left on disk — see
+		 * {@see self::gate_chain()}'s own docblock).
+		 *
+		 * A FRESHLY-RESOLVED default is gated too, BEFORE it is ever served or
+		 * persisted (adversarial review finding, s78 — FIX 1): every return
+		 * point of this method, including the default-resolution branches
+		 * below, now answers a GATED view or `null`, never a raw one, so this
+		 * accessor can never disagree with {@see self::get_customer_chain()}
+		 * about whether the customer has a location. Before this fix,
+		 * `resolve_default()` resolved against the store-setting/`RU` floor
+		 * ({@see self::resolve_default_country()}) while the gate's rule (b)
+		 * compares against the LIVE {@see self::customer_shipping_country()};
+		 * a customer who dropped an old `RU` record after switching to `BY`
+		 * would resolve a fresh `RU` default, the re-read gate would reject
+		 * it as stale, and the ungated fallback served it anyway — a record
+		 * `get_customer_record()` handed out while `get_customer_chain()`
+		 * answered `null` for the exact same state. The chosen fix is to gate
+		 * the default rather than to make `resolve_default()` country-aware:
+		 * a `fixed` default is a merchant-picked, specific locality whose
+		 * country cannot be bent to match an arbitrary customer without
+		 * picking a DIFFERENT locality (defeating what `fixed` means), and a
+		 * `geoip` default's country comes from the IP, not from the checkout
+		 * field — neither can honestly be re-targeted at the gate's country
+		 * authority. Gating is also simpler: it reuses the exact rule already
+		 * trusted for stored records instead of inventing a second country
+		 * chain for resolution alone. When a resolved default cannot pass
+		 * its own gate, this method answers `null` — precisely what
+		 * {@see self::get_customer_chain()} answers for the same state, per
+		 * this method's contract: "customer has no location" — rather than
+		 * silently degrading into a location the gate itself would refuse
+		 * to serve back.
+		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 Added the lazy default-locality resolution trigger
 		 *              (Task 14; spec D11).
@@ -189,18 +227,34 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 *              of the request, and serves it directly rather than
 		 *              re-reading a store that failed to write it (review
 		 *              finding F1 — {@see self::$unpersisted_default}).
+		 * @since 2.0.2 Routes the stored chain through {@see self::gated_current_entry()}
+		 *              rather than reading {@see Customer_Location_Store::get()}
+		 *              directly, so a STALE record (#346/#333) is treated as
+		 *              absent and the lazy default trigger runs for it exactly
+		 *              as it does for an empty store.
+		 * @since 2.0.2 Gates a freshly-resolved (or cached-unpersisted) default
+		 *              against the SAME staleness rule a stored record must
+		 *              pass, answering `null` rather than an ungated record
+		 *              when it fails (adversarial review finding, s78 — see
+		 *              above).
+		 * @since 2.0.2 Added the optional `$for_country` parameter, threaded
+		 *              through to the gate (#350/#352 follow-up).
+		 *
+		 * @param string|null $for_country Optional ISO-3166 alpha-2 country code — see {@see self::is_customer_record_stale()}.
 		 *
 		 * @return array{record: Location_Record, implicit: bool, saved_at: int}|null
 		 */
-		public function get_customer_record(): ?array {
-			$current = $this->customer_store->get();
+		public function get_customer_record( ?string $for_country = null ): ?array {
+			$current = $this->gated_current_entry( $for_country );
 
 			if ( null !== $current ) {
 				return $current;
 			}
 
 			if ( null !== $this->unpersisted_default ) {
-				return self::implicit_entry( $this->unpersisted_default );
+				return $this->is_customer_record_stale( $this->unpersisted_default, $for_country )
+					? null
+					: self::implicit_entry( $this->unpersisted_default );
 			}
 
 			$default = $this->resolve_default();
@@ -209,15 +263,35 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 				return null;
 			}
 
+			if ( $this->is_customer_record_stale( $default, $for_country ) ) {
+				// The resolved default cannot pass the SAME gate a stored
+				// record would have to pass (#346/#333) — see this method's
+				// own docblock (FIX 1) for why serving it anyway would
+				// disagree with get_customer_chain(). Neither persisted nor
+				// cached: a later call in the same request re-resolves it
+				// exactly as if nothing had ever resolved.
+				return null;
+			}
+
 			if ( $this->customer_store->set( $default, true ) ) {
-				return $this->customer_store->get();
+				// Re-read through the SAME gate: a default that just passed
+				// the pre-check above is expected to survive it (nothing
+				// about persisting it changes its provider or country), but
+				// re-gating here rather than trusting that keeps this
+				// accessor's contract uniform — every return point answers a
+				// gated view, never a raw one. Falls back to the in-memory
+				// entry on the theoretical chance it does not (this is now
+				// truly theoretical: the pre-check above already validated
+				// it against the same rule).
+				return $this->gated_current_entry( $for_country ) ?? self::implicit_entry( $default );
 			}
 
 			// The write failed (no session yet on this guest REST request — see
 			// self::$unpersisted_default). The resolution itself still
-			// succeeded: serve it for THIS call, and remember it so a later
-			// call in the SAME request neither loses it nor re-triggers
-			// resolve_default() a second time.
+			// succeeded and already passed the gate above: serve it for THIS
+			// call, and remember it so a later call in the SAME request
+			// neither loses it nor re-triggers resolve_default() a second
+			// time.
 			$this->unpersisted_default = $default;
 
 			return self::implicit_entry( $default );
@@ -246,15 +320,30 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * Gets the customer's whole location CHAIN (location-chain design §3:
 		 * `docs-internal/specs/2026-08-15-location-chain-design.md`) — every
 		 * level the customer has picked that {@see Customer_Location_Store::set()}
-		 * has not since dropped, plus which level is `current`.
+		 * has not since dropped AND that still passes the staleness gate
+		 * (#346/#333, {@see self::gate_chain()}), plus which level is
+		 * `current`.
 		 *
 		 * Routed through {@see self::get_customer_record()} FIRST, same as
 		 * {@see self::get_customer_record_at()} — never
 		 * {@see Customer_Location_Store::get_chain()} directly — so the lazy
 		 * default-locality trigger (spec D11, §4.6) stays in that ONE place: a
-		 * caller reaching for the chain before any record exists yet still gets
-		 * the store seeded exactly as a caller reaching for
-		 * {@see self::get_customer_record()} would.
+		 * caller reaching for the chain before any record exists yet (or
+		 * before anything SURVIVING one exists — a fully-stale chain reads
+		 * exactly like an empty one) still gets the store seeded exactly as a
+		 * caller reaching for {@see self::get_customer_record()} would.
+		 *
+		 * The chain itself is then re-read and gated a second time (rather
+		 * than reused from that first call) — not free, but not I/O either:
+		 * {@see self::gate_chain()} performs no I/O of its own, but a normal
+		 * `/suggest` call with a full 3-level chain still costs roughly seven
+		 * ownership walks ({@see self::provider_for_level()}, once per
+		 * surviving record in EACH of the two gate passes) plus provider and
+		 * customer-country resolution before any actual provider work runs —
+		 * cheap relative to a network call, not free. Re-gating here (rather
+		 * than reusing `get_customer_record()`'s bare entry) keeps this method
+		 * correct even though it cannot simply reuse that entry: THIS method
+		 * needs every surviving record, not only the one at `current`.
 		 *
 		 * Also covers the {@see self::$unpersisted_default} gap (review finding
 		 * F1): when {@see self::get_customer_record()} just resolved a default
@@ -272,20 +361,30 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * re-deriving it.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Gates the stored chain against staleness (#346/#333,
+		 *              {@see self::gate_chain()}) rather than returning
+		 *              {@see Customer_Location_Store::get_chain()}'s raw
+		 *              answer.
+		 * @since 2.0.2 Added the optional `$for_country` parameter, threaded
+		 *              through to {@see self::get_customer_record()} and
+		 *              {@see self::gate_chain()} (#350/#352 follow-up).
+		 *
+		 * @param string|null $for_country Optional ISO-3166 alpha-2 country code — see {@see self::is_customer_record_stale()}.
 		 *
 		 * @return array{records: array<string, Location_Record>, current: string, implicit: bool, saved_at: int}|null
 		 */
-		public function get_customer_chain(): ?array {
-			$current = $this->get_customer_record();
+		public function get_customer_chain( ?string $for_country = null ): ?array {
+			$current = $this->get_customer_record( $for_country );
 
 			if ( null === $current ) {
 				return null;
 			}
 
-			$chain = $this->customer_store->get_chain();
+			$raw   = $this->customer_store->get_chain();
+			$gated = null === $raw ? null : $this->gate_chain( $raw, $for_country );
 
-			if ( null !== $chain ) {
-				return $chain;
+			if ( null !== $gated ) {
+				return $gated;
 			}
 
 			// self::$unpersisted_default (review finding F1, see docblock above):
@@ -311,20 +410,294 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Location\\Location_Service'
 		 * reason documented there.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Added the optional `$for_country` parameter, threaded
+		 *              through to {@see self::get_customer_chain()} (#350/#352
+		 *              follow-up).
 		 *
-		 * @param string $level One of {@see Location_Record::LEVELS}.
+		 * @param string      $level       One of {@see Location_Record::LEVELS}.
+		 * @param string|null $for_country Optional ISO-3166 alpha-2 country code — see {@see self::is_customer_record_stale()}.
 		 *
 		 * @return Location_Record|null `null` for an unknown level string, or a
 		 *                               level the customer has not (yet) picked.
 		 */
-		public function get_customer_record_at( string $level ): ?Location_Record {
-			$chain = $this->get_customer_chain();
+		public function get_customer_record_at( string $level, ?string $for_country = null ): ?Location_Record {
+			$chain = $this->get_customer_chain( $for_country );
 
 			if ( null === $chain || ! isset( $chain['records'][ $level ] ) ) {
 				return null;
 			}
 
 			return $chain['records'][ $level ];
+		}
+
+		/**
+		 * Reads the customer's stored chain and gates it against staleness in
+		 * one step, projected down to {@see Customer_Location_Store::get()}'s
+		 * own entry shape (the record AT the gated chain's own `current`
+		 * level) — the single read path both {@see self::get_customer_record()}
+		 * and its post-write re-read share.
+		 *
+		 * @since 2.0.2
+		 * @since 2.0.2 Added the optional `$for_country` parameter, threaded
+		 *              through to {@see self::gate_chain()} (#350/#352
+		 *              follow-up).
+		 *
+		 * @param string|null $for_country Optional ISO-3166 alpha-2 country code — see {@see self::is_customer_record_stale()}.
+		 *
+		 * @return array{record: Location_Record, implicit: bool, saved_at: int}|null `null` when nothing is stored, or nothing SURVIVES the gate.
+		 */
+		private function gated_current_entry( ?string $for_country = null ): ?array {
+			$chain = $this->customer_store->get_chain();
+
+			if ( null === $chain ) {
+				return null;
+			}
+
+			$gated = $this->gate_chain( $chain, $for_country );
+
+			if ( null === $gated ) {
+				return null;
+			}
+
+			return [
+				'record'   => $gated['records'][ $gated['current'] ],
+				'implicit' => $gated['implicit'],
+				'saved_at' => $gated['saved_at'],
+			];
+		}
+
+		/**
+		 * Filters a raw stored chain down to the records that are still VALID
+		 * to serve on THIS read (#346/#333) — a record whose owning provider or
+		 * country has moved out from under it since it was written is STALE,
+		 * and a stale record is treated as ABSENT, never re-resolved (operator
+		 * decision: "считать отсутствующей"). See
+		 * {@see self::is_customer_record_stale()} for the two staleness rules
+		 * this applies per record.
+		 *
+		 * Gated in CASCADE ORDER ({@see Location_Record::LEVELS}), not
+		 * independently per level (adversarial review finding, s78): once a
+		 * level is dropped as stale, every DEEPER level is dropped too, even
+		 * one that would individually still pass. A surviving record must
+		 * have unbroken surviving ancestry — this mirrors
+		 * {@see Customer_Location_Store::rebuild_chain()}'s own invariant
+		 * (an ancestor only enters a rebuilt chain when the new record is
+		 * actually `is_within()` it), which a chain gated level-by-level
+		 * could otherwise violate: dropping a stale `settlement` while
+		 * keeping a surviving `address` would hand back `{address: …}` with
+		 * `current = address` — an address with no settlement above it,
+		 * a shape `rebuild_chain()` would never itself produce and the
+		 * cascade model `region > settlement > address` does not permit.
+		 *
+		 * The gate re-applies on EVERY read and never writes anything back —
+		 * the stored blob is left exactly as it is, staleness or not. A real
+		 * "forget" path for a permanently-stale blob (so it stops being
+		 * re-evaluated, and re-served as `implicit` history, on every future
+		 * request) is still missing; tracked separately as #356 rather than
+		 * folded into this read-side fix, which the operator scoped to
+		 * READING only ("Плюс почини сигнал" — the second half of that same
+		 * decision is Part 2 of this change, not a write).
+		 *
+		 * `current` is recomputed to the DEEPEST surviving level
+		 * ({@see Location_Record::LEVELS} cascade order) rather than trusting
+		 * the stored `current` pointer — a record dropped out from under that
+		 * pointer must not leave the gated chain pointing at a level no longer
+		 * present. This mirrors {@see Customer_Location_Store::rebuild_chain()}'s
+		 * own invariant that `current` always names the deepest record in the
+		 * chain.
+		 *
+		 * @since 2.0.2
+		 * @since 2.0.2 Gates in cascade order and drops every descendant of a
+		 *              dropped ancestor, rather than filtering each level
+		 *              independently (adversarial review finding, s78) — see
+		 *              above.
+		 * @since 2.0.2 Added the optional `$for_country` parameter, threaded
+		 *              through to {@see self::is_customer_record_stale()}
+		 *              (#350/#352 follow-up).
+		 *
+		 * @param array{records: array<string, Location_Record>, current: string, implicit: bool, saved_at: int} $chain       Raw stored chain.
+		 * @param string|null                                                                                    $for_country Optional ISO-3166 alpha-2 country code — see {@see self::is_customer_record_stale()}.
+		 *
+		 * @return array{records: array<string, Location_Record>, current: string, implicit: bool, saved_at: int}|null `null` when NOTHING survives — the caller must then treat this exactly like an empty store.
+		 */
+		private function gate_chain( array $chain, ?string $for_country = null ): ?array {
+			$records = [];
+			$broken  = false;
+
+			foreach ( Location_Record::LEVELS as $level ) {
+				if ( ! isset( $chain['records'][ $level ] ) ) {
+					continue;
+				}
+
+				if ( $broken || $this->is_customer_record_stale( $chain['records'][ $level ], $for_country ) ) {
+					// Once an ancestor is stale, every deeper level is stale
+					// too by construction — its ancestry is broken even if
+					// it would individually still pass the gate.
+					$broken = true;
+					continue;
+				}
+
+				$records[ $level ] = $chain['records'][ $level ];
+			}
+
+			if ( [] === $records ) {
+				return null;
+			}
+
+			$current = $chain['current'];
+
+			if ( ! isset( $records[ $current ] ) ) {
+				foreach ( array_reverse( Location_Record::LEVELS ) as $level ) {
+					if ( isset( $records[ $level ] ) ) {
+						$current = $level;
+						break;
+					}
+				}
+			}
+
+			return [
+				'records'  => $records,
+				'current'  => $current,
+				'implicit' => $chain['implicit'],
+				'saved_at' => $chain['saved_at'],
+			];
+		}
+
+		/**
+		 * Whether a stored customer record is STALE (#346/#333) — must be read
+		 * as ABSENT by {@see self::gate_chain()} even though it is still on
+		 * disk. Either rule below is sufficient on its own.
+		 *
+		 * (a) PROVIDER OWNERSHIP moved (#333): {@see self::provider_for_level()}
+		 * — the same D15 chain walk (active provider -> bundled fallback ->
+		 * nobody) every OTHER read of "who serves this level" already goes
+		 * through — no longer resolves to the SAME provider that produced this
+		 * record. This is deliberately NOT "the shop's active provider
+		 * changed": `provider_for_level()` itself falls back to the bundled
+		 * provider when the active one does not serve the level, so a record
+		 * the BUNDLED provider produced stays valid for as long as the bundled
+		 * provider remains the one the D15 chain actually resolves for that
+		 * level — only a change in WHICH provider is the resolved OWNER drops
+		 * it. A level nobody serves at all (`provider_for_level()` -> `null`)
+		 * is stale too — there is no owner left to vouch for it.
+		 *
+		 * (b) COUNTRY moved (#346): the record's own {@see Location_Record::country()}
+		 * no longer matches the country of authority for this read, as
+		 * `$for_country` (when given) or {@see self::customer_shipping_country()}
+		 * resolves it — switching the checkout country used to republish the
+		 * stale record with nothing catching it. There is deliberately no
+		 * "unknown country" escape here (operator correction, s79):
+		 * {@see self::customer_shipping_country()} ALWAYS answers something —
+		 * the same checkout-field -> store-setting -> `RU` floor
+		 * {@see self::resolve_default_country()} already guarantees — so an
+		 * "undeterminable" state this rule would need to special-case simply
+		 * does not exist, and a caller-supplied `$for_country` (already
+		 * normalized ISO-3166 by the caller — see `$for_country` below) is
+		 * never empty either.
+		 *
+		 * `$for_country` (optional, #350/#352 follow-up — call-site-aware
+		 * country authority): when given, rule (b) compares against IT
+		 * instead of the ambient {@see self::customer_shipping_country()}.
+		 * A REST read that already carries its own normalized `country`
+		 * request param (`/suggest`, `/list` — see
+		 * {@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller::build_scope()})
+		 * is a STRONGER authority for that one request than WooCommerce's
+		 * ambient customer object, which can disagree with it (a fresh
+		 * guest's shipping country resolves through
+		 * `wc_get_customer_default_location()`'s geolocation fallback, which
+		 * lands on a hardcoded `US` for a non-routable IP — gotcha
+		 * `wc-customer-default-location-geolocation-fallback` — entirely
+		 * independent of what country the CURRENT request is actually
+		 * asking about). Omitted (`null`, the default): behaves EXACTLY as
+		 * before this parameter was added — the checkout-render and pickup
+		 * paths, where the ambient WooCommerce customer IS the right
+		 * authority, are unaffected.
+		 *
+		 * `protected` (not `private`) as a test seam, same discipline as
+		 * {@see self::customer_shipping_country()} right below it: a test file
+		 * whose fixtures are not ABOUT staleness at all (e.g. `PickupHandlerTest`,
+		 * `ProviderSelectionScopeTest`) can override this to bypass the D15
+		 * provider-ownership/country machinery entirely rather than being forced
+		 * to open the real provider registry gate for every fixture record it
+		 * builds.
+		 *
+		 * @since 2.0.2
+		 * @since 2.0.2 Added the optional `$for_country` parameter (#350/#352
+		 *              follow-up) so a call-site with its own stronger country
+		 *              authority (a REST request's own `country` param) is no
+		 *              longer forced through the ambient customer object.
+		 *
+		 * @param Location_Record $record      Stored record to check.
+		 * @param string|null     $for_country Optional ISO-3166 alpha-2 country
+		 *                                     code to check rule (b) against
+		 *                                     instead of the ambient
+		 *                                     {@see self::customer_shipping_country()}.
+		 *
+		 * @return bool
+		 */
+		protected function is_customer_record_stale( Location_Record $record, ?string $for_country = null ): bool {
+			$owner = $this->provider_for_level( $record->level(), $record->country() );
+
+			if ( null === $owner || $owner->get_id() !== $record->provider_id() ) {
+				return true;
+			}
+
+			$country = $for_country ?? $this->customer_shipping_country();
+
+			return $country !== $record->country();
+		}
+
+		/**
+		 * The customer's shipping country — the authority
+		 * {@see self::is_customer_record_stale()}'s rule (b) checks a stored
+		 * record's own country against (#346). NEVER empty (operator
+		 * correction, s79): reuses the SAME chain
+		 * {@see self::resolve_default_country()} already embodies (checkout
+		 * field -> WooCommerce store setting -> `RU`) rather than inventing a
+		 * second, subtly different one — step 1 (the LIVE shipping field) is
+		 * added HERE, on top of it, because `resolve_default_country()`'s own
+		 * docblock is explicit that step 1 is each CALLER's job, never that
+		 * method's ({@see \Woodev\Framework\Shipping\Rest_Api\Location_Controller::perform_suggest()}
+		 * reads the REQUEST's own `country` param for step 1; this gate has no
+		 * request to read, so it reads WooCommerce's own live session value
+		 * for the customer instead — {@see \WC_Customer::get_shipping_country()},
+		 * the field the checkout's own `update_checkout` AJAX call keeps
+		 * current while the customer types).
+		 *
+		 * `protected` as a test seam — same shape and reasoning as
+		 * {@see Customer_Location_Store::session()} /
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::current_country()}:
+		 * a probe overrides this single line rather than needing `WC()` to be a
+		 * real function in the unit-test process (Brain Monkey's
+		 * Patchwork-based `Functions\when( 'WC' )` redefinition would leak
+		 * `function_exists( 'WC' )` as permanently `true` for the rest of that
+		 * PHPUnit process). Deliberately reads the SHIPPING field, not billing
+		 * — unlike `Checkout_Handler::current_country()`, which reads billing
+		 * for ITS OWN, unrelated purpose (enhancing the country field's
+		 * initial render).
+		 *
+		 * @since 2.0.2
+		 * @since 2.0.2 Dropped the "empty means unknown, survive rule (b)"
+		 *              behaviour (operator correction, s79): that state was
+		 *              never reachable — {@see self::resolve_default_country()}'s
+		 *              own floor guarantees a non-empty answer, so treating an
+		 *              empty LIVE field as anything other than "fall through to
+		 *              that floor" was untestable dead defensiveness, not a
+		 *              real case.
+		 *
+		 * @return string ISO-3166 alpha-2 country code (upper-case), never
+		 *                empty.
+		 */
+		protected function customer_shipping_country(): string {
+			if ( function_exists( 'WC' ) && WC()->customer ) {
+				$live = strtoupper( trim( (string) WC()->customer->get_shipping_country() ) );
+
+				if ( '' !== $live ) {
+					return $live;
+				}
+			}
+
+			return $this->resolve_default_country();
 		}
 
 		/**

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -180,6 +180,95 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		protected const LIST_HARD_CAP = 500;
 
 		/**
+		 * `within_status` value: no `within` param was sent at all.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var string
+		 */
+		public const WITHIN_STATUS_NOT_REQUESTED = 'not_requested';
+
+		/**
+		 * `within_status` value: `within` named a level the customer actually
+		 * picked, in the SAME country as this search, and
+		 * {@see Location_Scope::within()} accepted it as a parent constraint —
+		 * see {@see self::build_scope()}.
+		 *
+		 * Proves ONLY that the SCOPE BUILDER accepted the parent — NOT that
+		 * the provider that actually ran the search honoured it (clarified,
+		 * s78, adversarial review finding: an earlier reading of this value
+		 * treated `applied` as proof the search was narrowed). A mixed-owner
+		 * chain can still hand a parent from one provider to another
+		 * provider's `suggest()`/`list_localities()` call; whether that
+		 * provider could actually narrow by it is invisible from this field
+		 * alone — see gotcha `within-applied-reports-the-scope-builder-not-the-provider`
+		 * (#333) and the residual cross-provider gap tracked at #353.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var string
+		 */
+		public const WITHIN_STATUS_APPLIED = 'applied';
+
+		/**
+		 * `within_status` value: `within` named a key that matches NOTHING in
+		 * the customer's own chain (unknown, stale, already superseded, or the
+		 * customer has no chain at all yet) — see {@see self::build_scope()}.
+		 * Silently degraded to a country-wide scope, same as before this field
+		 * existed (issue #330's own rule: "stale client state must never brick
+		 * the field"), but now VISIBLE.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var string
+		 */
+		public const WITHIN_STATUS_UNKNOWN_KEY = 'unknown_key';
+
+		/**
+		 * `within_status` value: `within` matched a chain record, but that
+		 * record's country differs from this search's own `country` — refused
+		 * rather than silently moving the search to the parent's country (see
+		 * {@see self::build_scope()}'s own comment on why this is an
+		 * adversarial-review finding, not merely unhelpful).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var string
+		 */
+		public const WITHIN_STATUS_CROSS_COUNTRY = 'cross_country';
+
+		/**
+		 * `within_status` value: `within` matched a chain record in the right
+		 * country, but at the WRONG level for this search (e.g. a region key
+		 * "within" a region-level search) — refused by
+		 * {@see Location_Scope::within()} itself.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var string
+		 */
+		public const WITHIN_STATUS_BAD_LEVEL = 'bad_level';
+
+		/**
+		 * `within_status` value: the client DID send a `within` param, but no
+		 * provider serves the requested `$level` at all
+		 * ({@see Location_Service::provider_for_level()} -> `null`) — there is
+		 * nothing to resolve `within` against, and `build_scope()` never even
+		 * runs on this branch (adversarial review finding, s78 — the field
+		 * used to report {@see self::WITHIN_STATUS_NOT_REQUESTED} on this
+		 * branch UNCONDITIONALLY, including when the client had in fact sent a
+		 * `within`; that lied about a param it never inspected). A request
+		 * that sent NO `within` on this same branch still reports
+		 * `not_requested` — this value exists solely to keep that constant
+		 * truthful to its own docblock ("no `within` param was sent at all").
+		 *
+		 * @since 2.0.2
+		 *
+		 * @var string
+		 */
+		public const WITHIN_STATUS_UNSERVED_LEVEL = 'unserved_level';
+
+		/**
 		 * The façade this controller dispatches through. Defaults to a fresh
 		 * {@see Location_Service} (which itself defaults to the shared
 		 * {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry}
@@ -655,11 +744,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 *              indistinguishable from a genuine country-wide search — see
 		 *              the `within_applied` line below for the exact semantics,
 		 *              including the no-`within`-requested case.
+		 * @since 2.0.2 Response gained `within_status` (#333) — the ONE of
+		 *              `self::WITHIN_STATUS_*` {@see self::build_scope()}
+		 *              actually resolved, so a caller can tell "unknown key"
+		 *              from "cross-country" from "wrong level" instead of the
+		 *              single `within_applied` boolean collapsing all three
+		 *              (and "never requested") into the same `false`.
 		 *
 		 * @param \WP_REST_Request $request        request object.
 		 * @param string           $rate_limit_key Per-route rate-limit bucket prefix.
 		 *
-		 * @return \WP_REST_Response|\WP_Error|array{suggestions: array<int, array<string, mixed>>, within_applied: bool}
+		 * @return \WP_REST_Response|\WP_Error|array{suggestions: array<int, array<string, mixed>>, within_applied: bool, within_status: string}
 		 */
 		private function perform_suggest( $request, string $rate_limit_key ) {
 
@@ -701,10 +796,31 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 			if ( null === $provider ) {
 				// No scope is ever built on this branch — nothing was looked up,
 				// so no parent constraint could have been applied.
+				// `within_applied` stays `false` UNCONDITIONALLY here, mirroring
+				// its own established precedent on this exact branch: when no
+				// provider serves this level AT ALL, there is nothing to resolve
+				// `within` against regardless of the request, a bigger
+				// degradation than any single `within_status` value below names.
+				//
+				// `within_status`, unlike `within_applied`, DOES tell apart
+				// whether the client actually sent a `within` (adversarial
+				// review finding, s78 — FIX 4): reporting `not_requested`
+				// unconditionally here used to lie about a param this branch
+				// never even inspected. `self::WITHIN_STATUS_NOT_REQUESTED`'s
+				// own docblock promises "no `within` param was sent at all" —
+				// a promise this branch could not keep for a client that DID
+				// send one, since build_scope() (the only place that would
+				// have read it) never runs when there is no provider to search
+				// with.
+				$within_requested = '' !== $this->normalize_param( $request->get_param( 'within' ) );
+
 				return rest_ensure_response(
 					[
 						'suggestions'    => [],
 						'within_applied' => false,
+						'within_status'  => $within_requested
+							? self::WITHIN_STATUS_UNSERVED_LEVEL
+							: self::WITHIN_STATUS_NOT_REQUESTED,
 					]
 				);
 			}
@@ -746,9 +862,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 			 *   knows whether it sent one, so the two `false` causes never need
 			 *   telling apart from this field alone, and `has_parent()` is
 			 *   definitionally `false` in both.
+			 *
+			 * `within_status` (#333) is the field that DOES tell the two `false`
+			 * causes (and the "wrong level"/"cross country" ones) apart — see
+			 * {@see self::build_scope()} for exactly which value each cause
+			 * maps to. `within_applied` is kept AS IS (a shipped response
+			 * field) and is NOT derived from `within_status` here — both are
+			 * read from the same `$scope`/`$result` independently, so a future
+			 * change to one can never silently desync the other.
 			 */
 			try {
-				$scope = $this->build_scope( $country, $level, $within );
+				$result = $this->build_scope( $country, $level, $within );
 			} catch ( \InvalidArgumentException $exception ) {
 				return new \WP_Error(
 					'woodev_location_invalid_country',
@@ -756,6 +880,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 					[ 'status' => 400 ]
 				);
 			}
+
+			$scope         = $result['scope'];
+			$within_status = $result['within_status'];
 
 			/*
 			 * A well-formed but UNSUPPORTED country (the provider that will
@@ -780,6 +907,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 					[
 						'suggestions'    => [],
 						'within_applied' => $scope->has_parent(),
+						'within_status'  => $within_status,
 					]
 				);
 			}
@@ -796,6 +924,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 				[
 					'suggestions'    => $this->to_response_records( $records ),
 					'within_applied' => $scope->has_parent(),
+					'within_status'  => $within_status,
 				]
 			);
 		}
@@ -840,10 +969,15 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 * @since 2.0.2 Capped at {@see self::LIST_HARD_CAP} records, with an
 		 *              optional clamped `limit` arg and a `truncated` response
 		 *              flag (PR #304 review finding 5).
+		 * @since 2.0.2 Response gained `within_status` (#333) — see
+		 *              {@see self::build_scope()} for the values; unlike
+		 *              `/suggest` this route never shipped a `within_applied`
+		 *              boolean, so `within_status` is its ONLY `within`
+		 *              signal, not a supplement to one.
 		 *
 		 * @param \WP_REST_Request $request request object.
 		 *
-		 * @return \WP_REST_Response|\WP_Error|array{localities: array<int, array<string, mixed>>, truncated: bool}
+		 * @return \WP_REST_Response|\WP_Error|array{localities: array<int, array<string, mixed>>, truncated: bool, within_status: string}
 		 */
 		public function handle_list_request( $request ) {
 
@@ -874,7 +1008,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 			$limit     = $limit > 0 ? min( $limit, self::LIST_HARD_CAP ) : self::LIST_HARD_CAP;
 
 			try {
-				$scope = $this->build_scope( $country, $level, $within );
+				$result = $this->build_scope( $country, $level, $within );
 			} catch ( \InvalidArgumentException $exception ) {
 				return new \WP_Error(
 					'woodev_location_invalid_country',
@@ -882,6 +1016,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 					[ 'status' => 400 ]
 				);
 			}
+
+			$scope         = $result['scope'];
+			$within_status = $result['within_status'];
 
 			// Deliberately never reads `$request->get_param( 'provider' )` — same
 			// reasoning as `/suggest` above (see the class docblock and
@@ -909,8 +1046,9 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 
 			return rest_ensure_response(
 				[
-					'localities' => $this->to_response_records( $records ),
-					'truncated'  => $truncated,
+					'localities'    => $this->to_response_records( $records ),
+					'truncated'     => $truncated,
+					'within_status' => $within_status,
 				]
 			);
 		}
@@ -1126,7 +1264,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 
 		/**
 		 * Builds the lookup scope for a suggest call, resolving the optional
-		 * `within` parent constraint.
+		 * `within` parent constraint — and reports what actually happened to
+		 * that constraint via `within_status` (one of the
+		 * `self::WITHIN_STATUS_*` constants), so a caller no longer has to
+		 * infer it from `Location_Scope::has_parent()` alone (see
+		 * {@see self::perform_suggest()}'s own `within_applied` field, whose
+		 * docblock now cross-references this one).
 		 *
 		 * `within` is a locality KEY (not a components blob) the client believes
 		 * names one of its own already-picked levels. Since this controller has
@@ -1152,70 +1295,121 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 * {@see \Woodev\Framework\Shipping\Location\Providers\Dadata_Provider::build_locations_constraint()})
 		 * need no change at all and still get exact native ids.
 		 *
+		 * The FOREIGN-PROVIDER half of this — a `within` key resolving to a
+		 * record from a provider that no longer owns ITS OWN level — used to
+		 * be a silent hand-over to the provider (see gotcha
+		 * `within-applied-reports-the-scope-builder-not-the-provider`, #333).
+		 * {@see Location_Service::get_customer_chain()} (Part 1 of #346/#333)
+		 * now gates every record in the chain against exactly that staleness
+		 * (per-level provider ownership + country) before this method ever
+		 * sees it, so a record whose OWN level's owner no longer matches it
+		 * can no longer BE in `$records` below.
+		 *
+		 * That is NOT the same as "every parent handed to a provider now
+		 * shares that provider" (corrected, s78 — the previous docblock here
+		 * overclaimed this as structurally impossible, which is false): the
+		 * gate checks a record against the owner of ITS OWN level, never
+		 * against the level actually being searched. A legitimate MIXED-OWNER
+		 * chain — e.g. `{region: dadata, settlement: carrier}`, valid
+		 * precisely because `region` is OPTIONAL and a carrier may serve
+		 * `settlement` without serving `region` (issue #352) — still hands a
+		 * `dadata`-owned parent to a `carrier` provider when `within` matches
+		 * the region and the search level is deeper. Neither bundled provider
+		 * implementation reports whether it could actually honour a
+		 * cross-provider parent; that residual gap is tracked separately
+		 * (#353, not this fix) rather than banned here — banning cross-provider
+		 * scopes outright would also break the legitimate, WORKING case (a
+		 * DaData address search scoped by a CDEK settlement, measured on the
+		 * rig). Do not re-add a same-level provider check here for the
+		 * SINGLE-level staleness the chain read already refuses to hand
+		 * over — that part remains true.
+		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 Resolves `within` against the customer's WHOLE chain
 		 *              ({@see Location_Service::get_customer_chain()}), not only
 		 *              the current record (issue #330).
+		 * @since 2.0.2 Returns `within_status` alongside the scope (#333) —
+		 *              the failure this method used to swallow silently is now
+		 *              named for the caller.
+		 * @since 2.0.2 Passes this method's own already-normalized `$country`
+		 *              into {@see Location_Service::get_customer_chain()} as
+		 *              its `$for_country` argument (#350/#352 follow-up),
+		 *              rather than letting that read fall back to the ambient
+		 *              WooCommerce customer country — a `/suggest`/`/list`
+		 *              request's own `country` param is the stronger
+		 *              authority for THIS request; the ambient customer can
+		 *              disagree with it (gotcha
+		 *              `wc-customer-default-location-geolocation-fallback`).
 		 *
 		 * @param string $country    Normalized ISO-3166 alpha-2 country code.
 		 * @param string $level      One of {@see Location_Record::LEVELS} — already validated by the caller.
 		 * @param string $within_key Normalized `within` param, possibly `''`.
 		 *
-		 * @return Location_Scope
+		 * @return array{scope: Location_Scope, within_status: string}
 		 *
 		 * @throws \InvalidArgumentException When `$country` is not a well-formed
 		 *                                    ISO-3166 alpha-2 code — the caller
 		 *                                    converts this to a 400.
 		 */
-		private function build_scope( string $country, string $level, string $within_key ): Location_Scope {
+		private function build_scope( string $country, string $level, string $within_key ): array {
 
-			if ( '' !== $within_key ) {
-				$chain   = $this->service->get_customer_chain();
-				$records = null !== $chain ? $chain['records'] : [];
-
-				foreach ( $records as $chain_record ) {
-					if ( $chain_record->key() !== $within_key ) {
-						continue;
-					}
-
-					/*
-					 * A parent from ANOTHER COUNTRY is refused, not merely unhelpful
-					 * (adversarial review): Location_Scope::within() takes the scope's
-					 * country FROM THE PARENT RECORD — there is deliberately no
-					 * $country argument there, so the two cannot disagree — which means
-					 * honouring a stale cross-country `within` would silently move the
-					 * whole search to the parent's country while the customer is typing
-					 * an address in the one they actually selected. Treated exactly like
-					 * an unknown key: silent fall-through to the country-wide scope.
-					 *
-					 * `$country` is normalized HERE rather than trusted: it arrives from
-					 * `normalize_param()`, which cleans but does NOT upper-case, while a
-					 * record's own `country()` is always upper-cased by
-					 * {@see Location_Record::from_array()}. Comparing them raw would drop
-					 * a perfectly good parent for any client that sent `ru` instead of
-					 * `RU` — a silent narrowing introduced by a guard meant to prevent
-					 * one.
-					 */
-					if ( $chain_record->country() !== strtoupper( trim( $country ) ) ) {
-						break;
-					}
-
-					try {
-						return Location_Scope::within( $chain_record, $level );
-					} catch ( \InvalidArgumentException $exception ) {
-						// Level-ordering mismatch — treated exactly like an unknown key:
-						// fall through to the country-wide scope below.
-					}
-
-					break;
-				}
-
-				// No match at all (unknown/stale key, no customer record yet, or a
-				// level-ordering mismatch caught above) — deliberately silent, as if
-				// `within` had never been sent.
+			if ( '' === $within_key ) {
+				return [
+					'scope'         => Location_Scope::for_country( $country, $level ),
+					'within_status' => self::WITHIN_STATUS_NOT_REQUESTED,
+				];
 			}
 
-			return Location_Scope::for_country( $country, $level );
+			$chain   = $this->service->get_customer_chain( $country );
+			$records = null !== $chain ? $chain['records'] : [];
+
+			foreach ( $records as $chain_record ) {
+				if ( $chain_record->key() !== $within_key ) {
+					continue;
+				}
+
+				/*
+				 * A parent from ANOTHER COUNTRY is refused, not merely unhelpful
+				 * (adversarial review): Location_Scope::within() takes the scope's
+				 * country FROM THE PARENT RECORD — there is deliberately no
+				 * $country argument there, so the two cannot disagree — which means
+				 * honouring a stale cross-country `within` would silently move the
+				 * whole search to the parent's country while the customer is typing
+				 * an address in the one they actually selected.
+				 *
+				 * `$country` is normalized HERE rather than trusted: it arrives from
+				 * `normalize_param()`, which cleans but does NOT upper-case, while a
+				 * record's own `country()` is always upper-cased by
+				 * {@see Location_Record::from_array()}. Comparing them raw would drop
+				 * a perfectly good parent for any client that sent `ru` instead of
+				 * `RU` — a silent narrowing introduced by a guard meant to prevent
+				 * one.
+				 */
+				if ( $chain_record->country() !== strtoupper( trim( $country ) ) ) {
+					return [
+						'scope'         => Location_Scope::for_country( $country, $level ),
+						'within_status' => self::WITHIN_STATUS_CROSS_COUNTRY,
+					];
+				}
+
+				try {
+					return [
+						'scope'         => Location_Scope::within( $chain_record, $level ),
+						'within_status' => self::WITHIN_STATUS_APPLIED,
+					];
+				} catch ( \InvalidArgumentException $exception ) {
+					return [
+						'scope'         => Location_Scope::for_country( $country, $level ),
+						'within_status' => self::WITHIN_STATUS_BAD_LEVEL,
+					];
+				}
+			}
+
+			// No match at all — unknown/stale key, or no customer chain yet.
+			return [
+				'scope'         => Location_Scope::for_country( $country, $level ),
+				'within_status' => self::WITHIN_STATUS_UNKNOWN_KEY,
+			];
 		}
 
 		/**


### PR DESCRIPTION
Closes #346
Closes #333

## Одна правка на две карточки

Обе упирались в одно отсутствующее звено: **записи покупателя никто не проверял на чтении.**

- **#346** — смена страны чистит поля на клиенте, но серверную запись не гасит ничто, а пути «забыть» в слое нет вовсе. После перезагрузки `Checkout_Config` отдавал обратно российский НП, пока покупатель везёт в Беларусь: поле НП пустое, а адрес **разблокирован**, потому что слой считал, что НП выбран.
- **#333** — смена активного провайдера оставляла запись от старого живой и отдаваемой. Проверки на чтении не было ни одной: во всём слое ровно два сравнения `provider_id()`, и оба про магазинное `default_locality_record`.

## Решение оператора: считать отсутствующей + починить сигнал

Перерезолв через существующий `reresolve_fixed_default()` намеренно **не** переиспользован: его `unambiguous_match()` требует побайтового равенства `label()` у разных провайдеров, что для покупательской записи не сработает почти никогда (готча `a-locality-display-name-is-not-an-identifier`), и он кладёт живой вызов провайдера на каждый запрос, включая публичный гостевой `/suggest`.

- Гейт в `Location_Service` на всех трёх аксессорах чтения. Запись протухла, если цепочка D15 больше не резолвит её уровень на её же провайдера, либо её страна больше не совпадает со страной покупателя.
- **Каскадный порядок:** уронили предка — уронили и всех потомков, по инварианту `rebuild_chain()`. Просто отсутствующий уровень цепочку не ломает.
- Когда не выживает ничто, чтение ведёт себя ровно как пустое хранилище — включая ленивое умолчание, которое **тоже гейтится**. Поэтому `get_customer_record()` и `get_customer_chain()` не могут разойтись во мнении, есть ли у покупателя локация.
- **Гейт ничего не пишет.** Протухший блоб остаётся на диске и переоценивается на каждом чтении; настоящий путь «забыть» по-прежнему нужен — #356.
- **Авторитет страны по месту вызова:** у трёх аксессоров появился необязательный `$for_country`, `build_scope()` передаёт свою нормализованную страну. Ambient `WC()->customer` остаётся авторитетом только на рендере чекаута и в слое ПВЗ — в остальных местах он ненадёжен, потому что WooCommerce определяет свежего гостя геолокацией и падает на зашитый `US`.
- `/suggest` и `/list` отдают `within_status`: `not_requested`, `applied`, `unknown_key`, `cross_country`, `bad_level`, `unserved_level`.

## Что НЕ закрыто — сказано в докблоках прямо, а не замолчано

Законная цепочка со смешанным владением всё ещё может отдать провайдеру родителя, принадлежащего другому провайдеру: **регион необязателен**, и карьер может обслуживать НП, не обслуживая регион. Заведено как **#358**. Запретить кросс-провайдерный скоуп нельзя — замерено, что в паре СДЭК-НП + DaData-адрес он работает.

В первой редакции я утверждал в докблоке обратное — что гейт это структурно закрывает. Adversarial-критик (Codex) поймал; формулировка исправлена.

## Что ещё нашёл критик и что исправлено

- **P0** — ленивое умолчание обходило собственный гейт, а докблок рядом обещал «every return point answers a gated view».
- **P0** — `gate_chain()` фильтровал записи независимо и мог оставить адрес, уронив НП.
- **P1** — `within_status: not_requested` отдавался, когда уровень никем не обслуживается, даже если `within` прислали. Новое поле завели против врущих сигналов — и сразу вложили враньё.
- **P1/P2** — докблоки про «провайдер учёл скоуп» и «второй проход дёшев, нет I/O».

## Проверка

**2316 unit / 5732 ассертов** (было 2299/5690), **1177 jest**, **110 интеграционных**, phpcs 210/210, phpstan чисто, `lint:docs` OK при 163 готчах.

Каждое новое поведение проверено мутацией с подтверждением через `grep`, что мутация применилась.

**Риг, с контролями в том же прогоне.**

Смена провайдера:
```
до:      chain = { settlement: test-cdek:137 }   адрес открыт
после:   chain = []   current = null              адрес ЗАБЛОКИРОВАН   текст «Санкт-Петербург» цел
контроль: вернул провайдера -> test-cdek:137 ВЕРНУЛАСЬ
```
Контроль доказывает, что запись прячет гейт, а не теряет хранилище.

Смена страны:
```
БЫЛО (замер сегодня же):  BY -> current = { test-cdek:44 }, chain = { settlement }, адрес ОТКРЫТ
СТАЛО:                    BY -> current = null,             chain = [],             адрес ЗАБЛОКИРОВАН
```

## Связано

- #356 — настоящий путь «забыть» (гейт не пишет)
- #358 — провайдерский шов не сообщает, смог ли учесть чужого родителя
- #353 — минимальный уровень провайдера при регистрации

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hsd5RYaS8YSHiaCGMZZYD