### PR TITLE
docs(s84): уточнить вопрос про админ-детект — сначала достижимость, потом точность

### DIFF
--- a/docs-internal/specs/2026-08-21-settlement-search-design.md
+++ b/docs-internal/specs/2026-08-21-settlement-search-design.md
@@ -282,9 +282,13 @@ the control is presentation only, and `show_if` merely hides. Same pattern as #4
 - Whether `search_settlements_within` and `search_settlements_countrywide` are one contract method
   with an optional scope or two, given decision 7 collapses the difference to one bit.
 - What the settlement field offers when a provider declares neither settlement-search capability.
-- Whether an admin-time read of the checkout fields matches what the shopper actually gets, given
-  that some third-party hooks register on the front end only. Worth measuring before relying on the
-  greying-out; it does not affect correctness, only the quality of the hint.
+- **Is `WC()->checkout` reachable in wp-admin at all?** The operator doubts it, and that is the
+  sharper form of the question — not "does an admin-time read match what the shopper gets", but
+  "does the read work". `WC()->checkout()` instantiates lazily and the checkout object leans on
+  session and cart state that an admin request may not have. Measure that first; only if it IS
+  reachable does the second question arise — whether the merged field config differs there, given
+  that some third-party hooks register on the front end only. Neither affects correctness
+  (self-release does), only whether the checkbox can be greyed out with a truthful reason.
 
 ## Related
 


### PR DESCRIPTION
Оператор сомневается, что `WC()->checkout` в wp-admin вообще достижим — и это более острая форма вопроса, чем та, что была записана.

Меняется **что именно надо замерить**: не «совпадает ли админ-чтение с тем, что получит покупатель», а «работает ли чтение вообще». `WC()->checkout()` инстанцируется лениво и опирается на состояние сессии и корзины, которого у админского запроса может не быть.

Вопрос о точности возникает только если достижимость подтвердится. Ни то, ни другое не влияет на корректность — её несёт самоснятие; оба решают только, можно ли погасить чекбокс с правдивой причиной.

Гейты: `npm run lint:docs` — 180/180, structure OK; markdownlint — 0 issues.