### PR TITLE
fix(settings): boolean + is_multi больше не фаталит, и запрещена пара с toggle

### DIFF
--- a/tests/unit/PlatformNeutralSettingsApiTest.php
+++ b/tests/unit/PlatformNeutralSettingsApiTest.php
@@ -167,6 +167,22 @@ class PlatformNeutralSettingsApiTest extends TestCase {
 	}
 
 	/**
+	 * Float multi-value settings must receive the same element-wise database
+	 * conversion instead of discarding the complete stored array.
+	 *
+	 * @return void
+	 */
+	public function test_float_multi_setting_restores_each_stored_value(): void {
+		$settings = new Testable_Platform_Neutral_Settings( 'test-plugin' );
+		$setting  = new \Woodev_Setting();
+
+		$setting->set_type( \Woodev_Setting::TYPE_FLOAT );
+		$setting->set_is_multi( true );
+
+		$this->assertSame( [ 7.25, 42.5 ], $settings->convert_from_database( [ '7.25', '42.5' ], $setting ) );
+	}
+
+	/**
 	 * Malformed object data for a boolean setting must not reach strtolower().
 	 *
 	 * @return void

--- a/tests/unit/PlatformNeutralSettingsApiTest.php
+++ b/tests/unit/PlatformNeutralSettingsApiTest.php
@@ -50,6 +50,27 @@ class Testable_Platform_Neutral_Settings extends \Woodev_Abstract_Settings {
 }
 
 /**
+ * Settings handler that registers a boolean multi-value setting for load tests.
+ */
+class Boolean_Multi_Load_Settings extends \Woodev_Abstract_Settings {
+
+	/**
+	 * Registers the legacy-compatible boolean multi-value setting.
+	 *
+	 * @return void
+	 */
+	protected function register_settings() {
+		$this->register_setting(
+			'flags',
+			\Woodev_Setting::TYPE_BOOLEAN,
+			[
+				'is_multi' => true,
+			]
+		);
+	}
+}
+
+/**
  * Class PlatformNeutralSettingsApiTest.
  */
 class PlatformNeutralSettingsApiTest extends TestCase {
@@ -91,6 +112,72 @@ class PlatformNeutralSettingsApiTest extends TestCase {
 		$this->assertFalse( $settings->convert_from_database( 'false', $setting ) );
 		$this->assertFalse( $settings->convert_from_database( '0', $setting ) );
 		$this->assertNull( $settings->convert_from_database( null, $setting ) );
+	}
+
+	/**
+	 * Boolean multi-value settings must preserve the installed-site yes/no shape
+	 * for every element when saved.
+	 *
+	 * @return void
+	 */
+	public function test_boolean_multi_setting_persists_every_value_to_yes_no_contract(): void {
+		$settings = new Testable_Platform_Neutral_Settings( 'test-plugin' );
+		$setting  = new \Woodev_Setting();
+
+		$setting->set_type( \Woodev_Setting::TYPE_BOOLEAN );
+		$setting->set_is_multi( true );
+		$setting->set_value( [ true, false ] );
+
+		$this->assertSame( [ 'yes', 'no' ], $settings->convert_for_database( $setting ) );
+	}
+
+	/**
+	 * A previously stored boolean multi-value setting must load without a type
+	 * error and retain one native boolean for every stored element.
+	 *
+	 * @return void
+	 */
+	public function test_boolean_multi_setting_loads_stored_values(): void {
+		Functions\when( 'get_option' )->justReturn( [ 'yes', 'no' ] );
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = [] ) {
+				return array_merge( (array) $defaults, (array) $args );
+			}
+		);
+
+		$settings = new Boolean_Multi_Load_Settings( 'test-plugin' );
+
+		$this->assertSame( [ true, false ], $settings->get_value( 'flags' ) );
+	}
+
+	/**
+	 * Numeric multi-value settings must receive the same element-wise database
+	 * conversion instead of discarding the complete stored array.
+	 *
+	 * @return void
+	 */
+	public function test_integer_multi_setting_restores_each_stored_value(): void {
+		$settings = new Testable_Platform_Neutral_Settings( 'test-plugin' );
+		$setting  = new \Woodev_Setting();
+
+		$setting->set_type( \Woodev_Setting::TYPE_INTEGER );
+		$setting->set_is_multi( true );
+
+		$this->assertSame( [ 7, 42 ], $settings->convert_from_database( [ '7', '42' ], $setting ) );
+	}
+
+	/**
+	 * Malformed object data for a boolean setting must not reach strtolower().
+	 *
+	 * @return void
+	 */
+	public function test_boolean_setting_treats_stored_object_as_false(): void {
+		$settings = new Testable_Platform_Neutral_Settings( 'test-plugin' );
+		$setting  = new \Woodev_Setting();
+
+		$setting->set_type( \Woodev_Setting::TYPE_BOOLEAN );
+
+		$this->assertFalse( $settings->convert_from_database( new \stdClass(), $setting ) );
 	}
 
 	/**

--- a/tests/unit/SettingsApi/SettingsControlTypesTest.php
+++ b/tests/unit/SettingsApi/SettingsControlTypesTest.php
@@ -250,4 +250,24 @@ class SettingsControlTypesTest extends TestCase {
 		$this->assertSame( [ 'courier', 'pickup', 'locker' ], $this->settings->get_setting( 'methods' )->get_default() );
 		$this->assertSame( [ 'courier', 'pickup', 'locker' ], $this->settings->get_value( 'methods' ) );
 	}
+
+	/**
+	 * Scalar toggle and checkbox controls must not collapse a boolean multi-value setting.
+	 *
+	 * @return void
+	 */
+	public function test_boolean_multi_setting_rejects_scalar_toggle_and_checkbox_controls(): void {
+		$this->settings->register_setting(
+			'flags',
+			'boolean',
+			[ 'is_multi' => true ]
+		);
+		Functions\when( '_doing_it_wrong' )->justReturn();
+
+		foreach ( [ 'toggle', 'checkbox' ] as $type ) {
+			$this->assertFalse( $this->settings->register_control( 'flags', $type ) );
+		}
+
+		$this->assertNull( $this->settings->get_setting( 'flags' )->get_control() );
+	}
 }

--- a/woodev/settings-api/abstract-class-settings.php
+++ b/woodev/settings-api/abstract-class-settings.php
@@ -527,7 +527,9 @@ if ( ! class_exists( 'Woodev_Abstract_Settings' ) ) :
 			$value = $setting->get_value();
 
 			if ( null !== $value && Woodev_Setting::TYPE_BOOLEAN === $setting->get_type() ) {
-				$value = self::bool_to_string( $value );
+				$value = $setting->is_is_multi() && is_array( $value )
+					? array_map( [ self::class, 'bool_to_string' ], $value )
+					: self::bool_to_string( $value );
 			}
 
 			return $value;
@@ -547,15 +549,31 @@ if ( ! class_exists( 'Woodev_Abstract_Settings' ) ) :
 				switch ( $setting->get_type() ) {
 
 					case Woodev_Setting::TYPE_BOOLEAN:
-						$value = self::string_to_bool( $value );
+						$value = $setting->is_is_multi() && is_array( $value )
+							? array_map( [ self::class, 'string_to_bool' ], $value )
+							: self::string_to_bool( $value );
 						break;
 
 					case Woodev_Setting::TYPE_INTEGER:
-						$value = is_numeric( $value ) ? (int) $value : null;
+						$value = $setting->is_is_multi() && is_array( $value )
+							? array_map(
+								static function ( $item ) {
+									return is_numeric( $item ) ? (int) $item : null;
+								},
+								$value
+							)
+							: ( is_numeric( $value ) ? (int) $value : null );
 						break;
 
 					case Woodev_Setting::TYPE_FLOAT:
-						$value = is_numeric( $value ) ? (float) $value : null;
+						$value = $setting->is_is_multi() && is_array( $value )
+							? array_map(
+								static function ( $item ) {
+									return is_numeric( $item ) ? (float) $item : null;
+								},
+								$value
+							)
+							: ( is_numeric( $value ) ? (float) $value : null );
 						break;
 				}
 			}
@@ -570,9 +588,12 @@ if ( ! class_exists( 'Woodev_Abstract_Settings' ) ) :
 		 * @return bool
 		 */
 		private static function string_to_bool( $string ) {
-			$string = $string ?? '';
-
-			return is_bool( $string ) ? $string : ( 'yes' === strtolower( $string ) || 1 === $string || 'true' === strtolower( $string ) || '1' === $string );
+			return is_bool( $string )
+				? $string
+				: (
+					( is_string( $string ) && ( 'yes' === strtolower( $string ) || 'true' === strtolower( $string ) || '1' === $string ) )
+					|| 1 === $string
+				);
 		}
 
 		/**

--- a/woodev/settings-api/abstract-class-settings.php
+++ b/woodev/settings-api/abstract-class-settings.php
@@ -162,6 +162,11 @@ if ( ! class_exists( 'Woodev_Abstract_Settings' ) ) :
 					throw new InvalidArgumentException( "Setting {$setting_id} does not exist" );
 				}
 
+				if ( $setting->is_is_multi() && Woodev_Setting::TYPE_BOOLEAN === $setting->get_type()
+					&& in_array( $type, [ Woodev_Control::TYPE_TOGGLE, Woodev_Control::TYPE_CHECKBOX ], true ) ) {
+					throw new UnexpectedValueException( "{$type} controls only support scalar boolean settings" );
+				}
+
 				$setting_control_types = $this->get_setting_control_types( $setting );
 				if ( ! empty( $setting_control_types ) && ! in_array( $type, $setting_control_types, true ) ) {
 					throw new UnexpectedValueException( "{$type} is not a valid control type for setting {$setting->get_id()} of type {$setting->get_type()}" );
@@ -519,6 +524,12 @@ if ( ! class_exists( 'Woodev_Abstract_Settings' ) ) :
 		/**
 		 * Converts the value of a setting to be stored in an option.
 		 *
+		 * Multi-value settings are serialized element by element to match
+		 * Woodev_Setting::update_value(), which validates every element. Boolean
+		 * multi-values are therefore supported, but register_control() rejects
+		 * toggle and checkbox controls for them: the admin UI renders those
+		 * controls as one scalar boolean and would collapse the stored array.
+		 *
 		 * @param Woodev_Setting $setting
 		 * @return mixed
 		 */
@@ -537,6 +548,11 @@ if ( ! class_exists( 'Woodev_Abstract_Settings' ) ) :
 
 		/**
 		 * Converts the stored value of a setting to the proper setting type.
+		 *
+		 * Multi-value settings are restored element by element to preserve the
+		 * same generic is_multi contract used by Woodev_Setting::update_value().
+		 * Boolean multi-values must remain unpaired with toggle and checkbox
+		 * controls until an array-aware list-of-booleans control exists.
 		 *
 		 * @param mixed          $value the value stored in an option
 		 * @param Woodev_Setting $setting


### PR DESCRIPTION
## Что было

Комбинация `type: boolean` + `is_multi: true` давала фатальный TypeError **при каждом сохранении и каждой загрузке**. `get_value_for_database()` и `get_value_from_database()` зовут `bool_to_string()` / `string_to_bool()`, а те делают `strtolower($string)`; у `is_multi`-настройки значение — массив, и PHP 8 бросает `strtolower(): Argument #1 ($string) must be of type string, array given`.

Запрета на комбинацию не было: `set_is_multi()` — сеттер без валидации, `update_value()` обрабатывает `is_multi` одинаково для всех типов. Если значение уже лежало в опции, страница падала **на загрузке**, и настройку нельзя было починить через UI вообще.

## Что сделано

Выбрана **поддержка**, а не запрет комбинации, и вот почему: `Woodev_Setting::update_value()` (существующий код, не тронут) уже прогоняет каждый элемент `is_multi` через coerce/sanitize/validate независимо от типа. То есть расширить границу сериализации в БД до того же поведения — это согласовать её с уже существующим замыслом класса, а не выбрать наугад. Целые и дробные multi-значения получили ту же поэлементную обработку (раньше `is_numeric(array)` был false и весь массив молча превращался в `null` — тихая потеря данных).

`string_to_bool()` теперь проверяет `is_string()` до `strtolower()`, поэтому объект или массив в опции больше не роняют **загрузку** страницы.

## Что нашёл критик, и что из этого выросло

Вердикт: **APPROVE WITH FIXES**, блокирующих находок нет, все четыре гейта сошлись с числами воркера точь-в-точь. Но по дороге он нашёл мину:

- по всему `woodev/` и `plugins-reference/` **нет ни одной** регистрации `is_multi => true` ни для одного типа — возможность сейчас мёртвая;
- `src/components/control-field.js:206-212` резолвит `type === 'boolean'` в единственный `ToggleControl` **независимо от `is_multi`**, а `checked: !!value` истинно для любого непустого массива, и `onChange` отдаёт `update_value()` скаляр. То есть первое же редактирование boolean-multi настройки в UI **молча схлопнуло бы сохранённый массив** в `'yes'`/`'no'`.

Поэтому во втором круге добавлен **гард в `register_control()`**: пара boolean + `is_multi` + toggle/checkbox отвергается на регистрации. Это стандартное правило проекта — обязательство, о котором следующий автор может забыть, должно быть принуждено, а не задокументировано. Решение и сама опасность записаны в докблоках.

Вторая находка критика: формулировка воркера «позволяет пострадавшим сайтам открыть и починить настройку» — **преувеличение**. Под PHP 8 пре-фиксный `save()` всегда фаталил на кодировании массива ДО записи, так что ни один сайт на PHP 8 не мог записать такой массив штатным путём; на PHP 7 `strtolower(array)` вырождался в null и давал скаляр `'no'`, а не массив. Защита на чтении остаётся правильным оборонительным кодом — просто она не «чинит живые сайты».

## Тесты

Критик перевывел пре-фиксное поведение из `ce6d318` сам, а не поверил отчёту. Все тесты кусаются:

| Тест | На `main` |
|---|---|
| `test_boolean_multi_setting_persists_every_value_to_yes_no_contract` | фатал |
| `test_boolean_multi_setting_loads_stored_values` | фатал, причём через НАСТОЯЩИЙ путь конструктор → `load_settings()` → `get_option()` |
| `test_integer_multi_setting_restores_each_stored_value` | не фатал — весь массив становился `null` (потеря данных) |
| `test_boolean_setting_treats_stored_object_as_false` | фатал |

Плюс тест на float-multi и тест на гард `register_control()`.

## Гейты

PHPCS 217 файлов чисто, PHPStan 0 ошибок, 2502 unit / 6196 ассертов / 66 skipped, Jest 1260.

Closes #389