### PR TITLE
fix(payment-gateway): четыре дефекта шлюза — fatal на чекауте и две межзаказные утечки в одном запросе

### DIFF
--- a/tests/unit/PaymentGatewayCaptureStockReductionLeakTest.php
+++ b/tests/unit/PaymentGatewayCaptureStockReductionLeakTest.php
@@ -26,6 +26,14 @@ namespace {
 	if ( ! class_exists( 'WC_Order', false ) ) {
 		/**
 		 * Minimal WooCommerce order base for the order test double.
+		 *
+		 * get_id() returns 123 (not 0) to match the shape every other guarded
+		 * `WC_Order` stub in this suite uses (see PaymentGatewayDirectXssTest.php).
+		 * Because this class is declared behind a `class_exists()` guard in the
+		 * global namespace, whichever test file's version PHPUnit loads first for
+		 * the whole run "wins" for every other test file too — an id of 0 fails
+		 * `$order_id > 0` checks (e.g. Woodev_Order_Compatibility::update_order_meta())
+		 * in unrelated tests that construct a bare `new WC_Order()`.
 		 */
 		class WC_Order {
 
@@ -33,7 +41,7 @@ namespace {
 			 * @return int
 			 */
 			public function get_id(): int {
-				return 0;
+				return 123;
 			}
 		}
 	}

--- a/tests/unit/PaymentGatewayCaptureStockReductionLeakTest.php
+++ b/tests/unit/PaymentGatewayCaptureStockReductionLeakTest.php
@@ -1,0 +1,448 @@
+<?php
+/**
+ * Verifies #401: Woodev_Payment_Gateway_Capture_Handler::perform_capture() no longer
+ * leaks the `woocommerce_payment_complete_reduce_order_stock` suppression filter past
+ * its own payment_complete() call, so a later, unrelated payment_complete() in the same
+ * request (e.g. the "Capture charge" bulk order action) reduces stock normally.
+ *
+ * Brain Monkey's apply_filters() does not itself invoke callbacks registered via
+ * add_filter() — it only records that they were "added". To prove the filter is
+ * actually removed (not just that remove_filter() was called with plausible-looking
+ * arguments), this test stubs add_filter()/remove_filter() with a tiny in-memory
+ * registry and fires the captured callback itself, the same way WooCommerce would.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! class_exists( 'WC_Payment_Gateway', false ) ) {
+		/**
+		 * Minimal WooCommerce gateway base for the gateway test double.
+		 */
+		class WC_Payment_Gateway {}
+	}
+
+	if ( ! class_exists( 'WC_Order', false ) ) {
+		/**
+		 * Minimal WooCommerce order base for the order test double.
+		 */
+		class WC_Order {
+
+			/**
+			 * @return int
+			 */
+			public function get_id(): int {
+				return 0;
+			}
+		}
+	}
+
+	if ( ! class_exists( 'Woodev_Test_Fake_Hook_Registry', false ) ) {
+		/**
+		 * A minimal in-memory stand-in for WordPress's filter storage, used to prove
+		 * add_filter()/remove_filter() calls actually take effect rather than merely
+		 * asserting they were called with plausible-looking arguments.
+		 */
+		class Woodev_Test_Fake_Hook_Registry {
+
+			/** @var array<string, array<int, array{0: int, 1: callable}>> */
+			private $filters = [];
+
+			/**
+			 * @param string   $hook hook name
+			 * @param callable $callback callback
+			 * @param int      $priority priority
+			 * @return true
+			 */
+			public function add( $hook, $callback, $priority = 10 ) {
+				$this->filters[ $hook ][] = [ $priority, $callback ];
+
+				return true;
+			}
+
+			/**
+			 * @param string   $hook hook name
+			 * @param callable $callback callback
+			 * @param int      $priority priority
+			 * @return bool
+			 */
+			public function remove( $hook, $callback, $priority = 10 ) {
+				if ( ! isset( $this->filters[ $hook ] ) ) {
+					return false;
+				}
+
+				foreach ( $this->filters[ $hook ] as $i => $entry ) {
+					if ( $priority === $entry[0] && $callback === $entry[1] ) {
+						unset( $this->filters[ $hook ][ $i ] );
+
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			/**
+			 * Fires every callback still registered for the hook, in order, the same
+			 * way WordPress's apply_filters() would.
+			 *
+			 * @param string $hook hook name
+			 * @param mixed  ...$args value followed by any extra filter args
+			 * @return mixed
+			 */
+			public function apply( $hook, ...$args ) {
+				$value = array_shift( $args );
+
+				foreach ( $this->filters[ $hook ] ?? [] as $entry ) {
+					$value = call_user_func( $entry[1], $value, ...$args );
+				}
+
+				return $value;
+			}
+
+			/**
+			 * @param string $hook hook name
+			 * @return bool
+			 */
+			public function has_any( $hook ) {
+				return ! empty( $this->filters[ $hook ] );
+			}
+		}
+	}
+
+	require_once dirname( __DIR__, 2 ) . '/woodev/class-helper.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/class-plugin-exception.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/exceptions/class-payment-gateway-exception.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/api/interface-api-response.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/api/interface-payment-gateway-api-response.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/handlers/capture.php';
+
+	/**
+	 * Order double whose payment_complete() fires the
+	 * `woocommerce_payment_complete_reduce_order_stock` filter through the fake hook
+	 * registry, exactly like WC_Order::payment_complete() does, and records the result.
+	 */
+	class Woodev_Test_Capture_Order extends WC_Order {
+
+		/** @var int */
+		private $id;
+
+		/** @var float */
+		private $total;
+
+		/** @var array<string, mixed> */
+		private $meta = [];
+
+		/** @var Woodev_Test_Fake_Hook_Registry */
+		private $hooks;
+
+		/** @var bool */
+		private $throws;
+
+		/** @var stdClass capture context, matches production usage: $order->capture->amount */
+		public $capture;
+
+		/** @var bool[] each payment_complete() call's resolved stock-reduction flag */
+		public $stock_reduction_results = [];
+
+		/**
+		 * @param int                            $id order id
+		 * @param float                          $total order total
+		 * @param Woodev_Test_Fake_Hook_Registry $hooks shared fake filter registry
+		 * @param bool                           $throws whether payment_complete() should throw
+		 */
+		public function __construct( int $id, float $total, Woodev_Test_Fake_Hook_Registry $hooks, bool $throws = false ) {
+			$this->id      = $id;
+			$this->total   = $total;
+			$this->hooks   = $hooks;
+			$this->throws  = $throws;
+			$this->capture = (object) [ 'amount' => $total ];
+		}
+
+		/** @return int */
+		public function get_id(): int {
+			return $this->id;
+		}
+
+		/** @return string */
+		public function get_status() {
+			return 'processing';
+		}
+
+		/** @return float */
+		public function get_total() {
+			return $this->total;
+		}
+
+		/** @return string */
+		public function get_currency() {
+			return 'USD';
+		}
+
+		/**
+		 * @param string $note note text
+		 * @return void
+		 */
+		public function add_order_note( $note ) {}
+
+		/**
+		 * @param string $key meta key
+		 * @param bool   $single unused
+		 * @param string $context unused
+		 * @return mixed
+		 */
+		public function get_meta( $key, $single = true, $context = 'view' ) {
+			return $this->meta[ $key ] ?? '';
+		}
+
+		/**
+		 * @param string $key meta key
+		 * @param mixed  $value meta value
+		 * @return void
+		 */
+		public function update_meta_data( $key, $value ) {
+			$this->meta[ $key ] = $value;
+		}
+
+		/** @return void */
+		public function save_meta_data() {}
+
+		/**
+		 * @param string $transaction_id unused
+		 * @return bool
+		 */
+		public function payment_complete( $transaction_id = '' ) {
+
+			if ( $this->throws ) {
+				throw new \RuntimeException( 'simulated payment_complete() failure' );
+			}
+
+			$reduce                          = $this->hooks->apply( 'woocommerce_payment_complete_reduce_order_stock', true, $this->get_id() );
+			$this->stock_reduction_results[] = (bool) $reduce;
+
+			return true;
+		}
+	}
+
+	/**
+	 * Fake API whose credit_card_capture() always approves.
+	 */
+	class Woodev_Test_Capture_Api {
+
+		/**
+		 * @param object $order order being captured
+		 * @return object
+		 */
+		public function credit_card_capture( $order ) {
+			$response = \Mockery::mock( \Woodev_Payment_Gateway_API_Response::class );
+			$response->shouldReceive( 'transaction_approved' )->andReturn( true );
+			$response->shouldReceive( 'get_transaction_id' )->andReturn( '' );
+
+			return $response;
+		}
+	}
+
+	/**
+	 * Exposes Woodev_Payment_Gateway_Capture_Handler's dependencies with inert collaborators.
+	 */
+	class Woodev_Testable_Payment_Gateway_Capture extends \Woodev_Payment_Gateway {
+
+		/** @var object */
+		public $api;
+
+		/**
+		 * Skips the real constructor (settings/hooks bootstrap); this test only needs
+		 * the capture-related collaborator methods below.
+		 *
+		 * @since 2.0.2
+		 */
+		public function __construct() {}
+
+		/**
+		 * @return array
+		 * @since 2.0.2
+		 */
+		protected function get_method_form_fields(): array {
+			return [];
+		}
+
+		/**
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function get_id() {
+			return 'test-capture-gw';
+		}
+
+		/**
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function get_method_title() {
+			return 'Test Capture Gateway';
+		}
+
+		/**
+		 * @return bool
+		 * @since 2.0.2
+		 */
+		public function supports_credit_card_capture() {
+			return true;
+		}
+
+		/**
+		 * @return bool
+		 * @since 2.0.2
+		 */
+		public function supports_credit_card_partial_capture() {
+			return false;
+		}
+
+		/**
+		 * Keeps the constructor from auto-hooking maybe_capture_paid_order(), which is
+		 * outside the scope of this test.
+		 *
+		 * @return bool
+		 * @since 2.0.2
+		 */
+		public function is_paid_capture_enabled() {
+			return false;
+		}
+
+		/**
+		 * @return object
+		 * @since 2.0.2
+		 */
+		public function get_api() {
+			return $this->api;
+		}
+
+		/**
+		 * Bypasses the real get_order_for_capture() pipeline (site-name/description
+		 * building via wp_specialchars_decode() etc.), which is unrelated to the
+		 * stock-reduction filter leak under test here.
+		 *
+		 * @param object     $order order
+		 * @param float|null $amount unused
+		 * @return object
+		 * @since 2.0.2
+		 */
+		public function get_order_for_capture( $order, $amount = null ) {
+			$order->capture = (object) [ 'amount' => $amount ?? $order->get_total() ];
+
+			return $order;
+		}
+	}
+}
+
+namespace Woodev\Tests\Unit {
+
+	use Brain\Monkey\Functions;
+
+	/**
+	 * @covers \Woodev_Payment_Gateway_Capture_Handler
+	 */
+	final class PaymentGatewayCaptureStockReductionLeakTest extends TestCase {
+
+		/** @var \Woodev_Test_Fake_Hook_Registry */
+		private $hooks;
+
+		/** @var \Woodev_Testable_Payment_Gateway_Capture */
+		private $gateway;
+
+		/** @var \Woodev_Payment_Gateway_Capture_Handler */
+		private $handler;
+
+		/**
+		 * @return void
+		 */
+		protected function setUp(): void {
+			parent::setUp();
+
+			$this->hooks = new \Woodev_Test_Fake_Hook_Registry();
+
+			Functions\when( 'wc_price' )->justReturn( '$0.00' );
+
+			Functions\when( 'add_filter' )
+				->alias(
+					function ( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+						return $this->hooks->add( $hook, $callback, $priority );
+					}
+				);
+
+			Functions\when( 'remove_filter' )
+				->alias(
+					function ( $hook, $callback, $priority = 10 ) {
+						return $this->hooks->remove( $hook, $callback, $priority );
+					}
+				);
+
+			$this->gateway      = new \Woodev_Testable_Payment_Gateway_Capture();
+			$this->gateway->api = new \Woodev_Test_Capture_Api();
+			$this->handler       = new \Woodev_Payment_Gateway_Capture_Handler( $this->gateway );
+		}
+
+		/**
+		 * Reproduces the "Capture charge" bulk order action: the first fully-captured
+		 * order must have ITS OWN stock reduction suppressed (correct, intentional
+		 * behavior — stock was already reduced at authorization), but a later,
+		 * unrelated payment_complete() in the same request must NOT be affected.
+		 *
+		 * @return void
+		 */
+		public function test_stock_reduction_filter_does_not_leak_to_a_later_order_in_the_same_request(): void {
+			$order_a = new \Woodev_Test_Capture_Order( 100, 100.0, $this->hooks );
+			$this->gateway->update_order_meta( $order_a, 'trans_id', 'TXN-A' );
+
+			$result_a = $this->handler->perform_capture( $order_a );
+
+			$this->assertTrue( $result_a['success'] );
+			$this->assertSame(
+				[ false ],
+				$order_a->stock_reduction_results,
+				'the captured order\'s own stock reduction must be suppressed (it was already reduced at authorization)'
+			);
+
+			// a later, unrelated order completing payment in the SAME request (e.g. another
+			// listener on woocommerce_order_status_changed) must reduce stock normally
+			$order_b = new \Woodev_Test_Capture_Order( 200, 50.0, $this->hooks );
+			$order_b->payment_complete();
+
+			$this->assertSame(
+				[ true ],
+				$order_b->stock_reduction_results,
+				'an unrelated order completing payment afterwards must not inherit the suppression installed for order #100'
+			);
+		}
+
+		/**
+		 * The filter must be removed even when payment_complete() itself throws, so a
+		 * failure while capturing one order in a bulk action does not leak suppression
+		 * into every order processed afterwards.
+		 *
+		 * @return void
+		 */
+		public function test_filter_is_removed_even_when_payment_complete_throws(): void {
+			$order_a = new \Woodev_Test_Capture_Order( 100, 100.0, $this->hooks, true );
+			$this->gateway->update_order_meta( $order_a, 'trans_id', 'TXN-A' );
+
+			try {
+				$this->handler->perform_capture( $order_a );
+				$this->fail( 'Expected the simulated payment_complete() failure to propagate' );
+			} catch ( \RuntimeException $exception ) {
+				$this->assertSame( 'simulated payment_complete() failure', $exception->getMessage() );
+			}
+
+			$order_b = new \Woodev_Test_Capture_Order( 200, 50.0, $this->hooks );
+			$order_b->payment_complete();
+
+			$this->assertSame(
+				[ true ],
+				$order_b->stock_reduction_results,
+				'the filter must be removed via finally even though payment_complete() threw'
+			);
+		}
+	}
+}

--- a/tests/unit/PaymentGatewayHostedPaymentUrlTest.php
+++ b/tests/unit/PaymentGatewayHostedPaymentUrlTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Verifies #385: Woodev_Payment_Gateway_Hosted::get_payment_url() returns string|false
+ * as documented, never a WC_Order object, when the hosted pay page URL is unavailable.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! class_exists( 'WC_Payment_Gateway', false ) ) {
+		/**
+		 * Minimal WooCommerce gateway base for the hosted gateway test double.
+		 */
+		class WC_Payment_Gateway {}
+	}
+
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway-hosted.php';
+
+	/**
+	 * Exposes the protected get_payment_url() under test with inert collaborators.
+	 */
+	class Woodev_Testable_Payment_Gateway_Hosted_Url extends \Woodev_Payment_Gateway_Hosted {
+
+		/** @var object order stub returned by get_order() */
+		private $order;
+
+		/**
+		 * @param object $order order stub
+		 * @since 2.0.2
+		 */
+		public function __construct( object $order ) {
+			$this->order = $order;
+		}
+
+		/**
+		 * @return array
+		 * @since 2.0.2
+		 */
+		protected function get_method_form_fields(): array {
+			return [];
+		}
+
+		/**
+		 * Skips the real order-hydration pipeline; returns the injected stub instead.
+		 *
+		 * @param int|object $order_id order id
+		 * @return object
+		 * @since 2.0.2
+		 */
+		public function get_order( $order_id ) {
+			return $this->order;
+		}
+
+		/**
+		 * Simulates an unconfigured hosted pay page endpoint.
+		 *
+		 * @param object|null $order order
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function get_hosted_pay_page_url( $order = null ) {
+			return '';
+		}
+
+		/**
+		 * @param object $order order
+		 * @return array
+		 * @since 2.0.2
+		 */
+		public function get_hosted_pay_page_params( $order ) {
+			return [];
+		}
+
+		/**
+		 * Unused by this test; implements the abstract method so the class can be instantiated.
+		 *
+		 * @param array $request_response_data unused
+		 * @return object
+		 * @since 2.0.2
+		 */
+		protected function get_transaction_response( $request_response_data ) {
+			return new \stdClass();
+		}
+
+		/**
+		 * @return bool
+		 * @since 2.0.2
+		 */
+		public function empty_cart_before_redirect() {
+			return false;
+		}
+
+		/**
+		 * Exposes the protected get_payment_url() for direct assertions.
+		 *
+		 * @param int $order_id order id
+		 * @return string|false
+		 * @since 2.0.2
+		 */
+		public function expose_get_payment_url( $order_id ) {
+			return $this->get_payment_url( $order_id );
+		}
+	}
+}
+
+namespace Woodev\Tests\Unit {
+
+	/**
+	 * @covers \Woodev_Payment_Gateway_Hosted
+	 */
+	final class PaymentGatewayHostedPaymentUrlTest extends TestCase {
+
+		/**
+		 * When the hosted pay page URL is unavailable, get_payment_url() must return
+		 * false (per its own docblock), never the WC_Order object it built internally.
+		 *
+		 * @return void
+		 * @since 2.0.2
+		 */
+		public function test_get_payment_url_returns_false_when_hosted_pay_page_url_is_empty(): void {
+			$gateway = new \Woodev_Testable_Payment_Gateway_Hosted_Url( new \stdClass() );
+
+			$result = $gateway->expose_get_payment_url( 123 );
+
+			$this->assertFalse( $result, 'get_payment_url() must return false, not the order object, when the hosted pay page URL is empty' );
+		}
+
+		/**
+		 * process_payment() must surface a 'failure' result rather than handing an
+		 * object to WooCommerce as a redirect URL (which fatals in wp_redirect() on
+		 * the classic checkout path, or serializes an object into window.location on
+		 * the AJAX path).
+		 *
+		 * @return void
+		 * @since 2.0.2
+		 */
+		public function test_process_payment_returns_failure_when_hosted_pay_page_url_is_empty(): void {
+			$gateway = new \Woodev_Testable_Payment_Gateway_Hosted_Url( new \stdClass() );
+
+			$result = $gateway->process_payment( 123 );
+
+			$this->assertSame( [ 'result' => 'failure' ], $result );
+		}
+	}
+}

--- a/tests/unit/PaymentGatewayTransactionIdHposTest.php
+++ b/tests/unit/PaymentGatewayTransactionIdHposTest.php
@@ -19,6 +19,14 @@ namespace {
 	if ( ! class_exists( 'WC_Order', false ) ) {
 		/**
 		 * Minimal WooCommerce order base for the gateway test double.
+		 *
+		 * get_id() returns 123 (not 0) to match the shape every other guarded
+		 * `WC_Order` stub in this suite uses (see PaymentGatewayDirectXssTest.php).
+		 * Because this class is declared behind a `class_exists()` guard in the
+		 * global namespace, whichever test file's version PHPUnit loads first for
+		 * the whole run "wins" for every other test file too — an id of 0 fails
+		 * `$order_id > 0` checks (e.g. Woodev_Order_Compatibility::update_order_meta())
+		 * in unrelated tests that construct a bare `new WC_Order()`.
 		 */
 		class WC_Order {
 
@@ -26,7 +34,7 @@ namespace {
 			 * @return int
 			 */
 			public function get_id(): int {
-				return 0;
+				return 123;
 			}
 		}
 	}

--- a/tests/unit/PaymentGatewayTransactionIdHposTest.php
+++ b/tests/unit/PaymentGatewayTransactionIdHposTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Verifies #398: Woodev_Payment_Gateway::add_transaction_data() writes the core order
+ * transaction id through the HPOS-safe WC_Order setter, never update_post_meta(), which
+ * bypasses the orders table when HPOS (custom order tables) is enabled.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! class_exists( 'WC_Payment_Gateway', false ) ) {
+		/**
+		 * Minimal WooCommerce gateway base for the gateway test double.
+		 */
+		class WC_Payment_Gateway {}
+	}
+
+	if ( ! class_exists( 'WC_Order', false ) ) {
+		/**
+		 * Minimal WooCommerce order base for the gateway test double.
+		 */
+		class WC_Order {
+
+			/**
+			 * @return int
+			 */
+			public function get_id(): int {
+				return 0;
+			}
+		}
+	}
+
+	require_once dirname( __DIR__, 2 ) . '/woodev/class-helper.php';
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway.php';
+
+	/**
+	 * Order double that records core-prop writes (set_transaction_id()/save()) and
+	 * meta writes (update_meta_data()) separately, so the test can prove the
+	 * transaction id goes through the WC_Order setter rather than update_post_meta().
+	 */
+	class Woodev_Test_Transaction_Data_Order extends WC_Order {
+
+		/** @var array<string, mixed> */
+		private $meta = [];
+
+		/** @var string|null */
+		private $transaction_id;
+
+		/** @var int */
+		private $save_calls = 0;
+
+		/**
+		 * @return int
+		 */
+		public function get_id(): int {
+			return 555;
+		}
+
+		/**
+		 * @param string $key meta key
+		 * @param mixed  $value meta value
+		 * @return void
+		 */
+		public function update_meta_data( $key, $value ): void {
+			$this->meta[ $key ] = $value;
+		}
+
+		/**
+		 * @return void
+		 */
+		public function save_meta_data(): void {}
+
+		/**
+		 * @param string $value transaction id
+		 * @return void
+		 */
+		public function set_transaction_id( $value ): void {
+			$this->transaction_id = $value;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_transaction_id(): string {
+			return (string) $this->transaction_id;
+		}
+
+		/**
+		 * @return void
+		 */
+		public function save(): void {
+			++$this->save_calls;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function get_save_call_count(): int {
+			return $this->save_calls;
+		}
+
+		/**
+		 * @return array<string, mixed>
+		 */
+		public function get_meta_writes(): array {
+			return $this->meta;
+		}
+	}
+
+	/**
+	 * Exposes add_transaction_data() under test with inert collaborators.
+	 */
+	class Woodev_Testable_Payment_Gateway_Transaction_Data extends \Woodev_Payment_Gateway {
+
+		/**
+		 * Skips the real constructor (settings/hooks bootstrap); this test only needs
+		 * add_transaction_data().
+		 *
+		 * @since 2.0.2
+		 */
+		public function __construct() {}
+
+		/**
+		 * @return array
+		 * @since 2.0.2
+		 */
+		protected function get_method_form_fields(): array {
+			return [];
+		}
+
+		/**
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function get_id() {
+			return 'test-gateway';
+		}
+
+		/**
+		 * @return array
+		 * @since 2.0.2
+		 */
+		public function get_environments() {
+			return [ 'production' => 'Production' ];
+		}
+
+		/**
+		 * @return bool
+		 * @since 2.0.2
+		 */
+		public function supports_customer_id() {
+			return false;
+		}
+
+		/**
+		 * @return bool
+		 * @since 2.0.2
+		 */
+		public function is_credit_card_gateway() {
+			return false;
+		}
+	}
+}
+
+namespace Woodev\Tests\Unit {
+
+	use Brain\Monkey\Functions;
+
+	/**
+	 * @covers \Woodev_Payment_Gateway
+	 */
+	final class PaymentGatewayTransactionIdHposTest extends TestCase {
+
+		/**
+		 * @return void
+		 */
+		protected function setUp(): void {
+			parent::setUp();
+
+			Functions\when( 'current_time' )->justReturn( '2026-08-21 00:00:00' );
+			Functions\when( 'do_action' )->justReturn( true );
+
+			// update_post_meta() bypasses the WC_Order object entirely, so it is never
+			// stubbed to succeed here — it must not be called at all.
+			Functions\expect( 'update_post_meta' )->never();
+		}
+
+		/**
+		 * @return void
+		 */
+		public function test_add_transaction_data_uses_the_core_setter_and_saves_the_order(): void {
+			$order    = new \Woodev_Test_Transaction_Data_Order();
+			$response = \Mockery::mock();
+			$response->shouldReceive( 'get_transaction_id' )->andReturn( 'TXN-42' );
+
+			$gateway = new \Woodev_Testable_Payment_Gateway_Transaction_Data();
+			$gateway->add_transaction_data( $order, $response );
+
+			$this->assertSame(
+				'TXN-42',
+				$order->get_transaction_id(),
+				'add_transaction_data() must call $order->set_transaction_id() so get_transaction_id() reflects it under HPOS'
+			);
+			$this->assertGreaterThan(
+				0,
+				$order->get_save_call_count(),
+				'the order must be saved so the HPOS-backed transaction id is actually persisted'
+			);
+			// the framework's own trans_id meta must still be written (data contract, unchanged)
+			$this->assertSame( 'TXN-42', $order->get_meta_writes()['_wc_test-gateway_trans_id'] ?? null );
+		}
+
+		/**
+		 * When there is no transaction id to record, neither the setter nor the meta
+		 * write should be touched.
+		 *
+		 * @return void
+		 */
+		public function test_add_transaction_data_skips_transaction_id_when_response_has_none(): void {
+			$order    = new \Woodev_Test_Transaction_Data_Order();
+			$response = \Mockery::mock();
+			$response->shouldReceive( 'get_transaction_id' )->andReturn( '' );
+
+			$gateway = new \Woodev_Testable_Payment_Gateway_Transaction_Data();
+			$gateway->add_transaction_data( $order, $response );
+
+			$this->assertSame( '', $order->get_transaction_id() );
+			$this->assertSame( 0, $order->get_save_call_count() );
+		}
+	}
+}

--- a/tests/unit/PaymentGatewayVoidedOrderLeakTest.php
+++ b/tests/unit/PaymentGatewayVoidedOrderLeakTest.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Verifies #392: mark_order_as_voided() / maybe_cancel_voided_order() no longer leak
+ * across orders processed within the same request (e.g. a bulk refund action, WP-CLI,
+ * or a REST/webhook run handling several orders).
+ *
+ * Brain Monkey's apply_filters() does not itself invoke callbacks registered via
+ * add_filter() — it only records that they were "added". To prove the filter is
+ * actually removed (not just that remove_filter() was called with plausible-looking
+ * arguments), this test stubs add_filter()/remove_filter() with a tiny in-memory
+ * registry and fires the captured callback itself, the same way WooCommerce would.
+ *
+ * @package Woodev\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! class_exists( 'WC_Payment_Gateway', false ) ) {
+		/**
+		 * Minimal WooCommerce gateway base for the gateway test double.
+		 */
+		class WC_Payment_Gateway {}
+	}
+
+	if ( ! class_exists( 'Woodev_Test_Fake_Hook_Registry', false ) ) {
+		/**
+		 * A minimal in-memory stand-in for WordPress's filter storage, used to prove
+		 * add_filter()/remove_filter() calls actually take effect rather than merely
+		 * asserting they were called with plausible-looking arguments.
+		 */
+		class Woodev_Test_Fake_Hook_Registry {
+
+			/** @var array<string, array<int, array{0: int, 1: callable}>> */
+			private $filters = [];
+
+			/**
+			 * @param string   $hook hook name
+			 * @param callable $callback callback
+			 * @param int      $priority priority
+			 * @return true
+			 */
+			public function add( $hook, $callback, $priority = 10 ) {
+				$this->filters[ $hook ][] = [ $priority, $callback ];
+
+				return true;
+			}
+
+			/**
+			 * @param string   $hook hook name
+			 * @param callable $callback callback
+			 * @param int      $priority priority
+			 * @return bool
+			 */
+			public function remove( $hook, $callback, $priority = 10 ) {
+				if ( ! isset( $this->filters[ $hook ] ) ) {
+					return false;
+				}
+
+				foreach ( $this->filters[ $hook ] as $i => $entry ) {
+					if ( $priority === $entry[0] && $callback === $entry[1] ) {
+						unset( $this->filters[ $hook ][ $i ] );
+
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			/**
+			 * Fires every callback still registered for the hook, in order, the same
+			 * way WordPress's apply_filters() would.
+			 *
+			 * @param string $hook hook name
+			 * @param mixed  ...$args value followed by any extra filter args
+			 * @return mixed
+			 */
+			public function apply( $hook, ...$args ) {
+				$value = array_shift( $args );
+
+				foreach ( $this->filters[ $hook ] ?? [] as $entry ) {
+					$value = call_user_func( $entry[1], $value, ...$args );
+				}
+
+				return $value;
+			}
+
+			/**
+			 * @param string $hook hook name
+			 * @return bool
+			 */
+			public function has_any( $hook ) {
+				return ! empty( $this->filters[ $hook ] );
+			}
+		}
+	}
+
+	require_once dirname( __DIR__, 2 ) . '/woodev/payment-gateway/class-payment-gateway.php';
+
+	/**
+	 * Exposes the void/refund-status hooks under test with inert collaborators.
+	 */
+	class Woodev_Testable_Payment_Gateway_Voided_Leak extends \Woodev_Payment_Gateway {
+
+		/**
+		 * Skips the real constructor (settings/hooks bootstrap); this test only needs
+		 * the void/refund-status methods.
+		 *
+		 * @since 2.0.2
+		 */
+		public function __construct() {}
+
+		/**
+		 * @return array
+		 * @since 2.0.2
+		 */
+		protected function get_method_form_fields(): array {
+			return [];
+		}
+
+		/**
+		 * @return string
+		 * @since 2.0.2
+		 */
+		public function get_method_title() {
+			return 'Test Gateway';
+		}
+	}
+}
+
+namespace Woodev\Tests\Unit {
+
+	use Brain\Monkey\Functions;
+
+	/**
+	 * @covers \Woodev_Payment_Gateway
+	 */
+	final class PaymentGatewayVoidedOrderLeakTest extends TestCase {
+
+		/** @var array<int, object> order id => order double, resolved by wc_get_order() */
+		private $orders = [];
+
+		/** @var \Woodev_Test_Fake_Hook_Registry */
+		private $hooks;
+
+		/**
+		 * @return void
+		 */
+		protected function setUp(): void {
+			parent::setUp();
+
+			$this->orders = [];
+			$this->hooks  = new \Woodev_Test_Fake_Hook_Registry();
+
+			Functions\when( 'wc_price' )->justReturn( '$10.00' );
+
+			Functions\when( 'wc_get_order' )
+				->alias(
+					function ( $order_id ) {
+						return $this->orders[ $order_id ] ?? null;
+					}
+				);
+
+			Functions\when( 'add_filter' )
+				->alias(
+					function ( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+						return $this->hooks->add( $hook, $callback, $priority );
+					}
+				);
+
+			Functions\when( 'remove_filter' )
+				->alias(
+					function ( $hook, $callback, $priority = 10 ) {
+						return $this->hooks->remove( $hook, $callback, $priority );
+					}
+				);
+		}
+
+		/**
+		 * Builds an order double. Voided orders are never `cancelled` already, so
+		 * `has_status( 'cancelled' )` must answer false for mark_order_as_voided() to
+		 * install the filter.
+		 *
+		 * @param int $id order id
+		 * @return \Mockery\MockInterface
+		 */
+		private function make_order( int $id ) {
+			$order = \Mockery::mock();
+			$order->shouldReceive( 'get_id' )->andReturn( $id );
+			$order->shouldReceive( 'has_status' )->with( 'cancelled' )->andReturn( false );
+			$order->shouldReceive( 'get_currency' )->andReturn( 'USD' );
+			$order->refund = (object) [ 'amount' => 12.34 ];
+
+			$this->orders[ $id ] = $order;
+
+			return $order;
+		}
+
+		/**
+		 * Reproduces the bulk-action scenario from the bug report: void order #100,
+		 * then fully refund an unrelated order #200 in the SAME request (simulated by
+		 * firing the `woocommerce_order_fully_refunded_status` filter WordPress-style,
+		 * through the fake registry, rather than calling the callback directly).
+		 * Order #200 must keep its own status and must never receive order #100's
+		 * void note.
+		 *
+		 * @return void
+		 */
+		public function test_maybe_cancel_voided_order_does_not_act_on_a_different_order_in_the_same_request(): void {
+			$order_100 = $this->make_order( 100 );
+			$order_100->shouldReceive( 'add_order_note' )->once();
+
+			$order_200 = $this->make_order( 200 );
+			$order_200->shouldReceive( 'add_order_note' )->never();
+
+			$response_100 = \Mockery::mock();
+			$response_100->shouldReceive( 'get_transaction_id' )->andReturn( false );
+
+			$gateway = new \Woodev_Testable_Payment_Gateway_Voided_Leak();
+
+			// void order #100 — installs the woocommerce_order_fully_refunded_status filter
+			$gateway->mark_order_as_voided( $order_100, $response_100 );
+
+			// simulate WC firing the filter for order #200 being fully refunded, in the same request
+			$result_for_200 = $this->hooks->apply( 'woocommerce_order_fully_refunded_status', 'refunded', 200 );
+
+			$this->assertSame( 'refunded', $result_for_200, 'order #200 must keep its own fully-refunded status, not be forced to cancelled' );
+
+			// order #100's own fully-refunded event must still be handled correctly afterwards
+			$result_for_100 = $this->hooks->apply( 'woocommerce_order_fully_refunded_status', 'refunded', 100 );
+
+			$this->assertSame( 'cancelled', $result_for_100, 'order #100 must still be cancelled when its own fully-refunded event fires' );
+		}
+
+		/**
+		 * Once every order the filter was installed for has been resolved, the filter
+		 * must be removed so it cannot affect a later, wholly unrelated refund event
+		 * (e.g. a third order refunded further down the same bulk action, with no void
+		 * involved at all).
+		 *
+		 * @return void
+		 */
+		public function test_filter_is_removed_after_the_voided_order_is_resolved(): void {
+			$order_100 = $this->make_order( 100 );
+			$order_100->shouldReceive( 'add_order_note' )->once();
+
+			$response_100 = \Mockery::mock();
+			$response_100->shouldReceive( 'get_transaction_id' )->andReturn( false );
+
+			$gateway = new \Woodev_Testable_Payment_Gateway_Voided_Leak();
+
+			$gateway->mark_order_as_voided( $order_100, $response_100 );
+			$this->hooks->apply( 'woocommerce_order_fully_refunded_status', 'refunded', 100 );
+
+			$this->assertFalse(
+				$this->hooks->has_any( 'woocommerce_order_fully_refunded_status' ),
+				'the filter must be removed once its order was resolved, so a later, unrelated refund in the same request is left untouched'
+			);
+		}
+	}
+}

--- a/woodev/payment-gateway/class-payment-gateway-hosted.php
+++ b/woodev/payment-gateway/class-payment-gateway-hosted.php
@@ -133,7 +133,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Hosted' ) ) :
 				}
 			}
 
-			return $order;
+			return false;
 		}
 
 

--- a/woodev/payment-gateway/class-payment-gateway.php
+++ b/woodev/payment-gateway/class-payment-gateway.php
@@ -2059,7 +2059,11 @@ if ( ! class_exists( 'Woodev_Payment_Gateway' ) ) :
 
 				$this->update_order_meta( $order, 'trans_id', $response->get_transaction_id() );
 
-				update_post_meta( $order->get_id(), '_transaction_id', $response->get_transaction_id() );
+				// use the core WC setter (HPOS-safe) instead of update_post_meta(), which bypasses
+				// the orders table when HPOS is enabled; the `_transaction_id` meta key itself is
+				// unchanged, only how it's written
+				$order->set_transaction_id( $response->get_transaction_id() );
+				$order->save();
 			}
 
 			// transaction date

--- a/woodev/payment-gateway/class-payment-gateway.php
+++ b/woodev/payment-gateway/class-payment-gateway.php
@@ -194,8 +194,8 @@ if ( ! class_exists( 'Woodev_Payment_Gateway' ) ) :
 		/** @var Woodev_Payment_Gateway_Payment_Form|null payment form instance */
 		protected $payment_form;
 
-		/** @var string transient voided order message, passed between mark_order_as_voided() and maybe_cancel_voided_order() */
-		private $voided_order_message = '';
+		/** @var array<int, string> transient voided order messages keyed by order ID, passed between mark_order_as_voided() and maybe_cancel_voided_order() */
+		private $voided_order_messages = [];
 
 
 		/**
@@ -1918,7 +1918,7 @@ if ( ! class_exists( 'Woodev_Payment_Gateway' ) ) :
 			// mark order as cancelled, since no money was actually transferred
 			if ( ! $order->has_status( 'cancelled' ) ) {
 
-				$this->voided_order_message = $message;
+				$this->voided_order_messages[ $order->get_id() ] = $message;
 
 				add_filter(
 					'woocommerce_order_fully_refunded_status',
@@ -1949,14 +1949,35 @@ if ( ! class_exists( 'Woodev_Payment_Gateway' ) ) :
 		 */
 		public function maybe_cancel_voided_order( $order_status, $order_id ) {
 
-			if ( empty( $this->voided_order_message ) ) {
+			// only act on the specific order(s) that mark_order_as_voided() installed this filter for;
+			// otherwise, in the same request, an unrelated order being fully refunded would incorrectly
+			// be forced to 'cancelled' and would pick up a stale order note meant for a different order
+			if ( ! isset( $this->voided_order_messages[ $order_id ] ) ) {
 				return $order_status;
+			}
+
+			$message = $this->voided_order_messages[ $order_id ];
+
+			unset( $this->voided_order_messages[ $order_id ] );
+
+			// once every order this filter was installed for has been handled, remove it so it
+			// doesn't affect any later, unrelated `woocommerce_order_fully_refunded_status` calls
+			// in the same request
+			if ( empty( $this->voided_order_messages ) ) {
+				remove_filter(
+					'woocommerce_order_fully_refunded_status',
+					array(
+						$this,
+						'maybe_cancel_voided_order',
+					),
+					10
+				);
 			}
 
 			$order = wc_get_order( $order_id );
 
 			// no way to set the order note with the status change
-			$order->add_order_note( $this->voided_order_message );
+			$order->add_order_note( $message );
 
 			return 'cancelled';
 		}

--- a/woodev/payment-gateway/handlers/capture.php
+++ b/woodev/payment-gateway/handlers/capture.php
@@ -172,11 +172,19 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Capture_Handler' ) ) :
 				// if the original auth amount has been captured, complete payment
 				if ( $this->get_gateway()->get_order_meta( $order, 'capture_total' ) >= $order->get_total() ) {
 
-					// prevent stock from being reduced when payment is completed as this is done when the charge was authorized
-					add_filter( 'woocommerce_payment_complete_reduce_order_stock', '__return_false', 100 );
+					// prevent stock from being reduced when payment is completed as this is done when the charge was authorized;
+					// use a handler-specific callback (not the generic __return_false) so remove_filter() below can never
+					// touch an identical __return_false callback a consumer plugin may have added independently
+					add_filter( 'woocommerce_payment_complete_reduce_order_stock', array( $this, 'suppress_order_stock_reduction' ), 100 );
 
-					// complete the order
-					$order->payment_complete();
+					try {
+						// complete the order
+						$order->payment_complete();
+					} finally {
+						// always remove the filter, even if payment_complete() throws, so it never leaks into a
+						// later payment_complete() call for a different order in the same request (e.g. bulk capture)
+						remove_filter( 'woocommerce_payment_complete_reduce_order_stock', array( $this, 'suppress_order_stock_reduction' ), 100 );
+					}
 				}
 
 				return array(
@@ -206,6 +214,24 @@ if ( ! class_exists( 'Woodev_Payment_Gateway_Capture_Handler' ) ) :
 					'message' => $exception->getMessage(),
 				);
 			}
+		}
+
+
+		/**
+		 * Callback for the `woocommerce_payment_complete_reduce_order_stock` filter, used to suppress
+		 * stock reduction for an order whose stock was already reduced when the charge was authorized.
+		 *
+		 * A dedicated method (rather than `__return_false`) is used so `remove_filter()` in
+		 * perform_capture() only ever removes the filter this handler added, never an identical
+		 * `__return_false` callback a consumer plugin may have added independently at the same priority.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return bool
+		 */
+		public function suppress_order_stock_reduction() {
+
+			return false;
 		}
 
 


### PR DESCRIPTION
Четыре независимых дефекта из ревью 27B. Две из них — утечки между заказами внутри одного запроса: они не оставляют ни ошибки, ни заметки, и всплывают только при инвентаризации или в статусах заказов.

## #385 — `get_payment_url()` возвращал `WC_Order` вместо `string|false`

При пустом hosted-URL метод возвращал объект заказа, хотя докблок обещает `string|false`. Проверка `if ( ! $payment_url )` написана под `false`, объект истинный — и уходил в `[ 'result' => 'success', 'redirect' => $payment_url ]`. На классическом пути объект доезжал до `wp_sanitize_redirect()` → `preg_replace()` → TypeError и фатальная 500 **прямо на чекауте**; на AJAX-пути сериализовался в JSON и присваивался `window.location`.

Теперь `return false` и результат `failure`. Проход по остальному `payment-gateway/` других расхождений «докблок обещает скаляр, код возвращает объект» не нашёл.

## #392 — фильтр возврата протекал на СЛЕДУЮЩИЙ заказ

`mark_order_as_voided()` вешал `woocommerce_order_fully_refunded_status` и никогда не снимал, `$voided_order_message` не очищался, а колбэк не сверял `$order_id` с тем заказом, для которого ставился.

В одном запросе: void заказа #100, затем полный возврат заказа #200 (массовое действие, WP-CLI, REST/вебхук) — **#200 получал статус `cancelled` вместо `refunded` и заметку о void'е чужого заказа с чужой суммой.**

Теперь сообщения отслеживаются **по id заказа**, а фильтр снимается, как только очередь опустела.

## #398 — `_transaction_id` писался мимо HPOS

`add_transaction_data()` делал `update_post_meta( $order->get_id(), '_transaction_id', … )` в обход объекта заказа — строкой выше тот же метод использовал HPOS-безопасный `update_order_meta()`. При включённом HPOS без синхронизации с таблицей постов `$order->get_transaction_id()` возвращал пусто: колонка в списке заказов пустая, возвраты/void/выгрузки id транзакции не видят.

Теперь через `$order->set_transaction_id()` + `save()`. **Ключ меты `_transaction_id` не менялся** — контракт установленной площадки сохранён.

## #401 — фильтр отключения списания склада не снимался

`perform_capture()` вешал `add_filter( 'woocommerce_payment_complete_reduce_order_stock', '__return_false', 100 )` перед `payment_complete()` и не снимал. Массовое действие «Capture charge» обрабатывает всю выборку в одном запросе: первый захваченный заказ ставил фильтр, **и все последующие `payment_complete()` в этом запросе проходили без списания остатков.** Ни ошибки, ни заметки.

Теперь снимается в `finally` и через **собственный колбэк хендлера**, а не `__return_false`: снятие не затрагивает одноимённый фильтр, который мог осознанно поставить сторонний плагин.

## Как проверялось

Воркер Sonnet. Каждый из восьми новых тестов проверен на падение на пре-фиксном коде через revert-test-restore. Для #392 и #401 тест меряет **второй заказ в том же запросе** — то есть саму утечку, а не то, что первый заказ работает.

### Что пришлось вернуть на доработку

Воркер отчитался о двух падениях в `PickupHandlerTest.php` как о «преэкзистующих, не связанных». Замер это опроверг:

```
main            --filter PickupHandlerTest  →  OK (206 тестов, 745 ассертов)
ветка (до)      --filter PickupHandlerTest  →  FAILURES, 2 (206 тестов, 741 ассерт)
```

Фильтр выбирает только этот файл, так что порядок тестов ни при чём. Причина оказалась поучительной: два новых тест-файла объявляли **глобальный класс `WC_Order` под `class_exists()`-гардом** с `get_id()`, возвращающим `0`. Гард означает, что определение выигрывает тот файл, который загрузился первым — а мои по алфавиту опережали устоявшийся стаб из `PaymentGatewayDirectXssTest.php` с `123`. Дальше `new WC_Order()` в PickupHandlerTest получал `get_id() === 0`, это не проходило гард `$order_id > 0` в `Woodev_Order_Compatibility::update_order_meta()`, и запись меты молча не происходила.

Исправлено пятым коммитом. Заодно вскрылось, что `.phpunit.result.cache` при `executionOrder="depends,defects"` делает прогон невоспроизводимым: тот же ворктри дал 45 ошибок со старым кэшем и 2 падения после его удаления. Обе находки записаны готчами.

## Гейты (кэш результатов удалён перед каждым прогоном)

phpcs 217/217 чисто, phpstan 0 ошибок, 2504 unit / 6208 ассертов / 66 skipped / 0 падений, jest 1260.

Разница 2504 против 2508 на `main` — ветка форкнута от `ce6d318`, а `main` с тех пор ушёл на два смерженных PR (#428, #430).

Closes #385
Closes #392
Closes #398
Closes #401