### PR TITLE
fix(utilities): три дефекта фоновых джобов — порча статусов, дыра в AJAX, деление на ноль

### DIFF
--- a/tests/unit/BackgroundJobHandlerTest.php
+++ b/tests/unit/BackgroundJobHandlerTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Background job handler tests.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace Woodev\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use Mockery;
+
+require_once dirname( __DIR__, 2 ) . '/woodev/utilities/class-woodev-async-request.php';
+require_once dirname( __DIR__, 2 ) . '/woodev/utilities/class-woodev-background-job-handler.php';
+
+/**
+ * Minimal handler for terminal-status tests.
+ */
+class Testable_Background_Job_Handler extends \Woodev_Background_Job_Handler {
+
+	/** @var array<int, object> */
+	private $jobs = [];
+
+	/** @var int */
+	public $shutdown_handler_registrations = 0;
+
+	/**
+	 * Avoid runtime hooks in the isolated unit tests.
+	 */
+	public function __construct() {
+		$this->identifier = 'test_job';
+	}
+
+	/**
+	 * Seeds queued jobs for a handle() invocation.
+	 *
+	 * @param array<int, object> $jobs Jobs.
+	 * @return void
+	 */
+	public function set_jobs( array $jobs ): void {
+		$this->jobs = $jobs;
+	}
+
+	/**
+	 * Exposes the protected queue loop.
+	 *
+	 * @return void
+	 */
+	public function handle_public(): void {
+		$this->handle();
+	}
+
+	/**
+	 * Records the callback registration without adding a real test-process handler.
+	 *
+	 * @return void
+	 */
+	protected function register_shutdown_handler(): void {
+		++$this->shutdown_handler_registrations;
+	}
+
+	/** @return void */
+	protected function lock_process(): void {}
+
+	/** @return Testable_Background_Job_Handler */
+	protected function unlock_process() {
+		return $this;
+	}
+
+	/** @return bool */
+	protected function time_exceeded(): bool {
+		return false;
+	}
+
+	/** @return bool */
+	protected function memory_exceeded(): bool {
+		return false;
+	}
+
+	/** @return bool */
+	protected function is_queue_empty(): bool {
+		return empty( $this->jobs );
+	}
+
+	/**
+	 * Returns the next test job.
+	 *
+	 * @param string|null $id Unused job identifier.
+	 * @return object|null
+	 */
+	public function get_job( $id = null ) {
+		return array_shift( $this->jobs );
+	}
+
+	/**
+	 * Marks the job complete without touching WordPress persistence.
+	 *
+	 * @param object   $job             Job.
+	 * @param int|null $items_per_batch Unused item cap.
+	 * @return object
+	 */
+	public function process_job( $job, $items_per_batch = null ) {
+		$job->status = 'completed';
+
+		return $job;
+	}
+
+	/** @return void */
+	protected function complete(): void {}
+
+	/**
+	 * No item processing is needed for terminal-status tests.
+	 *
+	 * @param mixed  $item Item.
+	 * @param object $job  Job.
+	 * @return void
+	 */
+	protected function process_item( $item, $job ) {}
+}
+
+/**
+ * Class BackgroundJobHandlerTest.
+ */
+class BackgroundJobHandlerTest extends TestCase {
+
+	/**
+	 * Multiple jobs in one request receive one shutdown callback, which follows
+	 * only the current job if a later job causes a fatal error.
+	 *
+	 * @return void
+	 */
+	public function test_handle_registers_one_shutdown_callback_for_multiple_jobs(): void {
+		$handler = new Testable_Background_Job_Handler();
+		$handler->set_jobs(
+			[
+				(object) [ 'id' => 'first', 'status' => 'queued' ],
+				(object) [ 'id' => 'second', 'status' => 'queued' ],
+				(object) [ 'id' => 'third', 'status' => 'queued' ],
+			]
+		);
+
+		Functions\when( 'wp_die' )->justReturn( null );
+
+		$handler->handle_public();
+
+		$this->assertSame( 1, $handler->shutdown_handler_registrations );
+	}
+
+	/**
+	 * A fatal while a later job is active must never rewrite an earlier completed
+	 * job or emit a second job-failed action for it.
+	 *
+	 * @return void
+	 */
+	public function test_fail_job_preserves_completed_job_after_later_fatal_error(): void {
+		global $wpdb;
+
+		$wpdb          = Mockery::mock();
+		$wpdb->options = 'options';
+		$wpdb->shouldNotReceive( 'update' );
+
+		Functions\when( 'current_time' )->justReturn( '2026-08-21 12:00:00' );
+		Functions\expect( 'do_action' )->never();
+
+		$completed_job = (object) [
+			'id'     => 'completed-job',
+			'status' => 'completed',
+		];
+		$later_job     = (object) [
+			'id'     => 'fatal-job',
+			'status' => 'processing',
+		];
+
+		$handler = new Testable_Background_Job_Handler();
+		$result  = $handler->fail_job( $completed_job, 'Fatal error in ' . $later_job->id );
+
+		$this->assertSame( $completed_job, $result );
+		$this->assertSame( 'completed', $completed_job->status );
+		$this->assertObjectNotHasProperty( 'failure_reason', $completed_job );
+	}
+}

--- a/tests/unit/PlatformNeutralJobBatchHandlerTest.php
+++ b/tests/unit/PlatformNeutralJobBatchHandlerTest.php
@@ -42,6 +42,54 @@ class Testable_Platform_Neutral_Job_Batch_Handler extends \Woodev_Job_Batch_Hand
 	public function render_js_public(): void {
 		$this->render_js();
 	}
+
+	/**
+	 * Exposes job status formatting for testing.
+	 *
+	 * @param object $job Job status source.
+	 * @return object
+	 */
+	public function process_job_status_public( $job ) {
+		return $this->process_job_status( $job );
+	}
+
+	/**
+	 * Requires an explicit capability from the consumer plugin.
+	 *
+	 * @return string
+	 */
+	protected function get_required_capability(): string {
+		return 'manage_woocommerce';
+	}
+
+	/**
+	 * Tracks whether ajax_process_batch() tried to process a job.
+	 *
+	 * @var bool
+	 */
+	public $processed_batch = false;
+
+	/**
+	 * Job returned by the test batch processor.
+	 *
+	 * @var object|null
+	 */
+	public $batch_job;
+
+	/**
+	 * Test double for the batch processor.
+	 *
+	 * @param string $job_id Job identifier.
+	 * @return object
+	 */
+	public function process_batch( $job_id ) {
+		$this->processed_batch = true;
+
+		return $this->batch_job ?: (object) [
+			'progress' => 1,
+			'total'    => 1,
+		];
+	}
 }
 
 /**
@@ -93,5 +141,109 @@ class PlatformNeutralJobBatchHandlerTest extends TestCase {
 			'window.test_job_batch_handler = new Woodev_Job_Batch_Handler( {"id":"test_job","process_nonce":"nonce-test_job_process_batch","cancel_nonce":"nonce-test_job_cancel_job"} );',
 			$woodev_queued_js
 		);
+	}
+
+	/**
+	 * A zero-item job has already completed in the background handler, so the
+	 * batch response must report 100% rather than throw a division-by-zero error.
+	 *
+	 * @return void
+	 */
+	public function test_process_job_status_marks_zero_total_completed_job_as_complete(): void {
+		$handler = new Testable_Platform_Neutral_Job_Batch_Handler();
+		$job     = (object) [
+			'status'   => 'completed',
+			'progress' => 0,
+			'total'    => 0,
+		];
+
+		$result = $handler->process_job_status_public( $job );
+
+		$this->assertSame( '100.00', $result->percentage );
+	}
+
+	/**
+	 * The public AJAX path returns a completed zero-item job at 100%, avoiding an
+	 * uncaught DivisionByZeroError and a 500 response.
+	 *
+	 * @return void
+	 */
+	public function test_ajax_process_batch_returns_completed_zero_total_job(): void {
+		$job_handler = Mockery::mock();
+		$job_handler->shouldReceive( 'get_identifier' )->andReturn( 'test_job' );
+
+		$handler = new Testable_Platform_Neutral_Job_Batch_Handler();
+		$handler->set_job_handler( $job_handler );
+		$handler->batch_job = (object) [
+			'status'   => 'completed',
+			'progress' => 0,
+			'total'    => 0,
+		];
+
+		Functions\when( 'check_ajax_referer' )->justReturn( true );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\expect( 'current_user_can' )->once()->with( 'manage_woocommerce' )->andReturn( true );
+		Functions\expect( 'wp_send_json_success' )->once()->with(
+			Mockery::on(
+				static function ( array $job ): bool {
+					return 'completed' === $job['status'] && '100.00' === $job['percentage'];
+				}
+			)
+		);
+
+		$_POST['job_id'] = 'job-1';
+		$handler->ajax_process_batch();
+		unset( $_POST['job_id'] );
+	}
+
+	/**
+	 * A nonce does not authorize a user without the consumer-selected capability
+	 * to process a job batch.
+	 *
+	 * @return void
+	 */
+	public function test_ajax_process_batch_rejects_user_without_required_capability(): void {
+		$job_handler = Mockery::mock();
+		$job_handler->shouldReceive( 'get_identifier' )->andReturn( 'test_job' );
+
+		$handler = new Testable_Platform_Neutral_Job_Batch_Handler();
+		$handler->set_job_handler( $job_handler );
+
+		Functions\when( 'check_ajax_referer' )->justReturn( true );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_send_json_success' )->justReturn( null );
+		Functions\expect( 'current_user_can' )->once()->with( 'manage_woocommerce' )->andReturn( false );
+		Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::type( 'array' ), 403 );
+
+		$_POST['job_id'] = 'job-1';
+		$handler->ajax_process_batch();
+		unset( $_POST['job_id'] );
+
+		$this->assertFalse( $handler->processed_batch );
+	}
+
+	/**
+	 * A nonce does not authorize a user without the consumer-selected capability
+	 * to delete a job.
+	 *
+	 * @return void
+	 */
+	public function test_ajax_cancel_job_rejects_user_without_required_capability(): void {
+		$job_handler = Mockery::mock();
+		$job_handler->shouldReceive( 'get_identifier' )->andReturn( 'test_job' );
+		$job_handler->shouldNotReceive( 'delete_job' );
+
+		$handler = new Testable_Platform_Neutral_Job_Batch_Handler();
+		$handler->set_job_handler( $job_handler );
+
+		Functions\when( 'check_ajax_referer' )->justReturn( true );
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_send_json_success' )->justReturn( null );
+		Functions\expect( 'current_user_can' )->once()->with( 'manage_woocommerce' )->andReturn( false );
+		Functions\expect( 'wp_send_json_error' )->once()->with( Mockery::type( 'array' ), 403 );
+
+		$_POST['job_id'] = 'job-1';
+		$handler->ajax_cancel_job();
+		unset( $_POST['job_id'] );
 	}
 }

--- a/woodev/utilities/class-woodev-background-job-handler.php
+++ b/woodev/utilities/class-woodev-background-job-handler.php
@@ -49,6 +49,9 @@ if ( ! class_exists( 'Woodev_Background_Job_Handler' ) ) :
 		/** @var string debug message, used by the system status tool */
 		protected $debug_message;
 
+		/** @var stdClass|object|null job being processed when PHP shuts down */
+		protected $job_being_processed;
+
 
 		/**
 		 * Initiate new background job handler
@@ -549,13 +552,15 @@ if ( ! class_exists( 'Woodev_Background_Job_Handler' ) ) :
 
 			$this->lock_process();
 
+			// Only the current job may be failed by a fatal error. Registering once
+			// prevents a later fatal from being applied to every earlier job.
+			$this->register_shutdown_handler();
+
 			do {
 
 				// Get next job in the queue
-				$job = $this->get_job();
-
-				// handle PHP errors from here on out
-				register_shutdown_function( array( $this, 'handle_shutdown' ), $job );
+				$job                        = $this->get_job();
+				$this->job_being_processed = $job;
 
 				// Start processing
 				$this->process_job( $job );
@@ -754,6 +759,12 @@ if ( ! class_exists( 'Woodev_Background_Job_Handler' ) ) :
 				return false;
 			}
 
+			// A shutdown callback can run after a job has already reached a terminal
+			// state. Never corrupt that result or emit a duplicate failure signal.
+			if ( in_array( $job->status, [ 'completed', 'failed' ], true ) ) {
+				return $job;
+			}
+
 			$job->status    = 'failed';
 			$job->failed_at = current_time( 'mysql' );
 
@@ -814,6 +825,17 @@ if ( ! class_exists( 'Woodev_Background_Job_Handler' ) ) :
 			$this->clear_scheduled_event();
 		}
 
+
+		/**
+		 * Registers the single shutdown callback for the active process.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return void
+		 */
+		protected function register_shutdown_handler(): void {
+			register_shutdown_function( [ $this, 'handle_shutdown' ] );
+		}
 
 		/**
 		 * Schedule cron healthcheck
@@ -910,16 +932,18 @@ if ( ! class_exists( 'Woodev_Background_Job_Handler' ) ) :
 		/**
 		 * Handles PHP shutdown, say after a fatal error.
 		 *
-		 * @param stdClass|object $job the job being processed
+		 * @since 2.0.2
+		 *
+		 * @return void
 		 */
-		public function handle_shutdown( $job ) {
+		public function handle_shutdown(): void {
 
 			$error = error_get_last();
 
 			// if shutting down because of a fatal error, fail the job
-			if ( $error && E_ERROR === $error['type'] ) {
+			if ( $error && E_ERROR === $error['type'] && $this->job_being_processed ) {
 
-				$this->fail_job( $job, $error['message'] );
+				$this->fail_job( $this->job_being_processed, $error['message'] );
 
 				$this->unlock_process();
 			}

--- a/woodev/utilities/class-woodev-job-batch-handler.php
+++ b/woodev/utilities/class-woodev-job-batch-handler.php
@@ -8,9 +8,11 @@ if ( ! class_exists( 'Woodev_Job_Batch_Handler' ) ) :
 	 * The job batch handler class.
 	 *
 	 * This provides a way for plugins to process "background" jobs in batches when
-	 * regular background processing isn't available.
+	 * regular background processing isn't available. Concrete subclasses must
+	 * implement get_required_capability() with the capability that authorizes their
+	 * users to process or cancel jobs; a nonce alone is not authorization.
 	 */
-	class Woodev_Job_Batch_Handler {
+	abstract class Woodev_Job_Batch_Handler {
 
 		/** @var Woodev_Background_Job_Handler job handler instance */
 		protected $job_handler;
@@ -125,6 +127,11 @@ if ( ! class_exists( 'Woodev_Job_Batch_Handler' ) ) :
 
 			check_ajax_referer( $this->get_job_handler()->get_identifier() . '_process_batch', 'security' );
 
+			if ( ! current_user_can( $this->get_required_capability() ) ) {
+				wp_send_json_error( [ 'message' => __( 'У вас нет прав для управления фоновыми задачами.', 'woodev-plugin-framework' ) ], 403 );
+				return;
+			}
+
 			$job_id = isset( $_POST['job_id'] ) ? sanitize_text_field( $_POST['job_id'] ) : '';
 
 			if ( empty( $job_id ) ) {
@@ -159,6 +166,11 @@ if ( ! class_exists( 'Woodev_Job_Batch_Handler' ) ) :
 
 			check_ajax_referer( $this->get_job_handler()->get_identifier() . '_cancel_job', 'security' );
 
+			if ( ! current_user_can( $this->get_required_capability() ) ) {
+				wp_send_json_error( [ 'message' => __( 'У вас нет прав для управления фоновыми задачами.', 'woodev-plugin-framework' ) ], 403 );
+				return;
+			}
+
 			$job_id = isset( $_POST['job_id'] ) ? sanitize_text_field( $_POST['job_id'] ) : '';
 
 			if ( empty( $job_id ) ) {
@@ -182,7 +194,9 @@ if ( ! class_exists( 'Woodev_Job_Batch_Handler' ) ) :
 		 */
 		protected function process_job_status( $job ) {
 
-			$job->percentage = Woodev_Helper::number_format( (int) $job->progress / (int) $job->total * 100 );
+			$job->percentage = 0 === (int) $job->total
+				? Woodev_Helper::number_format( 100 )
+				: Woodev_Helper::number_format( (int) $job->progress / (int) $job->total * 100 );
 
 			return $job;
 		}
@@ -227,6 +241,19 @@ if ( ! class_exists( 'Woodev_Job_Batch_Handler' ) ) :
 
 			return $items_per_batch > 0 ? $items_per_batch : 1;
 		}
+
+
+		/**
+		 * Gets the capability required to process and cancel jobs.
+		 *
+		 * Every concrete batch handler must choose the capability that grants access
+		 * to its jobs. This is required because a nonce protects only against CSRF.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		abstract protected function get_required_capability(): string;
 
 
 		/**


### PR DESCRIPTION
Три дефекта подсистемы фоновых джобов: две порчи данных и одна дыра в авторизации.

> ⚠️ **Ломающее для плагинов-потребителей:** `Woodev_Job_Batch_Handler` становится `abstract`, и
> `get_required_capability(): string` — абстрактный метод. Любой внешний плагин, наследующий этот
> класс, обязан его реализовать. Это намеренное следствие превращения молчаливой дыры в
> обязательство, и оно укладывается в clean-break политику v2 (ADR-005): внутренние API свободны
> ломаться, контракты данных установленной площадки — нет. Ни один класс в этом репозитории от него
> не наследует (проверено поиском), так что здесь ничего не ломается.

## #384 — обработчики shutdown помечали успешные джобы как failed

`Woodev_Background_Job_Handler::handle()` вызывал `register_shutdown_function()` **внутри** цикла —
по обработчику на итерацию, каждый со своим `$job`. PHP при завершении выполняет их все, а
`handle_shutdown()` решает только по `error_get_last()`, который для всех вернёт один и тот же
фатал. `fail_job()` при этом писал `status = 'failed'` безусловно.

Три джоба, первые два успешны, третий фаталит → все три в `failed` с текстом ошибки третьего, и
экшен `{identifier}_job_failed` срабатывает для двух успешных. Порча данных плюс ложный сигнал
каждому плагину-потребителю.

**Починены обе причины, а не симптом:** регистрация вынесена из цикла в `register_shutdown_handler()`
(ровно один раз), `handle_shutdown()` читает `$this->job_being_processed` вместо захваченного при
регистрации значения, и `fail_job()` не трогает джоб с уже терминальным статусом — **и не
испускает для него `{identifier}_job_failed`**, что и есть настоящее лечение.

Критик прошёл руками: фатал в первом джобе из трёх → падает только первый; фатал в N-м после
успешных 1..N-1 → падает только N-й; в узком окне, когда `job_being_processed` ещё указывает на
только что завершённый джоб, ловит гард терминального статуса; обычное завершение без фатала не
делает ничего. Реальный фатал на реально идущем джобе по-прежнему помечает ЕГО failed — обработчик
не выкинут.

## #388 — нет проверки прав в AJAX обработки батчей

`ajax_process_batch()` и `ajax_cancel_job()` проверяли только nonce, а `job_id` брался из `$_POST`.
Оба экшена — `wp_ajax_*`, то есть доступны любому залогиненному, и оба nonce печатались в футер
**каждой** страницы админки. Подписчик брал `cancel_nonce` с `/wp-admin/profile.php` и удалял чужой
джоб.

Оговорка карточки подтвердилась: сам фреймворк этот класс нигде не инстанцирует, дыра открывается
в плагине-потребителе. Поэтому чинить надо было и код, и **обязательство** автора плагина.

Сделано `get_required_capability(): string` абстрактным — это ровно правило проекта «общая
обязанность, о которой автор плагина может молча забыть, должна быть ОБЯЗАТЕЛЬСТВОМ, а не
необязательным параметром», и это тот же приём, что уже применён в
`Woodev_Setup_Wizard::get_required_capability()`.

**Владение джобом:** в схеме джоба (`id/status/progress/total/data/timestamps`) нет поля владельца
вообще — проверять нечего, способность здесь единственная осмысленная ось авторизации. Это не
пропуск, а свойство модели данных.

## #390 — деление на ноль в `process_job_status()`

`(int) $job->progress / (int) $job->total * 100` без проверки нуля. Вызывается из
`ajax_process_batch()` сразу после `process_batch()`, чей `catch` ловит только
`Woodev_Plugin_Exception`; `DivisionByZeroError` — это `Error`, он уходит наверх как 500, а
прогресс-бар виснет на 0% без текста ошибки.

Критик проверил на этой машине (PHP 8.5.1), что `0/0` действительно бросает, а не даёт старое
предупреждение с INF.

Утверждение воркера «базовый процессор и так завершает пустые джобы» тоже проверено по коду, а не
на слово: при пустых данных `total=0`, `progress=0`, условие завершения `0 >= 0` истинно, и
`complete_job()` отрабатывает ДО того, как считается процент. То есть 100% — честное значение
завершённого джоба, а не подгонка отображения.

## Как проверялось

Воркер Codex → независимый критик Claude Sonnet. **Вердикт: APPROVE по всем трём карточкам,
блокирующих находок нет.**

Каждый новый тест проверен на падение на `main` поимённо — все пять падают, ни один не вакуумный
(Brain Monkey ассертит точные счётчики вызовов и точную строку способности, а не «разрешить всё»).

Гейты: PHPCS чисто, PHPStan 0 ошибок, 2481 unit / 6127 ассертов / 71 skipped, Jest 1260.

## Что отложено карточками, а не сделано здесь

- Тест на связку `handle()` → `job_being_processed` → `handle_shutdown()` с настоящим фаталом:
  сейчас один тест считает регистрации, другой дёргает `fail_job()` напрямую. Критик проверил
  проводку чтением, но рефакторинг её не поймает.
- `job_id` по-прежнему только `sanitize_text_field()` без проверки формата и существования —
  преэкзистующее, к этим трём дефектам не относится.
- `process_job()` бросает голый `Exception` при отсутствующем ключе данных, который тот же `catch`
  тоже не поймает — преэкзистующее.

Closes #384
Closes #388
Closes #390
