### PR TITLE
fix(payment-gateway): экранировать поля токена в выводе (stored-XSS)

### DIFF
--- a/tests/unit/PaymentGatewayDirectXssTest.php
+++ b/tests/unit/PaymentGatewayDirectXssTest.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Unit tests for direct payment gateway customer notices.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! class_exists( 'WC_Payment_Gateway', false ) ) {
+		/**
+		 * Minimal WooCommerce gateway base for the direct gateway test double.
+		 */
+		class WC_Payment_Gateway {}
+	}
+
+	if ( ! class_exists( 'WC_Order', false ) ) {
+		/**
+		 * Minimal WooCommerce order base for the direct gateway test double.
+		 */
+		class WC_Order {
+
+			/**
+			 * Gets the order ID used by other unit-test doubles.
+			 *
+			 * @return int
+			 */
+			public function get_id(): int {
+				return 123;
+			}
+		}
+	}
+
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway-direct.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/payment-tokens/class-payment-gateway-payment-token.php';
+
+	/**
+	 * Supplies a user ID to the direct gateway transaction.
+	 */
+	class Woodev_Test_Direct_Xss_Order extends WC_Order {
+
+		/**
+		 * Gets the order user ID.
+		 *
+		 * @return int
+		 * @since 2.0.2
+		 */
+		public function get_user_id(): int {
+			return 1;
+		}
+	}
+
+	/**
+	 * Exposes the protected direct gateway transaction with inert dependencies.
+	 */
+	class Woodev_Testable_Payment_Gateway_Direct_Xss extends Woodev_Payment_Gateway_Direct {
+
+		/** @var object */
+		private $api;
+
+		/** @var object */
+		private $payment_tokens_handler_double;
+
+		/**
+		 * Initializes the transaction dependencies without constructing a full gateway.
+		 *
+		 * @param object $api API response provider
+		 * @param object $payment_tokens_handler token persistence handler
+		 * @since 2.0.2
+		 */
+		public function __construct( object $api, object $payment_tokens_handler ) {
+			$this->api                           = $api;
+			$this->payment_tokens_handler_double = $payment_tokens_handler;
+		}
+
+		/**
+		 * Runs the protected add-payment-method transaction.
+		 *
+		 * @param WC_Order $order order being processed
+		 * @return array
+		 * @since 2.0.2
+		 */
+		public function run_add_payment_method_transaction( WC_Order $order ): array {
+			return $this->do_add_payment_method_transaction( $order );
+		}
+
+		/**
+		 * Gets the API double.
+		 *
+		 * @return object
+		 * @since 2.0.2
+		 */
+		public function get_api(): object {
+			return $this->api;
+		}
+
+		/**
+		 * Gets the token persistence double.
+		 *
+		 * @return object
+		 * @since 2.0.2
+		 */
+		public function get_payment_tokens_handler(): object {
+			return $this->payment_tokens_handler_double;
+		}
+
+		/**
+		 * Treats the double as a credit-card gateway.
+		 *
+		 * @return bool
+		 * @since 2.0.2
+		 */
+		public function is_credit_card_gateway(): bool {
+			return true;
+		}
+
+		/**
+		 * Gets the gateway ID.
+		 *
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function get_id(): string {
+			return 'test-direct-gateway';
+		}
+
+		/**
+		 * Supplies no settings because the test does not initialize the gateway.
+		 *
+		 * @return array
+		 * @since 2.0.2
+		 */
+		protected function get_method_form_fields(): array {
+			return [];
+		}
+
+		/**
+		 * Skips user-meta persistence outside the message rendering under test.
+		 *
+		 * @param mixed $response API response
+		 * @return void
+		 * @since 2.0.2
+		 */
+		protected function add_add_payment_method_transaction_data( $response ): void {}
+
+		/**
+		 * Skips customer-meta persistence outside the message rendering under test.
+		 *
+		 * @param mixed $order order being processed
+		 * @param mixed $response API response
+		 * @return void
+		 * @since 2.0.2
+		 */
+		protected function add_add_payment_method_customer_data( $order, $response ): void {}
+	}
+}
+
+namespace Woodev\Tests\Unit {
+
+	use Brain\Monkey\Functions;
+
+	/**
+	 * @covers \Woodev_Payment_Gateway_Direct
+	 */
+	final class PaymentGatewayDirectXssTest extends TestCase {
+
+		/**
+		 * @return void
+		 * @since 2.0.2
+		 */
+		protected function setUp(): void {
+			parent::setUp();
+
+			Functions\when( 'do_action' )->justReturn( true );
+			Functions\when( 'esc_html' )->alias(
+				static function ( string $value ): string {
+					return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8', false );
+				}
+			);
+		}
+
+		/**
+		 * Customer notices must render stored token data as text rather than executable markup.
+		 *
+		 * @return void
+		 * @since 2.0.2
+		 */
+		public function test_add_payment_method_notice_escapes_token_details(): void {
+			$payload = '<img src=x onerror=alert(1)>';
+			$token   = \Mockery::mock( \Woodev_Payment_Gateway_Payment_Token::class );
+			$token->shouldReceive( 'get_id' )->andReturn( 'token-id' );
+			$token->shouldReceive( 'get_type_full' )->andReturn( $payload );
+			$token->shouldReceive( 'get_last_four' )->andReturn( $payload );
+			$token->shouldReceive( 'get_exp_date' )->andReturn( $payload );
+
+			$response = new class( $token ) {
+
+				/** @var Woodev_Payment_Gateway_Payment_Token */
+				private $token;
+
+				/**
+				 * @param \Woodev_Payment_Gateway_Payment_Token $token payment token
+				 */
+				public function __construct( \Woodev_Payment_Gateway_Payment_Token $token ) {
+					$this->token = $token;
+				}
+
+				/** @return bool */
+				public function transaction_approved(): bool {
+					return true;
+				}
+
+				/** @return \Woodev_Payment_Gateway_Payment_Token */
+				public function get_payment_token(): \Woodev_Payment_Gateway_Payment_Token {
+					return $this->token;
+				}
+			};
+			$api = new class( $response ) {
+
+				/** @var object */
+				private $response;
+
+				/**
+				 * @param object $response tokenization response
+				 */
+				public function __construct( object $response ) {
+					$this->response = $response;
+				}
+
+				/**
+				 * @param \WC_Order $order order being tokenized
+				 * @return object
+				 */
+				public function tokenize_payment_method( \WC_Order $order ): object {
+					return $this->response;
+				}
+			};
+			$handler = new class {
+
+				/**
+				 * @param int                                  $user_id user ID
+				 * @param \Woodev_Payment_Gateway_Payment_Token $token payment token
+				 * @return void
+				 */
+				public function add_token( int $user_id, \Woodev_Payment_Gateway_Payment_Token $token ): void {}
+			};
+			$gateway = new \Woodev_Testable_Payment_Gateway_Direct_Xss( $api, $handler );
+			$result  = $gateway->run_add_payment_method_transaction( new \Woodev_Test_Direct_Xss_Order() );
+
+			$this->assertStringContainsString( '&lt;img src=x onerror=alert(1)&gt;', $result['message'] );
+			$this->assertStringNotContainsString( $payload, $result['message'] );
+		}
+	}
+}

--- a/tests/unit/PaymentGatewayMyPaymentMethodsTest.php
+++ b/tests/unit/PaymentGatewayMyPaymentMethodsTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Unit tests for the My Payment Methods renderer.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace {
+
+	require_once dirname( __DIR__, 2 ) . '/woodev/handlers/script-handler.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/payment-tokens/class-payment-gateway-payment-token.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway-my-payment-methods.php';
+
+	/**
+	 * Minimal plugin double for the details HTML filter name.
+	 */
+	class Woodev_Test_Payment_Gateway_Plugin {
+
+		/**
+		 * Gets the gateway ID.
+		 *
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function get_id(): string {
+			return 'test-gateway';
+		}
+	}
+
+	/**
+	 * Exposes the details renderer without initializing its WordPress hooks.
+	 */
+	class Woodev_Testable_Payment_Gateway_My_Payment_Methods extends Woodev_Payment_Gateway_My_Payment_Methods {
+
+		/**
+		 * Renders details HTML for a token.
+		 *
+		 * @param Woodev_Payment_Gateway_Payment_Token $token token to render
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function render_details_html( Woodev_Payment_Gateway_Payment_Token $token ): string {
+			return $this->get_payment_method_details_html( $token );
+		}
+
+		/**
+		 * Gets the minimal plugin double needed by the renderer.
+		 *
+		 * @return Woodev_Test_Payment_Gateway_Plugin
+		 * @since 2.0.2
+		 */
+		public function get_plugin(): Woodev_Test_Payment_Gateway_Plugin {
+			return new Woodev_Test_Payment_Gateway_Plugin();
+		}
+	}
+}
+
+namespace Woodev\Tests\Unit {
+
+	use Brain\Monkey\Functions;
+
+	/**
+	 * @covers \Woodev_Payment_Gateway_My_Payment_Methods
+	 */
+	final class PaymentGatewayMyPaymentMethodsTest extends TestCase {
+
+		/**
+		 * @return void
+		 * @since 2.0.2
+		 */
+		protected function setUp(): void {
+			parent::setUp();
+
+			Functions\when( 'apply_filters' )->returnArg( 2 );
+			Functions\when( 'esc_html' )->alias(
+				static function ( string $value ): string {
+					return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8', false );
+				}
+			);
+		}
+
+		/**
+		 * A stored token field must remain text when its details are rendered on My Account.
+		 *
+		 * @return void
+		 * @since 2.0.2
+		 */
+		public function test_details_html_escapes_a_malicious_last_four_value(): void {
+			$token = new \Woodev_Payment_Gateway_Payment_Token(
+				'token-id',
+				[
+					'type'      => 'bank',
+					'last_four' => '<img src=x onerror=alert(1)>',
+				]
+			);
+			$methods = ( new \ReflectionClass( \Woodev_Testable_Payment_Gateway_My_Payment_Methods::class ) )->newInstanceWithoutConstructor();
+			$html    = $methods->render_details_html( $token );
+
+			$this->assertStringContainsString( '&lt;img src=x onerror=alert(1)&gt;', $html );
+			$this->assertStringNotContainsString( '<img src=x onerror=alert(1)>', $html );
+		}
+	}
+}

--- a/woodev/payment-gateway/class-payment-gateway-direct.php
+++ b/woodev/payment-gateway/class-payment-gateway-direct.php
@@ -560,8 +560,8 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Direct' ) ) :
 					$this->get_method_title(),
 					$this->is_test_environment() ? esc_html_x( 'Test', 'noun, software environment', 'woodev-plugin-framework' ) : '',
 					$this->perform_credit_card_authorization( $order ) ? esc_html_x( 'Authorization', 'credit card transaction type', 'woodev-plugin-framework' ) : esc_html_x( 'Charge', 'noun, credit card transaction type', 'woodev-plugin-framework' ),
-					Woodev_Payment_Gateway_Helper::payment_type_to_name( $card_type ),
-					$last_four
+					esc_html( Woodev_Payment_Gateway_Helper::payment_type_to_name( $card_type ) ),
+					esc_html( $last_four )
 				);
 
 				// add the expiry date if it is available
@@ -570,7 +570,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Direct' ) ) :
 					$message .= ' ' . sprintf(
 						/** translators: Placeholders: %s - credit card expiry date */
 						__( '(expires %s)', 'woodev-plugin-framework' ),
-						$order->payment->exp_month . '/' . substr( $order->payment->exp_year, - 2 )
+						esc_html( $order->payment->exp_month . '/' . substr( $order->payment->exp_year, - 2 ) )
 					);
 				}
 

--- a/woodev/payment-gateway/class-payment-gateway-direct.php
+++ b/woodev/payment-gateway/class-payment-gateway-direct.php
@@ -741,9 +741,9 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Direct' ) ) :
 					/* translators: Payment method as in a specific credit card. Placeholders: %1$s - card type (visa, mastercard, ...), %2$s - last four digits of the card, %3$s - card expiry date */
 					$message = sprintf(
 						esc_html__( 'Nice! New payment method added: %1$s ending in %2$s (expires %3$s)', 'woodev-plugin-framework' ),
-						$token->get_type_full(),
-						$token->get_last_four(),
-						$token->get_exp_date()
+						esc_html( $token->get_type_full() ),
+						esc_html( $token->get_last_four() ),
+						esc_html( $token->get_exp_date() )
 					);
 
 				} else {

--- a/woodev/payment-gateway/class-payment-gateway-hosted.php
+++ b/woodev/payment-gateway/class-payment-gateway-hosted.php
@@ -581,9 +581,9 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Hosted' ) ) :
 								sprintf(
 									__( '%1$s Payment Method Saved: %2$s ending in %3$s (expires %4$s)', 'woodev-plugin-framework' ),
 									$this->get_method_title(),
-									$token->get_type_full(),
-									$token->get_last_four(),
-									$token->get_exp_date()
+									esc_html( $token->get_type_full() ),
+									esc_html( $token->get_last_four() ),
+									esc_html( $token->get_exp_date() )
 								)
 							);
 

--- a/woodev/payment-gateway/class-payment-gateway-my-payment-methods.php
+++ b/woodev/payment-gateway/class-payment-gateway-my-payment-methods.php
@@ -704,7 +704,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_My_Payment_Methods' ) ) :
 			}
 
 			if ( $last_four = $token->get_last_four() ) {
-				$html .= "&bull; &bull; &bull; {$last_four}";
+				$html .= '&bull; &bull; &bull; ' . esc_html( $last_four );
 			}
 
 			/**

--- a/woodev/payment-gateway/class-payment-gateway.php
+++ b/woodev/payment-gateway/class-payment-gateway.php
@@ -2185,8 +2185,8 @@ if ( ! class_exists( 'Woodev_Payment_Gateway' ) ) :
 				$message .= ': ' . sprintf(
 					/* translators: Placeholders: %1$s - credit card type (MasterCard, Visa, etc...), %2$s - last four digits of the card */
 					__( '%1$s ending in %2$s', 'woocommerce-plugin-framework' ),
-					Woodev_Payment_Gateway_Helper::payment_type_to_name( $card_type ),
-					$last_four
+					esc_html( Woodev_Payment_Gateway_Helper::payment_type_to_name( $card_type ) ),
+					esc_html( $last_four )
 				);
 			}
 
@@ -2196,7 +2196,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway' ) ) :
 				$message .= ' ' . sprintf(
 					/** translators: Placeholders: %s - credit card expiry date */
 					__( '(expires %s)', 'woodev-plugin-framework' ),
-					$order->payment->exp_month . '/' . substr( $order->payment->exp_year, - 2 )
+					esc_html( $order->payment->exp_month . '/' . substr( $order->payment->exp_year, - 2 ) )
 				);
 			}
 

--- a/woodev/payment-gateway/payment-tokens/class-payment-gateway-payment-tokens-handler.php
+++ b/woodev/payment-gateway/payment-tokens/class-payment-gateway-payment-tokens-handler.php
@@ -785,9 +785,9 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Payment_Tokens_Handler' ) ) :
 				$message = sprintf(
 					__( '%1$s Payment Method Saved: %2$s ending in %3$s (expires %4$s)', 'woodev-plugin-framework' ),
 					$gateway->get_method_title(),
-					$token->get_type_full(),
-					$token->get_last_four(),
-					$token->get_exp_date()
+					esc_html( $token->get_type_full() ),
+					esc_html( $token->get_last_four() ),
+					esc_html( $token->get_exp_date() )
 				);
 			}
 


### PR DESCRIPTION
Закрывает stored-XSS в выводе полей платёжного токена.

## Что было

`Woodev_Payment_Gateway_My_Payment_Methods::get_payment_method_details_html()` интерполировал
`last_four` в HTML без экранирования, а `add_payment_method_details()` печатал результат сырым
`echo`. Парный путь вывода (`class-payment-gateway-payment-form.php`) экранирует правильно — то
есть это был пропуск, а не решение. Значение отравляемо: `validate_token_data()` в редакторе
токенов не валидирует ничего, а редактор доступен по `manage_woocommerce`, то есть роли
`shop_manager`, у которой нет `unfiltered_html`.

## Что сделано

Экранирование в точке вывода во всех найденных стоках полей токена:

- `class-payment-gateway-my-payment-methods.php` — сам дефект из карточки;
- `class-payment-gateway.php`, `class-payment-gateway-direct.php`,
  `class-payment-gateway-hosted.php`, `class-payment-gateway-payment-tokens-handler.php` —
  заметки к заказу и покупательские нотисы, где `esc_html__()` экранировал строку перевода, а
  подставляемые `sprintf()` значения шли сырыми. Заметки к заказу рендерятся через
  `wpautop`/`wptexturize`, которые НЕ экранируют.

Экранирование в `get_payment_method_details_html()` стоит **до** фильтра
`wc_<plugin_id>_my_payment_methods_table_details_html`: хук, возвращающий `$html` без изменений,
остаётся безопасным, а хуки, намеренно отдающие разметку, продолжают работать.

## Как проверялось

Воркер Codex → независимый критик Claude → фикс блокирующей находки тем же воркером.

Критик нашёл один **BLOCKING** пропуск в том же файле, который правил воркер:
`class-payment-gateway-direct.php:742-746`, покупательский нотис `wc_add_notice()` — сток с более
высокой экспозицией, чем уже исправленные админские заметки. Исправлено коммитом `df8c9f9`,
новый тест падает на коде до фикса (проверено).

Гейты в ворктри: PHPCS 217/217 чисто, PHPStan 0 ошибок, 2477 unit / 6116 ассертов, Jest 1260/1260.

## Что осталось за рамками

- #416 — `class-payment-gateway-payment-form.php`: `nickname` и срок действия выводятся без
  экранирования. Тот же класс дефекта, отдельная карточка, файл вне множества этого воркера.
- Неверный текст-домен `woocommerce-plugin-framework` в `class-payment-gateway.php:2188` —
  преэкзистующий, отдельной карточкой.

Closes #394
