### PR TITLE
fix(licensing): ключ лицензии больше не попадает в debug-лог — редактирование fail-safe по умолчанию

### DIFF
--- a/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
+++ b/tests/unit/Api/ApiBaseSanitizedHeadersTest.php
@@ -165,7 +165,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $value ) ), $headers['Authorization'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['Authorization'] );
 	}
 
 	/**
@@ -181,7 +181,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['X-Secret'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['X-Secret'] );
 		$this->assertStringNotContainsString( $secret, print_r( $headers, true ), 'the secret leaked into the sanitized headers' );
 	}
 
@@ -201,7 +201,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$this->assertArrayHasKey( 'x-secret', $headers );
 		$this->assertArrayNotHasKey( 'X-Secret', $headers );
-		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['x-secret'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['x-secret'] );
 	}
 
 	/**
@@ -218,7 +218,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['X-Custom-Secret'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['X-Custom-Secret'] );
 	}
 
 	/**
@@ -237,25 +237,25 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_headers_for_test();
 
-		$this->assertSame( '*', $headers['X-Secret'], "a credential of '0' must be masked, not passed through" );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['X-Secret'], "a credential of '0' must be masked, not passed through" );
 	}
 
 	/**
-	 * Masking a genuinely empty value is harmless: the mask is as long as the
-	 * value, so the header still logs as empty rather than as a row of stars.
+	 * Masking a genuinely empty value is not skipped either — it still logs as
+	 * {@see \Woodev_API_Base::SECRET_VALUE_MASK} rather than as `''`.
 	 *
 	 * Pinned so a future "optimisation" that skips empty values cannot quietly
 	 * reintroduce the `'0'` hole above.
 	 *
 	 * @return void
 	 */
-	public function test_an_empty_credential_value_stays_empty(): void {
+	public function test_an_empty_credential_value_is_still_masked(): void {
 		$api = new Testable_Api_Base();
 		$api->set_headers_for_test( [ 'Authorization' => '' ] );
 
 		$headers = $api->get_sanitized_headers_for_test();
 
-		$this->assertSame( '', $headers['Authorization'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['Authorization'] );
 	}
 
 	/**
@@ -292,7 +292,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_response_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $headers['Set-Cookie'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['Set-Cookie'] );
 		$this->assertStringNotContainsString( $cookie, print_r( $headers, true ), 'the cookie leaked into the sanitized response headers' );
 	}
 
@@ -310,7 +310,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_response_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $refreshed_token ) ), $headers['X-Auth-Token'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['X-Auth-Token'] );
 	}
 
 	/**
@@ -329,7 +329,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$this->assertArrayHasKey( 'set-cookie', $headers );
 		$this->assertArrayNotHasKey( 'Set-Cookie', $headers );
-		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $headers['set-cookie'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['set-cookie'] );
 	}
 
 	/**
@@ -346,7 +346,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_response_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers['X-Custom-Secret'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['X-Custom-Secret'] );
 	}
 
 	/**
@@ -405,7 +405,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 		$broadcast = $api->get_response_data_for_broadcast_for_test();
 
 		$this->assertArrayHasKey( 'headers', $broadcast );
-		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $broadcast['headers']['Set-Cookie'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $broadcast['headers']['Set-Cookie'] );
 		$this->assertStringNotContainsString(
 			$cookie,
 			print_r( $broadcast, true ),
@@ -435,7 +435,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$this->assertIsArray( $headers['Set-Cookie'], 'the array shape of a duplicated header must survive masking' );
 		$this->assertSame(
-			[ str_repeat( '*', strlen( $cookie_a ) ), str_repeat( '*', strlen( $cookie_b ) ) ],
+			[ \Woodev_API_Base::SECRET_VALUE_MASK, \Woodev_API_Base::SECRET_VALUE_MASK ],
 			$headers['Set-Cookie']
 		);
 
@@ -459,7 +459,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $cookie ) ), $headers['Cookie'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers['Cookie'] );
 	}
 
 	/**
@@ -482,7 +482,7 @@ final class ApiBaseSanitizedHeadersTest extends TestCase {
 
 		$headers = $api->get_sanitized_response_headers_for_test();
 
-		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $headers[ $header_name ] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $headers[ $header_name ] );
 	}
 
 	/**

--- a/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
+++ b/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
@@ -429,6 +429,18 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 	 * prettifies the XML — must still be masked by the base's own fail-safe
 	 * pass.
 	 *
+	 * #395 Round 5: this used to also assert that `<Format>json</Format>`
+	 * survived untouched, pinning the OLD regex backstop's partial-masking
+	 * behavior as if it were a contract. It never was one: an independent
+	 * critic review proved that same regex backstop cannot see a secret in a
+	 * `print_r()`-shaped body at all (see
+	 * `test_unknown_request_class_print_r_shaped_post_body_is_masked_in_full_by_default()`
+	 * below), so XML's partial masking was luck of the shape, not a
+	 * guarantee. The base now cannot tell a secret-named element apart from
+	 * a safe sibling one in ANY format it cannot parse structurally, so it
+	 * masks the whole body instead — deliberately coarser, and the correct
+	 * side to err on.
+	 *
 	 * @return void
 	 */
 	public function test_unknown_request_class_xml_post_body_is_masked_by_default(): void {
@@ -446,7 +458,41 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 			$safe_body,
 			'BLOCKING 2: an XML-shaped POST body the request class did not mask itself must still not leak its secret param by default'
 		);
-		$this->assertStringContainsString( '<Format>json</Format>', $safe_body, 'a non-secret element must survive the fallback untouched' );
+		$this->assertSame(
+			\Woodev_API_Base::UNPARSEABLE_BODY_MASK,
+			$safe_body,
+			'#395 Round 5: a body format the base cannot parse and walk structurally is masked in FULL, not selectively — it has no reliable way to tell the secret element apart from a safe sibling one'
+		);
+	}
+
+	/**
+	 * A `print_r()`-shaped (`[name] => value`) POST body — the exact shape
+	 * {@see \Woodev_Licensing_API_Request::to_string_safe()} produces, and the
+	 * shape an independent critic review used to demonstrate the gap this
+	 * round closes: neither of {@see \Woodev_API_Base::redact_secret_query_params()}'s
+	 * two regex shapes (`name=value`, `<name>value</name>`) can match
+	 * `[name] => value`, so a request class relying on the base's fail-safe
+	 * default — never masking its own body — leaked an UNMASKED secret in
+	 * this shape before this fix.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_request_class_print_r_shaped_post_body_is_masked_in_full_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( print_r( array( 'token' => $token, 'format' => 'json' ), true ) );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_body,
+			'#395 Round 5, Blocking: a print_r()-shaped body the request class did not mask itself must not leak its secret param'
+		);
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
 	}
 
 	/**
@@ -660,5 +706,55 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 		$this->assertStringNotContainsString( $secret, $safe_body );
 		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $decoded['auth']['token'] );
 		$this->assertSame( 'json', $decoded['format'], 'a non-secret sibling param must survive untouched' );
+	}
+
+	// -------------------------------------------------------------------------
+	// #395 Round 5, SHOULD-FIX: a body that decodes as a JSON SCALAR (a bare
+	// string, number, bool, or null) carries no key to redact by, so it must
+	// be returned unchanged — never partially mangled by a regex scan that
+	// cannot tell whether the scalar itself is the secret either.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A bare JSON string scalar that happens to LOOK like a `name=value` pair
+	 * must survive byte-for-byte: Round 4 ran it through the regex backstop,
+	 * which matched the trailing quote into the value and handed back
+	 * `"token=[REDACTED]` — truncated, invalid JSON — without ever being able
+	 * to tell whether the scalar was actually a secret.
+	 *
+	 * @return void
+	 */
+	public function test_scalar_json_string_body_passes_through_unchanged(): void {
+
+		$body    = json_encode( 'token=secret' );
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( $body );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertSame( $body, $safe_body, '#395 Round 5, SHOULD-FIX: a scalar JSON body has no key to redact by and must not be mangled' );
+	}
+
+	/**
+	 * A bare JSON `null` body must be treated the same coherent way as the
+	 * string-scalar case above — both are JSON scalars, so both pass through
+	 * unchanged, instead of `null` silently surviving while a string scalar
+	 * got mangled.
+	 *
+	 * @return void
+	 */
+	public function test_scalar_json_null_body_passes_through_unchanged(): void {
+
+		$body    = 'null';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( $body );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertSame( $body, $safe_body, '#395 Round 5, SHOULD-FIX: a scalar JSON body (including null) must pass through unchanged, coherently with the string-scalar case' );
 	}
 }

--- a/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
+++ b/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Unit tests for Woodev_API_Base's fail-safe DEFAULT redaction — #395,
+ * round-two critic fix (Blocking 1 & 2).
+ *
+ * The first round of the #395 fix (see LicensingApiRequestMaskingTest.php)
+ * only made `Woodev_Licensing_API_Request` mask its own `license` param, via
+ * an opt-in `get_path_safe()` / `to_string_safe()` seam on `Woodev_API_Base`.
+ * An independent critic review rejected it: any OTHER request class — a
+ * future one, or an existing third-party extension — that carries a
+ * credential in its path/body but does NOT implement that opt-in seam still
+ * logged it raw by default. Worse, `Woodev_API_Base::get_sanitized_request_uri()`
+ * applied the `woodev_{api_id}_api_request_uri` filter AFTER masking, so a
+ * filter that itself appended a secret-bearing param bypassed masking
+ * entirely.
+ *
+ * This file pins the round-two fix using a minimal `Woodev_API_Request`
+ * double that implements NEITHER `get_path_safe()` nor a masking
+ * `to_string_safe()` — i.e. exactly the "unknown request class" scenario the
+ * critic described:
+ *
+ * - {@see \Woodev_API_Base::get_sanitized_request_path()} masks a known
+ *   secret param name even with no `get_path_safe()` to delegate to;
+ * - {@see \Woodev_API_Base::get_sanitized_request_uri()} masks the same,
+ *   end to end;
+ * - a secret param appended by the `woodev_{api_id}_api_request_uri` filter
+ *   itself is ALSO masked — proving redaction runs after the filter, not
+ *   before;
+ * - a non-secret param passes through the fallback untouched.
+ *
+ * @package Woodev\Tests\Unit\Api
+ */
+
+namespace Woodev\Tests\Unit\Api;
+
+use Brain\Monkey\Functions;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/woodev/api/interface-api-request.php';
+require_once dirname( __DIR__, 3 ) . '/woodev/api/class-api-base.php';
+
+/**
+ * A minimal Woodev_API_Request implementation carrying a secret in its path
+ * under a common param name, implementing NEITHER `get_path_safe()` nor a
+ * masking `to_string_safe()` — the "unknown request class" scenario Blocking
+ * 1 was about.
+ */
+class Testable_Unknown_Secret_Carrying_Request implements \Woodev_API_Request {
+
+	/** @var string */
+	private $path;
+
+	/**
+	 * @param string $path Raw request path, query string included.
+	 */
+	public function __construct( string $path ) {
+		$this->path = $path;
+	}
+
+	/** @return string */
+	public function get_method() {
+		return 'GET';
+	}
+
+	/** @return string */
+	public function get_path() {
+		return $this->path;
+	}
+
+	/** @return string */
+	public function to_string() {
+		return '';
+	}
+
+	/**
+	 * Deliberately unsafe — mirrors what any interface-conforming request
+	 * class could still do before Woodev_API_JSON_Request's own default was
+	 * fixed. Not exercised by the path/URI tests in this file, but present
+	 * to satisfy the Woodev_API_Request interface.
+	 *
+	 * @return string
+	 */
+	public function to_string_safe() {
+		return $this->to_string();
+	}
+}
+
+/**
+ * Minimal concrete Woodev_API_Base double exposing the protected path/URI
+ * sanitizers under test, without pulling in the HTTP/broadcast machinery
+ * this fix does not touch.
+ */
+class Testable_Api_Base_For_Fallback_Test extends \Woodev_API_Base {
+
+	public function __construct() {
+		$this->request_uri = 'https://vendor.example';
+	}
+
+	/**
+	 * Seeds the request under test.
+	 *
+	 * @param \Woodev_API_Request $request Request instance.
+	 * @return void
+	 */
+	public function set_request_for_test( \Woodev_API_Request $request ): void {
+		$this->request = $request;
+	}
+
+	/**
+	 * Exposes the protected path sanitizer under test.
+	 *
+	 * @return string
+	 */
+	public function get_sanitized_request_path_for_test(): string {
+		return $this->get_sanitized_request_path();
+	}
+
+	/**
+	 * Exposes the protected URI sanitizer under test.
+	 *
+	 * @return string
+	 */
+	public function get_sanitized_request_uri_for_test(): string {
+		return $this->get_sanitized_request_uri();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return string
+	 */
+	protected function get_api_id() {
+		return 'test_vendor';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_new_request( $args = [] ) {
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_plugin() {
+		return null;
+	}
+}
+
+/**
+ * Class ApiBaseSecretParamFallbackTest.
+ */
+final class ApiBaseSecretParamFallbackTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $tag, $value = null ) {
+				return $value;
+			}
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_unknown_request_class_path_is_masked_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?token=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_path,
+			'BLOCKING 1: an unknown request class with no get_path_safe() must not leak its secret param by default'
+		);
+		$this->assertStringContainsString( 'format=json', $safe_path, 'a non-secret param must survive the fallback untouched' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_unknown_request_class_uri_is_masked_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?token=' . $token );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_uri = $api->get_sanitized_request_uri_for_test();
+
+		$this->assertStringNotContainsString( $token, $safe_uri, 'BLOCKING 1: the fallback URI must not leak the secret param either' );
+	}
+
+	/**
+	 * BLOCKING 1, second half: a filter on the `woodev_{api_id}_api_request_uri`
+	 * hook that ITSELF appends a secret-bearing param must not bypass masking
+	 * — redaction must run AFTER the filter, not before.
+	 *
+	 * @return void
+	 */
+	public function test_a_secret_param_appended_by_the_uri_filter_is_also_masked(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status' );
+
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $tag, $value = null ) use ( $token ) {
+
+				if ( 'woodev_test_vendor_api_request_uri' === $tag ) {
+					return $value . '?token=' . $token;
+				}
+
+				return $value;
+			}
+		);
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_uri = $api->get_sanitized_request_uri_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_uri,
+			'a secret param appended by the uri filter must still be masked — redaction runs AFTER the filter'
+		);
+	}
+}

--- a/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
+++ b/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
@@ -398,13 +398,21 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * A form-encoded (`name=value`) POST body from a request class whose
-	 * `to_string_safe()` naively aliases `to_string()` must still be masked
-	 * by the base's own fail-safe pass.
+	 * A genuinely form-encoded (`name=value&name=value…`) POST body from a
+	 * request class whose `to_string_safe()` naively aliases `to_string()`
+	 * must still be masked by the base's own fail-safe pass.
+	 *
+	 * #395 Round 6, Blocking 1: this used to also assert that `format=json`
+	 * survived untouched — the round-5 `parse_str()`/`http_build_query()`
+	 * path preserved safe sibling fields. That path is gone: no request class
+	 * in this codebase can prove a body is ACTUALLY form-encoded rather than
+	 * merely shaped like it (see the two regression cases below), so a body
+	 * this shaped is now whole-masked the same as XML or a `print_r()` dump —
+	 * deliberately coarser, and the correct side to err on.
 	 *
 	 * @return void
 	 */
-	public function test_unknown_request_class_form_encoded_post_body_is_masked_by_default(): void {
+	public function test_unknown_request_class_form_encoded_shaped_post_body_is_masked_in_full_by_default(): void {
 
 		$token   = 'super-secret-token-value';
 		$request = new Testable_Unknown_Secret_Carrying_Body_Request( 'token=' . $token . '&format=json' );
@@ -419,7 +427,73 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 			$safe_body,
 			'BLOCKING 2: a POST body the request class did not mask itself must still not leak its secret param by default'
 		);
-		$this->assertStringContainsString( 'format=json', $safe_body, 'a non-secret param must survive the fallback untouched' );
+		$this->assertSame(
+			\Woodev_API_Base::UNPARSEABLE_BODY_MASK,
+			$safe_body,
+			'#395 Round 6, Blocking 1: a body merely SHAPED like a form-encoded query string is not proof it is one, so it is masked in FULL, not selectively'
+		);
+	}
+
+	/**
+	 * A single `name=value` pair whose VALUE is a URL that itself embeds a
+	 * `token=SECRET`-looking query string — e.g. a callback/redirect URL a
+	 * caller passed as one param — passed the Round 5
+	 * `is_form_encoded_body()` syntax check (the "name" is only
+	 * `callback_url`; the rest, URL and all, is swallowed by the value's
+	 * greedy `[^&]*`), so it was parsed with `parse_str()` and stored whole
+	 * under the `callback_url` key — a key that is not itself a secret name,
+	 * so the secret embedded inside its value was never redacted. #395
+	 * Round 6, Blocking 1 — demonstrated by an independent critic review
+	 * invoking the sanitizer directly with this exact shape.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_request_class_url_shaped_value_post_body_is_masked_in_full_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( 'callback_url=https://vendor.example/callback?token=' . $token );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_body,
+			'#395 Round 6, Blocking 1: a secret embedded in a URL-shaped VALUE must not leak just because its own key is not a secret name'
+		);
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
+	}
+
+	/**
+	 * Free text spanning two lines, where the first line is an innocuous
+	 * `name=value` pair and the second line carries the secret — e.g. a
+	 * multi-line note a caller pasted as a body. The Round 5 syntax check's
+	 * value class (`[^&]*`) does not exclude `\n`, so the whole string still
+	 * matches as ONE `name=value` pair (the greedy value swallows the newline
+	 * and everything after it), and `parse_str()` then stores the SECOND
+	 * line's `token=SECRET` inside the FIRST line's value, under a key that
+	 * is never checked against the secret denylist — #395 Round 6, Blocking 1.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_request_class_newline_separated_free_text_post_body_is_masked_in_full_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( "note=irrelevant\ntoken=" . $token );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_body,
+			'#395 Round 6, Blocking 1: free text containing a newline must not leak a secret on one of its lines'
+		);
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
 	}
 
 	/**
@@ -563,13 +637,24 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 	}
 
 	/**
-	 * The same nesting gap, exercised via a form-encoded POST BODY instead of
-	 * a query string — {@see \Woodev_API_Base::redact_secret_query_params()}
-	 * is the shared matcher behind both call sites.
+	 * The same nesting-gap SHAPE, exercised via a POST BODY instead of a
+	 * query string. Through #395 Round 5 a form-encoded-shaped body was
+	 * parsed and walked the same way a query string is, so this used to prove
+	 * the same nested-key fix applied to bodies too, with `format=json`
+	 * surviving as an untouched sibling.
+	 *
+	 * #395 Round 6, Blocking 1: that per-field body parsing is gone — no
+	 * request class in this codebase can prove a body is actually
+	 * form-encoded rather than merely shaped like it (see
+	 * {@see \Woodev_API_Base::redact_secret_request_body()}), so a body this
+	 * shaped is now whole-masked. The nested-key gap itself remains closed
+	 * for the one body format that IS parsed structurally — see
+	 * {@see self::test_json_body_nested_secret_key_is_masked()} — this test
+	 * now documents that the once-selective body masking no longer exists.
 	 *
 	 * @return void
 	 */
-	public function test_secret_nested_under_a_non_secret_param_name_is_masked_in_the_body(): void {
+	public function test_secret_nested_under_a_non_secret_param_name_is_masked_in_full_in_the_body(): void {
 
 		$token   = 'super-secret-token-value';
 		$request = new Testable_Unknown_Secret_Carrying_Body_Request( 'a[token]=' . $token . '&format=json' );
@@ -584,7 +669,7 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 			$safe_body,
 			'#395 Round 4, BLOCKING: a[token]=SECRET must be masked in a body too'
 		);
-		$this->assertStringContainsString( 'format=json', $safe_body, 'a non-secret sibling param must survive untouched' );
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
 	}
 
 	// -------------------------------------------------------------------------
@@ -615,9 +700,16 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 	}
 
 	/**
+	 * #395 Round 6, Blocking 1: a `+`-separated body is form-encoded-SHAPED,
+	 * not provably form-encoded, so it is now whole-masked the same as any
+	 * other body this method cannot parse and walk structurally — see
+	 * {@see self::test_secret_nested_under_a_non_secret_param_name_is_masked_in_full_in_the_body()}
+	 * for the full reasoning; this test only pins that the plus-separator
+	 * shape is not special-cased back in.
+	 *
 	 * @return void
 	 */
-	public function test_plus_separated_secret_param_name_is_masked_in_the_body(): void {
+	public function test_plus_separated_secret_param_name_is_masked_in_full_in_the_body(): void {
 
 		$token   = 'super-secret-token-value';
 		$request = new Testable_Unknown_Secret_Carrying_Body_Request( 'api+key=' . $token . '&format=json' );
@@ -628,7 +720,7 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 		$safe_body = (string) $api->get_sanitized_request_body_for_test();
 
 		$this->assertStringNotContainsString( $token, $safe_body, '#395 Round 4, SHOULD-FIX 1: api+key=SECRET must be masked in a body too' );
-		$this->assertStringContainsString( 'format=json', $safe_body, 'a non-secret sibling param must survive untouched' );
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
 	}
 
 	// -------------------------------------------------------------------------
@@ -709,22 +801,56 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// #395 Round 5, SHOULD-FIX: a body that decodes as a JSON SCALAR (a bare
-	// string, number, bool, or null) carries no key to redact by, so it must
-	// be returned unchanged — never partially mangled by a regex scan that
-	// cannot tell whether the scalar itself is the secret either.
+	// #395 Round 6, Blocking 2: a body that decodes as a JSON SCALAR (a bare
+	// string, number, bool, or null) carries no key to redact by — Round 5
+	// concluded that meant it should pass through unchanged, but a bare
+	// string scalar has no key BECAUSE it IS the value, and nothing rules out
+	// that value being the secret itself. It is now masked in full, the same
+	// as any other body this method cannot parse and walk by key.
 	// -------------------------------------------------------------------------
 
 	/**
-	 * A bare JSON string scalar that happens to LOOK like a `name=value` pair
-	 * must survive byte-for-byte: Round 4 ran it through the regex backstop,
-	 * which matched the trailing quote into the value and handed back
-	 * `"token=[REDACTED]` — truncated, invalid JSON — without ever being able
-	 * to tell whether the scalar was actually a secret.
+	 * A JSON body that is nothing but the secret itself, as a bare string —
+	 * `"super-secret-token-value"` — is the scenario Round 5's "no key to
+	 * redact by, so pass it through" reasoning missed: with no key, the
+	 * scalar VALUE is the only thing there, so returning it unchanged handed
+	 * the secret straight to the log. #395 Round 6, Blocking 2.
 	 *
 	 * @return void
 	 */
-	public function test_scalar_json_string_body_passes_through_unchanged(): void {
+	public function test_scalar_json_string_body_that_is_the_secret_itself_is_masked_in_full(): void {
+
+		$token   = 'super-secret-token-value';
+		$body    = json_encode( $token );
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( $body );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_body,
+			'#395 Round 6, Blocking 2: a JSON scalar body that IS the secret must not be returned unchanged'
+		);
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
+	}
+
+	/**
+	 * A bare JSON string scalar that happens to LOOK like a `name=value` pair
+	 * — but is not the case above, since it carries no actual secret — is
+	 * masked the same way: #395 Round 4 ran this shape through the regex
+	 * backstop, which matched the trailing quote into the value and handed
+	 * back `"token=[REDACTED]` — truncated, invalid JSON. Round 5 fixed the
+	 * corruption by passing the scalar through unchanged; Round 6 masks it in
+	 * full instead, coherently with every other scalar, rather than trying to
+	 * special-case "this scalar happens to be safe" — there is no reliable
+	 * way to tell that apart from the case above without a key to check.
+	 *
+	 * @return void
+	 */
+	public function test_scalar_json_string_body_is_masked_in_full(): void {
 
 		$body    = json_encode( 'token=secret' );
 		$request = new Testable_Unknown_Secret_Carrying_Body_Request( $body );
@@ -734,18 +860,20 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 
 		$safe_body = (string) $api->get_sanitized_request_body_for_test();
 
-		$this->assertSame( $body, $safe_body, '#395 Round 5, SHOULD-FIX: a scalar JSON body has no key to redact by and must not be mangled' );
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body, '#395 Round 6, Blocking 2: a scalar JSON body has no key to redact by and is masked in full' );
 	}
 
 	/**
 	 * A bare JSON `null` body must be treated the same coherent way as the
-	 * string-scalar case above — both are JSON scalars, so both pass through
-	 * unchanged, instead of `null` silently surviving while a string scalar
-	 * got mangled.
+	 * string-scalar cases above: `null` cannot itself carry a secret, but a
+	 * reader of the log should not have to learn that JSON scalars split into
+	 * "one kind that's shown" and "three kinds that are masked" in order to
+	 * understand a log line. One rule for every scalar. #395 Round 6,
+	 * Blocking 2.
 	 *
 	 * @return void
 	 */
-	public function test_scalar_json_null_body_passes_through_unchanged(): void {
+	public function test_scalar_json_null_body_is_masked_in_full(): void {
 
 		$body    = 'null';
 		$request = new Testable_Unknown_Secret_Carrying_Body_Request( $body );
@@ -755,6 +883,6 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 
 		$safe_body = (string) $api->get_sanitized_request_body_for_test();
 
-		$this->assertSame( $body, $safe_body, '#395 Round 5, SHOULD-FIX: a scalar JSON body (including null) must pass through unchanged, coherently with the string-scalar case' );
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body, '#395 Round 6, Blocking 2: a null JSON body is masked in full, coherently with every other scalar' );
 	}
 }

--- a/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
+++ b/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
@@ -86,6 +86,52 @@ class Testable_Unknown_Secret_Carrying_Request implements \Woodev_API_Request {
 }
 
 /**
+ * A minimal Woodev_API_Request implementation for the BLOCKING 2 body tests:
+ * a POST request whose `to_string_safe()` deliberately aliases `to_string()`
+ * — the "custom request class that forgot to mask its own body" scenario —
+ * carrying a secret in a raw, non-JSON body shape.
+ */
+class Testable_Unknown_Secret_Carrying_Body_Request implements \Woodev_API_Request {
+
+	/** @var string */
+	private $body;
+
+	/**
+	 * @param string $body Raw request body, as `to_string()`/`to_string_safe()` return it.
+	 */
+	public function __construct( string $body ) {
+		$this->body = $body;
+	}
+
+	/** @return string */
+	public function get_method() {
+		return 'POST';
+	}
+
+	/** @return string */
+	public function get_path() {
+		return '/v1/status';
+	}
+
+	/** @return string */
+	public function to_string() {
+		return $this->body;
+	}
+
+	/**
+	 * Deliberately unsafe — mirrors what any interface-conforming request
+	 * class could still do: alias `to_string_safe()` straight to `to_string()`
+	 * without masking anything. This is the "the base promises body
+	 * redaction and does not apply it" scenario Blocking 2 was about.
+	 *
+	 * @return string
+	 */
+	public function to_string_safe() {
+		return $this->to_string();
+	}
+}
+
+/**
  * Minimal concrete Woodev_API_Base double exposing the protected path/URI
  * sanitizers under test, without pulling in the HTTP/broadcast machinery
  * this fix does not touch.
@@ -122,6 +168,15 @@ class Testable_Api_Base_For_Fallback_Test extends \Woodev_API_Base {
 	 */
 	public function get_sanitized_request_uri_for_test(): string {
 		return $this->get_sanitized_request_uri();
+	}
+
+	/**
+	 * Exposes the protected body sanitizer under test.
+	 *
+	 * @return string
+	 */
+	public function get_sanitized_request_body_for_test() {
+		return $this->get_sanitized_request_body();
 	}
 
 	/**
@@ -237,5 +292,177 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 			$safe_uri,
 			'a secret param appended by the uri filter must still be masked — redaction runs AFTER the filter'
 		);
+	}
+
+	// -------------------------------------------------------------------------
+	// #395 Round 3, BLOCKING 1: nested/percent-encoded/camelCase param names
+	// must still be recognised, not only the exact flat spelling.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_percent_encoded_nested_param_name_is_masked_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?token%5Bprimary%5D=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_path,
+			'BLOCKING 1: http_build_query()-style token%5Bprimary%5D= must be masked, exactly the shape Woodev_Licensing_API_Request::get_path() can emit'
+		);
+		$this->assertStringContainsString( 'format=json', $safe_path, 'a non-secret param must survive untouched' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_literal_bracket_nested_param_name_is_masked_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?token[primary]=' . $token );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringNotContainsString( $token, $safe_path, 'BLOCKING 1: the un-encoded token[primary]= form must be masked too' );
+	}
+
+	/**
+	 * @dataProvider provider_camel_case_secret_name_variants
+	 *
+	 * @param string $param_name camelCase variant of a name already on the default list.
+	 * @return void
+	 */
+	public function test_camel_case_variant_of_a_listed_name_is_masked_by_default( string $param_name ): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?' . $param_name . '=' . $token );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_path,
+			"BLOCKING 1: the camelCase spelling '{$param_name}' of a name already on the default list must be masked too"
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_camel_case_secret_name_variants(): array {
+		return [
+			'apiKey'     => [ 'apiKey' ],
+			'licenseKey' => [ 'licenseKey' ],
+			'accessToken' => [ 'accessToken' ],
+		];
+	}
+
+	/**
+	 * A param name that merely CONTAINS a secret name as a substring must not
+	 * be mistaken for the secret param itself — the fix for BLOCKING 1 must
+	 * not turn exact-name matching into substring matching.
+	 *
+	 * @return void
+	 */
+	public function test_a_param_name_merely_containing_a_secret_name_is_not_masked(): void {
+
+		$value   = 'not-a-secret-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?mylicense=' . $value );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringContainsString( $value, $safe_path, 'a param name that only CONTAINS "license" must not be masked' );
+	}
+
+	// -------------------------------------------------------------------------
+	// #395 Round 3, BLOCKING 2: the base must apply its own fail-safe
+	// redaction to whatever to_string_safe() returns, instead of trusting it
+	// outright — a POST body from a request class that forgot to mask itself
+	// must still not reach the log with a raw secret in it.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A form-encoded (`name=value`) POST body from a request class whose
+	 * `to_string_safe()` naively aliases `to_string()` must still be masked
+	 * by the base's own fail-safe pass.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_request_class_form_encoded_post_body_is_masked_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( 'token=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_body,
+			'BLOCKING 2: a POST body the request class did not mask itself must still not leak its secret param by default'
+		);
+		$this->assertStringContainsString( 'format=json', $safe_body, 'a non-secret param must survive the fallback untouched' );
+	}
+
+	/**
+	 * An XML-shaped (`<name>value</name>`) POST body from a request class
+	 * whose `to_string_safe()` masks nothing — exactly what
+	 * {@see \Woodev_API_XML_Request::to_string_safe()} does today, it only
+	 * prettifies the XML — must still be masked by the base's own fail-safe
+	 * pass.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_request_class_xml_post_body_is_masked_by_default(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( '<Token>' . $token . '</Token><Format>json</Format>' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_body,
+			'BLOCKING 2: an XML-shaped POST body the request class did not mask itself must still not leak its secret param by default'
+		);
+		$this->assertStringContainsString( '<Format>json</Format>', $safe_body, 'a non-secret element must survive the fallback untouched' );
+	}
+
+	/**
+	 * A GET/HEAD request never has a body — the fallback must not attempt to
+	 * mask a body that {@see \Woodev_API_Base::get_sanitized_request_body()}
+	 * short-circuits to `''` for.
+	 *
+	 * @return void
+	 */
+	public function test_get_request_body_stays_empty(): void {
+
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?token=irrelevant' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$this->assertSame( '', $api->get_sanitized_request_body_for_test() );
 	}
 }

--- a/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
+++ b/tests/unit/Api/ApiBaseSecretParamFallbackTest.php
@@ -465,4 +465,200 @@ final class ApiBaseSecretParamFallbackTest extends TestCase {
 
 		$this->assertSame( '', $api->get_sanitized_request_body_for_test() );
 	}
+
+	// -------------------------------------------------------------------------
+	// #395 Round 4, BLOCKING: a secret nested under a NON-secret param name
+	// must still be masked — the round-3 matcher only ever compared the FIRST
+	// bracket segment of a key against the denylist, so `a[token]=SECRET`
+	// (literal or percent-encoded) sailed through untouched because only `a`
+	// was checked, and `a` isn't itself a secret name.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_secret_nested_under_a_non_secret_param_name_is_masked_in_the_path(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?a[token]=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_path,
+			'#395 Round 4, BLOCKING: a[token]=SECRET must be masked even though the top-level name "a" is not itself a secret'
+		);
+		$this->assertStringContainsString( 'format=json', $safe_path, 'a non-secret sibling param must survive untouched' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_percent_encoded_secret_nested_under_a_non_secret_param_name_is_masked_in_the_path(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?a%5Btoken%5D=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_path,
+			'#395 Round 4, BLOCKING: the percent-encoded a%5Btoken%5D=SECRET form must be masked too'
+		);
+		$this->assertStringContainsString( 'format=json', $safe_path, 'a non-secret sibling param must survive untouched' );
+	}
+
+	/**
+	 * The same nesting gap, exercised via a form-encoded POST BODY instead of
+	 * a query string — {@see \Woodev_API_Base::redact_secret_query_params()}
+	 * is the shared matcher behind both call sites.
+	 *
+	 * @return void
+	 */
+	public function test_secret_nested_under_a_non_secret_param_name_is_masked_in_the_body(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( 'a[token]=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_body,
+			'#395 Round 4, BLOCKING: a[token]=SECRET must be masked in a body too'
+		);
+		$this->assertStringContainsString( 'format=json', $safe_body, 'a non-secret sibling param must survive untouched' );
+	}
+
+	// -------------------------------------------------------------------------
+	// #395 Round 4, SHOULD-FIX 1: `+` (an encoded space in a query string) must
+	// still be recognised as a separator between words in a param name, e.g.
+	// `api+key` must match the same denylist entry as `api_key`/`apiKey`.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_plus_separated_secret_param_name_is_masked_in_the_path(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Request( '/v1/status?api+key=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_path = $api->get_sanitized_request_path_for_test();
+
+		$this->assertStringNotContainsString(
+			$token,
+			$safe_path,
+			'#395 Round 4, SHOULD-FIX 1: api+key=SECRET must be masked — "+" is an encoded space, so this is the same name as api_key'
+		);
+		$this->assertStringContainsString( 'format=json', $safe_path, 'a non-secret sibling param must survive untouched' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_plus_separated_secret_param_name_is_masked_in_the_body(): void {
+
+		$token   = 'super-secret-token-value';
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( 'api+key=' . $token . '&format=json' );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+
+		$this->assertStringNotContainsString( $token, $safe_body, '#395 Round 4, SHOULD-FIX 1: api+key=SECRET must be masked in a body too' );
+		$this->assertStringContainsString( 'format=json', $safe_body, 'a non-secret sibling param must survive untouched' );
+	}
+
+	// -------------------------------------------------------------------------
+	// #395 Round 4, SHOULD-FIX 2: a JSON body must be redacted by parsing it,
+	// never by scanning its raw text for a `name=value` shape — the round-3
+	// regex backstop could mistake a `name=value`-looking SUBSTRING inside an
+	// unrelated string VALUE for a real param and truncate it, corrupting an
+	// otherwise-valid JSON body it was never meant to touch.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_json_body_secret_key_is_masked_without_corrupting_the_json(): void {
+
+		$secret = 'super-secret-token-value';
+		$body   = json_encode(
+			[
+				'note'     => 'contact support, token=should-stay-exactly-here for reference',
+				'password' => $secret,
+				'item_id'  => 42,
+			]
+		);
+
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( $body );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+		$decoded   = json_decode( $safe_body, true );
+
+		$this->assertIsArray( $decoded, 'SHOULD-FIX 2: the redacted body must still be valid, parseable JSON' );
+		$this->assertStringNotContainsString( $secret, $safe_body, 'the password value must not leak' );
+		$this->assertSame(
+			\Woodev_API_Base::SECRET_VALUE_MASK,
+			$decoded['password'],
+			'the password key must be masked by key, not by scanning the text'
+		);
+		$this->assertSame(
+			'contact support, token=should-stay-exactly-here for reference',
+			$decoded['note'],
+			'SHOULD-FIX 2: a name=value-looking SUBSTRING inside an unrelated string value must survive untouched'
+		);
+		$this->assertSame( 42, $decoded['item_id'], 'a non-secret param must survive untouched' );
+	}
+
+	/**
+	 * A secret nested inside a JSON object (not only at the top level) must
+	 * also be masked — the structural JSON walk redacts by key at ANY depth,
+	 * same as the query-string walk.
+	 *
+	 * @return void
+	 */
+	public function test_json_body_nested_secret_key_is_masked(): void {
+
+		$secret  = 'super-secret-token-value';
+		$body    = json_encode(
+			[
+				'auth' => [
+					'token' => $secret,
+				],
+				'format' => 'json',
+			]
+		);
+		$request = new Testable_Unknown_Secret_Carrying_Body_Request( $body );
+
+		$api = new Testable_Api_Base_For_Fallback_Test();
+		$api->set_request_for_test( $request );
+
+		$safe_body = (string) $api->get_sanitized_request_body_for_test();
+		$decoded   = json_decode( $safe_body, true );
+
+		$this->assertIsArray( $decoded, 'the redacted body must still be valid JSON' );
+		$this->assertStringNotContainsString( $secret, $safe_body );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $decoded['auth']['token'] );
+		$this->assertSame( 'json', $decoded['format'], 'a non-secret sibling param must survive untouched' );
+	}
 }

--- a/tests/unit/Api/LicensingApiRequestMaskingTest.php
+++ b/tests/unit/Api/LicensingApiRequestMaskingTest.php
@@ -1,0 +1,367 @@
+<?php
+/**
+ * Unit tests for license-key masking in logged licensing API requests — #395.
+ *
+ * With `WOODEV_LICENSE_DEBUG` on, every licensing request (the weekly
+ * check_license cron, activation, deactivation, an update check) reached
+ * `Woodev_API_Base::get_request_data_for_broadcast()`, which is handed
+ * straight to `Woodev_Plugin::log_api_request()` — the customer's license key
+ * reached the log in CLEAR TEXT, twice: once in the `uri` field (the query
+ * string `Woodev_Licensing_API_Request::get_path()` builds from
+ * `http_build_query( $this->get_params() )`, `license` among them), and once
+ * in the `body` field (`to_string_safe()` simply aliased `to_string()`, a
+ * `print_r()` dump of every param, masking nothing).
+ *
+ * Request headers already had a masking convention
+ * ({@see \Woodev_API_Base::mask_secret_headers()}, exercised by
+ * ApiBaseSanitizedHeadersTest.php) — the fix for #395 reuses that exact
+ * routine for the license param instead of inventing a second, differently
+ * shaped one, via two new opt-in seams on `Woodev_API_Base`:
+ * `get_sanitized_request_path()` / `get_sanitized_request_uri()`, mirroring
+ * the existing `is_callable( ..., 'to_string_safe' )` opt-in already used for
+ * the response body. `Woodev_Licensing_API_Request::get_path_safe()` /
+ * `to_string_safe()` are the opt-in implementations.
+ *
+ * This file pins:
+ *
+ * - the real wire-bound getters ({@see \Woodev_Licensing_API_Request::get_path()},
+ *   {@see \Woodev_Licensing_API_Request::to_string()}) still carry the REAL
+ *   license key — masking must affect ONLY what is logged, never what is sent;
+ * - the logging-only getters ({@see \Woodev_Licensing_API_Request::get_path_safe()},
+ *   {@see \Woodev_Licensing_API_Request::to_string_safe()}) mask the license
+ *   key, using the exact same convention as header masking (`*` repeated to
+ *   the value's original length);
+ * - non-secret params (edd_action, item_id, ...) pass through unmasked, on
+ *   both sides;
+ * - end to end, {@see \Woodev_API_Base::get_request_data_for_broadcast()}
+ *   contains no clear-text license key in either `uri` or `body`, while the
+ *   getters actually used to perform the request
+ *   ({@see \Woodev_API_Base::get_request_uri()}, {@see \Woodev_API_Base::get_request_body()})
+ *   are byte-for-byte unaffected by the fix.
+ *
+ * @package Woodev\Tests\Unit\Api
+ */
+
+namespace Woodev\Tests\Unit\Api;
+
+use Brain\Monkey\Functions;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/woodev/api/interface-api-request.php';
+require_once dirname( __DIR__, 3 ) . '/woodev/api/abstract-api-json-request.php';
+require_once dirname( __DIR__, 3 ) . '/woodev/api/class-api-base.php';
+require_once dirname( __DIR__, 3 ) . '/woodev/licensing/api/class-licensing-api-request.php';
+
+/**
+ * Minimal concrete Woodev_API_Base double wired with a real
+ * Woodev_Licensing_API_Request, exposing both the actual-wire getters and the
+ * logging (broadcast) getter for direct comparison — without pulling in the
+ * HTTP transport or the Woodev_Plugin/Woodev_Licensing_API machinery this fix
+ * does not touch.
+ */
+class Testable_Licensing_Request_Api_Base extends \Woodev_API_Base {
+
+	public function __construct() {
+		$this->request_uri = 'https://woodev.ru/';
+	}
+
+	/**
+	 * Seeds the request under test.
+	 *
+	 * @param \Woodev_Licensing_API_Request $request Request instance.
+	 * @return void
+	 */
+	public function set_request_for_test( \Woodev_Licensing_API_Request $request ): void {
+		$this->request = $request;
+	}
+
+	/**
+	 * Exposes the getter actually used to perform the request.
+	 *
+	 * @return string
+	 */
+	public function get_request_uri_for_test(): string {
+		return $this->get_request_uri();
+	}
+
+	/**
+	 * Exposes the getter actually used to build the request body sent over the wire.
+	 *
+	 * @return string
+	 */
+	public function get_request_body_for_test(): string {
+		return $this->get_request_body();
+	}
+
+	/**
+	 * Exposes the full broadcast (logging) payload under test.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_request_data_for_broadcast_for_test(): array {
+		return $this->get_request_data_for_broadcast();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Bypasses the Woodev_Plugin dependency this test double has none of.
+	 *
+	 * @return string
+	 */
+	protected function get_request_user_agent() {
+		return 'woodev-test/1.0';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return string
+	 */
+	protected function get_api_id() {
+		return 'test_license';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_new_request( $args = [] ) {
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_plugin() {
+		return null;
+	}
+}
+
+/**
+ * Class LicensingApiRequestMaskingTest.
+ */
+final class LicensingApiRequestMaskingTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $tag, $value = null ) {
+				return $value;
+			}
+		);
+	}
+
+	/**
+	 * Builds a real Woodev_Licensing_API_Request carrying a license key among
+	 * other, non-secret params — mirrors the shape Woodev_Plugins_License::dispatch()
+	 * actually sends.
+	 *
+	 * @param string $license_key License key to embed.
+	 * @return \Woodev_Licensing_API_Request
+	 */
+	private function make_request( string $license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value' ): \Woodev_Licensing_API_Request {
+
+		$request = new \Woodev_Licensing_API_Request();
+		$request->get_license(
+			[
+				'edd_action' => 'check_license',
+				'license'    => $license_key,
+				'item_id'    => 123,
+				'url'        => 'https://example.test',
+			]
+		);
+
+		return $request;
+	}
+
+	/**
+	 * Parses the query string off a `path?query` string into an assoc array,
+	 * so assertions don't depend on http_build_query()'s exact percent-encoding.
+	 *
+	 * @param string $path_with_query A path as returned by get_path()/get_path_safe().
+	 * @return array<string, string>
+	 */
+	private function parse_query( string $path_with_query ): array {
+
+		[, $query] = array_pad( explode( '?', $path_with_query, 2 ), 2, '' );
+
+		parse_str( (string) $query, $params );
+
+		return $params;
+	}
+
+	// -------------------------------------------------------------------------
+	// get_path() — the actual wire path — must stay untouched.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_get_path_still_carries_the_real_license_key(): void {
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$params = $this->parse_query( $request->get_path() );
+
+		$this->assertSame( $license_key, $params['license'], 'the real request must carry the real license key' );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_path_safe() — the logging-only path — must mask the license key.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_get_path_safe_masks_the_license_key(): void {
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$safe_path = $request->get_path_safe();
+		$params    = $this->parse_query( $safe_path );
+
+		$this->assertSame( str_repeat( '*', strlen( $license_key ) ), $params['license'] );
+		$this->assertStringNotContainsString( $license_key, $safe_path, 'the license key leaked into the sanitized path' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_get_path_safe_leaves_non_secret_params_untouched(): void {
+
+		$request = $this->make_request();
+
+		$params = $this->parse_query( $request->get_path_safe() );
+
+		$this->assertSame( 'check_license', $params['edd_action'] );
+		$this->assertSame( '123', $params['item_id'] );
+		$this->assertSame( 'https://example.test', $params['url'] );
+	}
+
+	/**
+	 * get_path() and get_path_safe() must build the SAME path apart from the
+	 * license value — the masking seam must not accidentally reorder, drop,
+	 * or re-encode any other param.
+	 *
+	 * @return void
+	 */
+	public function test_get_path_and_get_path_safe_agree_on_everything_but_the_license_value(): void {
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$real_params = $this->parse_query( $request->get_path() );
+		$safe_params = $this->parse_query( $request->get_path_safe() );
+
+		$this->assertSame( array_keys( $real_params ), array_keys( $safe_params ) );
+
+		unset( $real_params['license'], $safe_params['license'] );
+		$this->assertSame( $real_params, $safe_params, 'only the license param may differ between the two paths' );
+	}
+
+	// -------------------------------------------------------------------------
+	// to_string() vs to_string_safe() — the actual wire BODY must stay
+	// untouched; the logging-only body must mask the license key.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_to_string_still_carries_the_real_license_key(): void {
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$this->assertStringContainsString( $license_key, (string) $request->to_string(), 'the real request body must carry the real license key' );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_to_string_safe_masks_the_license_key(): void {
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$safe_body = (string) $request->to_string_safe();
+
+		$this->assertStringNotContainsString( $license_key, $safe_body, 'the license key leaked into the sanitized body' );
+		$this->assertStringContainsString( str_repeat( '*', strlen( $license_key ) ), $safe_body );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_to_string_safe_leaves_non_secret_params_untouched(): void {
+
+		$request = $this->make_request();
+
+		$safe_body = (string) $request->to_string_safe();
+
+		$this->assertStringContainsString( 'check_license', $safe_body );
+		$this->assertStringContainsString( '123', $safe_body );
+		$this->assertStringContainsString( 'example.test', $safe_body );
+	}
+
+	// -------------------------------------------------------------------------
+	// End to end: get_request_data_for_broadcast() — the array handed to the
+	// woodev_{api_id}_api_request_performed action, i.e. to the request
+	// logger — must not contain the license key in EITHER field, while the
+	// getters that build the actually-sent request stay byte-for-byte
+	// unaffected.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_broadcast_payload_masks_license_key_in_uri_and_body(): void {
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$api = new Testable_Licensing_Request_Api_Base();
+		$api->set_request_for_test( $request );
+
+		$broadcast = $api->get_request_data_for_broadcast_for_test();
+
+		$this->assertArrayHasKey( 'uri', $broadcast );
+		$this->assertArrayHasKey( 'body', $broadcast );
+		$this->assertStringNotContainsString( $license_key, $broadcast['uri'], 'the license key leaked into the broadcast uri' );
+		$this->assertStringNotContainsString( $license_key, $broadcast['body'], 'the license key leaked into the broadcast body' );
+		$this->assertStringNotContainsString(
+			$license_key,
+			print_r( $broadcast, true ),
+			'the license key leaked into the broadcast payload'
+		);
+	}
+
+	/**
+	 * The whole point of masking ONLY the broadcast/log path: the bytes
+	 * actually sent to the licensing server must be byte-for-byte identical
+	 * before and after this fix.
+	 *
+	 * @return void
+	 */
+	public function test_actual_wire_request_is_unaffected_by_broadcast_masking(): void {
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$api = new Testable_Licensing_Request_Api_Base();
+		$api->set_request_for_test( $request );
+
+		// Exercise the logging codepath first, to prove it has no side effect
+		// on the getters used to actually perform the request.
+		$api->get_request_data_for_broadcast_for_test();
+
+		$this->assertStringContainsString( $license_key, $api->get_request_uri_for_test() );
+		$this->assertStringContainsString( $license_key, $api->get_request_body_for_test() );
+	}
+}

--- a/tests/unit/Api/LicensingApiRequestMaskingTest.php
+++ b/tests/unit/Api/LicensingApiRequestMaskingTest.php
@@ -40,8 +40,8 @@
  *   license key — masking must affect ONLY what is logged, never what is sent;
  * - the logging-only getters ({@see \Woodev_Licensing_API_Request::get_path_safe()},
  *   {@see \Woodev_Licensing_API_Request::to_string_safe()}) mask the license
- *   key, using the exact same convention as header masking (`*` repeated to
- *   the value's original length);
+ *   key, using the same fixed placeholder as header masking
+ *   ({@see \Woodev_API_Base::SECRET_VALUE_MASK});
  * - non-secret params (edd_action, item_id, ...) pass through unmasked, on
  *   both sides;
  * - end to end, {@see \Woodev_API_Base::get_request_data_for_broadcast()}
@@ -414,7 +414,7 @@ final class LicensingApiRequestMaskingTest extends TestCase {
 		$safe_path = $request->get_path_safe();
 		$params    = $this->parse_query( $safe_path );
 
-		$this->assertSame( str_repeat( '*', strlen( $license_key ) ), $params['license'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $params['license'] );
 		$this->assertStringNotContainsString( $license_key, $safe_path, 'the license key leaked into the sanitized path' );
 	}
 
@@ -480,7 +480,7 @@ final class LicensingApiRequestMaskingTest extends TestCase {
 		$safe_body = (string) $request->to_string_safe();
 
 		$this->assertStringNotContainsString( $license_key, $safe_body, 'the license key leaked into the sanitized body' );
-		$this->assertStringContainsString( str_repeat( '*', strlen( $license_key ) ), $safe_body );
+		$this->assertStringContainsString( \Woodev_API_Base::SECRET_VALUE_MASK, $safe_body );
 	}
 
 	/**

--- a/tests/unit/Api/LicensingApiRequestMaskingTest.php
+++ b/tests/unit/Api/LicensingApiRequestMaskingTest.php
@@ -13,14 +13,25 @@
  * `print_r()` dump of every param, masking nothing).
  *
  * Request headers already had a masking convention
- * ({@see \Woodev_API_Base::mask_secret_headers()}, exercised by
+ * ({@see \Woodev_API_Base::mask_secret_values()}, exercised by
  * ApiBaseSanitizedHeadersTest.php) — the fix for #395 reuses that exact
  * routine for the license param instead of inventing a second, differently
- * shaped one, via two new opt-in seams on `Woodev_API_Base`:
- * `get_sanitized_request_path()` / `get_sanitized_request_uri()`, mirroring
- * the existing `is_callable( ..., 'to_string_safe' )` opt-in already used for
- * the response body. `Woodev_Licensing_API_Request::get_path_safe()` /
- * `to_string_safe()` are the opt-in implementations.
+ * shaped one, via `Woodev_API_Base::get_sanitized_request_path()` /
+ * `get_sanitized_request_uri()`, and `Woodev_Licensing_API_Request::get_path_safe()`
+ * / `to_string_safe()`.
+ *
+ * An independent critic review rejected the first round of this fix: both
+ * seams FAILED OPEN for any request class that didn't implement its own
+ * `get_path_safe()`/override `to_string_safe()` — falling back to the raw,
+ * unmasked path/body by default — and a transport-thrown WP_Error message
+ * could carry the raw URI straight into an exception, bypassing masking
+ * entirely. The round-two fix made both fail SAFE by default: an
+ * unconditional, regex-based redaction
+ * ({@see \Woodev_API_Base::get_secret_param_names()} /
+ * {@see \Woodev_API_Base::redact_secret_query_params()}) now runs on every
+ * path, URI (after the `woodev_{api_id}_api_request_uri` filter, not
+ * before), and WP_Error message — regardless of whether the concrete
+ * request class implements any masking of its own.
  *
  * This file pins:
  *
@@ -50,6 +61,8 @@ use Woodev\Tests\Unit\TestCase;
 require_once dirname( __DIR__, 3 ) . '/woodev/api/interface-api-request.php';
 require_once dirname( __DIR__, 3 ) . '/woodev/api/abstract-api-json-request.php';
 require_once dirname( __DIR__, 3 ) . '/woodev/api/class-api-base.php';
+require_once dirname( __DIR__, 3 ) . '/woodev/api/class-api-exception.php';
+require_once dirname( __DIR__, 3 ) . '/woodev/class-plugin-exception.php';
 require_once dirname( __DIR__, 3 ) . '/woodev/licensing/api/class-licensing-api-request.php';
 
 /**
@@ -142,6 +155,159 @@ class Testable_Licensing_Request_Api_Base extends \Woodev_API_Base {
 }
 
 /**
+ * A response class instantiable by {@see \Woodev_API_Base::get_parsed_response()}
+ * — this fix does not touch response parsing, only what is logged around it.
+ */
+class Testable_Licensing_Response_For_Wire_Test {
+
+	/**
+	 * @param string $raw_body Unused — only the constructor shape matters here.
+	 */
+	public function __construct( $raw_body ) {}
+}
+
+/**
+ * A minimal Woodev_Plugin double satisfying the one call
+ * {@see \Woodev_API_Base::perform_request()} makes on it directly.
+ */
+class Testable_License_Plugin_Stub {
+
+	/**
+	 * @return bool
+	 */
+	public function require_tls_1_2() {
+		return false;
+	}
+}
+
+/**
+ * Extends the shared test double with a transport override that CAPTURES its
+ * arguments instead of performing a real HTTP call, so
+ * {@see \Woodev_API_Base::perform_request()} can be exercised end to end —
+ * this is what the SHOULD-FIX critic finding asked the wire-parity test to
+ * actually do: observe the transport's real arguments, not just re-read the
+ * same getters the broadcast payload also reads.
+ */
+class Testable_Licensing_Request_Api_Base_With_Transport_Capture extends Testable_Licensing_Request_Api_Base {
+
+	/** @var string|null */
+	public $captured_request_uri;
+
+	/** @var array<string, mixed>|null */
+	public $captured_request_args;
+
+	/** @var array<string, mixed>|null */
+	public $captured_broadcast_request_data;
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $request_uri
+	 * @param array<string, mixed> $request_args
+	 * @return array<string, mixed>
+	 */
+	protected function do_remote_request( $request_uri, $request_args ) {
+
+		$this->captured_request_uri  = $request_uri;
+		$this->captured_request_args = $request_args;
+
+		return [
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'headers'  => [],
+			'body'     => '',
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Captures the broadcast (logging) payload alongside the raw transport
+	 * arguments above, so both sides of the same {@see \Woodev_API_Base::perform_request()}
+	 * call can be compared in one test.
+	 *
+	 * @return void
+	 */
+	protected function broadcast_request() {
+
+		$this->captured_broadcast_request_data = $this->get_request_data_for_broadcast();
+
+		parent::broadcast_request();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return string
+	 */
+	protected function get_response_handler() {
+		return Testable_Licensing_Response_For_Wire_Test::class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return Testable_License_Plugin_Stub
+	 */
+	protected function get_plugin() {
+		return new Testable_License_Plugin_Stub();
+	}
+
+	/**
+	 * Exposes the protected perform_request() under test.
+	 *
+	 * @param \Woodev_Licensing_API_Request $request Request instance.
+	 * @return mixed
+	 */
+	public function perform_request_for_test( $request ) {
+		return $this->perform_request( $request );
+	}
+}
+
+/**
+ * A transport override that returns a WP_Error carrying the RAW request URI
+ * it was given in its message — the concrete route from the license key to
+ * `error_log()` the critic identified (Blocking 2): a transport override or
+ * an `http_api_curl`-style filter is free to embed the URI in a failure
+ * message, and {@see \Woodev_API_Base::handle_response()} used to hand that
+ * message straight into the thrown exception unredacted.
+ */
+class Testable_Licensing_Request_Api_Base_With_Wp_Error_Transport extends Testable_Licensing_Request_Api_Base {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $request_uri
+	 * @param array<string, mixed> $request_args
+	 * @return \WP_Error
+	 */
+	protected function do_remote_request( $request_uri, $request_args ) {
+		return new \WP_Error( 'http_request_failed', 'cURL error 6: Could not resolve host: ' . $request_uri );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return Testable_License_Plugin_Stub
+	 */
+	protected function get_plugin() {
+		return new Testable_License_Plugin_Stub();
+	}
+
+	/**
+	 * Exposes the protected perform_request() under test.
+	 *
+	 * @param \Woodev_Licensing_API_Request $request Request instance.
+	 * @return mixed
+	 */
+	public function perform_request_for_test( $request ) {
+		return $this->perform_request( $request );
+	}
+}
+
+/**
  * Class LicensingApiRequestMaskingTest.
  */
 final class LicensingApiRequestMaskingTest extends TestCase {
@@ -154,6 +320,27 @@ final class LicensingApiRequestMaskingTest extends TestCase {
 				return $value;
 			}
 		);
+	}
+
+	/**
+	 * Stubs the WP HTTP-transport functions {@see \Woodev_API_Base::perform_request()}
+	 * and {@see \Woodev_API_Base::handle_response()} call, so those methods can
+	 * be exercised end to end without a real WordPress environment.
+	 *
+	 * @return void
+	 */
+	private function stub_wp_http_functions(): void {
+
+		Functions\when( 'do_action' )->justReturn( null );
+
+		Functions\when( 'is_wp_error' )->alias(
+			static fn( $thing ) => $thing instanceof \WP_Error
+		);
+
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		Functions\when( 'wp_remote_retrieve_response_message' )->justReturn( 'OK' );
+		Functions\when( 'wp_remote_retrieve_body' )->justReturn( '' );
+		Functions\when( 'wp_remote_retrieve_headers' )->justReturn( [] );
 	}
 
 	/**
@@ -301,13 +488,19 @@ final class LicensingApiRequestMaskingTest extends TestCase {
 	 */
 	public function test_to_string_safe_leaves_non_secret_params_untouched(): void {
 
-		$request = $this->make_request();
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
 
 		$safe_body = (string) $request->to_string_safe();
 
 		$this->assertStringContainsString( 'check_license', $safe_body );
 		$this->assertStringContainsString( '123', $safe_body );
 		$this->assertStringContainsString( 'example.test', $safe_body );
+
+		// SHOULD-FIX: this test previously only asserted the non-secret params
+		// were present, never that the secret was ABSENT — it passed both
+		// before and after the fix and proved nothing about masking.
+		$this->assertStringNotContainsString( $license_key, $safe_body, 'the license key must not appear in the sanitized body' );
 	}
 
 	// -------------------------------------------------------------------------
@@ -345,23 +538,90 @@ final class LicensingApiRequestMaskingTest extends TestCase {
 	/**
 	 * The whole point of masking ONLY the broadcast/log path: the bytes
 	 * actually sent to the licensing server must be byte-for-byte identical
-	 * before and after this fix.
+	 * before and after this fix. Exercises the REAL perform_request()
+	 * codepath end to end, with a transport override that CAPTURES its
+	 * actual arguments — rather than re-reading the same getters the
+	 * broadcast payload itself reads, which would pass even if masking
+	 * corrupted the wire request.
+	 *
+	 * SHOULD-FIX: the previous version of this test called
+	 * get_request_data_for_broadcast_for_test() and then asserted against
+	 * get_request_uri_for_test()/get_request_body_for_test() — the same two
+	 * getters perform_request() itself calls to build the wire request. It
+	 * never observed the transport, so it passed identically before and
+	 * after the fix and proved nothing about wire parity.
 	 *
 	 * @return void
 	 */
 	public function test_actual_wire_request_is_unaffected_by_broadcast_masking(): void {
 
+		$this->stub_wp_http_functions();
+
 		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
 		$request     = $this->make_request( $license_key );
 
-		$api = new Testable_Licensing_Request_Api_Base();
+		// The pre-redaction ground truth: what the wire request SHOULD look
+		// like, built independently of anything perform_request() does.
+		$expected_uri  = 'https://woodev.ru/' . $request->get_path();
+		$expected_body = $request->to_string();
+
+		$api = new Testable_Licensing_Request_Api_Base_With_Transport_Capture();
 		$api->set_request_for_test( $request );
 
-		// Exercise the logging codepath first, to prove it has no side effect
-		// on the getters used to actually perform the request.
-		$api->get_request_data_for_broadcast_for_test();
+		// do_remote_request() (captured, raw) runs BEFORE handle_response()
+		// -> broadcast_request() (captured, sanitized) — the real production
+		// order — so this proves the masking that runs second has no way to
+		// reach back and affect what already went out first.
+		$api->perform_request_for_test( $request );
 
-		$this->assertStringContainsString( $license_key, $api->get_request_uri_for_test() );
-		$this->assertStringContainsString( $license_key, $api->get_request_body_for_test() );
+		$this->assertStringContainsString( $license_key, $api->captured_request_uri, 'the real request must carry the real license key over the wire' );
+		$this->assertSame( $expected_uri, $api->captured_request_uri, 'query encoding must be byte-for-byte unaffected by broadcast masking' );
+
+		$this->assertStringContainsString( $license_key, $api->captured_request_args['body'], 'the real request body must carry the real license key over the wire' );
+		$this->assertSame( $expected_body, $api->captured_request_args['body'], 'body bytes must be byte-for-byte unaffected by broadcast masking' );
+
+		// And prove the masking actually ran, in the very same call, on the
+		// sibling broadcast payload.
+		$this->assertStringNotContainsString( $license_key, $api->captured_broadcast_request_data['uri'] );
+		$this->assertStringNotContainsString( $license_key, $api->captured_broadcast_request_data['body'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// BLOCKING 2 regression guard: a transport-thrown WP_Error message must
+	// be redacted before it reaches an exception (and, downstream,
+	// Woodev_Plugin_Updater::get_version_from_remote()'s error_log()).
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A transport override (or an `http_api_curl`-style filter) can return a
+	 * WP_Error whose message embeds the raw URI it was given — a real route
+	 * third-party code can trigger, independent of any request-class-specific
+	 * masking. Woodev_Plugin_Updater::get_version_from_remote() logs
+	 * `$e->getMessage()` verbatim via error_log() on ANY \Throwable, so an
+	 * unredacted WP_Error message here reaches the PHP error log regardless
+	 * of WOODEV_LICENSE_DEBUG or the WooCommerce logger.
+	 *
+	 * @return void
+	 */
+	public function test_wp_error_transport_message_is_redacted_before_it_reaches_an_exception(): void {
+
+		$this->stub_wp_http_functions();
+
+		$license_key = 'AAAA-BBBB-CCCC-DDDD-license-secret-value';
+		$request     = $this->make_request( $license_key );
+
+		$api = new Testable_Licensing_Request_Api_Base_With_Wp_Error_Transport();
+		$api->set_request_for_test( $request );
+
+		try {
+			$api->perform_request_for_test( $request );
+			$this->fail( 'Expected a Woodev_API_Exception to be thrown.' );
+		} catch ( \Woodev_API_Exception $e ) {
+			$this->assertStringNotContainsString(
+				$license_key,
+				$e->getMessage(),
+				'a raw transport WP_Error message leaked the license key into the exception'
+			);
+		}
 	}
 }

--- a/tests/unit/PlatformNeutralLicensingTest.php
+++ b/tests/unit/PlatformNeutralLicensingTest.php
@@ -149,12 +149,12 @@ class PlatformNeutralLicensingTest extends TestCase {
 		);
 
 		// #395: to_string_safe() must no longer alias to_string() verbatim — the
-		// license key is masked (same convention as Woodev_API_Base header
-		// masking), while every other param passes through untouched.
+		// license key is masked (same fixed placeholder as Woodev_API_Base
+		// header masking), while every other param passes through untouched.
 		$this->assertSame(
 			print_r(
 				[
-					'license' => str_repeat( '*', strlen( 'abc123' ) ),
+					'license' => \Woodev_API_Base::SECRET_VALUE_MASK,
 					'item_id' => 42,
 				],
 				true

--- a/tests/unit/PlatformNeutralLicensingTest.php
+++ b/tests/unit/PlatformNeutralLicensingTest.php
@@ -147,7 +147,20 @@ class PlatformNeutralLicensingTest extends TestCase {
 			),
 			$request->to_string()
 		);
-		$this->assertSame( $request->to_string(), $request->to_string_safe() );
+
+		// #395: to_string_safe() must no longer alias to_string() verbatim — the
+		// license key is masked (same convention as Woodev_API_Base header
+		// masking), while every other param passes through untouched.
+		$this->assertSame(
+			print_r(
+				[
+					'license' => str_repeat( '*', strlen( 'abc123' ) ),
+					'item_id' => 42,
+				],
+				true
+			),
+			$request->to_string_safe()
+		);
 	}
 
 	/**

--- a/tests/unit/Shipping/Location/DadataApiClientTest.php
+++ b/tests/unit/Shipping/Location/DadataApiClientTest.php
@@ -131,8 +131,9 @@ final class DadataApiClientTest extends TestCase {
 
 	/**
 	 * The masked X-Secret header must follow the SAME masking convention the
-	 * base class already applies to Authorization: same character, same
-	 * length (not a fixed-width placeholder, not merely absent).
+	 * base class already applies to Authorization: the fixed
+	 * {@see \Woodev_API_Base::SECRET_VALUE_MASK} placeholder, not a
+	 * length-revealing run of `*` (#395 Round 3) and not merely absent.
 	 */
 	public function test_the_masked_x_secret_header_matches_the_authorization_masking_style(): void {
 		$this->stub_http_response( 200, '{"suggestions":[]}' );
@@ -150,7 +151,7 @@ final class DadataApiClientTest extends TestCase {
 
 		( new Dadata_Api_Client( 'tok', $secret ) )->suggest_address( 'q' );
 
-		$this->assertSame( str_repeat( '*', strlen( $secret ) ), $broadcast['headers']['X-Secret'] );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $broadcast['headers']['X-Secret'] );
 	}
 
 	// -------------------------------------------------------------------------

--- a/woodev/api/abstract-api-json-request.php
+++ b/woodev/api/abstract-api-json-request.php
@@ -31,9 +31,52 @@ if ( ! class_exists( 'Woodev_API_JSON_Request' ) ) :
 			return ! empty( $params ) ? wp_json_encode( $params ) : '';
 		}
 
+		/**
+		 * Gets the sanitized request body, for logging.
+		 *
+		 * Fail-safe default: masks every param named in
+		 * {@see self::get_secret_param_names()} before serializing, instead of
+		 * aliasing {@see self::to_string()} outright — the previous default,
+		 * which meant any subclass that forgot to override this method logged
+		 * its FULL raw body, credentials included, by default. A subclass with a
+		 * concrete `to_string()` format of its own (e.g.
+		 * {@see Woodev_Licensing_API_Request}, which uses `print_r()` rather than
+		 * JSON) should still override this too, rather than rely on this generic
+		 * fallback — see #395 (Blocking 1).
+		 *
+		 * @since 2.0.2 masks known secret params instead of aliasing {@see self::to_string()}.
+		 *
+		 * @return string
+		 */
 		public function to_string_safe() {
 
-			return $this->to_string();
+			$params = $this->get_params();
+
+			if ( empty( $params ) ) {
+				return $this->to_string();
+			}
+
+			$params = Woodev_API_Base::mask_secret_values( $params, $this->get_secret_param_names() );
+
+			return wp_json_encode( $params );
+		}
+
+		/**
+		 * Names of request params whose values carry a credential and must be
+		 * masked before {@see self::to_string_safe()} hands the request off to
+		 * logging. Defaults to the same generic list
+		 * {@see Woodev_API_Base::get_secret_param_names()} uses for request
+		 * paths/URIs, so a param name known to be secret is masked in the body
+		 * the same way it is masked in the query string — one list, not two that
+		 * can drift apart. Override to extend it, the same pattern as
+		 * {@see Woodev_API_Base::get_secret_header_names()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<int, string>
+		 */
+		protected function get_secret_param_names(): array {
+			return Woodev_API_Base::get_default_secret_param_names();
 		}
 	}
 

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -278,19 +278,20 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * interface — for a request class that wants full control over its own
 		 * masking. Falls back to the real {@see self::get_request_path()} when it
 		 * doesn't. Either way, the result is then run through
-		 * {@see self::redact_secret_query_params()} unconditionally: a request
+		 * {@see self::redact_secret_query_string()} unconditionally: a request
 		 * class implementing `get_path_safe()` gets a harmless second pass over
 		 * an already-masked value, but a request class that implements NO masking
 		 * of its own — the common case, and the one a future or third-party
 		 * extension is most likely to be — is never logged with its raw path.
-		 * Before this fix, that fallback path was the raw, unmasked one; a
-		 * request carrying a credential under an unrecognised param name (e.g.
-		 * `token`, `api_key`, `secret`, `instance_id`) still logged it in clear
-		 * text by default — see #395 (Blocking 1).
 		 *
 		 * @since 2.0.2
-		 * @since 2.0.2 made fail-safe by default via {@see self::redact_secret_query_params()}
-		 *              instead of falling back to the raw path unconditionally.
+		 * @since 2.0.2 made fail-safe by default via redaction instead of falling
+		 *              back to the raw path unconditionally — #395 Blocking 1.
+		 * @since 2.0.2 redaction now parses the query string structurally via
+		 *              {@see self::redact_secret_query_string()} instead of
+		 *              scanning it with a `name=value` regex, so a secret nested
+		 *              under a NON-secret param name at any depth (e.g.
+		 *              `a[token]=…`) is still caught — #395 Round 4, Blocking.
 		 *
 		 * @return string
 		 */
@@ -302,7 +303,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				? $request->get_path_safe()
 				: $this->get_request_path();
 
-			return self::redact_secret_query_params( $path, $this->get_secret_param_names() );
+			return self::redact_secret_query_string( $path, $this->get_secret_param_names() );
 		}
 
 		/**
@@ -310,7 +311,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *
 		 * Same as {@see self::get_request_uri()} but built from
 		 * {@see self::get_sanitized_request_path()}, and with
-		 * {@see self::redact_secret_query_params()} run again on the FINAL
+		 * {@see self::redact_secret_query_string()} run again on the FINAL
 		 * string — AFTER the `woodev_{api_id}_api_request_uri` filter, not
 		 * before. A filter attached to that hook can append its own query
 		 * param (some third-party transports do, e.g. a signature or replay
@@ -323,6 +324,8 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 redaction now runs AFTER the request-uri filter, not before.
+		 * @since 2.0.2 redaction now parses the query string structurally via
+		 *              {@see self::redact_secret_query_string()} — #395 Round 4, Blocking.
 		 *
 		 * @return string
 		 */
@@ -331,7 +334,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			$uri = $this->request_uri . $this->get_sanitized_request_path();
 			$uri = apply_filters( 'woodev_' . $this->get_api_id() . '_api_request_uri', $uri, $this );
 
-			return self::redact_secret_query_params( $uri, $this->get_secret_param_names() );
+			return self::redact_secret_query_string( $uri, $this->get_secret_param_names() );
 		}
 
 
@@ -419,26 +422,34 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 
 		/**
 		 * Redacts every occurrence of a known secret param name anywhere it
-		 * appears in $text — a URI's query string, a request/response body of
-		 * ANY format, or free text such as a transport-thrown WP_Error message
-		 * that happens to embed the URI it was given (see #395). $text is
-		 * scanned for two shapes, independent of whether it happens to be a
-		 * well-formed `path?query` string, a form-encoded body, an XML body, or
-		 * an arbitrary error message:
+		 * appears in $text, by SCANNING the raw string for two shapes — this is
+		 * the regex-based backstop, kept (only) for text that {@see self::redact_secret_request_body()}
+		 * cannot structurally parse (XML, form-encoded, or free text such as a
+		 * transport-thrown WP_Error message that happens to embed the URI it was
+		 * given, see #395), and for {@see self::handle_response()}. A well-formed
+		 * `path?query` string is no longer scanned by this routine — see
+		 * {@see self::redact_secret_query_string()}, which parses it structurally
+		 * instead, so it cannot corrupt anything it rebuilds — #395 Round 4.
 		 *
-		 * - `name=value` (query string / form body), including the nested-array
-		 *   shape `http_build_query()` emits for an array value — both the
-		 *   percent-encoded wire form (`name%5Bsub%5D=value`) and the literal
-		 *   form (`name[sub]=value`) — matched by the array's own top-level
-		 *   name; the bracket suffix is preserved untouched in the output, only
-		 *   the value is masked;
+		 * $text is scanned for two shapes:
+		 *
+		 * - `name=value` (form-encoded body / free text), including the
+		 *   nested-array shape `http_build_query()` emits for an array value —
+		 *   both the percent-encoded wire form (`name%5Bsub%5D=value`) and the
+		 *   literal form (`name[sub]=value`) — matched against EVERY bracket
+		 *   segment of the key, not only the first, so a secret nested under a
+		 *   NON-secret outer name (`a[token]=…`) is still caught — #395 Round 4,
+		 *   Blocking. The key is URL-decoded (`+` included, so `api+key=…`
+		 *   canonicalizes the same as `api_key=…`) before any segment is
+		 *   compared — #395 Round 4, SHOULD-FIX. The bracket suffix is preserved
+		 *   untouched in the output, only the value is masked;
 		 * - `<name>value</name>` (a single, non-nested XML element) — the
-		 *   backstop {@see self::get_sanitized_request_body()} needs now that it
-		 *   runs this same routine over whatever an XML (or other non-JSON)
-		 *   request class's `to_string_safe()` returns, format be damned — see
-		 *   #395 Round 3, Blocking 2. {@see Woodev_API_XML_Request::to_string_safe()}
-		 *   is a concrete example already in this codebase of a `to_string_safe()`
-		 *   that applies NO masking of its own.
+		 *   backstop {@see self::get_sanitized_request_body()} needs for an XML
+		 *   (or other non-JSON) request class's `to_string_safe()` that masks
+		 *   nothing of its own — see #395 Round 3, Blocking 2.
+		 *   {@see Woodev_API_XML_Request::to_string_safe()} is a concrete example
+		 *   already in this codebase of a `to_string_safe()` that applies NO
+		 *   masking of its own.
 		 *
 		 * A candidate name is matched against $secret_names case- and
 		 * separator-insensitively (`api_key`, `api-key`, `apikey`, and `apiKey`
@@ -464,17 +475,6 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * no generic way to know which segment of an arbitrary path is the
 		 * secret one).
 		 *
-		 * This is the fail-safe backstop for
-		 * {@see self::get_sanitized_request_path()} (when a request class
-		 * implements no `get_path_safe()` of its own),
-		 * {@see self::get_sanitized_request_uri()} (run AFTER the
-		 * `woodev_{api_id}_api_request_uri` filter, so a filter that itself
-		 * appends a secret-bearing param cannot bypass it),
-		 * {@see self::get_sanitized_request_body()} (when a request class's
-		 * `to_string_safe()` masks nothing, or masks in a format this routine
-		 * doesn't otherwise recognise), and {@see self::handle_response()} (a
-		 * transport-thrown WP_Error message).
-		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 also matches a name's nested/percent-encoded/casing
 		 *              variants instead of only its exact literal spelling, also
@@ -482,6 +482,13 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *              {@see self::SECRET_VALUE_MASK} instead of a
 		 *              length-revealing run of `*` — #395 Round 3 (Blocking 1 & 2,
 		 *              and the masking-shape SHOULD-FIX).
+		 * @since 2.0.2 checks EVERY bracket segment of a key, not only the first,
+		 *              and URL-decodes the key (so `+` is treated as a space)
+		 *              before canonicalizing; no longer scans a `path?query`
+		 *              string (see {@see self::redact_secret_query_string()}) or a
+		 *              successfully-decoded JSON body (see
+		 *              {@see self::redact_secret_request_body()}) — #395 Round 4
+		 *              (Blocking, both SHOULD-FIXes).
 		 *
 		 * @param string             $text
 		 * @param array<int, string> $secret_names
@@ -496,16 +503,17 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
 
 			$text = (string) preg_replace_callback(
-				'/([A-Za-z0-9_\-\[\]%]+)=([^&\s]*)/',
+				'/([A-Za-z0-9_\-\[\]%+]+)=([^&\s]*)/',
 				static function ( array $matches ) use ( $canonical_secret_names ): string {
 
-					$base_name = self::get_query_param_base_name( $matches[1] );
+					foreach ( self::get_query_param_name_segments( $matches[1] ) as $segment ) {
 
-					if ( ! in_array( self::canonicalize_secret_param_name( $base_name ), $canonical_secret_names, true ) ) {
-						return $matches[0];
+						if ( in_array( self::canonicalize_secret_param_name( $segment ), $canonical_secret_names, true ) ) {
+							return $matches[1] . '=' . self::SECRET_VALUE_MASK;
+						}
 					}
 
-					return $matches[1] . '=' . self::SECRET_VALUE_MASK;
+					return $matches[0];
 				},
 				$text
 			);
@@ -522,6 +530,155 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				},
 				$text
 			);
+		}
+
+		/**
+		 * Redacts a `path?query` or full URI string by PARSING its query string
+		 * structurally, instead of scanning the text with a regex — the fix for
+		 * #395 Round 4, Blocking: {@see self::redact_secret_query_params()} only
+		 * ever compared the FIRST bracket segment of a key against the denylist,
+		 * so a secret nested under a non-secret outer name (`a[token]=SECRET`,
+		 * literal or percent-encoded) sailed through untouched.
+		 *
+		 * `parse_str()` decodes the query string into a real, arbitrarily-nested
+		 * PHP array — handling percent-encoding, `+`-as-space, and bracket
+		 * nesting the same way `http_build_query()` (which built the query in
+		 * the first place) emits them, for free. {@see self::redact_secret_values_recursively()}
+		 * then walks that array and redacts by canonicalized key at ANY depth,
+		 * and the result is rebuilt with `http_build_query()` — never by editing
+		 * the original text, so this cannot corrupt anything the way a text-scan
+		 * over an unrelated format can (see {@see self::redact_secret_request_body()}
+		 * for the JSON-body version of the same problem).
+		 *
+		 * Only the LOG string is rebuilt here; the request actually sent to the
+		 * server is always built independently from the real, unredacted params
+		 * (see {@see self::get_request_uri()}), so a rebuild being acceptable for
+		 * a log line has no bearing on the wire request.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string             $text A path (`?query` included), or a full URI.
+		 * @param array<int, string> $secret_names
+		 * @return string
+		 */
+		protected static function redact_secret_query_string( string $text, array $secret_names ): string {
+
+			if ( '' === $text || empty( $secret_names ) ) {
+				return $text;
+			}
+
+			$query_start = strpos( $text, '?' );
+
+			if ( false === $query_start ) {
+				return $text;
+			}
+
+			$query_string = substr( $text, $query_start + 1 );
+
+			if ( '' === $query_string ) {
+				return $text;
+			}
+
+			parse_str( $query_string, $params );
+
+			if ( empty( $params ) ) {
+				return $text;
+			}
+
+			$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
+			$redacted_params        = self::redact_secret_values_recursively( $params, $canonical_secret_names );
+
+			return substr( $text, 0, $query_start + 1 ) . http_build_query( $redacted_params, '', '&' );
+		}
+
+		/**
+		 * Redacts a request/response BODY, for logging — dispatches on format
+		 * instead of running one text-scanning regex over every shape, per #395
+		 * Round 4 (SHOULD-FIX 2): a JSON body containing the literal text
+		 * `token=value` inside a legitimate string field used to be truncated by
+		 * {@see self::redact_secret_query_params()}'s `name=value` scan, corrupting
+		 * a body the redactor was never meant to touch.
+		 *
+		 * A body that decodes as JSON is walked and redacted STRUCTURALLY —
+		 * `json_decode()`, {@see self::redact_secret_values_recursively()} by key
+		 * at any depth, `json_encode()` back — so a secret-shaped substring
+		 * embedded in an unrelated string VALUE is never touched, and the result
+		 * is always valid JSON because it was rebuilt from a decoded structure,
+		 * never edited as text.
+		 *
+		 * A body that does NOT decode as JSON (form-encoded, XML, a `print_r()`
+		 * dump, or anything else — "if it does not decode, it is not JSON") falls
+		 * back to {@see self::redact_secret_query_params()}, unchanged from
+		 * before: its `name=value` pass masks a form-encoded body, its
+		 * `<name>value</name>` pass masks an XML body, and a `print_r()` dump
+		 * (`[name] => value`) matches neither shape and passes through
+		 * untouched — which is correct, not a gap, because
+		 * {@see Woodev_Licensing_API_Request::to_string_safe()} already masked
+		 * its own `[license]` entry before handing the dump to this method; this
+		 * routine only needs to catch what a request class did NOT mask itself.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string             $body
+		 * @param array<int, string> $secret_names
+		 * @return string
+		 */
+		protected static function redact_secret_request_body( string $body, array $secret_names ): string {
+
+			if ( '' === $body || empty( $secret_names ) ) {
+				return $body;
+			}
+
+			$decoded = json_decode( $body, true );
+
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+
+				$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
+				$redacted               = self::redact_secret_values_recursively( $decoded, $canonical_secret_names );
+				$encoded                = json_encode( $redacted, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+
+				return false !== $encoded ? $encoded : $body;
+			}
+
+			return self::redact_secret_query_params( $body, $secret_names );
+		}
+
+		/**
+		 * Walks a decoded query-string or JSON array and redacts the value of
+		 * every entry whose KEY canonicalizes to a denylisted name, AT ANY DEPTH
+		 * — not only the top level. A matching key's entire value is replaced
+		 * with {@see self::SECRET_VALUE_MASK} in one shot, even when that value
+		 * is itself an array (e.g. `token[primary]=…`): there is no safe way to
+		 * partially mask a subtree whose very key is the secret's name. A
+		 * NON-matching key whose value is an array is recursed into, so a secret
+		 * nested under a non-secret outer name (`a[token]=…`) is still caught —
+		 * #395 Round 4, Blocking.
+		 *
+		 * Shared by {@see self::redact_secret_query_string()} (query strings) and
+		 * {@see self::redact_secret_request_body()} (JSON bodies) so both use the
+		 * exact same nesting rule.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param array<int|string, mixed> $values
+		 * @param array<int, string>       $canonical_secret_names Already-canonicalized names.
+		 * @return array<int|string, mixed>
+		 */
+		private static function redact_secret_values_recursively( array $values, array $canonical_secret_names ): array {
+
+			foreach ( $values as $key => $value ) {
+
+				if ( in_array( self::canonicalize_secret_param_name( (string) $key ), $canonical_secret_names, true ) ) {
+					$values[ $key ] = self::SECRET_VALUE_MASK;
+					continue;
+				}
+
+				if ( is_array( $value ) ) {
+					$values[ $key ] = self::redact_secret_values_recursively( $value, $canonical_secret_names );
+				}
+			}
+
+			return $values;
 		}
 
 		/**
@@ -543,24 +700,39 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		}
 
 		/**
-		 * Extracts the top-level param name from a possibly nested/percent-encoded
-		 * query key, e.g. `token%5Bprimary%5D` or `token[primary]` both yield
-		 * `token` — the name `http_build_query()` derives it from, and the one a
-		 * secret-param denylist entry is written against. A key with no bracket
-		 * suffix is returned unchanged. Used only by
-		 * {@see self::redact_secret_query_params()} — #395 Round 3, Blocking 1.
+		 * Splits a possibly nested/percent-encoded query key into ALL of its
+		 * name segments, e.g. `token%5Bprimary%5D` and `token[primary]` both
+		 * yield `[ 'token', 'primary' ]` — not only the top-level `token` a
+		 * previous round of this fix stopped at, which is how `a[token]=SECRET`
+		 * (a secret nested under a NON-secret outer name) sailed through: only
+		 * `a` was ever compared against the denylist. Every segment is now
+		 * returned so the caller can check ALL of them — #395 Round 4, Blocking.
+		 *
+		 * The key is fully URL-decoded (`urldecode()`, so `+` becomes a literal
+		 * space the same as any other percent-encoded byte) before splitting, so
+		 * `api+key` decodes to `api key`, which {@see self::canonicalize_secret_param_name()}
+		 * then folds down to `apikey` same as `api_key`/`api-key`/`apiKey` — #395
+		 * Round 4, SHOULD-FIX 1. A key with no bracket suffix yields a single
+		 * segment: itself, decoded.
+		 *
+		 * Used only by {@see self::redact_secret_query_params()}.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 renamed from `get_query_param_base_name()` and returns
+		 *              EVERY bracket segment instead of only the first; fully
+		 *              URL-decodes the key instead of unescaping only brackets —
+		 *              #395 Round 4 (Blocking, SHOULD-FIX 1).
 		 *
 		 * @param string $key Raw query key, as captured from the wire text.
-		 * @return string
+		 * @return array<int, string>
 		 */
-		private static function get_query_param_base_name( string $key ): string {
+		private static function get_query_param_name_segments( string $key ): array {
 
-			$decoded_key      = str_ireplace( [ '%5b', '%5d' ], [ '[', ']' ], $key );
-			$bracket_position = strpos( $decoded_key, '[' );
+			$decoded_key = urldecode( $key );
 
-			return false === $bracket_position ? $decoded_key : substr( $decoded_key, 0, $bracket_position );
+			preg_match_all( '/[^\[\]]+/', $decoded_key, $matches );
+
+			return $matches[0];
 		}
 
 		protected function get_request_args() {
@@ -606,7 +778,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * Same "harmless second pass" pattern as
 		 * {@see self::get_sanitized_request_path()}: whatever the request's
 		 * `to_string_safe()` returns is run through
-		 * {@see self::redact_secret_query_params()} unconditionally, instead of
+		 * {@see self::redact_secret_request_body()} unconditionally, instead of
 		 * being trusted outright. Before this, the base took the interface-required
 		 * `to_string_safe()` result on faith — but that method is opaque to the
 		 * base (it declares no format, and any concrete class is free to return
@@ -617,13 +789,20 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *
 		 * A `Woodev_API_JSON_Request`/`Woodev_Licensing_API_Request` body that
 		 * already masked its own secret params (via {@see self::mask_secret_values()}
-		 * before serializing) is unaffected: the second pass only rewrites text
-		 * matching a `name=value` or `<name>value</name>` shape, and neither JSON
-		 * (`"name":"value"`) nor a `print_r()` dump (`[name] => value`) matches
-		 * that shape, so an already-safe body passes through unchanged.
+		 * before serializing) is unaffected: a JSON body is walked and redacted
+		 * by key, so an already-masked value stays masked; a `print_r()` dump
+		 * (`[name] => value`) matches neither the JSON nor the form/XML shapes
+		 * {@see self::redact_secret_query_params()} scans for, so an already-safe
+		 * body passes through unchanged either way.
 		 *
 		 * @since 2.0.2 runs {@see self::redact_secret_query_params()} over whatever
 		 *              `to_string_safe()` returns, instead of trusting it outright.
+		 * @since 2.0.2 dispatches on body format via
+		 *              {@see self::redact_secret_request_body()} instead of running
+		 *              the same `name=value` text-scan over every body, so a JSON
+		 *              body is no longer at risk of the scan mistaking text inside
+		 *              a legitimate string value for a `name=value` pair and
+		 *              truncating it — #395 Round 4, SHOULD-FIX 2.
 		 *
 		 * @return string
 		 */
@@ -635,7 +814,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 
 			$body = ( $this->get_request() && $this->get_request()->to_string_safe() ) ? $this->get_request()->to_string_safe() : '';
 
-			return self::redact_secret_query_params( $body, $this->get_secret_param_names() );
+			return self::redact_secret_request_body( $body, $this->get_secret_param_names() );
 		}
 
 		protected function get_request_http_version() {

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -633,50 +633,62 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * is always valid JSON because it was rebuilt from a decoded structure,
 		 * never edited as text.
 		 *
-		 * A body that decodes as a JSON SCALAR (a bare string, number, bool, or
-		 * `null`) is returned UNCHANGED: there is no key to canonicalize against
-		 * the denylist, so — like a secret carried as a bare path segment (see
-		 * {@see self::redact_secret_query_params()}) — it is simply outside what
-		 * a name-keyed redactor can catch. Round 4 instead ran this case through
-		 * the `name=value` regex scan, which could match a trailing quote into
-		 * the value and hand back invalid, truncated JSON (`"token=secret"`
-		 * becoming `"token=[REDACTED]`, missing its closing quote) without
-		 * actually being able to tell whether the scalar itself was the secret —
-		 * #395 Round 5, SHOULD-FIX.
+		 * Anything else — a body that decodes as a JSON SCALAR (a bare string,
+		 * number, bool, or `null`), or a body that is not valid JSON at all — is
+		 * replaced with {@see self::UNPARSEABLE_BODY_MASK} IN FULL. This covers
+		 * three cases that used to be handled separately, and unsafely:
 		 *
-		 * A body that is NOT valid JSON at all is either:
-		 *
-		 * - genuinely query-string-shaped (`name=value&name=value…`, verified by
-		 *   {@see self::is_form_encoded_body()} rather than assumed) — parsed
-		 *   with `parse_str()` and walked the same way a query string is (see
-		 *   {@see self::redact_secret_query_string()}), so a form-encoded body
-		 *   gets the same per-field masking a JSON body does, siblings included; or
-		 * - anything else (XML, a `print_r()` dump, or free text) — replaced with
-		 *   {@see self::UNPARSEABLE_BODY_MASK} IN FULL. #395 Round 4 fell back to
-		 *   {@see self::redact_secret_query_params()} here on the theory that its
-		 *   `<name>value</name>` pass covers XML and a `print_r()` dump
-		 *   (`[name] => value`) never needed covering because
-		 *   {@see Woodev_Licensing_API_Request::to_string_safe()} already masks its
-		 *   own `license` entry before handing the dump to this method. An
-		 *   independent critic review proved that reasoning false by invoking this
-		 *   method directly with a `print_r()`-shaped body carrying an UNMASKED
-		 *   secret: the regex cannot match `[name] => value`, so the secret came
-		 *   back verbatim. Any request class whose body reaches this method
-		 *   without having masked itself first — not only the licensing one — was
-		 *   exposed the same way. Once a format cannot be parsed and walked, there
-		 *   is no reliable way to tell a secret-named field apart from a safe
-		 *   sibling one, so the whole body is masked instead — #395 Round 5,
+		 * - Round 4 fell back to {@see self::redact_secret_query_params()} for a
+		 *   non-JSON body, on the theory that its `<name>value</name>` pass
+		 *   covers XML and a `print_r()` dump (`[name] => value`) never needed
+		 *   covering because {@see Woodev_Licensing_API_Request::to_string_safe()}
+		 *   already masks its own `license` entry before handing the dump to
+		 *   this method. An independent critic review proved that reasoning
+		 *   false by invoking this method directly with a `print_r()`-shaped
+		 *   body carrying an UNMASKED secret: the regex cannot match
+		 *   `[name] => value`, so the secret came back verbatim — #395 Round 5,
 		 *   Blocking.
+		 * - Round 5 tried to parse a non-JSON body as a query string
+		 *   (`name=value&name=value…`) whenever it merely LOOKED shaped that
+		 *   way, via a syntax check ({@see self::is_form_encoded_body()},
+		 *   removed in Round 6). A critic review broke that with two shapes
+		 *   that both pass a syntax check without being a form body at all: a
+		 *   URL a caller pasted as free text (`https://x?token=SECRET`) parses
+		 *   as `https://x?token` `=` `SECRET`, and free text containing a
+		 *   newline still matches per-line. You cannot infer the body's actual
+		 *   format from what its bytes merely look like — #395 Round 6,
+		 *   Blocking 1. No concrete request class in this codebase ever
+		 *   produces a form-encoded body (every {@see self::set_request_content_type_header()}
+		 *   call in this codebase passes `application/json`; there is no
+		 *   `Woodev_API_Form_Request` counterpart to
+		 *   {@see Woodev_API_JSON_Request}/{@see Woodev_API_XML_Request}, and
+		 *   the `Woodev_API_Request` interface declares no content-type/format
+		 *   accessor a body could be checked against independently), so there
+		 *   is no trustworthy signal to parse the body against in the first
+		 *   place — whole-masking is not a lesser default, it is the only
+		 *   correct one until a request class can declare its own format
+		 *   through a channel the body's bytes cannot forge.
+		 * - Round 5 also returned a JSON SCALAR body unchanged, reasoning that
+		 *   there is no key to redact by. That is true, but incomplete: with no
+		 *   key, the scalar VALUE itself is the only thing there, and nothing
+		 *   rules out that value being the secret itself (a body that is
+		 *   `"super-secret-token-value"` and nothing else) — #395 Round 6,
+		 *   Blocking 2. A scalar has exactly the same "no key to redact by"
+		 *   problem a non-JSON body does, so it now gets the same answer:
+		 *   `null` is masked too, for the same reason — not because it can
+		 *   carry a secret (it cannot: it carries no value at all), but because
+		 *   a reader of the log should not have to learn that JSON scalars
+		 *   split into "one kind that's shown" and "three kinds that are
+		 *   masked" to understand a log line; one rule for every scalar is
+		 *   simpler and costs nothing a null body's absence of information
+		 *   didn't already cost.
 		 *
-		 * A parsed rendering of either shape is a LOG rendering, not the wire
-		 * bytes — over-redaction is the acceptable side to err on here, but a
-		 * reader relying on a log line to reconstruct the original request
-		 * should know these are lossy, by design:
+		 * A parsed rendering of the surviving case (a JSON array/object) is a
+		 * LOG rendering, not the wire bytes — over-redaction is the acceptable
+		 * side to err on here, but a reader relying on a log line to
+		 * reconstruct the original request should know this is lossy, by
+		 * design:
 		 *
-		 * - `parse_str()`/`http_build_query()` drop a duplicate key (only the
-		 *   last survives), turn a `.` or a space in a key into `_`, and are
-		 *   capped by PHP's `max_input_vars` — a body with more top-level keys
-		 *   than that ini setting allows is silently truncated;
 		 * - re-encoding through `json_decode()`/`json_encode()` changes a
 		 *   numeric literal's shape (`1.0` becomes `1`), the slash- and
 		 *   Unicode-escaping (this method requests `JSON_UNESCAPED_SLASHES |
@@ -698,6 +710,14 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *              a non-JSON body is genuinely query-string-shaped before
 		 *              parsing it as one, and returns a scalar JSON body unchanged
 		 *              instead of regex-scanning it — #395 Round 5.
+		 * @since 2.0.2 drops the query-string-shaped exception entirely — no
+		 *              request class in this codebase can prove a body is
+		 *              actually form-encoded rather than merely shaped like it,
+		 *              so every non-JSON-array/object body is now whole-masked
+		 *              — and masks a JSON scalar (including `null`) the same
+		 *              way, instead of returning it unchanged, because a bare
+		 *              scalar has no key to redact by and may itself BE the
+		 *              secret — #395 Round 6, Blocking 1 & 2.
 		 *
 		 * @param string             $body
 		 * @param array<int, string> $secret_names
@@ -711,12 +731,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 
 			$decoded = json_decode( $body, true );
 
-			if ( JSON_ERROR_NONE === json_last_error() ) {
-
-				if ( ! is_array( $decoded ) ) {
-					// A scalar/null JSON body carries no key to redact by.
-					return $body;
-				}
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
 
 				$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
 				$redacted               = self::redact_secret_values_recursively( $decoded, $canonical_secret_names );
@@ -725,48 +740,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				return false !== $encoded ? $encoded : $body;
 			}
 
-			if ( self::is_form_encoded_body( $body ) ) {
-
-				parse_str( $body, $params );
-
-				if ( ! empty( $params ) ) {
-
-					$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
-					$redacted               = self::redact_secret_values_recursively( $params, $canonical_secret_names );
-
-					return http_build_query( $redacted, '', '&' );
-				}
-			}
-
 			return self::UNPARSEABLE_BODY_MASK;
-		}
-
-		/**
-		 * Verifies that $text is GENUINELY shaped like a `name=value&name=value…`
-		 * query string, rather than merely containing an `=` somewhere — used by
-		 * {@see self::redact_secret_request_body()} to decide whether a non-JSON
-		 * body may be safely parsed with `parse_str()` and rebuilt with
-		 * `http_build_query()`, instead of assuming any body that isn't JSON must
-		 * be form-encoded. `parse_str()` is lenient enough to produce SOMETHING
-		 * for almost any input, including a `print_r()` dump — so a shape check
-		 * has to run first, or the "trust the format" guarantee this validates is
-		 * hollow.
-		 *
-		 * Every `name` segment, over the WHOLE string, must consist only of the
-		 * characters a real `http_build_query()` output ever uses for a key
-		 * (letters, digits, `_-[]%+`) immediately followed by `=` — the same
-		 * charset {@see self::redact_secret_query_params()} accepts for a
-		 * candidate key. A `print_r()` dump (`[name] => value`) or an XML body
-		 * (`<name>value</name>`) both fail this immediately: neither has a key
-		 * made up of nothing but that charset immediately followed by `=`.
-		 *
-		 * @since 2.0.2
-		 *
-		 * @param string $text
-		 * @return bool
-		 */
-		private static function is_form_encoded_body( string $text ): bool {
-			return 1 === preg_match( '/^[A-Za-z0-9_\-\[\]%+]+=[^&]*(?:&[A-Za-z0-9_\-\[\]%+]+=[^&]*)*$/D', $text );
 		}
 
 		/**

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -235,6 +235,54 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			return ( $this->get_request() ) ? $this->get_request()->get_path() : '';
 		}
 
+
+		/**
+		 * Gets the sanitized request path, for logging.
+		 *
+		 * Delegates to the request object's `get_path_safe()` when it implements
+		 * one — an opt-in method, not part of the {@see Woodev_API_Request}
+		 * interface, so a request class carrying nothing secret in its path
+		 * (the common case) is never forced to grow a method it doesn't need.
+		 * This mirrors the existing `is_callable()` opt-in already used by
+		 * {@see self::get_sanitized_response_body()} for `to_string_safe()`.
+		 * Falls back to the real {@see self::get_request_path()} — byte-for-byte
+		 * unchanged — for every request class that has nothing to mask.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		protected function get_sanitized_request_path() {
+
+			$request = $this->get_request();
+
+			return ( $request && is_callable( array( $request, 'get_path_safe' ) ) )
+				? $request->get_path_safe()
+				: $this->get_request_path();
+		}
+
+		/**
+		 * Gets the sanitized request URI, for logging.
+		 *
+		 * Same as {@see self::get_request_uri()} but built from
+		 * {@see self::get_sanitized_request_path()} instead of the raw path, so
+		 * a request class that carries a secret in its query string (e.g.
+		 * {@see Woodev_Licensing_API_Request}, whose `license` param used to
+		 * reach the log in clear text — see #395) never leaks it. The request
+		 * actually sent to the server always goes through the unmodified
+		 * {@see self::get_request_uri()}; only what gets logged changes here.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		protected function get_sanitized_request_uri() {
+
+			$uri = $this->request_uri . $this->get_sanitized_request_path();
+
+			return apply_filters( 'woodev_' . $this->get_api_id() . '_api_request_uri', $uri, $this );
+		}
+
 		protected function get_request_args() {
 
 			$args = array(
@@ -328,13 +376,14 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		}
 
 		/**
-		 * Masks the VALUE of every header whose name (matched case-insensitively —
-		 * HTTP header names are case-insensitive) appears in $secret_names, using
+		 * Masks the VALUE of every entry whose name (matched case-insensitively —
+		 * HTTP header names are case-insensitive, and this is also reused for
+		 * request/query params — see below) appears in $secret_names, using
 		 * the convention `*` repeated to the value's original length. The original
 		 * key casing is preserved in the returned array; only the comparison is
 		 * case-insensitive.
 		 *
-		 * A header value can itself be an array: WordPress's HTTP transport
+		 * A value can itself be an array: WordPress's HTTP transport
 		 * (`WP_HTTP_Requests_Response::get_headers()`) folds a duplicated response
 		 * header — e.g. multiple `Set-Cookie` lines, the normal shape of a
 		 * session-establishing response — into an array of values rather than a
@@ -346,20 +395,27 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * Shared by {@see self::get_sanitized_request_headers()} and
 		 * {@see self::get_sanitized_response_headers()} so both directions of the
 		 * `woodev_{api_id}_api_request_performed` broadcast mask header names
-		 * identically — one masking routine, never two that can drift apart. Marked
-		 * `protected` rather than `private` so a subclass overriding either
-		 * sanitizer can reuse it instead of re-implementing the masking convention.
+		 * identically — one masking routine, never two that can drift apart.
+		 * Despite the name (kept for git-blame continuity — the routine is fully
+		 * generic over any associative array), also reused by
+		 * {@see Woodev_Licensing_API_Request} to mask the `license` param out of
+		 * the logged query string and request body — see #395. Marked `public`
+		 * rather than `protected` so a request class outside this hierarchy can
+		 * reuse it instead of re-implementing the masking convention.
 		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 masks array-valued headers element-wise instead of casting the
 		 *              whole array to a string.
+		 * @since 2.0.2 widened from `protected` to `public` so request classes that
+		 *              don't extend this hierarchy (e.g. {@see Woodev_Licensing_API_Request})
+		 *              can reuse it for masking secret-carrying request params.
 		 *
-		 * @param array<string, mixed> $headers Header name/value pairs (value: string, or array<int, string>
+		 * @param array<string, mixed> $headers Name/value pairs (value: string, or array<int, string>
 		 *                              for a duplicated header), casing as sent/received.
-		 * @param array<int, string>   $secret_names Header names to mask, matched case-insensitively.
+		 * @param array<int, string>   $secret_names Names to mask, matched case-insensitively.
 		 * @return array<string, mixed>
 		 */
-		protected static function mask_secret_headers( array $headers, array $secret_names ): array {
+		public static function mask_secret_headers( array $headers, array $secret_names ): array {
 
 			$secret_names = array_map( 'strtolower', $secret_names );
 
@@ -467,12 +523,15 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * Gets the request data for broadcasting the request.
 		 * Overriding this method allows child classes to customize the request data when broadcasting the request.
 		 *
+		 * @since 2.0.2 `uri` is now {@see self::get_sanitized_request_uri()}
+		 *              instead of the raw {@see self::get_request_uri()} — see #395.
+		 *
 		 * @return array
 		 */
 		protected function get_request_data_for_broadcast() {
 			return array(
 				'method'     => $this->get_request_method(),
-				'uri'        => $this->get_request_uri(),
+				'uri'        => $this->get_sanitized_request_uri(),
 				'user-agent' => $this->get_request_user_agent(),
 				'headers'    => $this->get_sanitized_request_headers(),
 				'body'       => $this->get_sanitized_request_body(),

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -46,6 +46,30 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		protected $response;
 
 		/**
+		 * The fixed placeholder used everywhere a credential value is masked out
+		 * of a log — headers and request params (both via
+		 * {@see self::mask_secret_values()}, including through
+		 * {@see Woodev_Licensing_API_Request} and {@see Woodev_API_JSON_Request},
+		 * which reuse it outside this hierarchy) and free text
+		 * ({@see self::redact_secret_query_params()}).
+		 *
+		 * Round 1 and round 2 of #395 masked with `*` repeated to the value's
+		 * original length, matching the convention this class already used for
+		 * headers. Two independent critic passes flagged the same problem with
+		 * that convention: the mask's LENGTH still leaks information about the
+		 * secret — enough, for a fixed-format credential (this framework's own
+		 * license keys follow a known shape/length), to help fingerprint or
+		 * narrow down what kind of secret was logged from the redacted line
+		 * alone. A fixed placeholder leaks nothing about the original value at
+		 * all, which is the stronger property a log-redaction routine should
+		 * have — "consistency with the pre-existing header convention" doesn't
+		 * outweigh that once the same finding has been raised twice.
+		 *
+		 * @since 2.0.2
+		 */
+		public const SECRET_VALUE_MASK = '[REDACTED]';
+
+		/**
 		 * Perform the request and return the parsed response
 		 *
 		 * @param Woodev_API_Request|object $request class instance which implements Woodev_API_Request
@@ -346,13 +370,39 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * {@see Woodev_API_JSON_Request::get_secret_param_names()}) — one list,
 		 * never two that can drift apart.
 		 *
+		 * Matching against this list ({@see self::mask_secret_values()},
+		 * {@see self::redact_secret_query_params()}) is case- AND
+		 * separator-insensitive, so `api_key`, `api-key`, `apikey`, and `apiKey`
+		 * are all one entry as far as matching is concerned — kept spelled out
+		 * three ways below anyway, so the list stays self-documenting about the
+		 * real-world spellings it is guarding against, not because matching
+		 * needs it. `license_key` is included alongside `license` for the same
+		 * reason: it is the literal REST arg name used by
+		 * {@see Woodev_REST_API_License} and the `edd_license_key` checkout param
+		 * built by {@see Woodev_License_Messages}, i.e. a real spelling in THIS
+		 * codebase, not a hypothetical one.
+		 *
+		 * This list is defence in depth, NOT a guarantee that every credential a
+		 * request carries is masked: it can only mask a value that appears next
+		 * to one of these names in a `name=value` or `<name>value</name>` shape
+		 * (see {@see self::redact_secret_query_params()}) or as a `name => value`
+		 * array entry (see {@see self::mask_secret_values()}). A secret carried
+		 * under an uncommon name not on this list, or with no name attached at
+		 * all (a bare path segment), is not caught by this default — a request
+		 * class that knows its own shape should still mask itself explicitly
+		 * (as {@see Woodev_Licensing_API_Request} does for `license`) rather than
+		 * relying on this fallback alone.
+		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 added `license_key`; documented as defence in depth, not a
+		 *              guarantee — #395 Round 3, Blocking 1 & 2.
 		 *
 		 * @return array<int, string>
 		 */
 		public static function get_default_secret_param_names(): array {
 			return [
 				'license',
+				'license_key',
 				'token',
 				'access_token',
 				'refresh_token',
@@ -368,32 +418,70 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		}
 
 		/**
-		 * Redacts every `name=value` occurrence, for a known secret param name,
-		 * anywhere it appears in $text — a URI's query string, or free text such
-		 * as a transport-thrown WP_Error message that happens to embed the URI it
-		 * was given (see #395, Blocking 2). Matching is by exact param NAME, not
-		 * by a URL parse, so this works uniformly whether $text is a well-formed
-		 * `path?query` string or an arbitrary error message. A param name is only
-		 * matched when immediately followed by `=` and preceded by a non-word
-		 * character or the start of the string, so a value that happens to
-		 * CONTAIN a secret name as a substring (e.g. a license key literally
-		 * containing the word "license") is never mistaken for the param itself.
+		 * Redacts every occurrence of a known secret param name anywhere it
+		 * appears in $text — a URI's query string, a request/response body of
+		 * ANY format, or free text such as a transport-thrown WP_Error message
+		 * that happens to embed the URI it was given (see #395). $text is
+		 * scanned for two shapes, independent of whether it happens to be a
+		 * well-formed `path?query` string, a form-encoded body, an XML body, or
+		 * an arbitrary error message:
 		 *
-		 * Uses the same masking convention as {@see self::mask_secret_values()}
-		 * (`*` repeated to the value's original length) so a log reader sees one
-		 * consistent style everywhere; kept as a separate routine rather than
+		 * - `name=value` (query string / form body), including the nested-array
+		 *   shape `http_build_query()` emits for an array value — both the
+		 *   percent-encoded wire form (`name%5Bsub%5D=value`) and the literal
+		 *   form (`name[sub]=value`) — matched by the array's own top-level
+		 *   name; the bracket suffix is preserved untouched in the output, only
+		 *   the value is masked;
+		 * - `<name>value</name>` (a single, non-nested XML element) — the
+		 *   backstop {@see self::get_sanitized_request_body()} needs now that it
+		 *   runs this same routine over whatever an XML (or other non-JSON)
+		 *   request class's `to_string_safe()` returns, format be damned — see
+		 *   #395 Round 3, Blocking 2. {@see Woodev_API_XML_Request::to_string_safe()}
+		 *   is a concrete example already in this codebase of a `to_string_safe()`
+		 *   that applies NO masking of its own.
+		 *
+		 * A candidate name is matched against $secret_names case- and
+		 * separator-insensitively (`api_key`, `api-key`, `apikey`, and `apiKey`
+		 * all canonicalize to the same comparison key — #395 Round 3, Blocking 1),
+		 * never by substring: the FULL candidate name must canonicalize to a
+		 * canonicalized entry in $secret_names, so a value that happens to
+		 * CONTAIN a secret name (e.g. a param literally called `mylicense`, or a
+		 * license key value containing the word "license") is never mistaken for
+		 * the param itself.
+		 *
+		 * Uses {@see self::SECRET_VALUE_MASK} — the same fixed placeholder
+		 * {@see self::mask_secret_values()} uses — so a log reader sees one
+		 * consistent mask everywhere; kept as a separate routine rather than
 		 * reused through it because this one operates on a flat string, not an
 		 * associative array.
+		 *
+		 * This is defence in depth, NOT a guarantee: it can only mask a value
+		 * that carries an explicit name (a `key=` or a `<tag>` wrapper) somewhere
+		 * in the text. A secret carried as a bare PATH SEGMENT with no such
+		 * wrapper — e.g. a REST-style `/license/{key}/status` URL — has no name
+		 * to match against and is NOT caught here; a request class shaped that
+		 * way must mask its own {@see Woodev_API_Request} path getter (there is
+		 * no generic way to know which segment of an arbitrary path is the
+		 * secret one).
 		 *
 		 * This is the fail-safe backstop for
 		 * {@see self::get_sanitized_request_path()} (when a request class
 		 * implements no `get_path_safe()` of its own),
 		 * {@see self::get_sanitized_request_uri()} (run AFTER the
 		 * `woodev_{api_id}_api_request_uri` filter, so a filter that itself
-		 * appends a secret-bearing param cannot bypass it), and
-		 * {@see self::handle_response()} (a transport-thrown WP_Error message).
+		 * appends a secret-bearing param cannot bypass it),
+		 * {@see self::get_sanitized_request_body()} (when a request class's
+		 * `to_string_safe()` masks nothing, or masks in a format this routine
+		 * doesn't otherwise recognise), and {@see self::handle_response()} (a
+		 * transport-thrown WP_Error message).
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 also matches a name's nested/percent-encoded/casing
+		 *              variants instead of only its exact literal spelling, also
+		 *              masks a `<name>value</name>` XML element, and masks with
+		 *              {@see self::SECRET_VALUE_MASK} instead of a
+		 *              length-revealing run of `*` — #395 Round 3 (Blocking 1 & 2,
+		 *              and the masking-shape SHOULD-FIX).
 		 *
 		 * @param string             $text
 		 * @param array<int, string> $secret_names
@@ -405,16 +493,74 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				return $text;
 			}
 
-			$names_pattern = implode(
-				'|',
-				array_map( static fn( string $name ): string => preg_quote( $name, '/' ), $secret_names )
+			$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
+
+			$text = (string) preg_replace_callback(
+				'/([A-Za-z0-9_\-\[\]%]+)=([^&\s]*)/',
+				static function ( array $matches ) use ( $canonical_secret_names ): string {
+
+					$base_name = self::get_query_param_base_name( $matches[1] );
+
+					if ( ! in_array( self::canonicalize_secret_param_name( $base_name ), $canonical_secret_names, true ) ) {
+						return $matches[0];
+					}
+
+					return $matches[1] . '=' . self::SECRET_VALUE_MASK;
+				},
+				$text
 			);
 
 			return (string) preg_replace_callback(
-				'/\b(' . $names_pattern . ')=([^&\s]*)/i',
-				static fn( array $matches ): string => $matches[1] . '=' . str_repeat( '*', strlen( $matches[2] ) ),
+				'/<([A-Za-z0-9_-]+)>([^<]*)<\/\1>/',
+				static function ( array $matches ) use ( $canonical_secret_names ): string {
+
+					if ( ! in_array( self::canonicalize_secret_param_name( $matches[1] ), $canonical_secret_names, true ) ) {
+						return $matches[0];
+					}
+
+					return '<' . $matches[1] . '>' . self::SECRET_VALUE_MASK . '</' . $matches[1] . '>';
+				},
 				$text
 			);
+		}
+
+		/**
+		 * Canonicalizes a param/header/tag name for secret-name comparison:
+		 * lowercased, with every non-alphanumeric separator stripped. Folds
+		 * `api_key`, `api-key`, `apikey`, and `apiKey` (or `license_key` and
+		 * `licenseKey`) down to the same comparison key, so
+		 * {@see self::redact_secret_query_params()} recognises a casing or
+		 * separator variant of a listed name without the list needing an entry
+		 * for every spelling — #395 Round 3, Blocking 1.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $name
+		 * @return string
+		 */
+		private static function canonicalize_secret_param_name( string $name ): string {
+			return strtolower( (string) preg_replace( '/[^A-Za-z0-9]+/', '', $name ) );
+		}
+
+		/**
+		 * Extracts the top-level param name from a possibly nested/percent-encoded
+		 * query key, e.g. `token%5Bprimary%5D` or `token[primary]` both yield
+		 * `token` — the name `http_build_query()` derives it from, and the one a
+		 * secret-param denylist entry is written against. A key with no bracket
+		 * suffix is returned unchanged. Used only by
+		 * {@see self::redact_secret_query_params()} — #395 Round 3, Blocking 1.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $key Raw query key, as captured from the wire text.
+		 * @return string
+		 */
+		private static function get_query_param_base_name( string $key ): string {
+
+			$decoded_key      = str_ireplace( [ '%5b', '%5d' ], [ '[', ']' ], $key );
+			$bracket_position = strpos( $decoded_key, '[' );
+
+			return false === $bracket_position ? $decoded_key : substr( $decoded_key, 0, $bracket_position );
 		}
 
 		protected function get_request_args() {
@@ -457,6 +603,28 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		/**
 		 * Gets the sanitized request body, for logging.
 		 *
+		 * Same "harmless second pass" pattern as
+		 * {@see self::get_sanitized_request_path()}: whatever the request's
+		 * `to_string_safe()` returns is run through
+		 * {@see self::redact_secret_query_params()} unconditionally, instead of
+		 * being trusted outright. Before this, the base took the interface-required
+		 * `to_string_safe()` result on faith — but that method is opaque to the
+		 * base (it declares no format, and any concrete class is free to return
+		 * whatever it wants), so a request class that implements it naively still
+		 * logged a raw credential by default. {@see Woodev_API_XML_Request::to_string_safe()}
+		 * is a concrete example already in this codebase: it prettifies the XML
+		 * body but masks nothing in it. See #395 Round 3, Blocking 2.
+		 *
+		 * A `Woodev_API_JSON_Request`/`Woodev_Licensing_API_Request` body that
+		 * already masked its own secret params (via {@see self::mask_secret_values()}
+		 * before serializing) is unaffected: the second pass only rewrites text
+		 * matching a `name=value` or `<name>value</name>` shape, and neither JSON
+		 * (`"name":"value"`) nor a `print_r()` dump (`[name] => value`) matches
+		 * that shape, so an already-safe body passes through unchanged.
+		 *
+		 * @since 2.0.2 runs {@see self::redact_secret_query_params()} over whatever
+		 *              `to_string_safe()` returns, instead of trusting it outright.
+		 *
 		 * @return string
 		 */
 		protected function get_sanitized_request_body() {
@@ -465,7 +633,9 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				return '';
 			}
 
-			return ( $this->get_request() && $this->get_request()->to_string_safe() ) ? $this->get_request()->to_string_safe() : '';
+			$body = ( $this->get_request() && $this->get_request()->to_string_safe() ) ? $this->get_request()->to_string_safe() : '';
+
+			return self::redact_secret_query_params( $body, $this->get_secret_param_names() );
 		}
 
 		protected function get_request_http_version() {
@@ -481,8 +651,8 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *
 		 * Masks the VALUE of every header whose name (matched case-insensitively —
 		 * HTTP header names are case-insensitive) appears in
-		 * {@see self::get_secret_header_names()}, using the same convention
-		 * as before (`*` repeated to the value's original length). The original key
+		 * {@see self::get_secret_header_names()}, using
+		 * {@see self::mask_secret_values()}'s fixed placeholder. The original key
 		 * casing sent on the wire is preserved in the returned array; only the
 		 * comparison is case-insensitive.
 		 *
@@ -510,12 +680,15 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		}
 
 		/**
-		 * Masks the VALUE of every entry whose name (matched case-insensitively —
-		 * HTTP header names are case-insensitive, and this is also used for
-		 * request/query params — see below) appears in $secret_names, using
-		 * the convention `*` repeated to the value's original length. The original
-		 * key casing is preserved in the returned array; only the comparison is
-		 * case-insensitive.
+		 * Masks the VALUE of every entry whose name matches $secret_names, using
+		 * {@see self::SECRET_VALUE_MASK}. The match is decided by
+		 * {@see self::canonicalize_secret_param_name()} on both sides — lowercased,
+		 * separators stripped — so it is both case-insensitive (HTTP header names
+		 * are case-insensitive, and this is also used for request/query params —
+		 * see below) AND tolerant of a `snake_case`/`kebab-case`/`camelCase`
+		 * spelling difference (`api_key`, `api-key`, `apikey`, `apiKey` all match
+		 * the same entry — #395 Round 3, Blocking 1). The original key casing is
+		 * preserved in the returned array; only the comparison is normalized.
 		 *
 		 * A value can itself be an array: WordPress's HTTP transport
 		 * (`WP_HTTP_Requests_Response::get_headers()`) folds a duplicated response
@@ -549,32 +722,35 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * @since 2.0.2 renamed from `mask_secret_headers()` to `mask_secret_values()`
 		 *              — the name no longer matched what it masked once request
 		 *              params joined headers as callers.
+		 * @since 2.0.2 name matching is now separator-insensitive too (not only
+		 *              case-insensitive), and masks with {@see self::SECRET_VALUE_MASK}
+		 *              instead of a length-revealing run of `*` — #395 Round 3.
 		 *
 		 * @param array<string, mixed> $headers Name/value pairs (value: string, or array<int, string>
 		 *                              for a duplicated header), casing as sent/received.
-		 * @param array<int, string>   $secret_names Names to mask, matched case-insensitively.
+		 * @param array<int, string>   $secret_names Names to mask, matched case- and separator-insensitively.
 		 * @return array<string, mixed>
 		 */
 		public static function mask_secret_values( array $headers, array $secret_names ): array {
 
-			$secret_names = array_map( 'strtolower', $secret_names );
+			$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
 
 			/*
 			 * Membership is decided by header NAME alone, never by the value being
 			 * truthy: `empty()` is true for the string `'0'`, so a credential whose
 			 * value happens to be `0` would have reached the logger in clear text.
-			 * Masking a genuinely empty value costs nothing — the mask is as long as
-			 * the value, so an empty header still logs as empty.
+			 * Masking a genuinely empty value costs nothing — it still logs as
+			 * SECRET_VALUE_MASK rather than being skipped and logged as `''`.
 			 */
 			foreach ( $headers as $name => $value ) {
 
-				if ( ! in_array( strtolower( (string) $name ), $secret_names, true ) ) {
+				if ( ! in_array( self::canonicalize_secret_param_name( (string) $name ), $canonical_secret_names, true ) ) {
 					continue;
 				}
 
 				$headers[ $name ] = is_array( $value )
-					? array_map( static fn( $item ) => str_repeat( '*', strlen( (string) $item ) ), $value )
-					: str_repeat( '*', strlen( (string) $value ) );
+					? array_map( static fn( $item ) => self::SECRET_VALUE_MASK, $value )
+					: self::SECRET_VALUE_MASK;
 			}
 
 			return $headers;

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -70,6 +70,29 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		public const SECRET_VALUE_MASK = '[REDACTED]';
 
 		/**
+		 * The placeholder logged in place of an ENTIRE request/response body
+		 * whose format {@see self::redact_secret_request_body()} cannot parse
+		 * and walk structurally — #395 Round 5, Blocking.
+		 *
+		 * A body in an unrecognised shape (XML, a `print_r()` dump, or
+		 * anything else that is neither valid JSON nor a genuine query
+		 * string) has no reliable way to tell a secret-named field apart from
+		 * a safe sibling one: the round-4 regex backstop only matched a
+		 * `name=value` or `<name>value</name>` shape, so a `print_r()` dump
+		 * (`[name] => value`) — the exact shape
+		 * {@see Woodev_Licensing_API_Request::to_string_safe()} produces —
+		 * matched neither and passed through with any unmasked secret intact.
+		 * Masking the whole body is the fail-SAFE choice once the format
+		 * itself cannot be trusted: it is deliberately coarser than the
+		 * per-field masking a parseable body gets, and it can hide a
+		 * non-secret sibling param too — that loss of debugging convenience
+		 * is the acceptable side to err on, not a regression.
+		 *
+		 * @since 2.0.2
+		 */
+		public const UNPARSEABLE_BODY_MASK = '[REDACTED: body format could not be parsed for logging]';
+
+		/**
 		 * Perform the request and return the parsed response
 		 *
 		 * @param Woodev_API_Request|object $request class instance which implements Woodev_API_Request
@@ -423,17 +446,21 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		/**
 		 * Redacts every occurrence of a known secret param name anywhere it
 		 * appears in $text, by SCANNING the raw string for two shapes — this is
-		 * the regex-based backstop, kept (only) for text that {@see self::redact_secret_request_body()}
-		 * cannot structurally parse (XML, form-encoded, or free text such as a
-		 * transport-thrown WP_Error message that happens to embed the URI it was
-		 * given, see #395), and for {@see self::handle_response()}. A well-formed
-		 * `path?query` string is no longer scanned by this routine — see
-		 * {@see self::redact_secret_query_string()}, which parses it structurally
-		 * instead, so it cannot corrupt anything it rebuilds — #395 Round 4.
+		 * the regex-based backstop kept for {@see self::handle_response()}'s free
+		 * text (a transport-thrown WP_Error message that happens to embed the
+		 * URI it was given, see #395). A well-formed `path?query` string is no
+		 * longer scanned by this routine — see {@see self::redact_secret_query_string()},
+		 * which parses it structurally instead, so it cannot corrupt anything it
+		 * rebuilds — #395 Round 4. Nor is a request/response BODY any more — see
+		 * {@see self::redact_secret_request_body()}, which either parses it
+		 * structurally (JSON, or a body genuinely shaped like a query string) or,
+		 * since #395 Round 5, masks the WHOLE body rather than trust this scan to
+		 * find every secret in a format it was never built to understand (it
+		 * cannot match a `print_r()` dump's `[name] => value` shape at all).
 		 *
 		 * $text is scanned for two shapes:
 		 *
-		 * - `name=value` (form-encoded body / free text), including the
+		 * - `name=value` (free text), including the
 		 *   nested-array shape `http_build_query()` emits for an array value —
 		 *   both the percent-encoded wire form (`name%5Bsub%5D=value`) and the
 		 *   literal form (`name[sub]=value`) — matched against EVERY bracket
@@ -443,13 +470,10 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *   canonicalizes the same as `api_key=…`) before any segment is
 		 *   compared — #395 Round 4, SHOULD-FIX. The bracket suffix is preserved
 		 *   untouched in the output, only the value is masked;
-		 * - `<name>value</name>` (a single, non-nested XML element) — the
-		 *   backstop {@see self::get_sanitized_request_body()} needs for an XML
-		 *   (or other non-JSON) request class's `to_string_safe()` that masks
-		 *   nothing of its own — see #395 Round 3, Blocking 2.
-		 *   {@see Woodev_API_XML_Request::to_string_safe()} is a concrete example
-		 *   already in this codebase of a `to_string_safe()` that applies NO
-		 *   masking of its own.
+		 * - `<name>value</name>` (a single, non-nested XML element) — kept for
+		 *   the same free-text WP_Error message case; an XML-shaped BODY is now
+		 *   handled by {@see self::redact_secret_request_body()}'s whole-body
+		 *   mask instead, since #395 Round 5.
 		 *
 		 * A candidate name is matched against $secret_names case- and
 		 * separator-insensitively (`api_key`, `api-key`, `apikey`, and `apiKey`
@@ -489,6 +513,9 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *              successfully-decoded JSON body (see
 		 *              {@see self::redact_secret_request_body()}) — #395 Round 4
 		 *              (Blocking, both SHOULD-FIXes).
+		 * @since 2.0.2 no longer used as the BODY fallback at all — a non-JSON
+		 *              body is either genuinely query-string-shaped (parsed
+		 *              structurally) or masked in full — #395 Round 5, Blocking.
 		 *
 		 * @param string             $text
 		 * @param array<int, string> $secret_names
@@ -599,25 +626,78 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * {@see self::redact_secret_query_params()}'s `name=value` scan, corrupting
 		 * a body the redactor was never meant to touch.
 		 *
-		 * A body that decodes as JSON is walked and redacted STRUCTURALLY —
-		 * `json_decode()`, {@see self::redact_secret_values_recursively()} by key
-		 * at any depth, `json_encode()` back — so a secret-shaped substring
+		 * A body that decodes as a JSON ARRAY/OBJECT is walked and redacted
+		 * STRUCTURALLY — `json_decode()`, {@see self::redact_secret_values_recursively()}
+		 * by key at any depth, `json_encode()` back — so a secret-shaped substring
 		 * embedded in an unrelated string VALUE is never touched, and the result
 		 * is always valid JSON because it was rebuilt from a decoded structure,
 		 * never edited as text.
 		 *
-		 * A body that does NOT decode as JSON (form-encoded, XML, a `print_r()`
-		 * dump, or anything else — "if it does not decode, it is not JSON") falls
-		 * back to {@see self::redact_secret_query_params()}, unchanged from
-		 * before: its `name=value` pass masks a form-encoded body, its
-		 * `<name>value</name>` pass masks an XML body, and a `print_r()` dump
-		 * (`[name] => value`) matches neither shape and passes through
-		 * untouched — which is correct, not a gap, because
-		 * {@see Woodev_Licensing_API_Request::to_string_safe()} already masked
-		 * its own `[license]` entry before handing the dump to this method; this
-		 * routine only needs to catch what a request class did NOT mask itself.
+		 * A body that decodes as a JSON SCALAR (a bare string, number, bool, or
+		 * `null`) is returned UNCHANGED: there is no key to canonicalize against
+		 * the denylist, so — like a secret carried as a bare path segment (see
+		 * {@see self::redact_secret_query_params()}) — it is simply outside what
+		 * a name-keyed redactor can catch. Round 4 instead ran this case through
+		 * the `name=value` regex scan, which could match a trailing quote into
+		 * the value and hand back invalid, truncated JSON (`"token=secret"`
+		 * becoming `"token=[REDACTED]`, missing its closing quote) without
+		 * actually being able to tell whether the scalar itself was the secret —
+		 * #395 Round 5, SHOULD-FIX.
+		 *
+		 * A body that is NOT valid JSON at all is either:
+		 *
+		 * - genuinely query-string-shaped (`name=value&name=value…`, verified by
+		 *   {@see self::is_form_encoded_body()} rather than assumed) — parsed
+		 *   with `parse_str()` and walked the same way a query string is (see
+		 *   {@see self::redact_secret_query_string()}), so a form-encoded body
+		 *   gets the same per-field masking a JSON body does, siblings included; or
+		 * - anything else (XML, a `print_r()` dump, or free text) — replaced with
+		 *   {@see self::UNPARSEABLE_BODY_MASK} IN FULL. #395 Round 4 fell back to
+		 *   {@see self::redact_secret_query_params()} here on the theory that its
+		 *   `<name>value</name>` pass covers XML and a `print_r()` dump
+		 *   (`[name] => value`) never needed covering because
+		 *   {@see Woodev_Licensing_API_Request::to_string_safe()} already masks its
+		 *   own `license` entry before handing the dump to this method. An
+		 *   independent critic review proved that reasoning false by invoking this
+		 *   method directly with a `print_r()`-shaped body carrying an UNMASKED
+		 *   secret: the regex cannot match `[name] => value`, so the secret came
+		 *   back verbatim. Any request class whose body reaches this method
+		 *   without having masked itself first — not only the licensing one — was
+		 *   exposed the same way. Once a format cannot be parsed and walked, there
+		 *   is no reliable way to tell a secret-named field apart from a safe
+		 *   sibling one, so the whole body is masked instead — #395 Round 5,
+		 *   Blocking.
+		 *
+		 * A parsed rendering of either shape is a LOG rendering, not the wire
+		 * bytes — over-redaction is the acceptable side to err on here, but a
+		 * reader relying on a log line to reconstruct the original request
+		 * should know these are lossy, by design:
+		 *
+		 * - `parse_str()`/`http_build_query()` drop a duplicate key (only the
+		 *   last survives), turn a `.` or a space in a key into `_`, and are
+		 *   capped by PHP's `max_input_vars` — a body with more top-level keys
+		 *   than that ini setting allows is silently truncated;
+		 * - re-encoding through `json_decode()`/`json_encode()` changes a
+		 *   numeric literal's shape (`1.0` becomes `1`), the slash- and
+		 *   Unicode-escaping (this method requests `JSON_UNESCAPED_SLASHES |
+		 *   JSON_UNESCAPED_UNICODE`, which the original body may not have
+		 *   used), and can turn an empty JSON object (`{}`) into an empty PHP
+		 *   array that re-encodes as `[]`, or renumber a numeric-string JSON
+		 *   key;
+		 * - {@see self::canonicalize_secret_param_name()} folds separators away
+		 *   before comparing, so distinct keys like `api.key` and `api_key`
+		 *   canonicalize to the SAME comparison key and collide — a field
+		 *   that merely LOOKS like a secret name once its separators are
+		 *   stripped is over-redacted by design, per the "defence in depth,
+		 *   not a guarantee" note on {@see self::get_default_secret_param_names()}.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 no longer trusts an unparseable body to the `name=value`/
+		 *              `<name>value</name>` regex backstop — replaces it with
+		 *              {@see self::UNPARSEABLE_BODY_MASK} in full instead, verifies
+		 *              a non-JSON body is genuinely query-string-shaped before
+		 *              parsing it as one, and returns a scalar JSON body unchanged
+		 *              instead of regex-scanning it — #395 Round 5.
 		 *
 		 * @param string             $body
 		 * @param array<int, string> $secret_names
@@ -631,7 +711,12 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 
 			$decoded = json_decode( $body, true );
 
-			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+			if ( JSON_ERROR_NONE === json_last_error() ) {
+
+				if ( ! is_array( $decoded ) ) {
+					// A scalar/null JSON body carries no key to redact by.
+					return $body;
+				}
 
 				$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
 				$redacted               = self::redact_secret_values_recursively( $decoded, $canonical_secret_names );
@@ -640,7 +725,48 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 				return false !== $encoded ? $encoded : $body;
 			}
 
-			return self::redact_secret_query_params( $body, $secret_names );
+			if ( self::is_form_encoded_body( $body ) ) {
+
+				parse_str( $body, $params );
+
+				if ( ! empty( $params ) ) {
+
+					$canonical_secret_names = array_unique( array_map( [ self::class, 'canonicalize_secret_param_name' ], $secret_names ) );
+					$redacted               = self::redact_secret_values_recursively( $params, $canonical_secret_names );
+
+					return http_build_query( $redacted, '', '&' );
+				}
+			}
+
+			return self::UNPARSEABLE_BODY_MASK;
+		}
+
+		/**
+		 * Verifies that $text is GENUINELY shaped like a `name=value&name=value…`
+		 * query string, rather than merely containing an `=` somewhere — used by
+		 * {@see self::redact_secret_request_body()} to decide whether a non-JSON
+		 * body may be safely parsed with `parse_str()` and rebuilt with
+		 * `http_build_query()`, instead of assuming any body that isn't JSON must
+		 * be form-encoded. `parse_str()` is lenient enough to produce SOMETHING
+		 * for almost any input, including a `print_r()` dump — so a shape check
+		 * has to run first, or the "trust the format" guarantee this validates is
+		 * hollow.
+		 *
+		 * Every `name` segment, over the WHOLE string, must consist only of the
+		 * characters a real `http_build_query()` output ever uses for a key
+		 * (letters, digits, `_-[]%+`) immediately followed by `=` — the same
+		 * charset {@see self::redact_secret_query_params()} accepts for a
+		 * candidate key. A `print_r()` dump (`[name] => value`) or an XML body
+		 * (`<name>value</name>`) both fail this immediately: neither has a key
+		 * made up of nothing but that charset immediately followed by `=`.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string $text
+		 * @return bool
+		 */
+		private static function is_form_encoded_body( string $text ): bool {
+			return 1 === preg_match( '/^[A-Za-z0-9_\-\[\]%+]+=[^&]*(?:&[A-Za-z0-9_\-\[\]%+]+=[^&]*)*$/D', $text );
 		}
 
 		/**
@@ -787,13 +913,22 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * is a concrete example already in this codebase: it prettifies the XML
 		 * body but masks nothing in it. See #395 Round 3, Blocking 2.
 		 *
-		 * A `Woodev_API_JSON_Request`/`Woodev_Licensing_API_Request` body that
-		 * already masked its own secret params (via {@see self::mask_secret_values()}
-		 * before serializing) is unaffected: a JSON body is walked and redacted
-		 * by key, so an already-masked value stays masked; a `print_r()` dump
-		 * (`[name] => value`) matches neither the JSON nor the form/XML shapes
-		 * {@see self::redact_secret_query_params()} scans for, so an already-safe
-		 * body passes through unchanged either way.
+		 * A `Woodev_API_JSON_Request` body that already masked its own secret
+		 * params (via {@see self::mask_secret_values()} before serializing) is
+		 * unaffected: a JSON body is walked and redacted by key, so an
+		 * already-masked value stays masked. A `Woodev_Licensing_API_Request`
+		 * body, however, is a `print_r()` dump — a format
+		 * {@see self::redact_secret_request_body()} cannot parse and walk, so it
+		 * is now replaced with {@see self::UNPARSEABLE_BODY_MASK} in full, same
+		 * as any other unstructured body reaching this second pass (an
+		 * independent critic review proved, in #395 Round 5, that the previous
+		 * regex-based fallback here could not actually see a secret in that
+		 * shape — see {@see self::redact_secret_request_body()} for the full
+		 * account). This is a deliberate loss of debugging detail for an
+		 * already-self-masked body, not a regression: the base has no way to
+		 * distinguish "already masked, unstructured" from "never masked,
+		 * unstructured" without parsing the format, and only the latter is the
+		 * case this second pass exists to catch.
 		 *
 		 * @since 2.0.2 runs {@see self::redact_secret_query_params()} over whatever
 		 *              `to_string_safe()` returns, instead of trusting it outright.
@@ -803,6 +938,11 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *              body is no longer at risk of the scan mistaking text inside
 		 *              a legitimate string value for a `name=value` pair and
 		 *              truncating it — #395 Round 4, SHOULD-FIX 2.
+		 * @since 2.0.2 a body {@see self::redact_secret_request_body()} cannot
+		 *              parse and walk (e.g. a `print_r()` dump) is now masked in
+		 *              full via {@see self::UNPARSEABLE_BODY_MASK}, instead of
+		 *              being handed to a regex backstop that could not see a
+		 *              secret in that shape at all — #395 Round 5, Blocking.
 		 *
 		 * @return string
 		 */

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -95,6 +95,13 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		/**
 		 * Handle and parse the response
 		 *
+		 * @since 2.0.2 a WP_Error's message is redacted (see {@see self::redact_secret_query_params()})
+		 *              before it is used to build the thrown exception — a transport
+		 *              override or an `http_api_curl`-style filter is free to embed the
+		 *              raw request URI it was given in the error message, and that
+		 *              message is what {@see Woodev_Plugin_Updater::get_version_from_remote()}
+		 *              (and any other caller) ends up logging — see #395 (Blocking 2).
+		 *
 		 * @param array|WP_Error $response response data
 		 * @throws Woodev_API_Exception network issues, timeouts, API errors, etc
 		 * @return Woodev_API_Request|object request class instance that implements Woodev_API_Request
@@ -102,7 +109,10 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		protected function handle_response( $response ) {
 
 			if ( is_wp_error( $response ) ) {
-				throw new Woodev_API_Exception( $response->get_error_message(), (int) $response->get_error_code() );
+
+				$message = self::redact_secret_query_params( $response->get_error_message(), $this->get_secret_param_names() );
+
+				throw new Woodev_API_Exception( $message, (int) $response->get_error_code() );
 			}
 
 			$this->response_code     = wp_remote_retrieve_response_code( $response );
@@ -241,46 +251,170 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *
 		 * Delegates to the request object's `get_path_safe()` when it implements
 		 * one — an opt-in method, not part of the {@see Woodev_API_Request}
-		 * interface, so a request class carrying nothing secret in its path
-		 * (the common case) is never forced to grow a method it doesn't need.
-		 * This mirrors the existing `is_callable()` opt-in already used by
-		 * {@see self::get_sanitized_response_body()} for `to_string_safe()`.
-		 * Falls back to the real {@see self::get_request_path()} — byte-for-byte
-		 * unchanged — for every request class that has nothing to mask.
+		 * interface — for a request class that wants full control over its own
+		 * masking. Falls back to the real {@see self::get_request_path()} when it
+		 * doesn't. Either way, the result is then run through
+		 * {@see self::redact_secret_query_params()} unconditionally: a request
+		 * class implementing `get_path_safe()` gets a harmless second pass over
+		 * an already-masked value, but a request class that implements NO masking
+		 * of its own — the common case, and the one a future or third-party
+		 * extension is most likely to be — is never logged with its raw path.
+		 * Before this fix, that fallback path was the raw, unmasked one; a
+		 * request carrying a credential under an unrecognised param name (e.g.
+		 * `token`, `api_key`, `secret`, `instance_id`) still logged it in clear
+		 * text by default — see #395 (Blocking 1).
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 made fail-safe by default via {@see self::redact_secret_query_params()}
+		 *              instead of falling back to the raw path unconditionally.
 		 *
 		 * @return string
 		 */
-		protected function get_sanitized_request_path() {
+		protected function get_sanitized_request_path(): string {
 
 			$request = $this->get_request();
 
-			return ( $request && is_callable( array( $request, 'get_path_safe' ) ) )
+			$path = ( $request && is_callable( [ $request, 'get_path_safe' ] ) )
 				? $request->get_path_safe()
 				: $this->get_request_path();
+
+			return self::redact_secret_query_params( $path, $this->get_secret_param_names() );
 		}
 
 		/**
 		 * Gets the sanitized request URI, for logging.
 		 *
 		 * Same as {@see self::get_request_uri()} but built from
-		 * {@see self::get_sanitized_request_path()} instead of the raw path, so
-		 * a request class that carries a secret in its query string (e.g.
-		 * {@see Woodev_Licensing_API_Request}, whose `license` param used to
-		 * reach the log in clear text — see #395) never leaks it. The request
-		 * actually sent to the server always goes through the unmodified
-		 * {@see self::get_request_uri()}; only what gets logged changes here.
+		 * {@see self::get_sanitized_request_path()}, and with
+		 * {@see self::redact_secret_query_params()} run again on the FINAL
+		 * string — AFTER the `woodev_{api_id}_api_request_uri` filter, not
+		 * before. A filter attached to that hook can append its own query
+		 * param (some third-party transports do, e.g. a signature or replay
+		 * token); redacting before the filter ran would let such an addition
+		 * reach the log unmasked. Redacting after covers both the path this
+		 * class already sanitized AND anything the filter added — see #395
+		 * (Blocking 1). The request actually sent to the server always goes
+		 * through the unmodified {@see self::get_request_uri()}; only what
+		 * gets logged changes here.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 redaction now runs AFTER the request-uri filter, not before.
 		 *
 		 * @return string
 		 */
-		protected function get_sanitized_request_uri() {
+		protected function get_sanitized_request_uri(): string {
 
 			$uri = $this->request_uri . $this->get_sanitized_request_path();
+			$uri = apply_filters( 'woodev_' . $this->get_api_id() . '_api_request_uri', $uri, $this );
 
-			return apply_filters( 'woodev_' . $this->get_api_id() . '_api_request_uri', $uri, $this );
+			return self::redact_secret_query_params( $uri, $this->get_secret_param_names() );
+		}
+
+
+		/**
+		 * Names of query-string / body params — as opposed to headers, see
+		 * {@see self::get_secret_header_names()} — that carry a credential and
+		 * must be redacted from any request path, URI, exception message, or
+		 * body before it reaches a log. This is the list
+		 * {@see self::redact_secret_query_params()} applies unconditionally,
+		 * regardless of whether the concrete request class implements its own
+		 * `get_path_safe()`/`to_string_safe()` masking — the fail-safe backstop
+		 * for #395 (Blocking 1 & 2): an unknown or future request class carrying
+		 * a credential under one of these common names must never be logged raw
+		 * by default.
+		 *
+		 * A request class with a credential under an uncommon name should still
+		 * add its own masking (as {@see Woodev_Licensing_API_Request} does,
+		 * defensively, for `license` even though it is already in this default
+		 * list) — this list only covers the common cases so a class that forgets
+		 * to isn't left fully exposed. Override to extend it, the same pattern as
+		 * {@see self::get_secret_header_names()}.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<int, string>
+		 */
+		protected function get_secret_param_names(): array {
+			return self::get_default_secret_param_names();
+		}
+
+		/**
+		 * The default secret param name list, shared by
+		 * {@see self::get_secret_param_names()} and, statically, by request
+		 * classes outside this hierarchy that need the same fail-safe default
+		 * for their own body serialization (e.g.
+		 * {@see Woodev_API_JSON_Request::get_secret_param_names()}) — one list,
+		 * never two that can drift apart.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<int, string>
+		 */
+		public static function get_default_secret_param_names(): array {
+			return [
+				'license',
+				'token',
+				'access_token',
+				'refresh_token',
+				'api_key',
+				'api-key',
+				'apikey',
+				'api_secret',
+				'client_secret',
+				'secret',
+				'password',
+				'instance_id',
+			];
+		}
+
+		/**
+		 * Redacts every `name=value` occurrence, for a known secret param name,
+		 * anywhere it appears in $text — a URI's query string, or free text such
+		 * as a transport-thrown WP_Error message that happens to embed the URI it
+		 * was given (see #395, Blocking 2). Matching is by exact param NAME, not
+		 * by a URL parse, so this works uniformly whether $text is a well-formed
+		 * `path?query` string or an arbitrary error message. A param name is only
+		 * matched when immediately followed by `=` and preceded by a non-word
+		 * character or the start of the string, so a value that happens to
+		 * CONTAIN a secret name as a substring (e.g. a license key literally
+		 * containing the word "license") is never mistaken for the param itself.
+		 *
+		 * Uses the same masking convention as {@see self::mask_secret_values()}
+		 * (`*` repeated to the value's original length) so a log reader sees one
+		 * consistent style everywhere; kept as a separate routine rather than
+		 * reused through it because this one operates on a flat string, not an
+		 * associative array.
+		 *
+		 * This is the fail-safe backstop for
+		 * {@see self::get_sanitized_request_path()} (when a request class
+		 * implements no `get_path_safe()` of its own),
+		 * {@see self::get_sanitized_request_uri()} (run AFTER the
+		 * `woodev_{api_id}_api_request_uri` filter, so a filter that itself
+		 * appends a secret-bearing param cannot bypass it), and
+		 * {@see self::handle_response()} (a transport-thrown WP_Error message).
+		 *
+		 * @since 2.0.2
+		 *
+		 * @param string             $text
+		 * @param array<int, string> $secret_names
+		 * @return string
+		 */
+		protected static function redact_secret_query_params( string $text, array $secret_names ): string {
+
+			if ( '' === $text || empty( $secret_names ) ) {
+				return $text;
+			}
+
+			$names_pattern = implode(
+				'|',
+				array_map( static fn( string $name ): string => preg_quote( $name, '/' ), $secret_names )
+			);
+
+			return (string) preg_replace_callback(
+				'/\b(' . $names_pattern . ')=([^&\s]*)/i',
+				static fn( array $matches ): string => $matches[1] . '=' . str_repeat( '*', strlen( $matches[2] ) ),
+				$text
+			);
 		}
 
 		protected function get_request_args() {
@@ -355,14 +489,14 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * {@see self::get_request_headers()} is not return-typed, so a subclass
 		 * override is free to return something other than an array (e.g. `null`);
 		 * that is passed through unchanged rather than handed to
-		 * {@see self::mask_secret_headers()}, mirroring the guard
+		 * {@see self::mask_secret_values()}, mirroring the guard
 		 * {@see self::get_sanitized_response_headers()} already applies for the same
 		 * reason — a logging call must never fatal a request.
 		 *
 		 * @since 2.0.2 masks every header from {@see self::get_secret_header_names()},
 		 *              not only `Authorization`; guards against a non-array
 		 *              {@see self::get_request_headers()} override instead of letting
-		 *              {@see self::mask_secret_headers()}'s `array` type hint fatal.
+		 *              {@see self::mask_secret_values()}'s `array` type hint fatal.
 		 *
 		 * @return array<string, string>|null
 		 */
@@ -371,13 +505,13 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			$headers = $this->get_request_headers();
 
 			return is_array( $headers )
-				? self::mask_secret_headers( $headers, $this->get_secret_header_names() )
+				? self::mask_secret_values( $headers, $this->get_secret_header_names() )
 				: $headers;
 		}
 
 		/**
 		 * Masks the VALUE of every entry whose name (matched case-insensitively —
-		 * HTTP header names are case-insensitive, and this is also reused for
+		 * HTTP header names are case-insensitive, and this is also used for
 		 * request/query params — see below) appears in $secret_names, using
 		 * the convention `*` repeated to the value's original length. The original
 		 * key casing is preserved in the returned array; only the comparison is
@@ -396,12 +530,15 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * {@see self::get_sanitized_response_headers()} so both directions of the
 		 * `woodev_{api_id}_api_request_performed` broadcast mask header names
 		 * identically — one masking routine, never two that can drift apart.
-		 * Despite the name (kept for git-blame continuity — the routine is fully
-		 * generic over any associative array), also reused by
-		 * {@see Woodev_Licensing_API_Request} to mask the `license` param out of
-		 * the logged query string and request body — see #395. Marked `public`
-		 * rather than `protected` so a request class outside this hierarchy can
-		 * reuse it instead of re-implementing the masking convention.
+		 * Also reused by {@see Woodev_Licensing_API_Request} and
+		 * {@see Woodev_API_JSON_Request} to mask secret-carrying request params
+		 * out of the logged query string and request body — see #395. Named
+		 * generically (renamed from `mask_secret_headers()`, which had grown
+		 * misleading once params joined headers as callers) rather than after
+		 * either caller, since the routine itself is fully generic over any
+		 * associative array. Marked `public` rather than `protected` so a request
+		 * class outside this hierarchy can reuse it instead of re-implementing the
+		 * masking convention.
 		 *
 		 * @since 2.0.2
 		 * @since 2.0.2 masks array-valued headers element-wise instead of casting the
@@ -409,13 +546,16 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 * @since 2.0.2 widened from `protected` to `public` so request classes that
 		 *              don't extend this hierarchy (e.g. {@see Woodev_Licensing_API_Request})
 		 *              can reuse it for masking secret-carrying request params.
+		 * @since 2.0.2 renamed from `mask_secret_headers()` to `mask_secret_values()`
+		 *              — the name no longer matched what it masked once request
+		 *              params joined headers as callers.
 		 *
 		 * @param array<string, mixed> $headers Name/value pairs (value: string, or array<int, string>
 		 *                              for a duplicated header), casing as sent/received.
 		 * @param array<int, string>   $secret_names Names to mask, matched case-insensitively.
 		 * @return array<string, mixed>
 		 */
-		public static function mask_secret_headers( array $headers, array $secret_names ): array {
+		public static function mask_secret_values( array $headers, array $secret_names ): array {
 
 			$secret_names = array_map( 'strtolower', $secret_names );
 
@@ -582,7 +722,7 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			$headers = $this->get_response_headers();
 
 			return is_array( $headers )
-				? self::mask_secret_headers( $headers, $this->get_secret_header_names() )
+				? self::mask_secret_values( $headers, $this->get_secret_header_names() )
 				: $headers;
 		}
 

--- a/woodev/licensing/api/class-licensing-api-request.php
+++ b/woodev/licensing/api/class-licensing-api-request.php
@@ -102,8 +102,8 @@ if ( ! class_exists( 'Woodev_Licensing_API_Request' ) ) :
 		/**
 		 * Masks the VALUE of every param named in {@see self::get_secret_param_names()}.
 		 *
-		 * Reuses {@see Woodev_API_Base::mask_secret_values()} — the same masking
-		 * convention (`*` repeated to the value's original length) already applied
+		 * Reuses {@see Woodev_API_Base::mask_secret_values()} — the same fixed
+		 * placeholder ({@see Woodev_API_Base::SECRET_VALUE_MASK}) already applied
 		 * to request/response headers, so a log reader sees one consistent masking
 		 * style everywhere instead of a second, differently-shaped one.
 		 *

--- a/woodev/licensing/api/class-licensing-api-request.php
+++ b/woodev/licensing/api/class-licensing-api-request.php
@@ -83,28 +83,37 @@ if ( ! class_exists( 'Woodev_Licensing_API_Request' ) ) :
 		 * masked before {@see self::get_path_safe()} or {@see self::to_string_safe()}
 		 * hand the request off to logging — see #395.
 		 *
+		 * `license` is already in the parent's generic default list (see
+		 * {@see Woodev_API_Base::get_default_secret_param_names()}), so this
+		 * override is redundant with it today — kept anyway, `protected` instead
+		 * of `private`, so this class documents its OWN known secret explicitly
+		 * and stays correct even if the generic default list ever changes.
+		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 widened from `private` to `protected` and merged with the
+		 *              parent's list instead of replacing it outright.
 		 *
 		 * @return array<int, string>
 		 */
-		private function get_secret_param_names(): array {
-			return [ 'license' ];
+		protected function get_secret_param_names(): array {
+			return array_merge( parent::get_secret_param_names(), [ 'license' ] );
 		}
 
 		/**
 		 * Masks the VALUE of every param named in {@see self::get_secret_param_names()}.
 		 *
-		 * Reuses {@see Woodev_API_Base::mask_secret_headers()} — the same masking
+		 * Reuses {@see Woodev_API_Base::mask_secret_values()} — the same masking
 		 * convention (`*` repeated to the value's original length) already applied
 		 * to request/response headers, so a log reader sees one consistent masking
 		 * style everywhere instead of a second, differently-shaped one.
 		 *
 		 * @since 2.0.2
+		 * @since 2.0.2 reuses the renamed {@see Woodev_API_Base::mask_secret_values()}.
 		 *
 		 * @return array<string, mixed>
 		 */
 		private function get_masked_params(): array {
-			return Woodev_API_Base::mask_secret_headers( $this->get_params(), $this->get_secret_param_names() );
+			return Woodev_API_Base::mask_secret_values( $this->get_params(), $this->get_secret_param_names() );
 		}
 
 		/**

--- a/woodev/licensing/api/class-licensing-api-request.php
+++ b/woodev/licensing/api/class-licensing-api-request.php
@@ -23,6 +23,32 @@ if ( ! class_exists( 'Woodev_Licensing_API_Request' ) ) :
 			return $path;
 		}
 
+
+		/**
+		 * Gets the sanitized request path, for logging.
+		 *
+		 * Same as {@see self::get_path()} but the query string is built from
+		 * {@see self::get_masked_params()} instead of the raw params, so the
+		 * `license` param never reaches the log — see #395. The actual request
+		 * sent to the server is unaffected: {@see self::get_path()} is untouched
+		 * and still builds the real query string with the real license key.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		public function get_path_safe() {
+
+			$path   = $this->path;
+			$params = $this->get_params();
+
+			if ( in_array( $this->get_method(), array( 'GET', 'POST' ) ) && ! empty( $params ) ) {
+				$path .= '?' . http_build_query( $this->get_masked_params(), '', '&' );
+			}
+
+			return $path;
+		}
+
 		public function to_string() {
 
 			if ( in_array( $this->get_method(), array( 'GET', 'POST' ), true ) ) {
@@ -31,8 +57,54 @@ if ( ! class_exists( 'Woodev_Licensing_API_Request' ) ) :
 			}
 		}
 
+		/**
+		 * Gets the sanitized request body, for logging.
+		 *
+		 * Same as {@see self::to_string()} but dumps {@see self::get_masked_params()}
+		 * instead of the raw params, so the `license` param never reaches the
+		 * log — see #395. {@see self::to_string()} (used to build the real
+		 * request body sent to the server) is untouched.
+		 *
+		 * @since 2.0.2 actually sanitizes, instead of aliasing {@see self::to_string()}.
+		 *
+		 * @return string|bool|null
+		 */
 		public function to_string_safe() {
-			return $this->to_string();
+
+			if ( in_array( $this->get_method(), array( 'GET', 'POST' ), true ) ) {
+				return self::print_r( $this->get_masked_params(), true );
+			}
+
+			return null;
+		}
+
+		/**
+		 * Names of request params whose values carry a credential and must be
+		 * masked before {@see self::get_path_safe()} or {@see self::to_string_safe()}
+		 * hand the request off to logging — see #395.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<int, string>
+		 */
+		private function get_secret_param_names(): array {
+			return [ 'license' ];
+		}
+
+		/**
+		 * Masks the VALUE of every param named in {@see self::get_secret_param_names()}.
+		 *
+		 * Reuses {@see Woodev_API_Base::mask_secret_headers()} — the same masking
+		 * convention (`*` repeated to the value's original length) already applied
+		 * to request/response headers, so a log reader sees one consistent masking
+		 * style everywhere instead of a second, differently-shaped one.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return array<string, mixed>
+		 */
+		private function get_masked_params(): array {
+			return Woodev_API_Base::mask_secret_headers( $this->get_params(), $this->get_secret_param_names() );
 		}
 
 		/**


### PR DESCRIPTION
> **Самая тяжёлая карточка ночи: пять кругов воркера и четыре прохода критика, первые четыре вердикта — REJECT, и каждый по делу.** История ниже, потому что она объясняет, почему решение выглядит именно так.

## Что было

При включённом debug-логировании лицензий ключ уходил в лог открытым текстом **дважды**:

- `Woodev_API_Base::get_request_data_for_broadcast()` клал в лог `'uri' => $this->get_request_uri()` без маскировки, а `Woodev_Licensing_API_Request::get_path()` подклеивает `http_build_query( $this->get_params() )`, где лежит `'license' => $license_key`;
- тело бралось из `to_string_safe()`, который в этом классе просто возвращал `to_string()` — `print_r` всех параметров.

Контраст был очевиден: заголовки маскировались полноценно, то есть намерение скрывать секреты было, а пропущены ровно те два поля, в которых ключ и лежит.

## Что сделано в итоге

Редактирование **fail-safe по умолчанию** и **структурное, а не текстовое**:

| Что | Как обрабатывается |
|---|---|
| Query-строка (path и URI) | `parse_str()` → рекурсивный обход с редактированием по канонизированному имени **на любой глубине** → `http_build_query()` |
| JSON-тело (массив/объект) | `json_decode()` → тот же обход → `json_encode()` |
| Тело в форме `name=value&...` | `parse_str()`, но только если **вся** строка проходит проверку `is_form_encoded_body()` |
| XML, `print_r`-дампы, свободный текст | **Целиком заменяется на `UNPARSEABLE_BODY_MASK`** |
| `WP_Error` из транспорта | Редактируется ДО того, как станет `Woodev_API_Exception` и попадёт в `error_log()` апдейтера |

Маска — фиксированная `[REDACTED]`, а не звёздочки по длине ключа (два критика указали на утечку длины). Байты, уходящие на провод, не меняются — это доказано тестом, перехватывающим аргументы `do_remote_request()`.

## Почему пять кругов

1. **REJECT.** Редактирование было **opt-in**: любой класс запроса, не реализовавший хук, логировал секрет по умолчанию. Плюс фильтр `woodev_{api_id}_api_request_uri` отрабатывал ПОСЛЕ маскирования, то есть мог дописать секрет к уже замаскированной строке.
2. **REJECT.** Матчер сравнивал только литеральное `name=`, поэтому `token%5Bprimary%5D=` — ровно то, что выдаёт `http_build_query()`, которым этот же код строит путь лицензии — проходило насквозь. Как и `licenseKey`, `apiKey`. Тела не редактировались вообще, хотя докблок утверждал обратное.
3. **REJECT.** Матчер переписали на канонизацию имён, но он читал только ПЕРВЫЙ сегмент скобок, так что `a[token]=SECRET` (секрет под несекретным именем) по-прежнему тёк. И тот же regex, запущенный по тексту тела, **портил валидный JSON**, в строковом значении которого встречалось `token=`.
4. **REJECT.** Четвёртый круг перешёл на парсинг и закрыл всё вышеперечисленное — но осознанно НЕ стал возвращать маркер для нераспознанных форматов, сославшись на зелёные тесты. **Критик не стал спорить, а вызвал метод** с телом в форме `print_r` и получил `super-secret-token-value` дословно: regex не матчит `[token] => secret`. Собственное наблюдение воркера из предыдущего круга было той самой подсказкой, за которой он не пошёл: `print_r`-тело лицензии безопасно только потому, что `Woodev_Licensing_API_Request` маскирует себя ДО того, как база его увидит.
5. Пятый круг вернул маркер для всего, что нельзя разобрать. Тест, который стоял на пути, переписан: он пинил вывод старого regex-бэкстопа как контракт, а не как поведение. Три form-encoded теста менять не пришлось — они действительно query-подобные и по-прежнему получают пофайловое редактирование с сохранением соседних параметров.

## Что критики подтвердили

- Рекурсивный обход редактирует на **каждой** глубине и по каждому ключу, включая массивы секретов.
- Денилист и канонизация **общие** для обоих путей, не продублированы.
- Три ключевых теста четвёртого круга прогнаны критиком против `a633091` — 3/3 падают, включая тело JSON, которое одновременно портилось И утекало.
- Контракты установленной площадки не тронуты: сам HTTP-запрос, имена лог-хендлов, ключи опций и хуков байт в байт те же.

## Честно записанные потери

В докблоке `redact_secret_request_body()` зафиксировано, что лог — это **отредактированное представление**, а не байты с провода:

- `parse_str()`/`http_build_query()` теряют дубликаты ключей, превращают `.` и пробел в `_`, ограничены `max_input_vars`;
- пересборка JSON меняет `1.0`, экранирование слэшей и юникода, объекты с числовыми ключами;
- `api.key` канонизируется в коллизию с `api_key` и перередактируется — **осознанно**, ошибаться в эту сторону правильнее.

## Гейты (кэш результатов удалён)

phpcs 217/217 чисто, phpstan 0 ошибок, 2507/2507 unit при 71 skipped (ворктри создан до фикса `.worktreeinclude`, в главном дереве будет 66), jest 1260/1260.

## Что осталось отдельной карточкой

**#427** — тело ОТВЕТА по-прежнему логируется без редактирования. Подтверждённой утечки ключа там сегодня нет (поле `license` в ответе EDD — это статус-токен, а не ключ клиента), но гарантии тоже нет.

Closes #395