### PR TITLE
build(orca): выровнять гейт агентского ворктри с CI (plugins-reference) + 5 готчей

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -22,3 +22,11 @@
 # A real copy resolves inside the worktree and works. Measured s83: the copy
 # costs seconds on one volume, `composer install` costs ~7 minutes.
 vendor
+
+# Donor plugin copies the contract tests read. Gitignored (.gitignore line 25) and 17 MB, so a
+# fresh worktree arrives without them and the four tests/unit/Contract/Yandex*ContractTest.php
+# classes silently markTestSkipped(). Measured s84: the main checkout runs 2475 tests with 66
+# skipped, an agent worktree runs the same 2475 with 71 skipped — five release-blocking
+# data-contract guards, gone, with a green suite either way. COPIED rather than shared: these are
+# read-only references, and a copy keeps a worker from writing through into the primary checkout.
+plugins-reference

--- a/docs-internal/GOTCHAS.md
+++ b/docs-internal/GOTCHAS.md
@@ -1,6 +1,6 @@
 # Gotchas — Woodev Plugin Framework
 
-> **Index only.** 173 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
+> **Index only.** 178 atomic gotchas across 31 namespaces. Every entry is ONE line: a hook you can
 > recognise, and a link to the file that holds the detail. Never paste the detail here — a second
 > copy drifts from the first, and this file is read at the start of every session.
 > **Adding one:** create `gotchas/{slug}.md` (format: `DOCS-SCHEMA.md`), then add one line below
@@ -266,6 +266,11 @@
 - [tooling/parallel-agents] **`input_accepted` is not proof a worker started — the prompt can sit queued in the TUI while every liveness signal reads healthy.** → [input-accepted-is-not-proof-a-worker-started](gotchas/input-accepted-is-not-proof-a-worker-started.md) (s83)
 - [tooling/parallel-agents] **A worker's Serena `activate_project` path must be its OWN worktree — the repo-root path from CLAUDE.md silently splits its work across two checkouts.** → [serena-activate-path-must-be-the-worker-s-worktree](gotchas/serena-activate-path-must-be-the-worker-s-worktree.md) (s83)
 - [tooling/parallel-agents] **Two agents editing one file is the ORCHESTRATOR's bug — one `git checkout` erased another agent's finished, uncommitted work.** → [two-agents-one-file-is-the-orchestrator-s-bug](gotchas/two-agents-one-file-is-the-orchestrator-s-bug.md) (s82)
+- [tooling/parallel-agents] **A green suite in a worktree is not the same suite — five contract tests SKIP there because `plugins-reference/` is gitignored. Compare the skip count, not the assertion count.** → [a-worktree-silently-skips-five-contract-tests](gotchas/a-worktree-silently-skips-five-contract-tests.md) (s84)
+- [tooling/parallel-agents] **A local `npm run build` cannot prove assets parity — worktrees share `node_modules` and its warm webpack cache; only the CI job is authoritative.** → [local-npm-run-build-is-not-assets-parity-evidence](gotchas/local-npm-run-build-is-not-assets-parity-evidence.md) (s84)
+- [tooling/parallel-agents] **Every fresh worktree starts dirty with seven CRLF-only files — a worker running `git add -A` commits 483 lines of line-ending churn.** → [an-orca-worktree-starts-dirty-with-crlf-churn](gotchas/an-orca-worktree-starts-dirty-with-crlf-churn.md) (s84)
+- [tooling/parallel-agents] **`worker-start --agent codex` lands in a PowerShell prompt that executes the brief; launching Codex takes four steps, ESC for the update dialog included.** → [starting-codex-under-orca-needs-four-steps-not-one](gotchas/starting-codex-under-orca-needs-four-steps-not-one.md) (s84)
+- [tooling/parallel-agents] **Three agents is this machine's real cap — past it phpcs blames innocent files and jest OOMs, both of which read as code defects.** → [three-agents-is-the-concurrency-cap-on-this-machine](gotchas/three-agents-is-the-concurrency-cap-on-this-machine.md) (s84)
 - [tooling/codex-shell-sandbox-broken-windows] **Codex's shell WORKS — launch it in an Orca terminal; only `codex exec -s read-only` hits the broken windows sandbox. Same binary, trusted project, no sandbox.** → [codex-shell-sandbox-broken-windows](gotchas/codex-shell-sandbox-broken-windows.md) (s10, extended s61, root-caused s72, **solved s82**)
 - [tooling/windows] **Git Bash mangles Cyrillic in curl arguments — the API answers 400/500 and it reads as the API's fault.** → [git-bash-mangles-cyrillic-in-curl-arguments](gotchas/git-bash-mangles-cyrillic-in-curl-arguments.md) (s76)
 - [tooling/serena-eol-flip] **Serena `replace_content`/`replace_symbol_body` rewrites the whole file as CRLF on Windows.** → [serena-replace-content-eol-flip](gotchas/serena-replace-content-eol-flip.md) (s25)

--- a/docs-internal/gotchas/a-worktree-silently-skips-five-contract-tests.md
+++ b/docs-internal/gotchas/a-worktree-silently-skips-five-contract-tests.md
@@ -1,0 +1,59 @@
+# gotcha: a green suite in an agent worktree is not the same suite as in the primary checkout
+
+**Namespace:** `[tooling/parallel-agents]`
+**Discovered:** s84 (2026-08-21)
+
+## What happened
+
+Two independent workers reported their unit gate as green and quoted numbers that did not match
+the baseline the brief gave them:
+
+```text
+primary checkout   2475 tests, 6128 assertions, 66 skipped
+agent worktree     2475 tests, 6114 assertions, 71 skipped
+```
+
+Same test count, fourteen fewer assertions, five more skips. One critic concluded the brief's
+baseline was "stale". It was not. Five tests that RUN in the primary checkout SKIP in every fresh
+Orca worktree, and both suites report success either way.
+
+## Root cause: the tests need a gitignored directory that no worktree receives
+
+The four `tests/unit/Contract/Yandex*ContractTest.php` classes (five test methods, fourteen
+assertions) guard installed-site data contracts against a donor plugin copy:
+
+```php
+$this->markTestSkipped(
+    'plugins-reference/woocommerce-yandex-delivery is not present (gitignored); this yandex
+     contract guard runs where the reference plugin copy exists.'
+);
+```
+
+`plugins-reference/` is gitignored (`.gitignore` line 25), so `git worktree add` never creates it,
+and it was absent from `.worktreeinclude`, so Orca never copied it. A worker therefore ran five
+fewer **release-blocking** data-contract guards than CI — and had no way to notice, because a
+skipped test is not a failed test.
+
+## ✅ Fixed — `plugins-reference` is copied into every worktree
+
+```text
+# .worktreeinclude
+plugins-reference
+```
+
+COPIED rather than shared (17 MB): these are read-only references, and a copy keeps a worker from
+writing through into the primary checkout. After the fix a worktree measures the same 66 skips as
+the primary checkout.
+
+## The transferable lesson
+
+A conditional `markTestSkipped()` turns an absent file into a silently weaker gate. When a
+worker's test numbers disagree with the baseline, **the skip count is the first thing to compare**
+— not the assertion count, which only tells you something changed. And a brief that quotes a
+baseline should quote `tests / assertions / skipped`, all three.
+
+## Related
+
+- [sharing-vendor-breaks-composer-autoload-in-a-worktree](sharing-vendor-breaks-composer-autoload-in-a-worktree.md) — the other `.worktreeinclude` decision, and why it is a copy too
+- [local-npm-run-build-is-not-assets-parity-evidence](local-npm-run-build-is-not-assets-parity-evidence.md) — the other gate that lies inside a worktree
+- `../wiki/orchestrating-agents-with-orca.md` — where the worktree contract is documented

--- a/docs-internal/gotchas/an-orca-worktree-starts-dirty-with-crlf-churn.md
+++ b/docs-internal/gotchas/an-orca-worktree-starts-dirty-with-crlf-churn.md
@@ -1,0 +1,51 @@
+# gotcha: every fresh Orca worktree starts dirty with seven CRLF-only files — never `git add -A` there
+
+**Namespace:** `[tooling/parallel-agents]`
+**Discovered:** s84 (2026-08-21)
+
+## What happens
+
+A worker creates nothing, edits nothing, and `git status` in its brand-new worktree already shows:
+
+```text
+ M .github/ISSUE_TEMPLATE/2-feature-request.yml
+ M .github/SECURITY.md
+ M .github/labeler.yml
+ M woodev/assets/js/admin/jquery.jquery-confirm.min.js
+ M woodev/assets/js/admin/woodev-admin-job-batch-handler.js
+ M woodev/assets/js/admin/woodev-admin-script.js
+ M woodev/payment-gateway/assets/js/frontend/woodev-payment-gateway-frontend.js
+```
+
+Every one is 100% context — `git diff --numstat` reports identical insertion and deletion counts
+(`68 68`, `105 105`, …) and git warns:
+
+```text
+warning: in the working copy of '.github/SECURITY.md', CRLF will be replaced by LF the next time
+Git touches it
+```
+
+The primary checkout is clean. Only worktrees show it.
+
+## Why it matters
+
+A worker that finishes its task and runs `git add -A && git commit` ships 483 lines of pure
+line-ending churn alongside its three-line fix. The diff becomes unreviewable, the PR looks like a
+mass rewrite, and a reviewer cannot tell the real change from the noise.
+
+## ✅ Correct
+
+- **Every brief must say: never run `git add -A` in a worktree. Stage only the files you edited.**
+  Both s84 workers that were told this reported back that they had left the seven files untouched
+  and unstaged — the warning works.
+- **Every critic brief must say the seven files are pre-existing and not a finding**, or the critic
+  spends a paragraph on them.
+- Reading another revision is safe and does not touch the tree: `git show <ref>:<path>`,
+  `git diff`, `git log`, `git ls-files --eol`. `git checkout --` and `git add -A` in a live
+  worktree are how another agent's work disappears.
+
+## Related
+
+- [two-agents-one-file-is-the-orchestrator-s-bug](two-agents-one-file-is-the-orchestrator-s-bug.md) — the loss that made tree-mutating git commands a standing worry
+- [serena-replace-content-eol-flip](serena-replace-content-eol-flip.md) — the other line-ending trap in this repo, from the other direction
+- `../wiki/orchestrating-agents-with-orca.md` — the brief template these rules belong in

--- a/docs-internal/gotchas/local-npm-run-build-is-not-assets-parity-evidence.md
+++ b/docs-internal/gotchas/local-npm-run-build-is-not-assets-parity-evidence.md
@@ -1,0 +1,56 @@
+# gotcha: a local `npm run build` cannot prove assets parity from an agent worktree
+
+**Namespace:** `[tooling/parallel-agents]`
+**Discovered:** s84 (2026-08-21)
+
+## What happened
+
+A worker changed two shared files under `src/components/`, rebuilt, and committed all five
+bundles. Its critic then ran the check independently and wrote:
+
+> Ran `npm run build` myself after `generate-class-map.php`:
+> `git status --short -- woodev/assets/build/` came back EMPTY — my fresh rebuild reproduced the
+> author's committed bundles byte-for-byte across all 5 entries. So the build IS reproducible.
+
+CI disagreed. The `Assets build parity` job failed on **all ten** files:
+
+```text
+##[error]The committed bundle in woodev/assets/build/ does not match the build output.
+woodev/assets/build/license-page/index.asset.php
+woodev/assets/build/license-page/index.js
+… (all five entries)
+```
+
+Two agents measured parity locally and both got zero diff. Both were wrong.
+
+## Root cause: worktrees share `node_modules`, so they share its cache and its drift
+
+`orca.yaml` shares `node_modules` by symlink so a fresh worktree can run the JS gate without a
+658 MB install. That symlink also shares:
+
+- `node_modules/.cache/` — babel-loader and webpack's persistent cache, warm from every previous
+  build in the primary checkout, which is what assigns module ids and content hashes;
+- whatever dependency versions the primary checkout happens to hold, which may have drifted from
+  `package-lock.json`.
+
+CI runs `npm ci && npm run build` — a **cold** build from the lock file. The two disagree, and the
+local one is the one that lies. That CI is the honest half is measurable: PRs #413 and #420 both
+passed the parity job against `main`'s committed bundles, so a cold build does reproduce `main`.
+
+## ✅ Correct
+
+- **The CI job is the only authority on assets parity.** A local `npm run build` producing no diff
+  is not evidence; say "CI will decide" rather than "parity holds".
+- Before committing bundles, make the local build cold: `npm ci` in the **primary checkout** (it
+  refreshes the shared tree to the lock and drops the cache), then rebuild. Never run `npm ci`
+  while another agent is using the shared `node_modules` — it deletes and reinstalls the tree
+  under them.
+- Always run the **full** `npm run build`. `control-field.js` and `location-picker-field.js` are
+  shared UI-kit modules imported by all five entry bundles, so a single-entry build
+  (`npm run build:settings`) silently desyncs the other four.
+
+## Related
+
+- [a-worktree-silently-skips-five-contract-tests](a-worktree-silently-skips-five-contract-tests.md) — the other gate that reads green in a worktree and is not
+- [sharing-vendor-breaks-composer-autoload-in-a-worktree](sharing-vendor-breaks-composer-autoload-in-a-worktree.md) — why `vendor` is copied while `node_modules` is shared
+- [jest-scans-agent-worktrees-inside-the-repo](jest-scans-agent-worktrees-inside-the-repo.md) — the other JS-tooling trap that worktrees create

--- a/docs-internal/gotchas/starting-codex-under-orca-needs-four-steps-not-one.md
+++ b/docs-internal/gotchas/starting-codex-under-orca-needs-four-steps-not-one.md
@@ -1,0 +1,77 @@
+# gotcha: starting a Codex worker under Orca takes four steps — `worker-start --agent codex` alone lands in a shell
+
+**Namespace:** `[tooling/parallel-agents]`
+**Discovered:** s84 (2026-08-21)
+
+## What happens
+
+`orca orchestration worker-start --agent codex` exits 0 with `stage: input_accepted` and an effect
+list that looks correct. Three times out of four in s84 the terminal it produced was **PowerShell**,
+not Codex, and the injected brief was executed by the shell as a here-string:
+
+```text
+>> ## RULE 2 — Gates you MUST run before reporting
+>>     npm run test:js -- --roots "<rootDir>/tests/js"
+ParserError:
+     | Missing closing ')' in expression.
+PS D:\Projects\woodev_framework\.orca\worktrees\woodev_framework\fix-411-truncated-list>
+```
+
+`orca terminal list --json` confirms it: the title is the `pwsh.exe` path, and the worktree has
+exactly one terminal. `worker-show` still reports `ready` and `dispatched`.
+
+The same launch works for Claude every time. It also worked for Codex on the very first
+new-top-level create of the session and then stopped working — including on a fresh
+`new-top-level`, so it is not specific to reusing an existing worktree.
+
+## ✅ The four-step launch that works every time
+
+```bash
+# 1. Real Codex terminal, launched with an explicit command
+H=$(orca terminal create --worktree "id:<repoId>::<path>" --title codex-x --command "codex" --json \
+      | jq -r .result.terminal.handle)
+
+# 2. Clear the update dialog. `tui-idle` reports satisfied:false with
+#    blockedReason "codex-update-prompt" until you do.
+orca terminal wait --terminal $H --for tui-idle --timeout-ms 120000 --json
+orca terminal send --terminal $H --text $'\033' --json     # ESC
+orca terminal wait --terminal $H --for tui-idle --timeout-ms 60000 --json   # now satisfied:true
+
+# 3. Deliver the task
+orca orchestration dispatch --task <task_id> --to $H --inject --json
+
+# 4. SUBMIT it — the brief arrives as "[Pasted Content N chars]" and sits there
+orca terminal send --terminal $H --text "" --enter --json
+orca terminal read --terminal $H --json     # look for "Working (Ns • esc to interrupt)"
+```
+
+Step 4 needed a second `--enter` more than once: if the paste has not finished rendering, the first
+Enter lands on an empty composer and does nothing. Always read the buffer back.
+
+## Recovering a botched launch
+
+`worker-stop` moves the task to `blocked`, and `dispatch` then refuses it:
+
+```text
+Task task_… is blocked; only ready tasks can be dispatched
+```
+
+So the recovery is:
+
+```bash
+orca orchestration worker-stop --dispatch <ctx_id> --json
+orca orchestration task-update --id <task_id> --status ready --json
+# … then the four steps above
+```
+
+## Also worth knowing
+
+`orca orchestration worker-release` returns `state: "retained"`, `reason: "user_takeover"` for any
+terminal the coordinator ever wrote to with `terminal send` — which, given step 4, is every Codex
+worker. Those must be closed with `orca terminal close --terminal <handle>`.
+
+## Related
+
+- [input-accepted-is-not-proof-a-worker-started](input-accepted-is-not-proof-a-worker-started.md) — the s83 half of this: the receipt lies about delivery
+- [codex-shell-sandbox-broken-windows](codex-shell-sandbox-broken-windows.md) — why Codex must run in an Orca terminal at all
+- `../wiki/orchestrating-agents-with-orca.md` — the launch recipe

--- a/docs-internal/gotchas/three-agents-is-the-concurrency-cap-on-this-machine.md
+++ b/docs-internal/gotchas/three-agents-is-the-concurrency-cap-on-this-machine.md
@@ -1,0 +1,47 @@
+# gotcha: three agents is the real concurrency cap here — past it, gates fail in ways that look like code bugs
+
+**Namespace:** `[tooling/parallel-agents]`
+**Discovered:** s84 (2026-08-21)
+
+## What happens
+
+This machine has **15.3 GB** of RAM, with Docker Desktop (the rig) and WSL (about 2 GB) always up.
+With six agents live, free memory reached **0.4 GB** and a starting Codex printed:
+
+```text
+[low_level_alloc.cc : 590] RAW: Check new_pages != nullptr failed: VirtualAlloc failed
+```
+
+Even after cutting back to **three** agents, free memory sat at 1.0 GB while their gates ran, and
+three separate agents hit three different failures that all look like defects until you know why:
+
+| Symptom | Agent | What it actually was |
+|---|---|---|
+| `Fatal process out of memory: Zone`, jest never printed an aggregate | critic-383 | OOM |
+| `composer phpcs` failed with five PHPCS **internal exceptions**, three of them failed `shell_exec()` syntax checks on unrelated files | critic-395 | `fork()` failing under pressure |
+| `composer phpcs` OOM-crashed outright | critic-412-415 | OOM; it got through with `php -d memory_limit=1G ./vendor/bin/phpcs` |
+
+Note the shape of the middle one: PHPCS blamed **five unrelated pre-existing files**. An agent
+reading that at face value files a bug against innocent code.
+
+A Codex terminal is far heavier than a Claude one — each starts about **eleven MCP servers** of its
+own.
+
+## ✅ Correct
+
+- **Cap the wave at three agents** while Docker and WSL are up. Release and close settled workers
+  BEFORE starting the next wave, not at the end of the session.
+- **Put the warning in every brief.** The wording that worked: *"several agents share this machine
+  and it has been low on memory tonight … if that happens, say so plainly and retry once; never
+  report a gate as green if you did not see its aggregate result, and never substitute npx jest."*
+  Every s84 agent that hit an OOM after being told this reported it honestly instead of claiming a
+  green gate.
+- `orca orchestration worker-release` returns `retained` / `user_takeover` for any terminal the
+  coordinator wrote to. Close those with `orca terminal close --terminal <handle>` or the process
+  stays resident.
+
+## Related
+
+- [starting-codex-under-orca-needs-four-steps-not-one](starting-codex-under-orca-needs-four-steps-not-one.md) — why the coordinator ends up writing to every Codex terminal, which is what blocks release
+- [powershell-drops-the-roots-flag-from-the-jest-command](powershell-drops-the-roots-flag-from-the-jest-command.md) — the other way a jest run reports success it did not earn
+- `../wiki/orchestrating-agents-with-orca.md` — wave planning

--- a/docs-internal/wiki/orchestrating-agents-with-orca.md
+++ b/docs-internal/wiki/orchestrating-agents-with-orca.md
@@ -174,6 +174,51 @@ same runtime carries running workers is the wrong trade. **Rig verification stay
 chrome-devtools MCP against `:8973`.** Anyone who wants to revisit this should do it with no
 workers in flight.
 
+## What s84 added — three agents, four launch steps, two lying gates
+
+The s83 recipe above is still right. s84 ran twelve dispatches through it and found four things it
+did not say.
+
+**Cap the wave at three agents.** With six live, free RAM hit 0.4 GB of 15.3 GB and a starting
+Codex died on `VirtualAlloc`. Even at three, `composer phpcs` OOM'd for one agent and blamed five
+innocent files for another (failed `shell_exec()` syntax checks read as PHPCS internal exceptions),
+and jest died with `Fatal process out of memory`. A Codex terminal starts about eleven MCP servers
+of its own, so it is much heavier than a Claude one. Release AND close settled workers before the
+next wave, not at the end — and note that `worker-release` refuses with
+`retained / user_takeover` for any terminal the coordinator wrote to, which is every Codex worker.
+Gotcha: `three-agents-is-the-concurrency-cap-on-this-machine`.
+
+**Launching Codex takes four steps.** `worker-start --agent codex` produced a bare PowerShell
+terminal three times out of four, and the injected brief was executed by the shell as a here-string
+until it hit a ParserError. The reliable path is `terminal create --command codex` → ESC the
+`codex-update-prompt` that `tui-idle` reports → `dispatch --inject` → `terminal send --text "" --enter`
+because the brief arrives as `[Pasted Content N chars]` and sits unsubmitted. After a `worker-stop`
+the task goes to `blocked`; `task-update --status ready` before redispatching. Gotcha:
+`starting-codex-under-orca-needs-four-steps-not-one`.
+
+**Two gates read green in a worktree and are not.** Five `Contract/Yandex*` tests SKIP there
+because `plugins-reference/` is gitignored (fixed in s84 by adding it to `.worktreeinclude`), and
+`npm run build` reproduces the committed bundles because the worktree shares the primary
+checkout's warm webpack cache — while CI's cold `npm ci && npm run build` does not. PR #422 went
+red on assets parity after two agents had independently measured zero diff. Gotchas:
+`a-worktree-silently-skips-five-contract-tests`, `local-npm-run-build-is-not-assets-parity-evidence`.
+
+**Every brief needs four standing lines.** They earned their place: every agent told about the
+memory pressure reported its OOM honestly instead of claiming a green gate, and every agent told
+about the CRLF churn left the seven dirty files unstaged.
+
+1. Serena `activate_project` on YOUR worktree — get it from `git rev-parse --show-toplevel`, then
+   verify a `find_symbol` result reports a path under it.
+2. No install step. `vendor` and `node_modules` are already there.
+3. Never `git add -A` — this worktree starts dirty with seven CRLF-only files.
+4. The machine is shared and low on memory; if a gate OOMs, say so and retry once — never report a
+   gate green whose aggregate result you never saw, and never substitute `npx jest`.
+
+A fifth line is worth its weight on anything non-trivial: **you are licensed to contradict this
+brief; if the code disagrees, the code wins.** In s84 it produced a correction in almost every
+report — a third AJAX handler with the same hole, a preflight check that existed but was never
+consumed, and a "the brief's baseline is stale" that turned out to be the skipped-test gap above.
+
 ## Traps
 
 - **`terminal wait --for tui-idle` lies.** It counts an open dialog as idle. Check the


### PR DESCRIPTION
## Зачем

Свежий Orca-ворктри прогонял **на пять юнит-тестов меньше**, чем главное дерево, и оба прогона были зелёными.

```
главное дерево   2475 тестов, 6128 ассертов, 66 skipped
агентский ворктри 2475 тестов, 6114 ассертов, 71 skipped
```

Четыре класса `tests/unit/Contract/Yandex*ContractTest.php` делают `markTestSkipped()`, когда нет `plugins-reference/woocommerce-yandex-delivery`. Каталог в `.gitignore` (строка 25), поэтому `git worktree` его не создаёт, а в `.worktreeinclude` его не было. Итог: пять **релиз-блокирующих** контрактных гардов молча не выполнялись ни у одного воркера всю ночь.

Нашли независимо двое: я при разборе расхождения в отчётах воркеров и критик #411, который докопался до той же причины сам.

## Что сделано

`plugins-reference` добавлен в `.worktreeinclude`. **Копией, не шарой:** 17 МБ read-only донорских плагинов, и копия не даёт воркеру писать сквозь симлинк в главное дерево.

## Заодно записаны четыре ловушки s84

Из двенадцати диспатчей за ночь:

- `three-agents-is-the-concurrency-cap-on-this-machine` — при шести агентах свободной памяти осталось 0.4 ГБ из 15.3, Codex упал на `VirtualAlloc`. Даже при трёх `composer phpcs` то падал по OOM, то обвинял пять невиновных файлов (это `shell_exec()` не форкался), а jest умирал с `Fatal process out of memory`. Все три симптома читаются как дефекты кода.
- `starting-codex-under-orca-needs-four-steps-not-one` — `worker-start --agent codex` три раза из четырёх дал голый PowerShell, который исполнил бриф как here-string.
- `an-orca-worktree-starts-dirty-with-crlf-churn` — семь файлов грязные с порога, чистый CRLF→LF.
- `local-npm-run-build-is-not-assets-parity-evidence` — ровно то, на чём покраснел #422.

Плюс раздел в `wiki/orchestrating-agents-with-orca.md` с шаблоном брифа: четыре обязательные строки, каждая из которых за ночь окупилась.

Гейты: `npm run lint:docs` — 178 файлов / 178 записей индекса, structure OK; markdownlint по новым файлам — 0 issues.