### PR TITLE
fix(shipping): показывать покупателю, что список локаций обрезан на 500

### DIFF
--- a/tests/js/location-select-modes.test.js
+++ b/tests/js/location-select-modes.test.js
@@ -360,6 +360,35 @@ describe( 'related-list settlement renderer', () => {
 		expect( fetchJsonCalls[ 0 ].url ).not.toContain( 'within=' );
 	} );
 
+	it( 'shows the translated truncation hint when the list response was capped', async () => {
+		mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), buildOptions() );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [],
+			truncated: true,
+			truncated_message: 'Показаны первые 500 населённых пунктов. Уточните регион.',
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		const notice = document.querySelector( '.woodev-location-list-truncated-notice' );
+
+		expect( notice ).not.toBeNull();
+		expect( notice.textContent ).toBe( 'Показаны первые 500 населённых пунктов. Уточните регион.' );
+	} );
+
+	it( 'does not show a truncation hint when the list response is complete', async () => {
+		mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), buildOptions() );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [],
+			truncated: false,
+			truncated_message: 'Показаны первые 500 населённых пунктов. Уточните регион.',
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( document.querySelector( '.woodev-location-list-truncated-notice' ) ).toBeNull();
+	} );
+
 	it( 'picking an option calls the shared onSelect with the matching record — the SAME persist path as every other level', async () => {
 		const options = buildOptions( { node: { level: 'settlement', fieldId: 'billing_city' } } );
 

--- a/tests/js/location-select-modes.test.js
+++ b/tests/js/location-select-modes.test.js
@@ -389,6 +389,27 @@ describe( 'related-list settlement renderer', () => {
 		expect( document.querySelector( '.woodev-location-list-truncated-notice' ) ).toBeNull();
 	} );
 
+	it( 'removes a truncation hint when the next list response is complete', async () => {
+		const options = buildOptions();
+		const first = mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), options );
+
+		fetchJsonCalls[ 0 ].resolve( {
+			localities: [],
+			truncated: true,
+			truncated_message: 'Показаны первые 500 населённых пунктов. Уточните регион.',
+		} );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( document.querySelector( '.woodev-location-list-truncated-notice' ) ).not.toBeNull();
+
+		first.detach();
+		mod.attachRelatedListSettlement( document.getElementById( 'billing_city' ), options );
+		fetchJsonCalls[ 1 ].resolve( { localities: [], truncated: false, truncated_message: '' } );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( document.querySelector( '.woodev-location-list-truncated-notice' ) ).toBeNull();
+	} );
+
 	it( 'picking an option calls the shared onSelect with the matching record — the SAME persist path as every other level', async () => {
 		const options = buildOptions( { node: { level: 'settlement', fieldId: 'billing_city' } } );
 

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -1797,6 +1797,7 @@ final class LocationControllerTest extends TestCase {
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
 		$this->assertCount( 500, $result['localities'], 'the response must never exceed LIST_HARD_CAP' );
 		$this->assertTrue( $result['truncated'] );
+		$this->assertSame( 'Показаны первые 500 населённых пунктов. Уточните регион для более точного списка.', $result['truncated_message'] );
 	}
 
 	public function test_list_exactly_at_the_hard_cap_is_not_reported_truncated(): void {
@@ -1809,6 +1810,7 @@ final class LocationControllerTest extends TestCase {
 
 		$this->assertCount( 500, $result['localities'] );
 		$this->assertFalse( $result['truncated'], 'the provider handed back exactly the cap, nothing was actually cut' );
+		$this->assertSame( '', $result['truncated_message'] );
 	}
 
 	public function test_list_limit_arg_narrows_the_response_below_the_hard_cap(): void {

--- a/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
+++ b/tests/unit/Shipping/Rest_Api/LocationControllerTest.php
@@ -1800,6 +1800,22 @@ final class LocationControllerTest extends TestCase {
 		$this->assertSame( 'Показаны первые 500 населённых пунктов. Уточните регион для более точного списка.', $result['truncated_message'] );
 	}
 
+	public function test_list_truncation_message_acknowledges_an_applied_region_scope(): void {
+		$region   = $this->region_record( 'dadata:region-1' );
+		$provider = new Location_Controller_Fake_List_Provider( fn() => $this->many_records( 501 ) );
+		$service  = new Location_Controller_Fake_Service( true, null, [ 'record' => $region, 'implicit' => false, 'saved_at' => 0 ], true, true, null, null, $provider );
+		$ctrl     = new Location_Controller_Probe( $service );
+
+		$request = new WP_REST_Request(
+			[ 'level' => Location_Record::LEVEL_SETTLEMENT, 'country' => 'RU', 'within' => 'dadata:region-1' ]
+		);
+		$result = $ctrl->handle_list_request( $request );
+
+		$this->assertTrue( $result['truncated'] );
+		$this->assertSame( 'applied', $result['within_status'] );
+		$this->assertSame( 'Показаны первые 500 населённых пунктов выбранного региона. Если нужного населённого пункта нет в списке, выберите другой регион.', $result['truncated_message'] );
+	}
+
 	public function test_list_exactly_at_the_hard_cap_is_not_reported_truncated(): void {
 		$provider = new Location_Controller_Fake_List_Provider( fn() => $this->many_records( 500 ) );
 		$service  = new Location_Controller_Fake_Service( true, null, null, true, true, null, null, $provider );

--- a/woodev/shipping-method/assets/js/frontend/location-select-modes.js
+++ b/woodev/shipping-method/assets/js/frontend/location-select-modes.js
@@ -227,7 +227,7 @@
 	 *
 	 * @param {HTMLInputElement} input
 	 * @param {Object}           options   See the file docblock's shared contract.
-	 * @param {{ajax: boolean, fetchEntries: function(string): Promise<Array>}} strategy
+	 * @param {{ajax: boolean, fetchEntries: function(string): Promise<Array|{entries: Array, truncated: boolean, truncatedMessage: string}>}} strategy
 	 *   `ajax: false` — `fetchEntries()` is called ONCE (a static, region-scoped full list —
 	 *   `related-list` settlement); the `<select>` is populated with real `<option>` elements
 	 *   up front, and select2 (when present) gets NO `ajax` config at all — it search-filters
@@ -256,6 +256,7 @@
 		/** @type {Object.<string, Object>} locality key -> the record it resolves to. */
 		var dataByKey = {};
 		var lastHandledValue = null;
+		var listTruncatedNotice = null;
 
 		/**
 		 * Applies a batch of `{key, label, level, record}` entries (Task 8/13's shared
@@ -294,6 +295,37 @@
 					select.appendChild( option );
 				}
 			} );
+		}
+
+		/**
+		 * Shows the server-supplied explanation when a static list was capped, or removes the
+		 * explanation when the list is complete. The REST response owns the wording because it is
+		 * translated by WordPress, just like the cascade's other location strings.
+		 *
+		 * @param {{truncated?: boolean, truncatedMessage?: string}} result
+		 * @returns {void}
+		 */
+		function updateListTruncatedNotice( result ) {
+			if ( listTruncatedNotice && listTruncatedNotice.parentNode ) {
+				listTruncatedNotice.parentNode.removeChild( listTruncatedNotice );
+			}
+
+			listTruncatedNotice = null;
+
+			if ( ! result || true !== result.truncated || 'string' !== typeof result.truncatedMessage || '' === result.truncatedMessage ) {
+				return;
+			}
+
+			var notice = document.createElement( 'p' );
+
+			notice.className = 'woodev-location-notice woodev-location-list-truncated-notice';
+			notice.setAttribute( 'role', 'status' );
+			notice.textContent = result.truncatedMessage;
+
+			if ( select.parentNode ) {
+				select.parentNode.insertBefore( notice, select.nextSibling );
+				listTruncatedNotice = notice;
+			}
 		}
 
 		function handleChange() {
@@ -362,13 +394,17 @@
 			ensureSelect2();
 		} else {
 			strategy.fetchEntries( '' ).then(
-				function( entries ) {
+				function( result ) {
+					var entries = result && Array.isArray( result.entries ) ? result.entries : ( Array.isArray( result ) ? result : [] );
+
 					applyEntries( entries, true );
+					updateListTruncatedNotice( result );
 					ensureSelect2();
 				},
 				function( error ) {
 					logError( error );
 					applyEntries( [], true );
+					updateListTruncatedNotice();
 					ensureSelect2();
 				}
 			);
@@ -391,6 +427,8 @@
 					select.parentNode.insertBefore( input, select );
 					select.parentNode.removeChild( select );
 				}
+
+				updateListTruncatedNotice();
 			},
 		};
 	}
@@ -430,7 +468,11 @@
 					{ method: 'GET', headers: options.nonceHeader() }
 				).then(
 					function( body ) {
-						return body && Array.isArray( body.localities ) ? body.localities : [];
+						return {
+							entries: body && Array.isArray( body.localities ) ? body.localities : [],
+							truncated: body && true === body.truncated,
+							truncatedMessage: body && 'string' === typeof body.truncated_message ? body.truncated_message : '',
+						};
 					},
 					function( error ) {
 						logError( error );

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -1073,7 +1073,7 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 *
 		 * @param \WP_REST_Request $request request object.
 		 *
-		 * @return \WP_REST_Response|\WP_Error|array{localities: array<int, array<string, mixed>>, truncated: bool, within_status: string}
+		 * @return \WP_REST_Response|\WP_Error|array{localities: array<int, array<string, mixed>>, truncated: bool, truncated_message: string, within_status: string}
 		 */
 		public function handle_list_request( $request ) {
 
@@ -1139,11 +1139,17 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 
 			$truncated = count( $records ) > $limit;
 			$records   = array_slice( $records, 0, $limit );
+			$truncated_message = $truncated ? sprintf(
+				/* translators: %d: number of location records shown. */
+				__( 'Показаны первые %d населённых пунктов. Уточните регион для более точного списка.', 'woodev-plugin-framework' ),
+				$limit
+			) : '';
 
 			return rest_ensure_response(
 				[
 					'localities'    => $this->to_response_records( $records ),
 					'truncated'     => $truncated,
+					'truncated_message' => $truncated_message,
 					'within_status' => $within_status,
 				]
 			);

--- a/woodev/shipping-method/rest-api/class-location-controller.php
+++ b/woodev/shipping-method/rest-api/class-location-controller.php
@@ -1065,6 +1065,8 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 		 * @since 2.0.2 Capped at {@see self::LIST_HARD_CAP} records, with an
 		 *              optional clamped `limit` arg and a `truncated` response
 		 *              flag (PR #304 review finding 5).
+		 * @since 2.0.2 Returns a translated `truncated_message` that acknowledges
+		 *              when the requested `within` region was applied (#411).
 		 * @since 2.0.2 Response gained `within_status` (#333) — see
 		 *              {@see self::build_scope()} for the values; unlike
 		 *              `/suggest` this route never shipped a `within_applied`
@@ -1137,13 +1139,19 @@ if ( ! class_exists( '\\Woodev\\Framework\\Shipping\\Rest_Api\\Location_Controll
 				return $this->upstream_error();
 			}
 
-			$truncated = count( $records ) > $limit;
-			$records   = array_slice( $records, 0, $limit );
-			$truncated_message = $truncated ? sprintf(
-				/* translators: %d: number of location records shown. */
-				__( 'Показаны первые %d населённых пунктов. Уточните регион для более точного списка.', 'woodev-plugin-framework' ),
-				$limit
-			) : '';
+			$truncated         = count( $records ) > $limit;
+			$records           = array_slice( $records, 0, $limit );
+			$truncated_message = '';
+
+			if ( $truncated ) {
+				$truncated_message = sprintf(
+					/* translators: %d: number of location records shown. */
+					self::WITHIN_STATUS_APPLIED === $within_status
+						? __( 'Показаны первые %d населённых пунктов выбранного региона. Если нужного населённого пункта нет в списке, выберите другой регион.', 'woodev-plugin-framework' )
+						: __( 'Показаны первые %d населённых пунктов. Уточните регион для более точного списка.', 'woodev-plugin-framework' ),
+					$limit
+				);
+			}
 
 			return rest_ensure_response(
 				[


### PR DESCRIPTION
> ⛔ **НЕ мержить без ручной проверки оператора.** Правка видимая покупателю, на риге не проверялась.
> Ниже есть вопрос по формулировке — он твой.

## Что было

`Location_Controller` режет `/location/list` на `LIST_HARD_CAP = 500` и честно ставит в ответ флаг
`truncated`. **Ни один клиент его не читал** — поиск по `woodev/shipping-method/assets/js/` и `src/`
давал ноль вхождений. В режиме «Предустановленный список» покупатель получал `<select>` с первыми
500 записями и никакого признака, что список неполон: если его населённого пункта там нет, это
читается как «моего города нет в базе». Тот же класс тихого отказа, что #405.

## Что сделано

Клиент читает `truncated` и рисует подсказку существующим паттерном location-notice. Текст приходит
из REST-слоя переведённым и зависит от `within_status`:

| `within_status` | Что видит покупатель |
|---|---|
| `applied` (регион уже выбран) | «Показаны первые 500 населённых пунктов **выбранного региона**. Если нужного населённого пункта нет в списке, выберите другой регион.» |
| `not_requested`, `unknown_key`, `cross_country`, `bad_level` | «Показаны первые 500 населённых пунктов. **Уточните регион** для более точного списка.» |

Подсказка снимается, когда следующий ответ приходит без обрезки.

Админский picker проверен и этой слепотой не страдает: он ходит в отдельный эндпоинт
`default-locality`/`suggest`.

## Как проверялось

Воркер Codex → независимый критик Claude Sonnet (**APPROVE WITH FIXES**) → все три находки закрыты
тем же воркером коммитом `a6cd99c`:

1. **Тупик для покупателя, который регион уже выбрал.** Ответ несёт `within_status`, а сообщение его
   игнорировало — человеку, уже уточнившему регион, советовали уточнить регион. Отсюда таблица выше.
2. **«Подсказка снимается сама» была реализована, но не проверялась тестом.** Добавлен jest-тест на
   переход truncated → complete.
3. **Не продолжен `@since`-changelog** в докблоке для нового поля `truncated_message`.

Тесты, падающие на коде до фикса, проверены поимённо: новый REST-тест падал на `f461cd0` со старым
обобщённым текстом; jest-тест перехода падал при отключённом рендерере подсказки.

Гейты в ворктри: PHPCS 217/217, PHPStan 0 ошибок, 2476 unit / 6117 ассертов / 71 skipped, Jest 1263.

## ❓ Вопрос к оператору по формулировке

В ветке `applied` совет «**выберите другой регион**» — так себе совет: покупатель не может сменить
регион, в котором живёт. Вариант честнее — не советовать ничего, а просто признать обрезку
(«показаны первые 500 — если вашего пункта нет, воспользуйтесь поиском»), но режим поля выбирает
магазинщик, а не покупатель, так что «воспользуйтесь поиском» может быть недоступно. Оставил как
есть, потому что копирайт — твоя развилка.

Отдельно: сам потолок в 500 без скоупа по региону выбирается мгновенно, так что настоящее лечение —
это #404 (гейт «Предустановленного списка» по оси региона), а эта карточка лишь перестаёт врать
молчанием.

## 🔍 Чек-лист ручной проверки (`:8973`, `/classic-checkout/`)

1. Настроить ось НП в режим «Предустановленный список», регион НЕ выбирать → в списке должна
   появиться подсказка «Уточните регион».
2. Выбрать регион, у которого больше 500 населённых пунктов → подсказка должна смениться на вариант
   «выбранного региона».
3. Выбрать регион, у которого меньше 500 → подсказка должна **исчезнуть**, а не остаться висеть.
4. Консоль должна быть чистой.

Closes #411
