### PR TITLE
feat(shipping): «Поля» — настройки, политика через два шва WC, восстановление инвариантов

### DIFF
--- a/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutConfigTest.php
@@ -21,6 +21,8 @@ namespace Woodev\Tests\Unit\Shipping\Checkout;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Woodev\Framework\Shipping\Checkout\Checkout_Config;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Environment;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings;
 use Woodev\Framework\Shipping\Checkout\Checkout_Fields;
 use Woodev\Framework\Shipping\Checkout\Field;
 use Woodev\Framework\Shipping\Location\Abstract_Location_Provider;
@@ -56,6 +58,8 @@ require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/providers
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/providers/class-dadata-api-response.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/providers/class-dadata-api-client.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/location/providers/class-dadata-provider.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-environment.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-settings.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-config.php';
 
 /**
@@ -442,6 +446,59 @@ class CheckoutConfigTest extends TestCase {
 		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ] ) )->build( $fields );
 
 		$this->assertSame( [], $config['fields']['carrier_pvz']['pickup_slot_placements'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// field_policy / pickup_method_ids — Task 6, issue #362, spec §4.3
+	// -------------------------------------------------------------------------
+
+	public function test_field_policy_defaults_to_all_show_when_no_settings_injected(): void {
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ] ) )->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame(
+			[ 'address' => 'show', 'postcode' => 'show', 'country' => 'show' ],
+			$config['field_policy']
+		);
+	}
+
+	/**
+	 * The `field_policy` block reads through the SAME `Checkout_Field_Settings::effective()`
+	 * clamp-on-read contract Task 5 already pins — this test proves Checkout_Config
+	 * genuinely calls it (through the injected collaborator) rather than reading the
+	 * raw stored option itself.
+	 */
+	public function test_field_policy_reads_effective_values_from_the_injected_settings_handler(): void {
+		Functions\when( 'get_option' )->alias(
+			static function ( $name ) {
+				return false !== strpos( (string) $name, 'postcode_field' ) ? 'hide_for_pickup' : null;
+			}
+		);
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $tag, $default = null ) {
+				return $default;
+			}
+		);
+
+		// Off the block checkout ($block_checkout = false), so hide_for_pickup is offered.
+		$settings = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ], null, $settings ) )
+			->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame( 'hide_for_pickup', $config['field_policy']['postcode'] );
+		$this->assertSame( 'show', $config['field_policy']['address'] );
+		$this->assertSame( 'show', $config['field_policy']['country'] );
+	}
+
+	public function test_pickup_method_ids_is_empty_when_wc_is_unavailable(): void {
+		$config = ( new Checkout_Config( 'carrier', 'https://x/wp-json/woodev/v1', 'N', [ 'RU' ] ) )->build( Checkout_Fields::from_array( [] ) );
+
+		$this->assertSame( [], $config['pickup_method_ids'] );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
@@ -56,13 +56,17 @@ final class CheckoutFieldPolicyTest extends TestCase {
 
 	public function test_locale_contribution_for_preset_only(): void {
 		$out = Checkout_Field_Policy::locale_contribution( [ 'field_order_preset' => true, 'region_field' => 'show', 'postcode_field' => 'show' ], [ 'RU' => [] ], [ 'RU', 'KZ' ] );
-		$this->assertSame( 10, $out['RU']['country']['priority'] );
-		$this->assertSame( 20, $out['RU']['state']['priority'] );
-		$this->assertSame( 30, $out['RU']['city']['priority'] );
-		$this->assertSame( 40, $out['RU']['address_1']['priority'] );
-		$this->assertSame( 50, $out['RU']['address_2']['priority'] );
-		$this->assertSame( 60, $out['RU']['postcode']['priority'] );
-		$this->assertSame( 20, $out['KZ']['state']['priority'] );        // every shipping country (S5)
+		// The address block keeps WooCommerce's own 40-90 band (first_name 10 / last_name 20 /
+		// company 30 sit below it, phone 100 / email 110 above), reordered to
+		// Страна > Регион > Город > Адрес > Кв. > Индекс. Measured on the rig: the design's
+		// original 10-60 collided with the name block and split the customer's name in half.
+		$this->assertSame( 40, $out['RU']['country']['priority'] );
+		$this->assertSame( 50, $out['RU']['state']['priority'] );
+		$this->assertSame( 60, $out['RU']['city']['priority'] );
+		$this->assertSame( 70, $out['RU']['address_1']['priority'] );
+		$this->assertSame( 80, $out['RU']['address_2']['priority'] );
+		$this->assertSame( 90, $out['RU']['postcode']['priority'] );
+		$this->assertSame( 50, $out['KZ']['state']['priority'] );        // every shipping country (S5)
 		$this->assertTrue( $out['RU']['city']['required'] );            // settlement invariant, always
 		$this->assertArrayNotHasKey( 'hidden', $out['RU']['state'] );
 	}

--- a/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
@@ -149,6 +149,40 @@ final class CheckoutFieldPolicyTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The invariant is «the settlement field EXISTS and is REQUIRED» — both halves, always.
+	 * `WC_Countries::get_default_address_fields()` is itself filterable
+	 * (`woocommerce_default_address_fields`), which is exactly where a third-party field
+	 * manager would relax `city`. Re-inserting that template verbatim would then restore an
+	 * OPTIONAL settlement field while reporting success — the invariant silently half-kept.
+	 */
+	public function test_a_restored_settlement_field_is_required_even_when_the_template_is_not(): void {
+		$fields = [ 'billing' => [ 'billing_address_1' => [] ], 'shipping' => [ 'shipping_address_1' => [] ] ];
+		$policy = new Checkout_Field_Policy();
+
+		$out = $policy->restore_invariants( $fields, [ 'city' => [ 'label' => 'Город', 'required' => false, 'priority' => 70 ] ] );
+
+		$this->assertTrue( $out['billing']['billing_city']['required'] );
+		$this->assertTrue( $out['shipping']['shipping_city']['required'] );
+		// Everything else in the template survives — only the invariant is asserted over it.
+		$this->assertSame( 'Город', $out['billing']['billing_city']['label'] );
+		$this->assertSame( 70, $out['billing']['billing_city']['priority'] );
+	}
+
+	/**
+	 * Degenerate case: no WooCommerce runtime, so the template is empty. The field must still
+	 * come back required rather than as a bare `[]` that renders as an optional text input.
+	 */
+	public function test_a_restored_settlement_field_is_required_when_no_template_exists(): void {
+		$fields = [ 'billing' => [], 'shipping' => [] ];
+		$policy = new Checkout_Field_Policy();
+
+		$out = $policy->restore_invariants( $fields, [] );
+
+		$this->assertTrue( $out['billing']['billing_city']['required'] );
+		$this->assertTrue( $out['shipping']['shipping_city']['required'] );
+	}
+
 	public function test_settlement_made_optional_is_made_required_again(): void {
 		$fields = [ 'billing' => [ 'billing_city' => [ 'required' => false ] ], 'shipping' => [ 'shipping_city' => [ 'required' => false ] ] ];
 		$policy = new Checkout_Field_Policy();

--- a/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
@@ -129,6 +129,58 @@ final class CheckoutFieldPolicyTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// restore_invariants() — settlement-field invariant restoration (S8), instance
+	// -------------------------------------------------------------------------
+
+	public function test_settlement_removed_by_a_third_party_is_restored_and_recorded(): void {
+		$fields = [ 'billing' => [ 'billing_address_1' => [] ], 'shipping' => [ 'shipping_address_1' => [] ] ];
+		$policy = new Checkout_Field_Policy();
+		$out    = $policy->restore_invariants( $fields, [ 'city' => [ 'label' => 'Город', 'required' => true, 'class' => [ 'form-row-wide' ], 'priority' => 70 ] ] );
+
+		$this->assertTrue( $out['billing']['billing_city']['required'] );
+		$this->assertTrue( $out['shipping']['shipping_city']['required'] );
+		$this->assertSame(
+			[ [ 'field' => 'city', 'what' => 'restored' ], [ 'field' => 'city', 'what' => 'restored' ] ],
+			array_map( static fn( $o ) => [ 'field' => $o['field'], 'what' => $o['what'] ], $policy->get_overrides() )
+		);
+	}
+
+	public function test_settlement_made_optional_is_made_required_again(): void {
+		$fields = [ 'billing' => [ 'billing_city' => [ 'required' => false ] ], 'shipping' => [ 'shipping_city' => [ 'required' => false ] ] ];
+		$policy = new Checkout_Field_Policy();
+		$out    = $policy->restore_invariants( $fields, [ 'city' => [ 'required' => true ] ] );
+
+		$this->assertTrue( $out['shipping']['shipping_city']['required'] );
+		$this->assertSame( 'required', $policy->get_overrides()[0]['what'] );
+	}
+
+	public function test_other_fields_are_left_to_the_field_manager(): void {
+		$fields = [ 'billing' => [ 'billing_city' => [ 'required' => true ], 'billing_phone' => [ 'required' => false ] ], 'shipping' => [ 'shipping_city' => [ 'required' => true ] ] ];
+		$policy = new Checkout_Field_Policy();
+		$out    = $policy->restore_invariants( $fields, [ 'city' => [ 'required' => true ] ] );
+
+		$this->assertFalse( $out['billing']['billing_phone']['required'] );
+		$this->assertSame( [], $policy->get_overrides() );
+	}
+
+	/**
+	 * A second call describes only the outcome of THAT pass — overrides never
+	 * accumulate across repeat filter applications within the same request.
+	 */
+	public function test_restore_invariants_resets_overrides_on_each_call(): void {
+		$policy = new Checkout_Field_Policy();
+
+		$policy->restore_invariants( [ 'billing' => [], 'shipping' => [] ], [ 'city' => [ 'required' => true ] ] );
+		$this->assertNotSame( [], $policy->get_overrides() );
+
+		$policy->restore_invariants(
+			[ 'billing' => [ 'billing_city' => [ 'required' => true ] ], 'shipping' => [ 'shipping_city' => [ 'required' => true ] ] ],
+			[ 'city' => [ 'required' => true ] ]
+		);
+		$this->assertSame( [], $policy->get_overrides(), 'a second call must not accumulate overrides from the first' );
+	}
+
+	// -------------------------------------------------------------------------
 	// register() / filter callbacks — real Checkout_Field_Settings
 	// -------------------------------------------------------------------------
 
@@ -154,6 +206,8 @@ final class CheckoutFieldPolicyTest extends TestCase {
 				return $default;
 			}
 		);
+		Functions\when( 'update_option' )->justReturn( true );
+		Functions\when( 'delete_option' )->justReturn( true );
 
 		return new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
 	}
@@ -245,5 +299,89 @@ final class CheckoutFieldPolicyTest extends TestCase {
 
 		$this->assertArrayNotHasKey( 'billing_postcode', $out['billing'] );
 		$this->assertArrayNotHasKey( 'shipping_postcode', $out['shipping'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// filter_checkout_fields() end-to-end — restoration is persisted (S8)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_filter_checkout_fields_restores_and_persists_the_override_report(): void {
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'WC' )->justReturn(
+			(object) [
+				'countries' => new class() {
+					public function get_default_address_fields(): array {
+						return [ 'city' => [ 'label' => 'Город', 'required' => true, 'priority' => 70 ] ];
+					}
+				},
+			]
+		);
+
+		$policy = Checkout_Field_Policy::instance();
+		$policy->register( $this->settings_handler() );
+
+		$written = null;
+		Functions\when( 'update_option' )->alias(
+			static function ( $name, $value ) use ( &$written ) {
+				$written = [ $name, $value ];
+
+				return true;
+			}
+		);
+		Functions\when( 'delete_option' )->justReturn( true );
+
+		$out = $policy->filter_checkout_fields(
+			[
+				'billing'  => [ 'billing_address_1' => [] ],
+				'shipping' => [ 'shipping_address_1' => [] ],
+			]
+		);
+
+		$this->assertTrue( $out['billing']['billing_city']['required'] );
+		$this->assertSame( Checkout_Field_Policy::OPTION_LAST_OVERRIDES, $written[0] );
+		$this->assertNotEmpty( $written[1] );
+	}
+
+	/**
+	 * The control case (design S8): once the offending plugin stops interfering —
+	 * the very next observation finds nothing to restore — the stale report must be
+	 * cleared, not left behind accusing a plugin that is no longer active.
+	 */
+	public function test_filter_checkout_fields_clears_a_stale_report_once_nothing_is_overridden(): void {
+		Functions\when( 'add_filter' )->justReturn( true );
+
+		$policy = Checkout_Field_Policy::instance();
+		$policy->register( $this->settings_handler() );
+
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				return false !== strpos( (string) $name, Checkout_Field_Policy::OPTION_LAST_OVERRIDES )
+					? [ [ 'field' => 'city', 'section' => 'billing', 'what' => 'restored' ] ]
+					: $default;
+			}
+		);
+
+		$deleted = false;
+		Functions\when( 'delete_option' )->alias(
+			static function ( $name ) use ( &$deleted ) {
+				$deleted = ( Checkout_Field_Policy::OPTION_LAST_OVERRIDES === $name );
+
+				return true;
+			}
+		);
+		Functions\when( 'update_option' )->justReturn( true );
+
+		$policy->filter_checkout_fields(
+			[
+				'billing'  => [ 'billing_city' => [ 'required' => true ] ],
+				'shipping' => [ 'shipping_city' => [ 'required' => true ] ],
+			]
+		);
+
+		$this->assertTrue( $deleted, 'once nothing needs restoring, the stale report must be cleared' );
 	}
 }

--- a/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutFieldPolicyTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Unit tests for Checkout_Field_Policy — the store-level singleton that turns the
+ * «Поля» settings (Task 5's Checkout_Field_Settings) into real WooCommerce checkout
+ * behaviour via two instruments (issue #362, design §4.3):
+ *
+ *  - `woocommerce_get_country_locale` (Instrument A) — reaches BOTH the classic and the
+ *    block checkout.
+ *  - `woocommerce_checkout_fields` (Instrument B) — classic checkout only, by
+ *    construction.
+ *
+ * The two pure contribution methods ({@see Checkout_Field_Policy::locale_contribution()}
+ * / {@see Checkout_Field_Policy::checkout_fields_contribution()}) are this file's main
+ * subject — they touch no WordPress function at all. A second group exercises
+ * {@see Checkout_Field_Policy::register()} and its two filter callbacks against a real
+ * {@see Checkout_Field_Settings} handler.
+ *
+ * @package Woodev\Tests\Unit\Shipping\Checkout
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Checkout;
+
+use Brain\Monkey\Functions;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Environment;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Policy;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/class-plugin-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/class-control.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/class-setting.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/abstract-class-settings.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-environment.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-settings.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-policy.php';
+
+/**
+ * @covers \Woodev\Framework\Shipping\Checkout\Checkout_Field_Policy
+ */
+final class CheckoutFieldPolicyTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Checkout_Field_Policy::reset_for_tests();
+	}
+
+	protected function tearDown(): void {
+		Checkout_Field_Policy::reset_for_tests();
+		parent::tearDown();
+	}
+
+	// -------------------------------------------------------------------------
+	// locale_contribution() — Instrument A, pure
+	// -------------------------------------------------------------------------
+
+	public function test_locale_contribution_for_preset_only(): void {
+		$out = Checkout_Field_Policy::locale_contribution( [ 'field_order_preset' => true, 'region_field' => 'show', 'postcode_field' => 'show' ], [ 'RU' => [] ], [ 'RU', 'KZ' ] );
+		$this->assertSame( 10, $out['RU']['country']['priority'] );
+		$this->assertSame( 20, $out['RU']['state']['priority'] );
+		$this->assertSame( 30, $out['RU']['city']['priority'] );
+		$this->assertSame( 40, $out['RU']['address_1']['priority'] );
+		$this->assertSame( 50, $out['RU']['address_2']['priority'] );
+		$this->assertSame( 60, $out['RU']['postcode']['priority'] );
+		$this->assertSame( 20, $out['KZ']['state']['priority'] );        // every shipping country (S5)
+		$this->assertTrue( $out['RU']['city']['required'] );            // settlement invariant, always
+		$this->assertArrayNotHasKey( 'hidden', $out['RU']['state'] );
+	}
+
+	public function test_locale_contribution_removes_region_and_postcode(): void {
+		$out = Checkout_Field_Policy::locale_contribution( [ 'field_order_preset' => false, 'region_field' => 'remove', 'postcode_field' => 'remove' ], [], [ 'RU' ] );
+		$this->assertTrue( $out['RU']['state']['hidden'] );
+		$this->assertFalse( $out['RU']['state']['required'] );
+		$this->assertTrue( $out['RU']['postcode']['hidden'] );
+		$this->assertArrayNotHasKey( 'priority', $out['RU']['country'] );
+		// existing locale keys survive
+		$out2 = Checkout_Field_Policy::locale_contribution( [ 'field_order_preset' => false, 'region_field' => 'show', 'postcode_field' => 'show' ], [ 'RU' => [ 'postcode' => [ 'label' => 'Индекс' ] ] ], [ 'RU' ] );
+		$this->assertSame( 'Индекс', $out2['RU']['postcode']['label'] );
+	}
+
+	/**
+	 * S5: an unconfigured store (no shipping countries) gets no contribution at all —
+	 * the locale array is returned unchanged, never a spurious empty-country entry.
+	 */
+	public function test_locale_contribution_is_a_no_op_when_no_shipping_countries(): void {
+		$locale = [ 'RU' => [ 'postcode' => [ 'label' => 'Индекс' ] ] ];
+		$out    = Checkout_Field_Policy::locale_contribution( [ 'field_order_preset' => true, 'region_field' => 'remove', 'postcode_field' => 'remove' ], $locale, [] );
+
+		$this->assertSame( $locale, $out );
+	}
+
+	// -------------------------------------------------------------------------
+	// checkout_fields_contribution() — Instrument B, pure
+	// -------------------------------------------------------------------------
+
+	public function test_checkout_fields_late_unset_removes_from_both_sections(): void {
+		$fields = [ 'billing' => [ 'billing_state' => [], 'billing_postcode' => [], 'billing_city' => [ 'required' => true ] ], 'shipping' => [ 'shipping_state' => [], 'shipping_postcode' => [], 'shipping_city' => [ 'required' => true ] ] ];
+		$out    = Checkout_Field_Policy::checkout_fields_contribution( [ 'region_field' => 'remove', 'postcode_field' => 'show' ], $fields );
+		$this->assertArrayNotHasKey( 'billing_state', $out['billing'] );
+		$this->assertArrayNotHasKey( 'shipping_state', $out['shipping'] );
+		$this->assertArrayHasKey( 'shipping_postcode', $out['shipping'] );
+	}
+
+	/**
+	 * A `postcode_field=remove` setting must ALSO unset the postcode field — not only
+	 * the region test above — proving both settings are wired independently, not just
+	 * one accidentally covering the other.
+	 */
+	public function test_checkout_fields_removes_postcode_independently_of_region(): void {
+		$fields = [ 'billing' => [ 'billing_state' => [], 'billing_postcode' => [] ], 'shipping' => [ 'shipping_state' => [], 'shipping_postcode' => [] ] ];
+		$out    = Checkout_Field_Policy::checkout_fields_contribution( [ 'region_field' => 'show', 'postcode_field' => 'remove' ], $fields );
+
+		$this->assertArrayHasKey( 'billing_state', $out['billing'] );
+		$this->assertArrayNotHasKey( 'billing_postcode', $out['billing'] );
+		$this->assertArrayNotHasKey( 'shipping_postcode', $out['shipping'] );
+	}
+
+	/**
+	 * A `hide_for_pickup` postcode value is a JS-driven, classic-only VALUE (T2) — this
+	 * PHP instrument must never unset for anything other than the literal `'remove'`
+	 * string.
+	 */
+	public function test_checkout_fields_does_not_touch_hide_for_pickup(): void {
+		$fields = [ 'billing' => [ 'billing_postcode' => [] ], 'shipping' => [ 'shipping_postcode' => [] ] ];
+		$out    = Checkout_Field_Policy::checkout_fields_contribution( [ 'region_field' => 'show', 'postcode_field' => 'hide_for_pickup' ], $fields );
+
+		$this->assertArrayHasKey( 'billing_postcode', $out['billing'] );
+		$this->assertArrayHasKey( 'shipping_postcode', $out['shipping'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// register() / filter callbacks — real Checkout_Field_Settings
+	// -------------------------------------------------------------------------
+
+	private function settings_handler( array $stored = [] ): Checkout_Field_Settings {
+		Functions\when( 'get_option' )->alias(
+			static function ( $name ) use ( $stored ) {
+				foreach ( $stored as $id => $value ) {
+					if ( false !== strpos( (string) $name, $id ) ) {
+						return $value;
+					}
+				}
+
+				return null;
+			}
+		);
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $tag, $default = null ) {
+				return $default;
+			}
+		);
+
+		return new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+	}
+
+	public function test_register_hooks_both_filters_at_the_late_priority(): void {
+		$calls = [];
+		Functions\when( 'add_filter' )->alias(
+			static function ( $hook, $callback, $priority = 10 ) use ( &$calls ) {
+				$calls[] = [ $hook, $priority ];
+
+				return true;
+			}
+		);
+
+		Checkout_Field_Policy::instance()->register( $this->settings_handler() );
+
+		$this->assertSame(
+			[
+				[ 'woocommerce_get_country_locale', Checkout_Field_Policy::LATE ],
+				[ 'woocommerce_checkout_fields', Checkout_Field_Policy::LATE ],
+			],
+			$calls
+		);
+	}
+
+	public function test_register_is_idempotent_across_repeat_calls(): void {
+		$call_count = 0;
+		Functions\when( 'add_filter' )->alias(
+			static function () use ( &$call_count ) {
+				++$call_count;
+
+				return true;
+			}
+		);
+
+		$policy   = Checkout_Field_Policy::instance();
+		$settings = $this->settings_handler();
+
+		$policy->register( $settings );
+		$policy->register( $settings );
+		$policy->register( $settings );
+
+		$this->assertSame( 2, $call_count, 'exactly two filters must be added, regardless of how many times register() is called' );
+	}
+
+	/**
+	 * Isolated in its own process — same idiom, and for the same reason, as
+	 * `CheckoutConfigTest::test_wc_states_degrades_a_false_get_states_result_to_states_present_false()`:
+	 * Brain Monkey/Patchwork instruments a mocked `WC()` for the REST OF THE PHP
+	 * PROCESS once any test stubs it, which would otherwise silently poison every
+	 * other test in the suite relying on `function_exists( 'WC' ) === false`.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_filter_country_locale_reads_effective_settings_and_shipping_countries(): void {
+		Functions\when( 'add_filter' )->justReturn( true );
+		Functions\when( 'WC' )->justReturn(
+			(object) [
+				'countries' => new class() {
+					public function get_shipping_countries(): array {
+						return [ 'RU' => 'Россия', 'KZ' => 'Казахстан' ];
+					}
+				},
+			]
+		);
+
+		$policy = Checkout_Field_Policy::instance();
+		$policy->register( $this->settings_handler( [ 'region_field' => 'remove' ] ) );
+
+		$out = $policy->filter_country_locale( [] );
+
+		$this->assertTrue( $out['RU']['state']['hidden'] );
+		$this->assertTrue( $out['KZ']['state']['hidden'] );
+	}
+
+	public function test_filter_checkout_fields_unsets_the_removed_field(): void {
+		Functions\when( 'add_filter' )->justReturn( true );
+
+		$policy = Checkout_Field_Policy::instance();
+		$policy->register( $this->settings_handler( [ 'postcode_field' => 'remove' ] ) );
+
+		$out = $policy->filter_checkout_fields(
+			[
+				'billing'  => [ 'billing_postcode' => [] ],
+				'shipping' => [ 'shipping_postcode' => [] ],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'billing_postcode', $out['billing'] );
+		$this->assertArrayNotHasKey( 'shipping_postcode', $out['shipping'] );
+	}
+}

--- a/tests/unit/Shipping/Checkout/CheckoutFieldSettingsTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutFieldSettingsTest.php
@@ -11,6 +11,7 @@ namespace Woodev\Tests\Unit\Shipping\Checkout;
 
 use Brain\Monkey\Functions;
 use Woodev\Framework\Shipping\Checkout\Checkout_Field_Environment;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Policy;
 use Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings;
 use Woodev\Tests\Unit\TestCase;
 
@@ -20,6 +21,7 @@ require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/class-setting.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/abstract-class-settings.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-environment.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-settings.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-policy.php';
 
 /**
  * @covers \Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings
@@ -160,5 +162,29 @@ final class CheckoutFieldSettingsTest extends TestCase {
 
 		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
 		$s->effective( 'not_a_real_setting' );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_section_note() — the settlement-restoration report (S8)
+	// -------------------------------------------------------------------------
+
+	public function test_section_note_is_empty_when_nothing_was_overridden(): void {
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+
+		$this->assertSame( '', $s->get_section_note() );
+	}
+
+	public function test_section_note_reports_a_restored_settlement_field(): void {
+		Functions\when( 'get_option' )->alias(
+			static function ( $name, $default = null ) {
+				return false !== strpos( (string) $name, Checkout_Field_Policy::OPTION_LAST_OVERRIDES )
+					? [ [ 'field' => 'city', 'section' => 'billing', 'what' => 'restored' ] ]
+					: $default;
+			}
+		);
+
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+
+		$this->assertStringContainsString( 'Город', $s->get_section_note() );
 	}
 }

--- a/tests/unit/Shipping/Checkout/CheckoutFieldSettingsTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutFieldSettingsTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Unit tests for Checkout_Field_Settings — the «Поля» settings handler (design
+ * S1/S4/S9), its availability rules (design §3.2/D11) and its `effective()`
+ * clamp-on-read contract (design §7).
+ *
+ * @package Woodev\Tests\Unit\Shipping\Checkout
+ */
+
+namespace Woodev\Tests\Unit\Shipping\Checkout;
+
+use Brain\Monkey\Functions;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Environment;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 4 ) . '/woodev/class-plugin-exception.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/class-control.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/class-setting.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/settings-api/abstract-class-settings.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-environment.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-settings.php';
+
+/**
+ * @covers \Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings
+ * @covers \Woodev\Framework\Shipping\Checkout\Checkout_Field_Environment
+ */
+final class CheckoutFieldSettingsTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'get_option' )->justReturn( null );
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $tag, $default = null ) {
+				return $default;
+			}
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Defaults, ids
+	// -------------------------------------------------------------------------
+
+	public function test_defaults_and_ids(): void {
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+
+		$this->assertSame(
+			[ 'field_order_preset', 'country_field', 'region_field', 'address_field', 'postcode_field' ],
+			$s->get_owned_setting_ids()
+		);
+		$this->assertTrue( $s->get_value( 'field_order_preset' ) );
+		$this->assertSame( 'show', $s->get_value( 'postcode_field' ) );
+		$this->assertSame( 'show', $s->get_value( 'country_field' ) );
+		$this->assertSame( 'show', $s->get_value( 'region_field' ) );
+		$this->assertSame( 'show', $s->get_value( 'address_field' ) );
+	}
+
+	public function test_single_country_classic_checkout_disables_nothing(): void {
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+
+		foreach ( $s->get_owned_setting_ids() as $id ) {
+			$this->assertFalse( $s->get_setting( $id )->get_control()->is_disabled(), "{$id} should not be disabled" );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// country_field availability — single-country gate
+	// -------------------------------------------------------------------------
+
+	public function test_country_hide_disabled_with_reason_when_store_ships_to_many_countries(): void {
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 3 ) );
+		$c = $s->get_setting( 'country_field' )->get_control();
+
+		$this->assertTrue( $c->is_disabled() );
+		$this->assertStringContainsString( 'одну страну', $c->get_disabled_reason() );
+	}
+
+	public function test_country_hide_disabled_with_reason_when_store_ships_to_zero_countries(): void {
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 0 ) );
+		$c = $s->get_setting( 'country_field' )->get_control();
+
+		$this->assertTrue( $c->is_disabled() );
+		$this->assertStringContainsString( 'одну страну', $c->get_disabled_reason() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Block checkout — availability
+	// -------------------------------------------------------------------------
+
+	public function test_block_checkout_disables_js_driven_options_and_narrows_postcode(): void {
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( true, 1 ) );
+
+		$this->assertTrue( $s->get_setting( 'address_field' )->get_control()->is_disabled() );
+		$this->assertTrue( $s->get_setting( 'country_field' )->get_control()->is_disabled() );
+		$this->assertSame( [ 'show', 'remove' ], array_keys( $s->get_setting( 'postcode_field' )->get_control()->get_options() ) );
+		$this->assertFalse( $s->get_setting( 'region_field' )->get_control()->is_disabled() ); // locale instrument reaches blocks
+		$this->assertFalse( $s->get_setting( 'field_order_preset' )->get_control()->is_disabled() );
+	}
+
+	// -------------------------------------------------------------------------
+	// effective() — clamp on read
+	// -------------------------------------------------------------------------
+
+	public function test_effective_values_clamp_on_read(): void {
+		Functions\when( 'get_option' )->alias( fn( $k, $d = false ) => 'woodev_checkout_fields_country_field' === $k ? 'hide' : $d );
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 2 ) );
+		$this->assertSame( 'show', $s->effective( 'country_field' ) ); // stored `hide`, no longer allowed
+
+		Functions\when( 'get_option' )->alias( fn( $k, $d = false ) => 'woodev_checkout_fields_postcode_field' === $k ? 'hide_for_pickup' : $d );
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( true, 1 ) );
+		$this->assertSame( 'show', $s->effective( 'postcode_field' ) );
+	}
+
+	public function test_effective_passes_through_stored_value_when_still_allowed(): void {
+		Functions\when( 'get_option' )->alias( fn( $k, $d = false ) => 'woodev_checkout_fields_country_field' === $k ? 'hide' : $d );
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+		$this->assertSame( 'hide', $s->effective( 'country_field' ) );
+
+		Functions\when( 'get_option' )->alias( fn( $k, $d = false ) => 'woodev_checkout_fields_postcode_field' === $k ? 'hide_for_pickup' : $d );
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+		$this->assertSame( 'hide_for_pickup', $s->effective( 'postcode_field' ) );
+
+		Functions\when( 'get_option' )->alias( fn( $k, $d = false ) => 'woodev_checkout_fields_address_field' === $k ? 'hide_for_pickup' : $d );
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+		$this->assertSame( 'hide_for_pickup', $s->effective( 'address_field' ) );
+	}
+
+	public function test_effective_address_field_clamps_to_show_on_block_checkout(): void {
+		Functions\when( 'get_option' )->alias( fn( $k, $d = false ) => 'woodev_checkout_fields_address_field' === $k ? 'hide_for_pickup' : $d );
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( true, 1 ) );
+		$this->assertSame( 'show', $s->effective( 'address_field' ) );
+	}
+
+	public function test_effective_region_field_and_field_order_preset_are_never_clamped(): void {
+		Functions\when( 'get_option' )->alias(
+			static function ( $k, $d = false ) {
+				if ( 'woodev_checkout_fields_region_field' === $k ) {
+					return 'remove';
+				}
+				if ( 'woodev_checkout_fields_field_order_preset' === $k ) {
+					return false;
+				}
+				return $d;
+			}
+		);
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( true, 3 ) );
+
+		$this->assertSame( 'remove', $s->effective( 'region_field' ) );
+		$this->assertFalse( $s->effective( 'field_order_preset' ) );
+	}
+
+	public function test_effective_throws_for_unknown_id(): void {
+		$this->expectException( \Woodev_Plugin_Exception::class );
+
+		$s = new Checkout_Field_Settings( new Checkout_Field_Environment( false, 1 ) );
+		$s->effective( 'not_a_real_setting' );
+	}
+}

--- a/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
+++ b/tests/unit/Shipping/Checkout/CheckoutHandlerEnqueueTest.php
@@ -141,6 +141,25 @@ class CheckoutHandlerEnqueueTest extends TestCase {
 		Functions\when( 'plugins_url' )->alias(
 			static fn( $path, $file ) => 'https://example.test/wp-content/plugins/x/' . basename( $path )
 		);
+
+		// enqueue_assets() now reaches Shipping_Settings_Tab::instance()->get_field_settings()
+		// for the `field_policy` config block (Task 6, issue #362) — that lazily constructs a
+		// real Checkout_Field_Settings, which registers settings/controls through
+		// Woodev_Abstract_Settings; stub the WP primitives that path touches, same as
+		// CheckoutFieldSettingsTest/ShippingSettingsTabTest.
+		Functions\when( 'get_option' )->justReturn( null );
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+
+		\Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab::reset_for_tests();
+	}
+
+	protected function tearDown(): void {
+		\Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab::reset_for_tests();
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/Shipping/Settings/ShippingSettingsTabTest.php
+++ b/tests/unit/Shipping/Settings/ShippingSettingsTabTest.php
@@ -28,6 +28,7 @@ require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-settings-page-
 require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-composite-settings-handler.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-environment.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-settings.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-policy.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-map-settings.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/settings/class-shipping-settings-tab.php';
 
@@ -40,6 +41,11 @@ class ShippingSettingsTabTest extends TestCase {
 		// is invoked directly, exactly like LocationProviderRegistryTest invokes collect()
 		// directly instead of firing a real `init` action.
 		Functions\when( 'add_action' )->justReturn( true );
+
+		// register() now also boots Checkout_Field_Policy (Task 6, issue #362), which
+		// hooks two real filters — stub add_filter so that call never touches the real
+		// WP function.
+		Functions\when( 'add_filter' )->justReturn( true );
 
 		// Building the «Поля» section now constructs a real Checkout_Field_Settings
 		// (Task 5), which registers settings/controls through Woodev_Abstract_Settings —

--- a/tests/unit/Shipping/Settings/ShippingSettingsTabTest.php
+++ b/tests/unit/Shipping/Settings/ShippingSettingsTabTest.php
@@ -26,6 +26,7 @@ require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-settings-secti
 require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-settings-provider.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-settings-page-registry.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/settings-page/class-composite-settings-handler.php';
+require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-environment.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/checkout/class-checkout-field-settings.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/pickup/class-pickup-map-settings.php';
 require_once dirname( __DIR__, 4 ) . '/woodev/shipping-method/settings/class-shipping-settings-tab.php';
@@ -39,6 +40,22 @@ class ShippingSettingsTabTest extends TestCase {
 		// is invoked directly, exactly like LocationProviderRegistryTest invokes collect()
 		// directly instead of firing a real `init` action.
 		Functions\when( 'add_action' )->justReturn( true );
+
+		// Building the «Поля» section now constructs a real Checkout_Field_Settings
+		// (Task 5), which registers settings/controls through Woodev_Abstract_Settings —
+		// stub the WP primitives that path touches, same as LocationProviderRegistryTest
+		// stubs for Location_Settings.
+		Functions\when( 'get_option' )->justReturn( null );
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $tag, $default = null ) {
+				return $default;
+			}
+		);
 
 		Shipping_Settings_Tab::reset_for_tests();
 		Settings_Page_Registry::instance()->reset_for_tests();

--- a/woodev/class-map.php
+++ b/woodev/class-map.php
@@ -31,6 +31,7 @@ return [
 	'Woodev\\Framework\\Shipping\\Admin\\Warehouse_Admin' => 'woodev/shipping-method/admin/class-warehouse-admin.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Condition' => 'woodev/shipping-method/checkout/class-checkout-condition.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' => 'woodev/shipping-method/checkout/class-checkout-config.php',
+	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Environment' => 'woodev/shipping-method/checkout/class-checkout-field-environment.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Settings' => 'woodev/shipping-method/checkout/class-checkout-field-settings.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' => 'woodev/shipping-method/checkout/class-checkout-fields.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler' => 'woodev/shipping-method/checkout/class-checkout-handler.php',

--- a/woodev/class-map.php
+++ b/woodev/class-map.php
@@ -32,6 +32,7 @@ return [
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Condition' => 'woodev/shipping-method/checkout/class-checkout-condition.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' => 'woodev/shipping-method/checkout/class-checkout-config.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Environment' => 'woodev/shipping-method/checkout/class-checkout-field-environment.php',
+	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Policy' => 'woodev/shipping-method/checkout/class-checkout-field-policy.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Settings' => 'woodev/shipping-method/checkout/class-checkout-field-settings.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Fields' => 'woodev/shipping-method/checkout/class-checkout-fields.php',
 	'Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler' => 'woodev/shipping-method/checkout/class-checkout-handler.php',

--- a/woodev/shipping-method/checkout/class-checkout-config.php
+++ b/woodev/shipping-method/checkout/class-checkout-config.php
@@ -37,10 +37,20 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 	 * Shape of the returned array:
 	 * ```
 	 * [
-	 *   'fields'   => [ field_id => [ id, type, section, source_kind, location_level, depends_on, required, is_pickup_slot ] ],
-	 *   'endpoint' => '{rest_base}/shipping/checkout/{plugin_id}/field-source',
-	 *   'nonce'    => string,
-	 *   'takeover' => [ field_id => [ country_code => bool ] ],
+	 *   'fields'            => [ field_id => [ id, type, section, source_kind, location_level, depends_on, required, is_pickup_slot ] ],
+	 *   'endpoint'          => '{rest_base}/shipping/checkout/{plugin_id}/field-source',
+	 *   'nonce'             => string,
+	 *   'takeover'          => [ field_id => [ country_code => bool ] ],
+	 *   // Checkout field policy (Task 6, issue #362, spec §4.3): effective values of the
+	 *   // three classic-only/JS-driven settings — this config only PUBLISHES them,
+	 *   // Checkout_Field_Policy (not this class) applies region/postcode/preset via
+	 *   // woocommerce_get_country_locale + woocommerce_checkout_fields.
+	 *   'field_policy'      => [
+	 *     'address'  => string, // 'show' | 'hide_for_pickup'
+	 *     'postcode' => string, // 'show' | 'hide_for_pickup' | 'remove'
+	 *     'country'  => string, // 'show' | 'hide'
+	 *   ],
+	 *   'pickup_method_ids' => string[], // WC_Shipping_Method::$id of every pickup-shipping method.
 	 *   // Present only when a Location_Service was injected AND is_active() (Task 9):
 	 *   'location' => [
 	 *     'endpoints' => [ 'suggest' => string, 'select' => string, 'list' => string ], // 'list' added Task 13
@@ -120,6 +130,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		private ?\Woodev\Framework\Shipping\Location\Location_Service $location_service;
 
 		/**
+		 * Task 6's «Поля» store-level settings handler (issue #362, spec §4.3), or `null`
+		 * when this config was built without checkout-field-policy awareness (an older
+		 * caller, or a unit test that does not care about it). `null` clamps every
+		 * `field_policy` value to `'show'`; `pickup_method_ids()` never depends on this
+		 * collaborator at all — see {@see self::build()}.
+		 *
+		 * @since 2.0.2
+		 * @var Checkout_Field_Settings|null
+		 */
+		private ?Checkout_Field_Settings $field_settings;
+
+		/**
 		 * Constructor.
 		 *
 		 * Country codes are injected for testability; the real caller should
@@ -129,6 +151,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 * @since 2.0.2
 		 * @since 2.0.2 Added the optional `$location_service` collaborator
 		 *              (location-provider layer Task 9).
+		 * @since 2.0.2 Added the optional `$field_settings` collaborator (checkout
+		 *              field policy Task 6, issue #362).
 		 *
 		 * @param string                                                    $plugin_id        Plugin identifier (used in REST endpoint path).
 		 * @param string                                                    $rest_base        REST API base URL without a trailing slash.
@@ -136,19 +160,27 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 * @param string[]                                                  $countries        Country codes to evaluate takeover predicates against.
 		 * @param \Woodev\Framework\Shipping\Location\Location_Service|null $location_service Location Provider layer façade; `null` omits the
 		 *                                                                                        `location` block entirely.
+		 * @param Checkout_Field_Settings|null                              $field_settings   The store-level «Поля» settings handler — always
+		 *                                                                                        {@see \Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab::get_field_settings()}
+		 *                                                                                        at the real call site, never a fresh instance
+		 *                                                                                        (its availability rules must not be computed
+		 *                                                                                        twice with different answers); `null` clamps
+		 *                                                                                        `field_policy` to all-`'show'`.
 		 */
 		public function __construct(
 			string $plugin_id,
 			string $rest_base,
 			string $nonce,
 			array $countries,
-			?\Woodev\Framework\Shipping\Location\Location_Service $location_service = null
+			?\Woodev\Framework\Shipping\Location\Location_Service $location_service = null,
+			?Checkout_Field_Settings $field_settings = null
 		) {
 			$this->plugin_id        = $plugin_id;
 			$this->rest_base        = rtrim( $rest_base, '/' );
 			$this->nonce            = $nonce;
 			$this->countries        = $countries;
 			$this->location_service = $location_service;
+			$this->field_settings   = $field_settings;
 		}
 
 		/**
@@ -181,6 +213,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 * @since 2.0.2 `pickup_slot_placements` is now `string[]|null` for a pickup-slot
 		 *              field, so a malformed filter return and a deliberate `[]` no longer
 		 *              collapse to the same value (issue #308 item 2).
+		 * @since 2.0.2 Added `field_policy` and `pickup_method_ids` (checkout field policy
+		 *              Task 6, issue #362).
 		 *
 		 * @param Checkout_Fields $fields Normalized field definitions to emit.
 		 *
@@ -199,6 +233,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 		 *     endpoint: string,
 		 *     nonce: string,
 		 *     takeover: array<string, array<string, bool>>,
+		 *     field_policy: array{address: string, postcode: string, country: string},
+		 *     pickup_method_ids: string[],
 		 *     location?: array{
 		 *         endpoints: array{suggest: string, select: string},
 		 *         nonce: string,
@@ -242,10 +278,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 			}
 
 			$config = [
-				'fields'   => $out_fields,
-				'endpoint' => $this->rest_base . '/shipping/checkout/' . $this->plugin_id . '/field-source',
-				'nonce'    => $this->nonce,
-				'takeover' => $takeover,
+				'fields'            => $out_fields,
+				'endpoint'          => $this->rest_base . '/shipping/checkout/' . $this->plugin_id . '/field-source',
+				'nonce'             => $this->nonce,
+				'takeover'          => $takeover,
+				'field_policy'      => $this->build_field_policy(),
+				'pickup_method_ids' => $this->pickup_method_ids(),
 			];
 
 			if ( null !== $this->location_service && $this->location_service->is_active() ) {
@@ -253,6 +291,72 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Config' 
 			}
 
 			return $config;
+		}
+
+		/**
+		 * Builds the `field_policy` block (Task 6, issue #362, spec §4.3): the effective
+		 * values of the three settings that stay classic-only/JS-driven
+		 * (`address_field`, `postcode_field`, `country_field` — Task 9 acts on them in
+		 * `checkout-field-classic.js`). This method only PUBLISHES the values; it never
+		 * acts on them in PHP (T2 — that stays this method's whole job, the actual
+		 * hiding/removal instruments live in {@see Checkout_Field_Policy}).
+		 *
+		 * `null` {@see self::$field_settings} (no policy handler was injected) clamps
+		 * every value to `'show'` — the same fallback {@see Checkout_Field_Settings::effective()}
+		 * itself uses for a stored value that names an option not currently offered.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array{address: string, postcode: string, country: string}
+		 */
+		private function build_field_policy(): array {
+			if ( null === $this->field_settings ) {
+				return [
+					'address'  => 'show',
+					'postcode' => 'show',
+					'country'  => 'show',
+				];
+			}
+
+			return [
+				'address'  => $this->field_settings->effective( 'address_field' ),
+				'postcode' => $this->field_settings->effective( 'postcode_field' ),
+				'country'  => $this->field_settings->effective( 'country_field' ),
+			];
+		}
+
+		/**
+		 * The WooCommerce shipping method ids (issue #362, spec §4.3) whose
+		 * {@see \Woodev\Framework\Shipping\Shipping_Method::is_pickup_shipping()} is
+		 * `true` — published so `checkout-field-classic.js` can match the customer's
+		 * CHOSEN method against them the exact same way
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Handler::chosen_method_matches()}
+		 * already does server-side: `$chosen === $id || 0 === strpos( $chosen, $id . ':' )`.
+		 * That is why this returns the plain method id — `WC_Shipping_Method::$id`, no
+		 * zone-instance suffix — never a per-zone rate id like `pickup:3`.
+		 *
+		 * Guarded for the unit suite (no `WC()` there): returns `[]` when WooCommerce's
+		 * shipping subsystem is unavailable, exactly like {@see self::wc_states()}
+		 * degrades for the same reason.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string[]
+		 */
+		private function pickup_method_ids(): array {
+			if ( ! function_exists( 'WC' ) || ! method_exists( WC(), 'shipping' ) || ! WC()->shipping() ) {
+				return [];
+			}
+
+			$ids = [];
+
+			foreach ( WC()->shipping()->get_shipping_methods() as $method ) {
+				if ( $method instanceof \Woodev\Framework\Shipping\Shipping_Method && $method->is_pickup_shipping() ) {
+					$ids[] = $method->get_id();
+				}
+			}
+
+			return array_values( array_unique( $ids ) );
 		}
 
 		/**

--- a/woodev/shipping-method/checkout/class-checkout-field-environment.php
+++ b/woodev/shipping-method/checkout/class-checkout-field-environment.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Woodev Checkout Field Environment
+ *
+ * The facts {@see Checkout_Field_Settings}'s availability rules (design §3.2) need to
+ * know about the current store, resolved ONCE by the caller into a plain value object
+ * so those rules stay unit-testable without a WordPress/WooCommerce runtime.
+ *
+ * @since 2.0.2
+ */
+
+namespace Woodev\Framework\Shipping\Checkout;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly
+
+if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Environment' ) ) :
+
+	/**
+	 * Immutable value object carrying the two facts the «Поля» availability rules
+	 * gate on: whether the store serves the block checkout, and how many countries
+	 * it ships to.
+	 *
+	 * PHP 7.4 target — no constructor property promotion, so the two properties are
+	 * declared and assigned long-hand.
+	 *
+	 * @since 2.0.2
+	 */
+	final class Checkout_Field_Environment {
+
+		/**
+		 * Whether WooCommerce currently serves the checkout BLOCK (as opposed to the
+		 * classic checkout shortcode) as the default checkout experience.
+		 *
+		 * @var bool
+		 */
+		public $block_checkout;
+
+		/**
+		 * How many countries the store currently ships to
+		 * ({@see \WC_Countries::get_shipping_countries()}).
+		 *
+		 * @var int
+		 */
+		public $shipping_country_count;
+
+		/**
+		 * Constructor.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param bool $block_checkout          whether the block checkout is in use.
+		 * @param int  $shipping_country_count  how many countries the store ships to.
+		 */
+		public function __construct( bool $block_checkout, int $shipping_country_count ) {
+			$this->block_checkout         = $block_checkout;
+			$this->shipping_country_count = $shipping_country_count;
+		}
+
+		/**
+		 * Builds the environment from the live WordPress/WooCommerce runtime.
+		 *
+		 * Block-checkout detection reuses {@see \Woodev_Blocks_Handler::is_checkout_block_in_use()}
+		 * (`woodev/handlers/blocks-handler.php`) rather than duplicating its
+		 * `CartCheckoutUtils` probe — that method is `public static` (not instance-bound
+		 * to a plugin object as the plan assumed), so it is directly reusable here.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return self
+		 */
+		public static function from_wc(): self {
+			$block = \Woodev_Blocks_Handler::is_checkout_block_in_use();
+			$count = function_exists( 'WC' ) && WC()->countries
+				? count( WC()->countries->get_shipping_countries() )
+				: 0;
+
+			return new self( $block, $count );
+		}
+	}
+
+endif;

--- a/woodev/shipping-method/checkout/class-checkout-field-policy.php
+++ b/woodev/shipping-method/checkout/class-checkout-field-policy.php
@@ -507,7 +507,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Po
 				$key = $section . '_city';
 
 				if ( ! isset( $fields[ $section ][ $key ] ) || ! is_array( $fields[ $section ][ $key ] ) ) {
-					$fields[ $section ][ $key ] = $default_city;
+					/*
+					 * BOTH halves of the invariant are asserted here, not just presence.
+					 * `$default_address_fields` comes from `WC_Countries::get_default_address_fields()`,
+					 * which is itself filterable through `woocommerce_default_address_fields` — the very
+					 * hook a third-party field manager would use to relax `city`. Re-inserting that
+					 * template verbatim could therefore restore an OPTIONAL settlement field while
+					 * reporting a successful restoration. The same hole opens when the template is
+					 * unavailable at all (no WooCommerce runtime), where `$default_city` is `[]`.
+					 */
+					$fields[ $section ][ $key ]               = $default_city;
+					$fields[ $section ][ $key ]['required']   = true;
 
 					$this->overrides[] = [
 						'field' => 'city',

--- a/woodev/shipping-method/checkout/class-checkout-field-policy.php
+++ b/woodev/shipping-method/checkout/class-checkout-field-policy.php
@@ -1,0 +1,391 @@
+<?php
+/**
+ * Woodev Checkout Field Policy
+ *
+ * Store-level singleton that turns the «Поля» settings (Task 5's
+ * {@see Checkout_Field_Settings}) into real WooCommerce checkout behaviour (issue #362,
+ * design §4.3). ONE policy object, TWO instruments:
+ *
+ *  - `woocommerce_get_country_locale` (Instrument A) — reaches BOTH the classic and the
+ *    block checkout (measured on WC 11.0.1: `CartCheckoutUtils::get_country_data()` maps
+ *    the locale entry's `priority` to the client's `index`, and treats `hidden` as
+ *    `required=false` + not rendered). {@see self::locale_contribution()} contributes
+ *    per-field `priority`/`hidden`/`required` for every shipping country of the store.
+ *  - `woocommerce_checkout_fields` (Instrument B) — the classic checkout ONLY, by
+ *    construction (`CheckoutFields::get_core_fields()` hard-codes the core address
+ *    fields on the block checkout — gotcha
+ *    `block-checkout-reads-country-locale-not-checkout-fields`).
+ *    {@see self::checkout_fields_contribution()} `unset()`s a field the merchant chose
+ *    to REMOVE from both the `billing` and `shipping` sections, so it leaves the DOM
+ *    entirely and its value never reaches the order.
+ *
+ * Removal is never done in JS; hiding is never done by unsetting (T1/T2). Both filters
+ * run at {@see self::LATE} — "after everyone who has an opinion" (T4) — so WooCommerce's
+ * own defaults and any third-party field-manager plugin have already had their say by
+ * the time this policy runs, and Task 7's settlement-invariant RESTORATION (which
+ * extends this same class rather than duplicating it) can still see a later hook if it
+ * ever needs one.
+ *
+ * `address_field=hide_for_pickup`, `postcode_field=hide_for_pickup` and
+ * `country_field=hide` are classic-only, JS-driven (Task 9's `checkout-field-classic.js`)
+ * — this class never acts on them; {@see \Woodev\Framework\Shipping\Checkout\Checkout_Config}
+ * only PUBLISHES their effective values to the browser.
+ *
+ * @since 2.0.2
+ * @package Woodev\Framework\Shipping\Checkout
+ */
+
+namespace Woodev\Framework\Shipping\Checkout;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly
+
+if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Policy' ) ) :
+
+	/**
+	 * Store-level singleton applying the «Поля» policy to the real WooCommerce checkout.
+	 *
+	 * @since 2.0.2
+	 */
+	final class Checkout_Field_Policy {
+
+		/**
+		 * Filter priority both instruments run at — "after everyone who has an opinion"
+		 * (T4): after WooCommerce's own defaults and after a typical third-party
+		 * field-manager plugin, while still leaving `PHP_INT_MAX - 10` of headroom below
+		 * `PHP_INT_MAX` for Task 7's invariant-restoration hook to run even later if it
+		 * ever needs to. The exact number is arbitrary; the ordering rule it encodes is
+		 * not.
+		 *
+		 * @since 2.0.2
+		 * @var int
+		 */
+		const LATE = PHP_INT_MAX - 10;
+
+		/**
+		 * @var self|null
+		 */
+		private static $instance = null;
+
+		/**
+		 * The live «Поля» settings handler {@see self::register()} was last given.
+		 *
+		 * @var Checkout_Field_Settings|null
+		 */
+		private $settings = null;
+
+		/**
+		 * The `effective()` map for all five owned settings, computed once per request
+		 * (design intent: the two filter callbacks below must never see two different
+		 * answers within the same request). Reset whenever {@see self::register()} is
+		 * called with a (possibly new) settings handler.
+		 *
+		 * @var array<string, bool|string>|null
+		 */
+		private $effective_cache = null;
+
+		/**
+		 * Whether the two filters have already been added.
+		 *
+		 * @var bool
+		 */
+		private $hooked = false;
+
+		/**
+		 * Returns the singleton instance.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return self
+		 */
+		public static function instance(): self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Resets all state. Test-only — same shape as
+		 * {@see \Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab::reset_for_tests()},
+		 * including its `remove_filter()` half: `self::$instance = null` alone discards
+		 * the PHP-level singleton reference but leaves any `add_filter()` call the OLD
+		 * instance made intact in WordPress's own hook table (`add_filter()`/
+		 * `remove_filter()` match by object identity, not by class), so a lingering
+		 * registration would keep firing against the discarded instance on every later
+		 * `apply_filters()` call in the same test process.
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return void
+		 */
+		public static function reset_for_tests(): void {
+			self::remove_hooked_instances( 'woocommerce_get_country_locale', self::class, 'filter_country_locale' );
+			self::remove_hooked_instances( 'woocommerce_checkout_fields', self::class, 'filter_checkout_fields' );
+
+			self::$instance = null;
+		}
+
+		/**
+		 * Removes every `$class::$method` callback registered on `$hook`, whichever
+		 * instance registered it. A no-op outside a full WordPress runtime (unit tests
+		 * run on Brain Monkey, where `$wp_filter` does not exist).
+		 *
+		 * @internal
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $hook   hook name to scrub.
+		 * @param string $class  fully-qualified class whose callbacks should be removed.
+		 * @param string $method method name to match.
+		 *
+		 * @return void
+		 */
+		private static function remove_hooked_instances( string $hook, string $class, string $method ): void {
+			$hooks = $GLOBALS['wp_filter'] ?? [];
+
+			if ( ! isset( $hooks[ $hook ] ) || ! is_object( $hooks[ $hook ] ) || ! isset( $hooks[ $hook ]->callbacks ) ) {
+				return;
+			}
+
+			foreach ( $hooks[ $hook ]->callbacks as $priority => $callbacks ) {
+				foreach ( $callbacks as $callback ) {
+					$function = $callback['function'] ?? null;
+
+					if ( ! is_array( $function ) || 2 !== count( $function ) ) {
+						continue;
+					}
+
+					if ( $function[0] instanceof $class && $method === $function[1] ) {
+						remove_filter( $hook, $function, $priority );
+					}
+				}
+			}
+		}
+
+		/**
+		 * Boots the policy against the given settings handler and hooks the two
+		 * instruments — exactly once. Called from
+		 * {@see \Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab::register()},
+		 * which runs on every request (including admin and REST, `init` priority 25);
+		 * harmless — the callbacks below are cheap, and re-registration is guarded so a
+		 * double call never double-adds the filters.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param Checkout_Field_Settings $settings the live «Поля» settings handler — always
+		 *                                           {@see \Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab::get_field_settings()},
+		 *                                           never a fresh instance (its availability
+		 *                                           rules must not be computed twice with
+		 *                                           different answers).
+		 *
+		 * @return void
+		 */
+		public function register( Checkout_Field_Settings $settings ): void {
+			$this->settings        = $settings;
+			$this->effective_cache = null;
+
+			if ( $this->hooked ) {
+				return;
+			}
+			$this->hooked = true;
+
+			add_filter( 'woocommerce_get_country_locale', [ $this, 'filter_country_locale' ], self::LATE );
+			add_filter( 'woocommerce_checkout_fields', [ $this, 'filter_checkout_fields' ], self::LATE );
+		}
+
+		/**
+		 * `woocommerce_get_country_locale` callback (Instrument A) — reaches both the
+		 * classic and the block checkout.
+		 *
+		 * @internal bound at {@see self::LATE} by {@see self::register()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param mixed $locale the locale array WooCommerce/third-party plugins built so far.
+		 *
+		 * @return array<string, array<string, array<string, mixed>>>
+		 */
+		public function filter_country_locale( $locale ): array {
+			return self::locale_contribution( $this->effective(), (array) $locale, $this->shipping_countries() );
+		}
+
+		/**
+		 * `woocommerce_checkout_fields` callback (Instrument B) — classic checkout only,
+		 * by construction (the block checkout never reads this filter).
+		 *
+		 * @internal bound at {@see self::LATE} by {@see self::register()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param mixed $fields the checkout fields array WooCommerce/third-party plugins built so far.
+		 *
+		 * @return array<string, array<string, array<string, mixed>>>
+		 */
+		public function filter_checkout_fields( $fields ): array {
+			return self::checkout_fields_contribution( $this->effective(), (array) $fields );
+		}
+
+		/**
+		 * The `effective()` value of all five owned settings, computed once per request
+		 * and cached — see {@see self::$effective_cache}'s own docblock.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, bool|string>
+		 */
+		private function effective(): array {
+			if ( null === $this->effective_cache ) {
+				$values = [];
+
+				if ( null !== $this->settings ) {
+					foreach ( $this->settings->get_owned_setting_ids() as $id ) {
+						$values[ $id ] = $this->settings->effective( $id );
+					}
+				}
+
+				$this->effective_cache = $values;
+			}
+
+			return $this->effective_cache;
+		}
+
+		/**
+		 * The store's shipping countries (S5 — the preset/removal rules apply to ALL of
+		 * them, not a fixed CIS list and not "countries the location layer serves").
+		 * Guarded for the unit suite (no `WC()` there): returns `[]`, which makes
+		 * {@see self::locale_contribution()} a no-op — an unconfigured store gets no
+		 * contribution, matching S5's own "if that list is empty, the preset contributes
+		 * nothing" clause.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string[]
+		 */
+		private function shipping_countries(): array {
+			if ( ! function_exists( 'WC' ) || ! WC()->countries ) {
+				return [];
+			}
+
+			return array_keys( WC()->countries->get_shipping_countries() );
+		}
+
+		/**
+		 * Instrument A's pure contribution. Every shipping country's locale entry gets
+		 * the `field_order_preset` priorities and/or the region/postcode `remove`
+		 * hide+unrequire, plus the settlement invariant (`city.required = true`, always,
+		 * re-asserted LAST so nothing above it can clobber it — Task 7's restoration
+		 * extends this same seam).
+		 *
+		 * Creates a fresh per-country entry — and fresh per-field sub-arrays — for a
+		 * country/field WC's own base locale has none for, rather than only merging into
+		 * ones that already exist: {@see self::LATE}'s whole point is running AFTER
+		 * WooCommerce's own `get_country_locale()` base map is already in `$locale`, and
+		 * that method merges this filtered array back over its base map BY COUNTRY KEY —
+		 * a new key for a real ISO country WC recognises (e.g. every one of the store's
+		 * own shipping countries) is a completely normal per-country override, the exact
+		 * same shape any third-party plugin's own `woocommerce_get_country_locale`
+		 * callback already produces. Every field key is pre-seeded to `[]` when absent —
+		 * not only the ones a setting actually touches — so a caller can always safely
+		 * read e.g. `$out[$country]['country']` even when `field_order_preset` is off.
+		 *
+		 * Pure — touches no WordPress function, so unit tests call it directly.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<string, bool|string>                         $settings           `effective()` values, keyed by setting id
+		 *                                                                                 (only `field_order_preset`/`region_field`/
+		 *                                                                                 `postcode_field` are read).
+		 * @param array<string, array<string, array<string, mixed>>> $locale             the locale array to contribute onto.
+		 * @param string[]                                           $shipping_countries every shipping country of the store (S5).
+		 *
+		 * @return array<string, array<string, array<string, mixed>>>
+		 */
+		public static function locale_contribution( array $settings, array $locale, array $shipping_countries ): array {
+			$preset           = ! empty( $settings['field_order_preset'] );
+			$region_removed   = 'remove' === ( $settings['region_field'] ?? 'show' );
+			$postcode_removed = 'remove' === ( $settings['postcode_field'] ?? 'show' );
+
+			foreach ( $shipping_countries as $country ) {
+				if ( ! isset( $locale[ $country ] ) ) {
+					$locale[ $country ] = [];
+				}
+
+				foreach ( [ 'country', 'state', 'city', 'address_1', 'address_2', 'postcode' ] as $field ) {
+					if ( ! isset( $locale[ $country ][ $field ] ) ) {
+						$locale[ $country ][ $field ] = [];
+					}
+				}
+
+				if ( $preset ) {
+					$locale[ $country ]['country']['priority']   = 10;
+					$locale[ $country ]['state']['priority']     = 20;
+					$locale[ $country ]['city']['priority']      = 30;
+					$locale[ $country ]['address_1']['priority'] = 40;
+					$locale[ $country ]['address_2']['priority'] = 50;
+					$locale[ $country ]['postcode']['priority']  = 60;
+				}
+
+				if ( $region_removed ) {
+					$locale[ $country ]['state']['hidden']   = true;
+					$locale[ $country ]['state']['required'] = false;
+				}
+
+				if ( $postcode_removed ) {
+					$locale[ $country ]['postcode']['hidden']   = true;
+					$locale[ $country ]['postcode']['required'] = false;
+				}
+
+				// Settlement invariant — always, re-asserted LAST. Task 7 extends this
+				// same seam with restoration of a third-party-removed city field; this
+				// line is the already-required baseline it builds on.
+				$locale[ $country ]['city']['required'] = true;
+			}
+
+			return $locale;
+		}
+
+		/**
+		 * Instrument B's pure contribution — a field the merchant set to `remove` is
+		 * `unset()` from BOTH the `billing` and `shipping` sections, so it leaves the DOM
+		 * entirely (T1/T2: removal is never done in JS, hiding is never done by
+		 * unsetting). Classic checkout only, by construction — the block checkout never
+		 * reads `woocommerce_checkout_fields`.
+		 *
+		 * Pure — touches no WordPress function, so unit tests call it directly.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<string, bool|string>                         $settings `effective()` values, keyed by setting id
+		 *                                                                      (only `region_field`/`postcode_field` are read).
+		 * @param array<string, array<string, array<string, mixed>>> $fields   the checkout fields array to contribute onto.
+		 *
+		 * @return array<string, array<string, array<string, mixed>>>
+		 */
+		public static function checkout_fields_contribution( array $settings, array $fields ): array {
+			$region_removed   = 'remove' === ( $settings['region_field'] ?? 'show' );
+			$postcode_removed = 'remove' === ( $settings['postcode_field'] ?? 'show' );
+
+			foreach ( [ 'billing', 'shipping' ] as $section ) {
+				if ( ! isset( $fields[ $section ] ) || ! is_array( $fields[ $section ] ) ) {
+					continue;
+				}
+
+				if ( $region_removed ) {
+					unset( $fields[ $section ][ $section . '_state' ] );
+				}
+
+				if ( $postcode_removed ) {
+					unset( $fields[ $section ][ $section . '_postcode' ] );
+				}
+			}
+
+			return $fields;
+		}
+	}
+
+endif;

--- a/woodev/shipping-method/checkout/class-checkout-field-policy.php
+++ b/woodev/shipping-method/checkout/class-checkout-field-policy.php
@@ -375,12 +375,28 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Po
 				}
 
 				if ( $preset ) {
-					$locale[ $country ]['country']['priority']   = 10;
-					$locale[ $country ]['state']['priority']     = 20;
-					$locale[ $country ]['city']['priority']      = 30;
-					$locale[ $country ]['address_1']['priority'] = 40;
-					$locale[ $country ]['address_2']['priority'] = 50;
-					$locale[ $country ]['postcode']['priority']  = 60;
+					/*
+					 * The preset reorders the ADDRESS BLOCK only, and stays inside the band
+					 * WooCommerce already reserves for it (measured on WC 11.0.1 via
+					 * `WC_Countries::get_default_address_fields()`): first_name 10, last_name 20,
+					 * company 30, country 40, address_1 50, address_2 60, city 70, state 80,
+					 * postcode 90, phone 100, email 110.
+					 *
+					 * The design document proposed 10/20/30/40/50/60 for this block. Those numbers
+					 * COLLIDE with the name block and were measured on the rig producing
+					 * «Имя · Страна · Фамилия · Регион · Город …» — the customer's name split in
+					 * half by address fields. Keeping the same relative order the design asks for
+					 * (Страна > Регион > Город > Адрес > Кв. > Индекс) inside WC's own 40–90 band
+					 * fixes that without touching any field the preset has no opinion about, and
+					 * leaves a third-party field slotted at e.g. 45 sitting inside the address
+					 * block rather than jumping ahead of the name.
+					 */
+					$locale[ $country ]['country']['priority']   = 40;
+					$locale[ $country ]['state']['priority']     = 50;
+					$locale[ $country ]['city']['priority']      = 60;
+					$locale[ $country ]['address_1']['priority'] = 70;
+					$locale[ $country ]['address_2']['priority'] = 80;
+					$locale[ $country ]['postcode']['priority']  = 90;
 				}
 
 				if ( $region_removed ) {

--- a/woodev/shipping-method/checkout/class-checkout-field-policy.php
+++ b/woodev/shipping-method/checkout/class-checkout-field-policy.php
@@ -64,6 +64,22 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Po
 		const LATE = PHP_INT_MAX - 10;
 
 		/**
+		 * Option name persisting the last non-empty settlement-invariant override
+		 * report (S8) across requests: {@see self::restore_invariants()} observes it
+		 * on a FRONTEND checkout render, but {@see \Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings::get_section_note()}
+		 * reads it from a completely different (wp-admin) request — so it must be
+		 * persisted somewhere. A plain option, not a transient: {@see self::persist_overrides()}
+		 * actively `delete_option()`s it the moment a checkout render finds nothing
+		 * left to restore, which clears a stale note on the VERY NEXT observation
+		 * rather than waiting out a transient's expiry — a stale note accusing a
+		 * plugin that has since been deactivated is worse than no note at all.
+		 *
+		 * @since 2.0.2
+		 * @var string
+		 */
+		const OPTION_LAST_OVERRIDES = 'woodev_checkout_fields_last_overrides';
+
+		/**
 		 * @var self|null
 		 */
 		private static $instance = null;
@@ -91,6 +107,16 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Po
 		 * @var bool
 		 */
 		private $hooked = false;
+
+		/**
+		 * The settlement-invariant overrides {@see self::restore_invariants()} recorded
+		 * on its most recent call — reset at the START of every call, never
+		 * accumulated across repeat filter applications within the same request.
+		 *
+		 * @since 2.0.2
+		 * @var array<int, array{field: string, section: string, what: string}>
+		 */
+		private $overrides = [];
 
 		/**
 		 * Returns the singleton instance.
@@ -216,18 +242,45 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Po
 
 		/**
 		 * `woocommerce_checkout_fields` callback (Instrument B) — classic checkout only,
-		 * by construction (the block checkout never reads this filter).
+		 * by construction (the block checkout never reads this filter). Also runs
+		 * Task 7's settlement-invariant RESTORATION (S8) AFTER this policy's own
+		 * contribution, so it sees the final `city`/`billing_city`/`shipping_city`
+		 * state a third-party field-manager plugin left behind and restores exactly
+		 * what that plugin removed or relaxed — see {@see self::restore_invariants()}.
 		 *
 		 * @internal bound at {@see self::LATE} by {@see self::register()}.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Restores the settlement-field invariants and persists the
+		 *              override report (Task 7, issue #362, design S8).
 		 *
 		 * @param mixed $fields the checkout fields array WooCommerce/third-party plugins built so far.
 		 *
 		 * @return array<string, array<string, array<string, mixed>>>
 		 */
 		public function filter_checkout_fields( $fields ): array {
-			return self::checkout_fields_contribution( $this->effective(), (array) $fields );
+			$fields = self::checkout_fields_contribution( $this->effective(), (array) $fields );
+
+			/**
+			 * Filters whether {@see self::restore_invariants()} should run on this
+			 * request. A legitimate escape hatch for a carrier plugin whose own field
+			 * manager deliberately needs `city` non-required for a specific flow (e.g.
+			 * a cash/self-pickup order) — the framework's own default is always to
+			 * restore. Never a new SETTING (design's standing rule): a filter only a
+			 * developer can reach, not a merchant-facing control.
+			 *
+			 * @since 2.0.2
+			 *
+			 * @param bool                                                 $restore whether to restore the settlement invariants.
+			 * @param array<string, array<string, array<string, mixed>>> $fields  the checkout fields array so far (after this policy's own contribution).
+			 */
+			if ( apply_filters( 'woodev_checkout_field_policy_restore_invariants', true, $fields ) ) {
+				$fields = $this->restore_invariants( $fields, $this->default_address_fields() );
+
+				$this->persist_overrides();
+			}
+
+			return $fields;
 		}
 
 		/**
@@ -385,6 +438,146 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Po
 			}
 
 			return $fields;
+		}
+
+		/**
+		 * Restores the settlement-field invariants a third-party field-manager plugin
+		 * broke (S8, design §4.4): `*_city` must EXIST in both the `billing` and
+		 * `shipping` sections of the final checkout fields array, and must be
+		 * `required`. Runs after {@see self::checkout_fields_contribution()} — and,
+		 * by virtue of {@see self::LATE}, after WooCommerce's own defaults and any
+		 * third-party field manager — so it restores exactly what got removed or
+		 * relaxed. Everything else about `city` (label, class, priority, …) and every
+		 * OTHER field is left untouched — that is the field manager's business, not
+		 * this framework's (S8's own words: the framework overrides only the values
+		 * that are not WC defaults, nothing more).
+		 *
+		 * Every restoration is recorded into {@see self::$overrides} (never applied
+		 * silently) so {@see self::persist_overrides()} can turn it into a report the
+		 * admin «Доставка» tab surfaces via
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings::get_section_note()}.
+		 * {@see self::$overrides} is reset at the START of every call — this method
+		 * describes the outcome of THIS pass over `$fields` only.
+		 *
+		 * Deliberately an INSTANCE method, not one of this class's other `_contribution()`
+		 * statics: unlike those, it has an observable side effect ({@see self::$overrides})
+		 * that is itself part of the contract (design §4.4 names
+		 * `Checkout_Field_Policy::get_overrides()` as the read side of it) — Task 7's
+		 * unit tests construct a plain `new self()` and call this method directly,
+		 * exactly like the existing pure statics are called directly, without needing
+		 * a WordPress runtime.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<string, array<string, array<string, mixed>>> $fields                 the checkout fields array to restore invariants onto — normally
+		 *                                                                                     the result of {@see self::checkout_fields_contribution()}.
+		 * @param array<string, array<string, mixed>>                $default_address_fields WC's default address-field template
+		 *                                                                                    ({@see \WC_Countries::get_default_address_fields()}), UNPREFIXED
+		 *                                                                                    keys (`city`, not `billing_city`) — the source for re-inserting
+		 *                                                                                    a `city` field a plugin removed entirely.
+		 *
+		 * @return array<string, array<string, array<string, mixed>>>
+		 */
+		public function restore_invariants( array $fields, array $default_address_fields ): array {
+			$this->overrides = [];
+
+			$default_city = $default_address_fields['city'] ?? [];
+
+			foreach ( [ 'billing', 'shipping' ] as $section ) {
+				if ( ! isset( $fields[ $section ] ) || ! is_array( $fields[ $section ] ) ) {
+					continue;
+				}
+
+				$key = $section . '_city';
+
+				if ( ! isset( $fields[ $section ][ $key ] ) || ! is_array( $fields[ $section ][ $key ] ) ) {
+					$fields[ $section ][ $key ] = $default_city;
+
+					$this->overrides[] = [
+						'field' => 'city',
+						'section' => $section,
+						'what' => 'restored',
+					];
+
+					continue;
+				}
+
+				if ( empty( $fields[ $section ][ $key ]['required'] ) ) {
+					$fields[ $section ][ $key ]['required'] = true;
+
+					$this->overrides[] = [
+						'field' => 'city',
+						'section' => $section,
+						'what' => 'required',
+					];
+				}
+			}
+
+			return $fields;
+		}
+
+		/**
+		 * The overrides {@see self::restore_invariants()} recorded on its most recent
+		 * call — part of this class's public contract (design §4.4).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<int, array{field: string, section: string, what: string}>
+		 */
+		public function get_overrides(): array {
+			return $this->overrides;
+		}
+
+		/**
+		 * WC's default address-field template ({@see \WC_Countries::get_default_address_fields()}),
+		 * the source {@see self::restore_invariants()} re-inserts a removed `city`
+		 * field from. Guarded for the unit suite (no `WC()` there), same shape as
+		 * {@see self::shipping_countries()}: returns `[]`, which degrades
+		 * `restore_invariants()`'s re-insertion to an empty stub rather than failing —
+		 * harmless outside a real WooCommerce runtime.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, array<string, mixed>>
+		 */
+		private function default_address_fields(): array {
+			if ( ! function_exists( 'WC' ) || ! WC()->countries ) {
+				return [];
+			}
+
+			return WC()->countries->get_default_address_fields();
+		}
+
+		/**
+		 * Persists {@see self::$overrides} to {@see self::OPTION_LAST_OVERRIDES} for
+		 * {@see \Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings::get_section_note()}
+		 * to read from a later (wp-admin) request — a write on a frontend checkout
+		 * READ path, so guarded hard: only writes when the report is non-empty AND
+		 * differs from what is already stored.
+		 *
+		 * The control case (S8): once a checkout render finds NOTHING to restore, any
+		 * previously stored report is actively deleted — the note disappears on the
+		 * very next observation once the offending plugin stops interfering, rather
+		 * than lingering and accusing a plugin that may no longer even be active.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return void
+		 */
+		private function persist_overrides(): void {
+			$stored = (array) get_option( self::OPTION_LAST_OVERRIDES, [] );
+
+			if ( empty( $this->overrides ) ) {
+				if ( ! empty( $stored ) ) {
+					delete_option( self::OPTION_LAST_OVERRIDES );
+				}
+
+				return;
+			}
+
+			if ( $this->overrides !== $stored ) {
+				update_option( self::OPTION_LAST_OVERRIDES, $this->overrides, false );
+			}
 		}
 	}
 

--- a/woodev/shipping-method/checkout/class-checkout-field-settings.php
+++ b/woodev/shipping-method/checkout/class-checkout-field-settings.php
@@ -7,10 +7,28 @@
  * (`woodev_checkout_fields_*`) so it never collides with `Location_Settings`'s
  * `woodev_location_*` options.
  *
- * Deliberately empty — Task 5 fills in the checkout field policy fields. Kept
- * present (rather than deferred) so {@see \Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab}
- * always has three composite children to route to, and the «Поля» section
- * renders (empty) from the moment any plugin declares a shipping plugin.
+ * Owns five settings, each a single select naming genuinely different mechanisms
+ * (design S4): `field_order_preset` (checkbox), `country_field`, `region_field`,
+ * `address_field`, `postcode_field`. `remove` takes the field out of the DOM — its
+ * value never reaches the order; `hide`/`hide_for_pickup` only visually hides it —
+ * its value (e.g. an address written by the pickup point) still reaches the order.
+ * The two mechanisms are never conflated; the framework never REMOVES the address
+ * field, only hides it.
+ *
+ * Availability (design §3.2) is computed once at construction from an injected
+ * {@see Checkout_Field_Environment}, so a control that cannot currently be used
+ * renders disabled with a visible reason (D11) instead of hidden or silently dead.
+ * The block checkout never reads `woocommerce_checkout_fields` — only
+ * `woocommerce_get_country_locale` (measured on WC 11.0.1) — so `address_field`,
+ * `country_field`, and the postcode `hide_for_pickup` VALUE only work on the
+ * classic checkout; `field_order_preset` and `region_field` reach both checkouts
+ * and are never disabled.
+ *
+ * {@see self::effective()} is this class's real contract with the rest of the
+ * system (Task 6's `Checkout_Field_Policy` calls it for all five ids): the stored
+ * value clamped to what is currently allowed (design §7 — clamp on READ, never
+ * rewrite), mirroring
+ * {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::get_field_mode()}.
  *
  * @since 2.0.2
  */
@@ -24,18 +42,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Settings' ) ) :
 
 	/**
-	 * Settings handler for the checkout field policy («Поля» section). Empty until Task 5.
+	 * Settings handler for the checkout field policy («Поля» section).
 	 *
 	 * @since 2.0.2
 	 */
 	class Checkout_Field_Settings extends \Woodev_Abstract_Settings {
 
 		/**
+		 * Environment facts the availability rules gate on, resolved once at
+		 * construction.
+		 *
+		 * @var Checkout_Field_Environment
+		 */
+		private $env;
+
+		/**
 		 * Constructor.
 		 *
 		 * @since 2.0.2
+		 *
+		 * @param Checkout_Field_Environment|null $env environment facts the availability
+		 *                                              rules gate on; defaults to
+		 *                                              {@see Checkout_Field_Environment::from_wc()}
+		 *                                              so production callers never have to
+		 *                                              build one by hand.
 		 */
-		public function __construct() {
+		public function __construct( ?Checkout_Field_Environment $env = null ) {
+			$this->env = $env ?? Checkout_Field_Environment::from_wc();
+
 			parent::__construct( 'checkout_fields' );
 		}
 
@@ -49,11 +83,18 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Se
 		 * @return string[]
 		 */
 		public function get_owned_setting_ids(): array {
-			return [];
+			return [
+				'field_order_preset',
+				'country_field',
+				'region_field',
+				'address_field',
+				'postcode_field',
+			];
 		}
 
 		/**
-		 * Optional note shown under the «Поля» section heading.
+		 * Optional note shown under the «Поля» section heading. Empty until Task 7
+		 * fills it in with the override report (design S8).
 		 *
 		 * @since 2.0.2
 		 *
@@ -64,12 +105,193 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Se
 		}
 
 		/**
+		 * The value the checkout must ACT on: the stored value clamped to what is
+		 * currently allowed (design §7 — clamp on READ, never rewrite). The stored
+		 * option itself is left untouched, so a condition change (e.g. the merchant
+		 * adding a second shipping country, or switching checkout experience) restores
+		 * the merchant's original choice the moment it becomes valid again — same shape
+		 * as {@see \Woodev\Framework\Shipping\Location\Location_Provider_Registry::get_field_mode()}.
+		 *
+		 * Clamping rules:
+		 *  - `field_order_preset` — never disabled, returned as stored (cast to bool).
+		 *  - `country_field` — `hide` allowed only when the store ships to exactly one
+		 *    country AND the block checkout is not in use; otherwise clamps to `show`.
+		 *  - `region_field` — never disabled (the `remove` value reaches both checkouts
+		 *    via the locale instrument), returned as stored when it names a known option.
+		 *  - `address_field` — `hide_for_pickup` allowed only on the classic checkout;
+		 *    clamps to `show` on the block checkout.
+		 *  - `postcode_field` — `hide_for_pickup` allowed only on the classic checkout
+		 *    (`remove` works on both); clamps to `show` when the stored value names an
+		 *    option not currently offered.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $id one of {@see self::get_owned_setting_ids()}.
+		 *
+		 * @return bool|string
+		 *
+		 * @throws \Woodev_Plugin_Exception when `$id` is not one of this handler's own settings.
+		 */
+		public function effective( string $id ) {
+
+			if ( 'field_order_preset' === $id ) {
+				return (bool) $this->get_value( $id );
+			}
+
+			switch ( $id ) {
+
+				case 'country_field':
+					$offered = ( 1 === $this->env->shipping_country_count && ! $this->env->block_checkout )
+						? [ 'show', 'hide' ]
+						: [ 'show' ];
+					break;
+
+				case 'region_field':
+					$offered = [ 'show', 'remove' ];
+					break;
+
+				case 'address_field':
+					$offered = $this->env->block_checkout ? [ 'show' ] : [ 'show', 'hide_for_pickup' ];
+					break;
+
+				case 'postcode_field':
+					$offered = $this->env->block_checkout
+						? [ 'show', 'remove' ]
+						: [ 'show', 'hide_for_pickup', 'remove' ];
+					break;
+
+				default:
+					throw new \Woodev_Plugin_Exception( "Checkout_Field_Settings::effective(): unknown setting id \"{$id}\"" );
+			}
+
+			$stored = (string) $this->get_value( $id );
+
+			return in_array( $stored, $offered, true ) ? $stored : 'show';
+		}
+
+		/**
 		 * {@inheritDoc}
 		 *
 		 * @since 2.0.2
 		 */
 		protected function register_settings() {
-			// Task 5 fills this in.
+
+			$this->register_setting(
+				'field_order_preset',
+				\Woodev_Setting::TYPE_BOOLEAN,
+				[
+					'name'    => __( 'Единый порядок и формат полей адреса', 'woodev-plugin-framework' ),
+					'default' => true,
+				]
+			);
+			$this->register_control( 'field_order_preset', \Woodev_Control::TYPE_CHECKBOX );
+
+			$this->register_setting(
+				'country_field',
+				\Woodev_Setting::TYPE_STRING,
+				[
+					'name'    => __( 'Страна', 'woodev-plugin-framework' ),
+					'options' => [
+						'show' => __( 'Показывать', 'woodev-plugin-framework' ),
+						'hide' => __( 'Скрывать', 'woodev-plugin-framework' ),
+					],
+					'default' => 'show',
+				]
+			);
+			$this->register_control( 'country_field', \Woodev_Control::TYPE_SELECT );
+
+			$this->register_setting(
+				'region_field',
+				\Woodev_Setting::TYPE_STRING,
+				[
+					'name'    => __( 'Регион', 'woodev-plugin-framework' ),
+					'options' => [
+						'show'   => __( 'Показывать', 'woodev-plugin-framework' ),
+						'remove' => __( 'Удалять', 'woodev-plugin-framework' ),
+					],
+					'default' => 'show',
+				]
+			);
+			$this->register_control( 'region_field', \Woodev_Control::TYPE_SELECT );
+
+			$this->register_setting(
+				'address_field',
+				\Woodev_Setting::TYPE_STRING,
+				[
+					'name'    => __( 'Адрес', 'woodev-plugin-framework' ),
+					'options' => [
+						'show'            => __( 'Показывать', 'woodev-plugin-framework' ),
+						'hide_for_pickup' => __( 'Скрывать для методов ПВЗ', 'woodev-plugin-framework' ),
+					],
+					'default' => 'show',
+				]
+			);
+			$this->register_control( 'address_field', \Woodev_Control::TYPE_SELECT );
+
+			$this->register_setting(
+				'postcode_field',
+				\Woodev_Setting::TYPE_STRING,
+				[
+					'name'    => __( 'Индекс', 'woodev-plugin-framework' ),
+					'options' => [
+						'show'            => __( 'Показывать', 'woodev-plugin-framework' ),
+						'hide_for_pickup' => __( 'Скрывать для методов ПВЗ', 'woodev-plugin-framework' ),
+						'remove'          => __( 'Удалять', 'woodev-plugin-framework' ),
+					],
+					'default' => 'show',
+				]
+			);
+			$this->register_control( 'postcode_field', \Woodev_Control::TYPE_SELECT );
+
+			$this->apply_availability();
+		}
+
+		/**
+		 * Disables controls the current environment cannot serve, with a visible
+		 * reason (design D11) — never hidden, never silently dead.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return void
+		 */
+		private function apply_availability(): void {
+
+			$block        = $this->env->block_checkout;
+			$reason_block = __( 'Недоступно на блочном чекауте: эта опция работает через скрипт классической формы оформления.', 'woodev-plugin-framework' );
+
+			if ( 1 !== $this->env->shipping_country_count ) {
+				$this->get_setting( 'country_field' )->get_control()->set_disabled(
+					true,
+					__( 'Доступно, когда магазин доставляет ровно в одну страну (WooCommerce → Настройки → Общие → Доставка в).', 'woodev-plugin-framework' )
+				);
+			} elseif ( $block ) {
+				$this->get_setting( 'country_field' )->get_control()->set_disabled( true, $reason_block );
+			}
+
+			if ( $block ) {
+				$this->get_setting( 'address_field' )->get_control()->set_disabled( true, $reason_block );
+
+				$postcode_setting = $this->get_setting( 'postcode_field' );
+				$postcode_control = $postcode_setting->get_control();
+
+				// Only the `hide_for_pickup` VALUE is inert on the block checkout — `remove`
+				// still works there — so the option list is narrowed rather than the whole
+				// control disabled. `array_keys()` because `Woodev_Control::set_options()`
+				// checks membership of `$valid_options` by VALUE (`in_array( $key, $valid_options, true )`
+				// — see `class-control.php`), so it needs a plain list of valid keys, not the
+				// `key => label` map `Woodev_Setting::get_options()` itself returns; passing
+				// that map straight through would silently empty the option list.
+				$postcode_control->set_options(
+					[
+						'show'   => __( 'Показывать', 'woodev-plugin-framework' ),
+						'remove' => __( 'Удалять', 'woodev-plugin-framework' ),
+					],
+					array_keys( $postcode_setting->get_options() )
+				);
+				$postcode_control->set_description(
+					trim( $postcode_control->get_description() . ' ' . __( 'Значение «Скрывать для методов ПВЗ» недоступно на блочном чекауте.', 'woodev-plugin-framework' ) )
+				);
+			}
 		}
 	}
 

--- a/woodev/shipping-method/checkout/class-checkout-field-settings.php
+++ b/woodev/shipping-method/checkout/class-checkout-field-settings.php
@@ -93,15 +93,35 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Field_Se
 		}
 
 		/**
-		 * Optional note shown under the «Поля» section heading. Empty until Task 7
-		 * fills it in with the override report (design S8).
+		 * Note shown under the «Поля» section heading, reporting Task 7's
+		 * settlement-invariant restoration (design S8): when a third-party
+		 * checkout-field-manager plugin removed the settlement (`*_city`) field or
+		 * made it non-required, {@see \Woodev\Framework\Shipping\Checkout\Checkout_Field_Policy}
+		 * restores it and this note explains why — silently fixing someone else's
+		 * plugin and saying nothing is exactly the failure this codebase avoids.
+		 * Empty when nothing was overridden.
+		 *
+		 * Reads the RAW option ({@see \Woodev\Framework\Shipping\Checkout\Checkout_Field_Policy::OPTION_LAST_OVERRIDES})
+		 * with a plain `get_option()`, deliberately NOT through this class's own
+		 * settings API: {@see \Woodev_Setting::get_value()} returns a cached property
+		 * loaded once at construction, not a live option read (gotcha
+		 * `woodev-setting-get-value-is-cached-not-a-live-option-read`) — the override
+		 * report is written by a DIFFERENT (frontend checkout) request than the one
+		 * that renders this note (wp-admin), so a cached value would never see it.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Reports Task 7's settlement-invariant override (issue #362, design S8).
 		 *
 		 * @return string
 		 */
 		public function get_section_note(): string {
-			return '';
+			$overrides = get_option( Checkout_Field_Policy::OPTION_LAST_OVERRIDES, [] );
+
+			if ( empty( $overrides ) ) {
+				return '';
+			}
+
+			return __( 'Поле «Город» было изменено сторонним кодом (снята обязательность / удалено); фреймворк восстановил его — оформление заказа зависит от этого поля.', 'woodev-plugin-framework' );
 		}
 
 		/**

--- a/woodev/shipping-method/checkout/class-checkout-handler.php
+++ b/woodev/shipping-method/checkout/class-checkout-handler.php
@@ -544,7 +544,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Checkout\\Checkout_Handler'
 				rtrim( rest_url( 'woodev/v1' ), '/' ),
 				wp_create_nonce( 'wp_rest' ),
 				$this->wc_country_codes(),
-				$this->location_service()
+				$this->location_service(),
+				// Checkout field policy (Task 6, issue #362): store-level, reached through
+				// the tab singleton rather than constructed here — its availability rules
+				// must not be computed twice with a different answer than the «Поля»
+				// section itself uses.
+				\Woodev\Framework\Shipping\Settings\Shipping_Settings_Tab::instance()->get_field_settings()
 			) )->build( $this->fields );
 			// No `required` string here any more (#274): the client no longer renders an
 			// inline «Заполните обязательное поле.» under the field or under the pickup

--- a/woodev/shipping-method/class-shipping-plugin.php
+++ b/woodev/shipping-method/class-shipping-plugin.php
@@ -149,6 +149,11 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Shipping_Plugin' ) ) :
 			// the registrar stays inert until declare_shipping_plugin() is called.
 			require_once $path . '/checkout/class-checkout-field-environment.php';
 			require_once $path . '/checkout/class-checkout-field-settings.php';
+			// Checkout field policy (Task 6; issue #362): applies the «Поля» settings to
+			// the real checkout via woocommerce_get_country_locale + woocommerce_checkout_fields.
+			// Required unconditionally, same reasoning as the tab registrar above — it stays
+			// inert until Shipping_Settings_Tab::register() boots it.
+			require_once $path . '/checkout/class-checkout-field-policy.php';
 			require_once $path . '/pickup/class-pickup-map-settings.php';
 			require_once $path . '/settings/class-shipping-settings-tab.php';
 

--- a/woodev/shipping-method/class-shipping-plugin.php
+++ b/woodev/shipping-method/class-shipping-plugin.php
@@ -147,6 +147,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Shipping_Plugin' ) ) :
 			// stub handlers it composes with the location layer's handler. Required
 			// unconditionally, same reasoning as the location-provider block below —
 			// the registrar stays inert until declare_shipping_plugin() is called.
+			require_once $path . '/checkout/class-checkout-field-environment.php';
 			require_once $path . '/checkout/class-checkout-field-settings.php';
 			require_once $path . '/pickup/class-pickup-map-settings.php';
 			require_once $path . '/settings/class-shipping-settings-tab.php';

--- a/woodev/shipping-method/settings/class-shipping-settings-tab.php
+++ b/woodev/shipping-method/settings/class-shipping-settings-tab.php
@@ -25,6 +25,7 @@ use Woodev\Framework\Settings\Composite_Settings_Handler;
 use Woodev\Framework\Settings\Settings_Page_Registry;
 use Woodev\Framework\Settings\Settings_Provider;
 use Woodev\Framework\Settings\Settings_Section;
+use Woodev\Framework\Shipping\Checkout\Checkout_Field_Policy;
 use Woodev\Framework\Shipping\Checkout\Checkout_Field_Settings;
 use Woodev\Framework\Shipping\Pickup\Pickup_Map_Settings;
 
@@ -116,6 +117,12 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Settings\\Shipping_Settings
 			self::remove_hooked_instances( 'init', self::class, 'register' );
 
 			self::$instance = null;
+
+			// Checkout_Field_Policy (Task 6, issue #362) is booted from register() above,
+			// but is its OWN singleton with its own hooked filters — reset it here too so
+			// a test that calls register() more than once never leaks a stale filter
+			// registration into a later test in the same process.
+			Checkout_Field_Policy::reset_for_tests();
 		}
 
 		/**
@@ -309,11 +316,20 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Settings\\Shipping_Settings
 
 		/**
 		 * Builds the composite handler and registers the «Доставка» tab on the SP-1
-		 * surface.
+		 * surface. Also boots {@see Checkout_Field_Policy} (Task 6, issue #362) against
+		 * the same «Поля» handler this tab's own section is built from — never a fresh
+		 * instance, so its availability rules are computed exactly once.
+		 *
+		 * Runs on EVERY request this hook fires on (`init` priority 25, including admin
+		 * and REST) — harmless: {@see Checkout_Field_Policy::register()} is itself
+		 * idempotent (guards its own `add_filter()` calls behind a `$hooked` flag), so a
+		 * repeat call here only refreshes its settings reference, never double-adds a
+		 * filter.
 		 *
 		 * @internal bound to `init` priority 25 by {@see self::hook_once()}.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 Boots {@see Checkout_Field_Policy} (Task 6, issue #362).
 		 *
 		 * @return void
 		 */
@@ -325,6 +341,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Settings\\Shipping_Settings
 					$this->map_needed ? $this->get_map_settings() : null,
 				]
 			);
+
+			Checkout_Field_Policy::instance()->register( $this->get_field_settings() );
 
 			Settings_Page_Registry::instance()->register_service(
 				Settings_Provider::create(


### PR DESCRIPTION
Refs #362 — PR #2 of 4 (задачи 5–7 плана `docs-internal/plans/2026-08-18-shipping-settings-v2-plan.md`).

**База — ветка PR #363**, не `main`: PR #1 ещё не смержен. После его мержа этот PR перетаргетится на `main` сам.

Наполняет секцию «Поля» и подключает её к настоящему поведению чекаута.

## Что внутри

- **Задача 5** — `Checkout_Field_Settings`: пять настроек (`field_order_preset`, `country_field`, `region_field`, `address_field`, `postcode_field`) с правилами доступности по D11 и `effective()` — зажимом сохранённого значения ПРИ ЧТЕНИИ, без перезаписи опции.
- **Задача 6** — `Checkout_Field_Policy`: два шва WooCommerce и ничего больше. `woocommerce_get_country_locale` (доходит до ОБОИХ чекаутов) даёт порядок, `hidden`, `required`; поздний `woocommerce_checkout_fields` (`PHP_INT_MAX - 10`) делает `unset` для `remove` — только классика. Плюс `field_policy` и `pickup_method_ids` в конфиг браузера для задачи 9.
- **Задача 7** — восстановление инвариантов поля НП поверх ИТОГОВОГО массива (S8) и заметка об этом в админке.

## Две правки против плана, обе по замеру

1. **Полоса приоритетов пресета.** Спека фиксировала `country 10 … postcode 60`. Эти числа сталкиваются с блоком имени WC (`first_name 10`, `last_name 20`, `company 30`), и на риге получалось «Имя · **Страна** · Фамилия · **Регион** · Город …» — имя покупателя разрезано пополам. Контроль с выключенным пресетом даёт нормальное «Имя · Фамилия · Страна · Адрес …». Сдвинул в адресную полосу самого WC (`country 40 … postcode 90`), сохранив требуемый порядок.
2. **`Woodev_Control::set_options()`** сверяет КЛЮЧИ переданных опций со ЗНАЧЕНИЯМИ `$valid_options`. Сниппет из плана передавал туда карту `ключ => подпись`, что молча обнулило бы список опций индекса. Латентный баг, обойдён.

## Проверено на риге `:8973`, каждый пункт с контролем

- Классический чекаут: `Имя · Фамилия · Страна · Регион · Город · Адрес · Кв. · Индекс · Телефон · Email`. Контроль (пресет выключен) — порядок WC по умолчанию.
- Блочный чекаут `/checkout/`: тот же порядок полей, в `wcSettings.countryData.RU.locale` лежат наши значения уже как `index` — S6 подтверждено вживую.
- Фильтр локали реально висит на `prio = PHP_INT_MAX - 10`, локаль WC до этого момента не закеширована, существующие ключи стран переживают вклад.
- **Чужой менеджер полей:** одноразовый mu-плагин сносил `shipping_city` и снимал обязательность с `billing_city` на приоритете 20 → фреймворк вернул поле на место и обязательность обоим, в админке появилась заметка. Контроль: плагин снят → `woodev_checkout_fields_last_overrides` удалена, заметка исчезла. Обвинять невиновный плагин она не будет.
- Все пять контролов рисуются по-русски; «Страна» заблокирована с причиной (магазин возит в 250 стран). Ни одного заблокированного контрола без объяснения.

## Проверено гейтами

- `composer test:unit` — 2361 тест / 5842 ассерта, зелено.
- Интеграционные — 110 тестов / 434 ассерта, зелено.
- `composer phpcs` + `composer phpstan` — чисто, без baseline.

## Побочная находка

Локаль стран растёт с 10 КБ до 58 КБ на блочном чекауте — прямое следствие S5+S6, не дефект. Замер с контролем в карточке #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdLPBs1A9CQCcNqxVHNYrt
