### PR TITLE
fix(payment-gateway): закрыть IDOR в AJAX редактора платёжных токенов

### DIFF
--- a/tests/unit/PaymentTokenEditorAjaxAuthorizationTest.php
+++ b/tests/unit/PaymentTokenEditorAjaxAuthorizationTest.php
@@ -14,6 +14,14 @@
  * capability plus the profile/user-edit admin screens, so the nonces are never
  * localized for an unauthorized visitor.
  *
+ * Follow-up: `manage_woocommerce` alone does not authorize acting on an
+ * arbitrary target user — WordPress checks object-level capabilities like
+ * `edit_user` per target, so a shop manager holding `manage_woocommerce` is
+ * not necessarily allowed to edit an administrator. ajax_remove_token() and
+ * ajax_refresh_tokens() now also normalize the requested `user_id` to a
+ * positive integer referencing an existing user and require
+ * `current_user_can( 'edit_user', $user_id )` before touching anything.
+ *
  * @package Woodev\Tests\Unit
  */
 
@@ -68,16 +76,16 @@ namespace {
 	class Token_Editor_IDOR_Test_Editor extends \Woodev_Payment_Gateway_Admin_Payment_Token_Editor {
 
 		/** @var array<int,array{0:mixed,1:mixed}> */
-		public $removed_tokens = array();
+		public $removed_tokens = [];
 
 		/** @var bool */
 		public $remove_token_return = true;
 
 		/** @var array<int,mixed> */
-		public $refreshed_user_ids = array();
+		public $refreshed_user_ids = [];
 
 		protected function remove_token( $user_id, $token_id ) {
-			$this->removed_tokens[] = array( $user_id, $token_id );
+			$this->removed_tokens[] = [ $user_id, $token_id ];
 
 			return $this->remove_token_return;
 		}
@@ -107,12 +115,16 @@ namespace Woodev\Tests\Unit {
 			Functions\when( 'sanitize_text_field' )->returnArg();
 			Functions\when( 'wp_unslash' )->returnArg();
 
+			// Default: the requested target user exists. Tests covering an
+			// absent/nonexistent user_id override this per-test.
+			Functions\when( 'get_userdata' )->justReturn( true );
+
 			$GLOBALS['current_screen'] = null;
 		}
 
 		protected function tearDown(): void {
 			unset( $GLOBALS['current_screen'] );
-			unset( $_REQUEST['user_id'], $_REQUEST['token_id'] );
+			unset( $_REQUEST['user_id'], $_REQUEST['token_id'], $_REQUEST['index'] );
 
 			parent::tearDown();
 		}
@@ -147,6 +159,33 @@ namespace Woodev\Tests\Unit {
 			return $screen;
 		}
 
+		/**
+		 * Stubs current_user_can() so `manage_woocommerce` is always granted
+		 * (the feature capability the shop manager legitimately holds) while
+		 * `edit_user` is granted only for the given allowed target user ID(s)
+		 * — modelling a shop manager who is NOT permitted to edit every user
+		 * on the site (e.g. an administrator, or another site's user).
+		 *
+		 * @param int[] $editable_user_ids user IDs `edit_user` should allow
+		 */
+		private function stub_capabilities_for_shop_manager( array $editable_user_ids ): void {
+
+			Functions\when( 'current_user_can' )->alias(
+				static function ( $capability, ...$args ) use ( $editable_user_ids ) {
+
+					if ( 'manage_woocommerce' === $capability ) {
+						return true;
+					}
+
+					if ( 'edit_user' === $capability ) {
+						return in_array( $args[0], $editable_user_ids, true );
+					}
+
+					return false;
+				}
+			);
+		}
+
 		// -------------------------------------------------------------------
 		// ajax_remove_token() — GH-383: deletes another user's saved card
 		// -------------------------------------------------------------------
@@ -164,7 +203,7 @@ namespace Woodev\Tests\Unit {
 
 			$editor->ajax_remove_token();
 
-			$this->assertSame( array(), $editor->removed_tokens, 'remove_token() must never run for an unauthorized caller — this is the #383 IDOR' );
+			$this->assertSame( [], $editor->removed_tokens, 'remove_token() must never run for an unauthorized caller — this is the #383 IDOR' );
 		}
 
 		public function test_ajax_remove_token_succeeds_for_an_authorized_caller(): void {
@@ -180,7 +219,7 @@ namespace Woodev\Tests\Unit {
 
 			$editor->ajax_remove_token();
 
-			$this->assertSame( array( array( '7', 'tok_1' ) ), $editor->removed_tokens, 'A capable, correctly-nonced caller must still be able to remove a token' );
+			$this->assertSame( [ [ 7, 'tok_1' ] ], $editor->removed_tokens, 'A capable, correctly-nonced caller must still be able to remove a token' );
 		}
 
 		public function test_ajax_remove_token_rejects_an_invalid_nonce_even_for_a_capable_user(): void {
@@ -195,7 +234,90 @@ namespace Woodev\Tests\Unit {
 
 			$editor->ajax_remove_token();
 
-			$this->assertSame( array(), $editor->removed_tokens, 'The nonce stays a required CSRF check on top of the capability check' );
+			$this->assertSame( [], $editor->removed_tokens, 'The nonce stays a required CSRF check on top of the capability check' );
+		}
+
+		public function test_ajax_remove_token_rejects_a_shop_manager_targeting_a_user_they_may_not_edit(): void {
+			$editor = $this->make_editor();
+
+			// A shop manager holds manage_woocommerce, but user 1 (e.g. an
+			// administrator) is outside the set of users they may edit.
+			$_REQUEST['user_id']  = '1';
+			$_REQUEST['token_id'] = 'tok_1';
+
+			$this->stub_capabilities_for_shop_manager( [] );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/permission/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( [], $editor->removed_tokens, 'manage_woocommerce alone must not authorize removing an arbitrary target user\'s token — GH-383 follow-up' );
+		}
+
+		public function test_ajax_remove_token_rejects_a_non_numeric_user_id(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id']  = 'not-a-number';
+			$_REQUEST['token_id'] = 'tok_1';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/user id/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( [], $editor->removed_tokens, 'A non-numeric user_id must be rejected before it reaches remove_token()' );
+		}
+
+		public function test_ajax_remove_token_rejects_a_negative_user_id(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id']  = '-5';
+			$_REQUEST['token_id'] = 'tok_1';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/user id/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( [], $editor->removed_tokens, 'A negative user_id must be rejected before it reaches remove_token()' );
+		}
+
+		public function test_ajax_remove_token_rejects_an_array_user_id(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id']  = [ '1', '2' ];
+			$_REQUEST['token_id'] = 'tok_1';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/user id/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( [], $editor->removed_tokens, 'An array user_id must be rejected — it must never reach a user-ID array key downstream' );
+		}
+
+		public function test_ajax_remove_token_rejects_a_nonexistent_user_id(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id']  = '999999';
+			$_REQUEST['token_id'] = 'tok_1';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\when( 'get_userdata' )->justReturn( false );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/user id/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( [], $editor->removed_tokens, 'A user_id that does not resolve to an existing user must be rejected' );
 		}
 
 		// -------------------------------------------------------------------
@@ -213,7 +335,7 @@ namespace Woodev\Tests\Unit {
 
 			$editor->ajax_refresh_tokens();
 
-			$this->assertSame( array(), $editor->refreshed_user_ids, 'display_tokens() must never run for an unauthorized caller — this is the #383 IDOR' );
+			$this->assertSame( [], $editor->refreshed_user_ids, 'display_tokens() must never run for an unauthorized caller — this is the #383 IDOR' );
 		}
 
 		public function test_ajax_refresh_tokens_succeeds_for_an_authorized_caller(): void {
@@ -227,7 +349,77 @@ namespace Woodev\Tests\Unit {
 
 			$editor->ajax_refresh_tokens();
 
-			$this->assertSame( array( '99' ), $editor->refreshed_user_ids, 'A capable, correctly-nonced caller must still be able to refresh the tokens list' );
+			$this->assertSame( [ 99 ], $editor->refreshed_user_ids, 'A capable, correctly-nonced caller must still be able to refresh the tokens list' );
+		}
+
+		public function test_ajax_refresh_tokens_rejects_a_shop_manager_targeting_a_user_they_may_not_edit(): void {
+			$editor = $this->make_editor();
+
+			// A shop manager holds manage_woocommerce, but user 1 (e.g. an
+			// administrator) is outside the set of users they may edit.
+			$_REQUEST['user_id'] = '1';
+
+			$this->stub_capabilities_for_shop_manager( [] );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/permission/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_refresh_tokens();
+
+			$this->assertSame( [], $editor->refreshed_user_ids, 'manage_woocommerce alone must not authorize listing an arbitrary target user\'s tokens — GH-383 follow-up' );
+		}
+
+		public function test_ajax_refresh_tokens_allows_a_shop_manager_targeting_a_user_they_may_edit(): void {
+			$editor = $this->make_editor();
+
+			// The shop manager IS allowed to edit this customer (e.g. a
+			// subscriber they created / manage), so the refresh must succeed.
+			$_REQUEST['user_id'] = '42';
+
+			$this->stub_capabilities_for_shop_manager( [ 42 ] );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_success' )->once()->with( 'tokens-markup-for-42' );
+			Functions\expect( 'wp_send_json_error' )->never();
+
+			$editor->ajax_refresh_tokens();
+
+			$this->assertSame( [ 42 ], $editor->refreshed_user_ids, 'A shop manager must still be able to refresh tokens for a customer they are allowed to edit' );
+		}
+
+		public function test_ajax_refresh_tokens_rejects_a_nonexistent_user_id(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id'] = '999999';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\when( 'get_userdata' )->justReturn( false );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/user id/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_refresh_tokens();
+
+			$this->assertSame( [], $editor->refreshed_user_ids, 'A user_id that does not resolve to an existing user must be rejected' );
+		}
+
+		// -------------------------------------------------------------------
+		// ajax_get_blank_token() — no target user_id, but must still gate on
+		// the feature capability, and do so before the CSRF check
+		// -------------------------------------------------------------------
+
+		public function test_ajax_get_blank_token_rejects_an_uncapable_caller_with_a_valid_nonce(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['index'] = '1';
+
+			Functions\when( 'current_user_can' )->justReturn( false );
+			// Authorization must precede the CSRF check consistently across
+			// all three handlers, so check_ajax_referer() must never run here.
+			Functions\expect( 'check_ajax_referer' )->never();
+			Functions\expect( 'wp_send_json_error' )->once()->withNoArgs();
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_get_blank_token();
 		}
 
 		// -------------------------------------------------------------------

--- a/tests/unit/PaymentTokenEditorAjaxAuthorizationTest.php
+++ b/tests/unit/PaymentTokenEditorAjaxAuthorizationTest.php
@@ -320,6 +320,45 @@ namespace Woodev\Tests\Unit {
 			$this->assertSame( [], $editor->removed_tokens, 'A user_id that does not resolve to an existing user must be rejected' );
 		}
 
+		/**
+		 * Pins the enumeration fix: a shop manager who is not allowed to edit
+		 * the target must see the SAME error for a real-but-forbidden user ID
+		 * as for one that does not exist at all, so the response can never be
+		 * used to fingerprint which arbitrary IDs are real users.
+		 */
+		public function test_ajax_remove_token_gives_the_same_error_for_an_existing_forbidden_user_id_as_for_a_nonexistent_one(): void {
+			$this->stub_capabilities_for_shop_manager( [] );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+
+			$errors = [];
+			Functions\when( 'wp_send_json_error' )->alias(
+				static function ( $message = null ) use ( &$errors ) {
+					$errors[] = $message;
+				}
+			);
+
+			$_REQUEST['token_id'] = 'tok_1';
+
+			// An existing user (e.g. an administrator) the shop manager may not edit.
+			$_REQUEST['user_id'] = '1';
+			Functions\when( 'get_userdata' )->justReturn( true );
+			$editor_forbidden = $this->make_editor();
+			$editor_forbidden->ajax_remove_token();
+
+			// A user_id that does not resolve to any user at all.
+			$_REQUEST['user_id'] = '999999';
+			Functions\when( 'get_userdata' )->justReturn( false );
+			$editor_nonexistent = $this->make_editor();
+			$editor_nonexistent->ajax_remove_token();
+
+			$this->assertCount( 2, $errors, 'Both requests must be rejected' );
+			$this->assertSame( $errors[0], $errors[1], 'A capable caller must not be able to tell an existing-but-forbidden user apart from a nonexistent one' );
+			$this->assertMatchesRegularExpression( '/permission/i', (string) $errors[0], 'The capability check — not the existence lookup — must be what rejects both requests' );
+
+			$this->assertSame( [], $editor_forbidden->removed_tokens );
+			$this->assertSame( [], $editor_nonexistent->removed_tokens );
+		}
+
 		// -------------------------------------------------------------------
 		// ajax_refresh_tokens() — GH-383: lists another user's saved cards
 		// -------------------------------------------------------------------

--- a/tests/unit/PaymentTokenEditorAjaxAuthorizationTest.php
+++ b/tests/unit/PaymentTokenEditorAjaxAuthorizationTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Regression tests for GH-383: the payment-token editor AJAX endpoints
+ * (Woodev_Payment_Gateway_Admin_Payment_Token_Editor::ajax_remove_token(),
+ * ::ajax_refresh_tokens()) had no capability check at all — any logged-in user
+ * could read and delete another user's saved payment tokens by supplying an
+ * arbitrary `user_id`, using a nonce that enqueue_scripts_styles() localized
+ * for every logged-in user on every admin screen.
+ *
+ * The fix adds a `current_user_can( 'manage_woocommerce' )` gate on every AJAX
+ * handler (matching the capability already enforced by the outer
+ * Woodev_Payment_Gateway_Admin_User_Handler::add_profile_section() /
+ * save_profile_fields()), and gates enqueue_scripts_styles() on that same
+ * capability plus the profile/user-edit admin screens, so the nonces are never
+ * localized for an unauthorized visitor.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace {
+
+	require_once dirname( __DIR__, 2 ) . '/woodev/class-plugin-exception.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/exceptions/class-payment-gateway-exception.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/class-plugin.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/class-helper.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php';
+
+	if ( ! class_exists( 'WP_Screen', false ) ) {
+		/**
+		 * Minimal WP_Screen stub — Woodev_Helper::get_current_screen() declares a
+		 * `?WP_Screen` return type, so the global must be an instance of it.
+		 */
+		class Token_Editor_IDOR_Test_WP_Screen_Stub {
+			/** @var string */
+			public $id;
+		}
+
+		class_alias( Token_Editor_IDOR_Test_WP_Screen_Stub::class, 'WP_Screen' );
+	}
+
+	/**
+	 * Stub plugin backing the stub gateway — only the accessors
+	 * enqueue_scripts_styles() actually calls.
+	 */
+	class Token_Editor_IDOR_Test_Plugin_Stub {
+
+		public function get_payment_gateway_framework_assets_url() {
+			return 'https://example.test/assets/payment-gateway';
+		}
+	}
+
+	/**
+	 * Stub gateway — avoids constructing a real Woodev_Payment_Gateway (a heavy
+	 * WC_Payment_Gateway subclass) just to exercise the editor's AJAX handlers.
+	 */
+	class Token_Editor_IDOR_Test_Gateway_Stub {
+
+		public function get_plugin() {
+			return new Token_Editor_IDOR_Test_Plugin_Stub();
+		}
+	}
+
+	/**
+	 * Testable token editor: overrides the two protected/public methods that
+	 * would otherwise reach into a real payment-tokens handler, and records
+	 * whether — and with what arguments — they were invoked.
+	 */
+	class Token_Editor_IDOR_Test_Editor extends \Woodev_Payment_Gateway_Admin_Payment_Token_Editor {
+
+		/** @var array<int,array{0:mixed,1:mixed}> */
+		public $removed_tokens = array();
+
+		/** @var bool */
+		public $remove_token_return = true;
+
+		/** @var array<int,mixed> */
+		public $refreshed_user_ids = array();
+
+		protected function remove_token( $user_id, $token_id ) {
+			$this->removed_tokens[] = array( $user_id, $token_id );
+
+			return $this->remove_token_return;
+		}
+
+		public function display_tokens( $user_id ) {
+			$this->refreshed_user_ids[] = $user_id;
+
+			echo 'tokens-markup-for-' . $user_id;
+		}
+	}
+
+}
+
+namespace Woodev\Tests\Unit {
+
+	use Brain\Monkey\Functions;
+	use Mockery;
+
+	/**
+	 * @covers \Woodev_Payment_Gateway_Admin_Payment_Token_Editor
+	 */
+	class PaymentTokenEditorAjaxAuthorizationTest extends TestCase {
+
+		protected function setUp(): void {
+			parent::setUp();
+
+			Functions\when( 'sanitize_text_field' )->returnArg();
+			Functions\when( 'wp_unslash' )->returnArg();
+
+			$GLOBALS['current_screen'] = null;
+		}
+
+		protected function tearDown(): void {
+			unset( $GLOBALS['current_screen'] );
+			unset( $_REQUEST['user_id'], $_REQUEST['token_id'] );
+
+			parent::tearDown();
+		}
+
+		/**
+		 * Builds a Token_Editor_IDOR_Test_Editor without running the real
+		 * constructor (which registers WP hooks against a real gateway), and
+		 * injects the stub gateway directly via the inherited `$gateway` property.
+		 */
+		private function make_editor(): \Token_Editor_IDOR_Test_Editor {
+
+			$reflection = new \ReflectionClass( \Token_Editor_IDOR_Test_Editor::class );
+			$editor     = $reflection->newInstanceWithoutConstructor();
+
+			$gateway_property = new \ReflectionProperty( \Woodev_Payment_Gateway_Admin_Payment_Token_Editor::class, 'gateway' );
+			if ( PHP_VERSION_ID < 80100 ) {
+				$gateway_property->setAccessible( true );
+			}
+			$gateway_property->setValue( $editor, new \Token_Editor_IDOR_Test_Gateway_Stub() );
+
+			return $editor;
+		}
+
+		/**
+		 * Builds a WP_Screen stub with the given screen id, for the global
+		 * $current_screen that Woodev_Helper::is_current_screen() reads.
+		 */
+		private function make_screen( string $id ): \WP_Screen {
+			$screen     = new \WP_Screen();
+			$screen->id = $id;
+
+			return $screen;
+		}
+
+		// -------------------------------------------------------------------
+		// ajax_remove_token() — GH-383: deletes another user's saved card
+		// -------------------------------------------------------------------
+
+		public function test_ajax_remove_token_rejects_a_caller_without_manage_woocommerce(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id']  = '7';
+			$_REQUEST['token_id'] = 'tok_1';
+
+			Functions\when( 'current_user_can' )->justReturn( false );
+			Functions\expect( 'check_ajax_referer' )->never();
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/permission/i' ) );
+			Functions\expect( 'wp_send_json_success' )->never();
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( array(), $editor->removed_tokens, 'remove_token() must never run for an unauthorized caller — this is the #383 IDOR' );
+		}
+
+		public function test_ajax_remove_token_succeeds_for_an_authorized_caller(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id']  = '7';
+			$_REQUEST['token_id'] = 'tok_1';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_success' )->once()->withNoArgs();
+			Functions\expect( 'wp_send_json_error' )->never();
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( array( array( '7', 'tok_1' ) ), $editor->removed_tokens, 'A capable, correctly-nonced caller must still be able to remove a token' );
+		}
+
+		public function test_ajax_remove_token_rejects_an_invalid_nonce_even_for_a_capable_user(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id']  = '7';
+			$_REQUEST['token_id'] = 'tok_1';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( false );
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/nonce/i' ) );
+
+			$editor->ajax_remove_token();
+
+			$this->assertSame( array(), $editor->removed_tokens, 'The nonce stays a required CSRF check on top of the capability check' );
+		}
+
+		// -------------------------------------------------------------------
+		// ajax_refresh_tokens() — GH-383: lists another user's saved cards
+		// -------------------------------------------------------------------
+
+		public function test_ajax_refresh_tokens_rejects_a_caller_without_manage_woocommerce(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id'] = '99';
+
+			Functions\when( 'current_user_can' )->justReturn( false );
+			Functions\expect( 'check_ajax_referer' )->never();
+			Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::pattern( '/permission/i' ) );
+
+			$editor->ajax_refresh_tokens();
+
+			$this->assertSame( array(), $editor->refreshed_user_ids, 'display_tokens() must never run for an unauthorized caller — this is the #383 IDOR' );
+		}
+
+		public function test_ajax_refresh_tokens_succeeds_for_an_authorized_caller(): void {
+			$editor = $this->make_editor();
+
+			$_REQUEST['user_id'] = '99';
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'check_ajax_referer' )->justReturn( true );
+			Functions\expect( 'wp_send_json_success' )->once()->with( 'tokens-markup-for-99' );
+
+			$editor->ajax_refresh_tokens();
+
+			$this->assertSame( array( '99' ), $editor->refreshed_user_ids, 'A capable, correctly-nonced caller must still be able to refresh the tokens list' );
+		}
+
+		// -------------------------------------------------------------------
+		// enqueue_scripts_styles() — GH-383: both AJAX nonces were localized
+		// for every logged-in user on every admin screen
+		// -------------------------------------------------------------------
+
+		public function test_enqueue_does_not_localize_nonces_for_a_user_without_the_capability(): void {
+			$editor = $this->make_editor();
+
+			$GLOBALS['current_screen'] = $this->make_screen( 'profile' );
+
+			Functions\when( 'current_user_can' )->justReturn( false );
+			Functions\expect( 'wp_create_nonce' )->never();
+			Functions\expect( 'wp_localize_script' )->never();
+			Functions\expect( 'wp_enqueue_script' )->never();
+			Functions\expect( 'wp_enqueue_style' )->never();
+
+			$editor->enqueue_scripts_styles();
+		}
+
+		public function test_enqueue_does_not_localize_nonces_on_an_unrelated_admin_screen(): void {
+			$editor = $this->make_editor();
+
+			// Capable user, but on e.g. the Posts list screen — not a user-profile screen.
+			$GLOBALS['current_screen'] = $this->make_screen( 'edit-post' );
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\expect( 'wp_create_nonce' )->never();
+			Functions\expect( 'wp_localize_script' )->never();
+
+			$editor->enqueue_scripts_styles();
+		}
+
+		public function test_enqueue_still_localizes_nonces_for_a_capable_user_on_the_profile_screen(): void {
+			$editor = $this->make_editor();
+
+			$GLOBALS['current_screen'] = $this->make_screen( 'profile' );
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'admin_url' )->justReturn( 'https://example.test/wp-admin/admin-ajax.php' );
+			Functions\when( 'wp_create_nonce' )->justReturn( 'a-nonce' );
+			Functions\expect( 'wp_enqueue_style' )->once();
+			Functions\expect( 'wp_enqueue_script' )->once();
+			Functions\expect( 'wp_localize_script' )->once();
+
+			$editor->enqueue_scripts_styles();
+		}
+
+		public function test_enqueue_still_localizes_nonces_for_a_capable_user_editing_another_users_profile(): void {
+			$editor = $this->make_editor();
+
+			// user-edit.php — the screen used when an admin/shop_manager edits someone else's profile.
+			$GLOBALS['current_screen'] = $this->make_screen( 'user-edit' );
+
+			Functions\when( 'current_user_can' )->justReturn( true );
+			Functions\when( 'admin_url' )->justReturn( 'https://example.test/wp-admin/admin-ajax.php' );
+			Functions\when( 'wp_create_nonce' )->justReturn( 'a-nonce' );
+			Functions\when( 'wp_enqueue_style' )->justReturn( null );
+			Functions\when( 'wp_enqueue_script' )->justReturn( null );
+			Functions\expect( 'wp_localize_script' )->once();
+
+			$editor->enqueue_scripts_styles();
+		}
+	}
+
+}

--- a/woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php
+++ b/woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php
@@ -201,7 +201,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 		 * Add a token via AJAX.
 		 *
 		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
-		 * @since 2.0.3 capability check now runs before the nonce check, consistent with the other handlers
+		 * @since 2.0.2 capability check now runs before the nonce check, consistent with the other handlers
 		 */
 		public function ajax_get_blank_token() {
 
@@ -246,7 +246,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 		 * Remove a token via AJAX.
 		 *
 		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
-		 * @since 2.0.3 also requires `edit_user` on the target user, since `manage_woocommerce`
+		 * @since 2.0.2 also requires `edit_user` on the target user, since `manage_woocommerce`
 		 *              alone does not authorize acting on an arbitrary user object
 		 */
 		public function ajax_remove_token() {
@@ -284,7 +284,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 		 * Refresh the tokens list via AJAX.
 		 *
 		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
-		 * @since 2.0.3 also requires `edit_user` on the target user, since `manage_woocommerce`
+		 * @since 2.0.2 also requires `edit_user` on the target user, since `manage_woocommerce`
 		 *              alone does not authorize acting on an arbitrary user object
 		 */
 		public function ajax_refresh_tokens() {
@@ -319,23 +319,34 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 		/**
 		 * Resolve and authorize the user ID targeted by an AJAX request.
 		 *
-		 * Normalizes the requested value to a positive integer referencing an
-		 * existing user, then requires `edit_user` on that specific user object.
-		 * `manage_woocommerce` alone does not authorize acting on an arbitrary
-		 * target: WordPress checks object-level capabilities like `edit_user`
-		 * per target, so a shop manager holding `manage_woocommerce` is not
-		 * necessarily allowed to edit an administrator (or, on multisite, a
-		 * user outside the current site).
+		 * Normalizes the requested value to a positive integer, then requires
+		 * `edit_user` on it, and only then confirms the ID resolves to an
+		 * existing user. `manage_woocommerce` alone does not authorize acting
+		 * on an arbitrary target: WordPress checks object-level capabilities
+		 * like `edit_user` per target, so a shop manager holding
+		 * `manage_woocommerce` is not necessarily allowed to edit an
+		 * administrator (or, on multisite, a user outside the current site).
 		 *
-		 * @since 2.0.3
+		 * The capability check runs before the existence lookup deliberately:
+		 * `current_user_can( 'edit_user', $id )` resolves to WordPress core's
+		 * generic `edit_users` capability for any non-self, non-multisite-superadmin
+		 * target — it does not query whether `$id` is a real user — so a caller
+		 * without `edit_user` on the target is denied identically whether that
+		 * target exists or not. Running `get_userdata()` first would instead let
+		 * such a caller distinguish an existing-but-forbidden user ID from a
+		 * nonexistent one by which error comes back.
+		 *
+		 * @since 2.0.2
+		 * @since 2.0.2 capability check now runs before the existence lookup, so
+		 *              a caller cannot use the error to enumerate real user IDs
 		 *
 		 * @param string $key the request key holding the target user ID
 		 *
 		 * @return int the authorized target user ID
 		 *
-		 * @throws Woodev_Payment_Gateway_Exception if the user ID is missing, invalid, or not editable by the current user
+		 * @throws Woodev_Payment_Gateway_Exception if the user ID is missing, invalid, not editable by the current user, or does not resolve to an existing user
 		 */
-		protected function get_authorized_target_user_id( $key = 'user_id' ) {
+		protected function get_authorized_target_user_id( string $key = 'user_id' ): int {
 
 			$raw_user_id = Woodev_Helper::get_requested_value( $key );
 
@@ -345,12 +356,16 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 			$user_id = filter_var( $raw_user_id, FILTER_VALIDATE_INT );
 
-			if ( false === $user_id || $user_id <= 0 || ! get_userdata( $user_id ) ) {
+			if ( false === $user_id || $user_id <= 0 ) {
 				throw new Woodev_Payment_Gateway_Exception( 'User ID is missing' );
 			}
 
 			if ( ! current_user_can( 'edit_user', $user_id ) ) {
 				throw new Woodev_Payment_Gateway_Exception( 'You do not have permission to do this' );
+			}
+
+			if ( ! get_userdata( $user_id ) ) {
+				throw new Woodev_Payment_Gateway_Exception( 'User ID is missing' );
 			}
 
 			return $user_id;

--- a/woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php
+++ b/woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php
@@ -68,8 +68,22 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 		/**
 		 * Load the editor scripts and styles.
+		 *
+		 * Only enqueued for a capable user (`manage_woocommerce`) viewing a user
+		 * profile screen, so the editor's AJAX nonces are never localized for an
+		 * unauthorized visitor or on unrelated admin screens.
+		 *
+		 * @since 2.0.2
 		 */
 		public function enqueue_scripts_styles() {
+
+			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+				return;
+			}
+
+			if ( ! Woodev_Helper::is_current_screen( 'profile' ) && ! Woodev_Helper::is_current_screen( 'user-edit' ) ) {
+				return;
+			}
 
 			// Stylesheet
 			wp_enqueue_style( 'woodev-payment-gateway-token-editor', $this->get_gateway()->get_plugin()->get_payment_gateway_framework_assets_url() . '/css/admin/woodev-payment-gateway-token-editor.css', array(), Woodev_Plugin::VERSION );
@@ -185,10 +199,17 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 		/**
 		 * Add a token via AJAX.
+		 *
+		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
 		 */
 		public function ajax_get_blank_token() {
 
 			check_ajax_referer( 'wc_payment_gateway_admin_get_blank_payment_token', 'security' );
+
+			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+				wp_send_json_error();
+				return;
+			}
 
 			$index = Woodev_Helper::get_requested_value( 'index' );
 
@@ -222,10 +243,16 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 		/**
 		 * Remove a token via AJAX.
+		 *
+		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
 		 */
 		public function ajax_remove_token() {
 
 			try {
+
+				if ( ! current_user_can( 'manage_woocommerce' ) ) {
+					throw new Woodev_Payment_Gateway_Exception( 'You do not have permission to do this' );
+				}
 
 				if ( ! check_ajax_referer( 'wc_payment_gateway_admin_remove_payment_token', 'security' ) ) {
 					throw new Woodev_Payment_Gateway_Exception( 'Invalid nonce' );
@@ -256,10 +283,16 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 		/**
 		 * Refresh the tokens list via AJAX.
+		 *
+		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
 		 */
 		public function ajax_refresh_tokens() {
 
 			try {
+
+				if ( ! current_user_can( 'manage_woocommerce' ) ) {
+					throw new Woodev_Payment_Gateway_Exception( 'You do not have permission to do this' );
+				}
 
 				if ( ! check_ajax_referer( 'wc_payment_gateway_admin_refresh_payment_tokens', 'security', false ) ) {
 					throw new Woodev_Payment_Gateway_Exception( 'Invalid nonce' );

--- a/woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php
+++ b/woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php
@@ -201,15 +201,16 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 		 * Add a token via AJAX.
 		 *
 		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
+		 * @since 2.0.3 capability check now runs before the nonce check, consistent with the other handlers
 		 */
 		public function ajax_get_blank_token() {
-
-			check_ajax_referer( 'wc_payment_gateway_admin_get_blank_payment_token', 'security' );
 
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
 				wp_send_json_error();
 				return;
 			}
+
+			check_ajax_referer( 'wc_payment_gateway_admin_get_blank_payment_token', 'security' );
 
 			$index = Woodev_Helper::get_requested_value( 'index' );
 
@@ -245,6 +246,8 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 		 * Remove a token via AJAX.
 		 *
 		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
+		 * @since 2.0.3 also requires `edit_user` on the target user, since `manage_woocommerce`
+		 *              alone does not authorize acting on an arbitrary user object
 		 */
 		public function ajax_remove_token() {
 
@@ -258,12 +261,8 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 					throw new Woodev_Payment_Gateway_Exception( 'Invalid nonce' );
 				}
 
-				$user_id  = Woodev_Helper::get_requested_value( 'user_id' );
+				$user_id  = $this->get_authorized_target_user_id();
 				$token_id = Woodev_Helper::get_requested_value( 'token_id' );
-
-				if ( ! $user_id ) {
-					throw new Woodev_Payment_Gateway_Exception( 'User ID is missing' );
-				}
 
 				if ( ! $token_id ) {
 					throw new Woodev_Payment_Gateway_Exception( 'Token ID is missing' );
@@ -285,6 +284,8 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 		 * Refresh the tokens list via AJAX.
 		 *
 		 * @since 2.0.2 gated behind `manage_woocommerce`, in addition to the nonce
+		 * @since 2.0.3 also requires `edit_user` on the target user, since `manage_woocommerce`
+		 *              alone does not authorize acting on an arbitrary user object
 		 */
 		public function ajax_refresh_tokens() {
 
@@ -298,11 +299,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 					throw new Woodev_Payment_Gateway_Exception( 'Invalid nonce' );
 				}
 
-				$user_id = Woodev_Helper::get_requested_value( 'user_id' );
-
-				if ( ! $user_id ) {
-					throw new Woodev_Payment_Gateway_Exception( 'User ID is missing' );
-				}
+				$user_id = $this->get_authorized_target_user_id();
 
 				ob_start();
 
@@ -316,6 +313,47 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Admin_Payment_Token_Editor' ) ) :
 
 				wp_send_json_error( $e->getMessage() );
 			}
+		}
+
+
+		/**
+		 * Resolve and authorize the user ID targeted by an AJAX request.
+		 *
+		 * Normalizes the requested value to a positive integer referencing an
+		 * existing user, then requires `edit_user` on that specific user object.
+		 * `manage_woocommerce` alone does not authorize acting on an arbitrary
+		 * target: WordPress checks object-level capabilities like `edit_user`
+		 * per target, so a shop manager holding `manage_woocommerce` is not
+		 * necessarily allowed to edit an administrator (or, on multisite, a
+		 * user outside the current site).
+		 *
+		 * @since 2.0.3
+		 *
+		 * @param string $key the request key holding the target user ID
+		 *
+		 * @return int the authorized target user ID
+		 *
+		 * @throws Woodev_Payment_Gateway_Exception if the user ID is missing, invalid, or not editable by the current user
+		 */
+		protected function get_authorized_target_user_id( $key = 'user_id' ) {
+
+			$raw_user_id = Woodev_Helper::get_requested_value( $key );
+
+			if ( ! is_scalar( $raw_user_id ) ) {
+				throw new Woodev_Payment_Gateway_Exception( 'User ID is missing' );
+			}
+
+			$user_id = filter_var( $raw_user_id, FILTER_VALIDATE_INT );
+
+			if ( false === $user_id || $user_id <= 0 || ! get_userdata( $user_id ) ) {
+				throw new Woodev_Payment_Gateway_Exception( 'User ID is missing' );
+			}
+
+			if ( ! current_user_can( 'edit_user', $user_id ) ) {
+				throw new Woodev_Payment_Gateway_Exception( 'You do not have permission to do this' );
+			}
+
+			return $user_id;
 		}
 
 


### PR DESCRIPTION
Закрывает критический IDOR: любой подписчик читал и удалял чужие сохранённые карты.

## Что было

В `woodev/payment-gateway/admin/class-payment-gateway-admin-payment-token-editor.php` AJAX-хендлеры
`ajax_remove_token()` и `ajax_refresh_tokens()` **не проверяли права вообще** — `current_user_can`
в файле не встречался, — а `user_id` брался прямо из запроса. Внешний слой
(`Woodev_Payment_Gateway_Admin_User_Handler`) проверяет `manage_woocommerce`, но AJAX-эндпоинты им
не закрыты: `init_admin` висит на `admin_init`, а `admin-ajax.php` этот хук выполняет.

Nonce — не авторизация, и здесь он даже не был барьером: `enqueue_scripts_styles()` висел на голом
`admin_enqueue_scripts` без проверки экрана и прав, поэтому `wp_localize_script()` выдавал **оба**
nonce любому залогиненному пользователю на любой странице админки.

## Что сделано

Три круга, два независимых критика Codex, ни один агент не принимал свою работу.

**Круг 1 (`61c929a`).** `manage_woocommerce` на всех трёх AJAX-хендлерах — воркер нашёл ту же дыру
в четвёртом, `ajax_get_blank_token()`, которого в карточке не было. `enqueue_scripts_styles()`
зажат по той же способности плюс экраны `profile` / `user-edit`. Nonce оставлены как CSRF-защита.

**Критик 1: REJECT.** `manage_woocommerce` — способность ФИЧИ, а не авторизация над конкретным
объектом-пользователем. Ею владеет `shop_manager`, который не обязан иметь право редактировать
администратора. То есть IDOR был сужен, но не закрыт: `user_id` оставался непроверенной ссылкой на
объект для всякого, у кого эта способность есть.

**Круг 2 (`7752dff`).** Общий `get_authorized_target_user_id()`: нормализация к положительному int
(`is_scalar` + `filter_var` + `get_userdata`), затем `current_user_can( 'edit_user', $user_id )` —
мета-способность, которую WordPress проверяет **по цели**. Порядок гардов выровнен по всем трём
хендлерам.

**Критик 2 (re-critic): APPROVE WITH FIXES** — барьер признан закрытым, блокирующих дефектов нет.
Три SHOULD-FIX, все закрыты в круге 3 (`ab69afd`):

1. Четыре тега `@since 2.0.3` → `2.0.2`. `@since` — это **планируемый релиз** (решение оператора,
   #409), а не номер, инкрементируемый на каждый коммит; оба коммита едут в один релиз.
2. У `get_authorized_target_user_id()` не было типов — теперь `string $key` и `: int`.
3. **Оракул существования пользователя.** `get_userdata()` стоял ДО отказа по `edit_user`, поэтому
   владелец `manage_woocommerce` с валидным nonce мог отличить существующего-но-запрещённого
   пользователя от несуществующего по тексту ошибки. Проверка способности перенесена ВПЕРЁД:
   `current_user_can( 'edit_user', $id )` на одиночном сайте резолвится через `map_meta_cap` в
   generic `edit_users` независимо от существования цели, так что отказ теперь одинаков в обоих
   случаях.

## Что критики проверили и подтвердили

- У класса ровно пять точек входа, ни одной `wp_ajax_nopriv`, REST-роута или другой
  неаутентифицированной двери.
- `remove_token()` уже связывает id токена с переданным user_id через
  `user_has_token( $user_id, $token, $environment_id )` — обхода по одному только id токена нет.
- `FILTER_VALIDATE_INT` принимает пробелы по краям и `+5`, но отбрасывает ведущие нули, hex, float
  и экспоненту. `get_requested_value()` сохраняет массивы, и гард `is_scalar` их блокирует.
- На мультисайте WordPress мапит `edit_user` на network-авторитет, так что обычный `shop_manager`
  не читает через границу сайта.
- **Все девять тестов круга 2 прогнаны против `61c929a` подменой файла — падают все девять.** Тест
  круга 3 на оракул проверен против `7752dff` — падает.
- Контракты установленной площадки не тронуты: имена AJAX-экшенов и nonce-экшенов байт в байт те же.

## Роли, которые провёл воркер

Администратор, редактирующий любого пользователя, — работает как раньше. `shop_manager`,
редактирующий покупателя, которого ему **можно** редактировать, — работает. `shop_manager`,
целящийся в администратора, — теперь отказ на обоих хендлерах.

## Гейты

phpcs 217/217, phpstan 0 ошибок, 2494 unit / 6168 ассертов / 71 skipped, jest 1260/1260.

> 71 skipped — это ворктри-базлайн: пять контрактных Yandex-тестов пропускаются там, где нет
> `plugins-reference/`. Починено отдельно в #424, но этот ворктри создан раньше.

Closes #383
