### PR TITLE
fix(api): redact response body before logging, kill raw-body fallback

### DIFF
--- a/tests/unit/Api/ApiBaseSanitizedResponseBodyTest.php
+++ b/tests/unit/Api/ApiBaseSanitizedResponseBodyTest.php
@@ -1,0 +1,483 @@
+<?php
+/**
+ * Unit tests for Woodev_API_Base::get_sanitized_response_body() /
+ * get_response_data_for_broadcast() — #427.
+ *
+ * #395 built a fail-safe-by-default redactor for the REQUEST side of
+ * {@see \Woodev_API_Base}: {@see \Woodev_API_Base::get_sanitized_request_body()}
+ * runs whatever `to_string_safe()` returns through
+ * {@see \Woodev_API_Base::redact_secret_request_body()} unconditionally, so an
+ * unknown/future request class that never masks its own body still cannot leak
+ * a credential by default. The RESPONSE side had no such pass at all: every
+ * concrete response class in this codebase ({@see \Woodev_API_JSON_Response},
+ * {@see \Woodev_API_XML_Response}) aliases `to_string_safe()` straight onto the
+ * raw `to_string()`, and {@see \Woodev_API_Base::get_sanitized_response_body()}
+ * just returned that unredacted value.
+ *
+ * Worse, {@see \Woodev_API_Base::get_response_data_for_broadcast()} built the
+ * `body` field as `get_sanitized_response_body() ?: get_raw_response_body()` —
+ * so ANY response whose sanitized body was falsy (no response object yet, a
+ * class with no `to_string_safe()`, or one returning `''`/`'0'`) fell straight
+ * through to {@see \Woodev_API_Base::get_raw_response_body()}: the untouched
+ * bytes off the wire, in exactly the case redaction exists to cover.
+ *
+ * This file pins the #427 fix:
+ *
+ * - a response body carrying a secret at the top level is masked, end to end,
+ *   through {@see \Woodev_API_Base::get_response_data_for_broadcast()};
+ * - a falsy-but-real `to_string_safe()` return value (`''`, `'0'`) no longer
+ *   triggers the raw-body fallback — the second, undocumented leak behind #427;
+ * - a JSON response body is walked structurally: the secret is redacted at
+ *   depth, a harmless sibling stays readable;
+ * - an unparseable response body (XML, a `print_r()` dump, free text) is
+ *   whole-masked, the same fail-safe the request side already gets;
+ * - the actual response object the caller receives — the wire bytes — is
+ *   byte-for-byte unaffected: redaction is a LOG concern only.
+ *
+ * @package Woodev\Tests\Unit\Api
+ */
+
+namespace Woodev\Tests\Unit\Api;
+
+use Brain\Monkey\Functions;
+use Woodev\Tests\Unit\TestCase;
+
+require_once dirname( __DIR__, 3 ) . '/woodev/api/interface-api-response.php';
+require_once dirname( __DIR__, 3 ) . '/woodev/api/class-api-base.php';
+
+/**
+ * A minimal Woodev_API_Response implementation carrying a secret in its body,
+ * whose `to_string_safe()` deliberately aliases `to_string()` — exactly what
+ * {@see \Woodev_API_JSON_Response::to_string_safe()} and
+ * {@see \Woodev_API_XML_Response::to_string_safe()} do today (#427): a
+ * response class that never masks its own body.
+ */
+class Testable_Unknown_Secret_Carrying_Response implements \Woodev_API_Response {
+
+	/** @var string */
+	private $body;
+
+	/**
+	 * @param string $body Raw response body, as `to_string()`/`to_string_safe()` return it.
+	 */
+	public function __construct( string $body ) {
+		$this->body = $body;
+	}
+
+	/** @return string */
+	public function to_string() {
+		return $this->body;
+	}
+
+	/**
+	 * Deliberately unsafe — mirrors what a response class in this codebase
+	 * does today: alias `to_string_safe()` straight to `to_string()` without
+	 * masking anything.
+	 *
+	 * @return string
+	 */
+	public function to_string_safe() {
+		return $this->to_string();
+	}
+}
+
+/**
+ * A Woodev_API_Response double whose `to_string_safe()` returns a FALSY value
+ * (`''` or `'0'`) that is nonetheless a deliberate return value, not "no
+ * response" — the second #427 defect: the pre-fix `?:` fallback in
+ * {@see \Woodev_API_Base::get_response_data_for_broadcast()} could not tell
+ * this apart from "sanitization produced nothing", and fell back to the raw
+ * body either way.
+ */
+class Testable_Falsy_To_String_Safe_Response implements \Woodev_API_Response {
+
+	/** @var string */
+	private $safe_value;
+
+	/**
+	 * @param string $safe_value The falsy value `to_string_safe()` returns.
+	 */
+	public function __construct( string $safe_value ) {
+		$this->safe_value = $safe_value;
+	}
+
+	/** @return string */
+	public function to_string() {
+		return $this->safe_value;
+	}
+
+	/** @return string */
+	public function to_string_safe() {
+		return $this->safe_value;
+	}
+}
+
+/**
+ * Minimal concrete Woodev_API_Base double exposing the protected response-body
+ * sanitizer and broadcast payload under test, without pulling in the
+ * HTTP/broadcast machinery this fix does not touch.
+ */
+class Testable_Api_Base_For_Response_Body_Test extends \Woodev_API_Base {
+
+	/**
+	 * Seeds the response under test, bypassing the HTTP transport.
+	 *
+	 * @param object $response Response instance.
+	 * @return void
+	 */
+	public function set_response_for_test( object $response ): void {
+		$this->response = $response;
+	}
+
+	/**
+	 * Seeds the raw response body under test — the untouched bytes off the
+	 * wire, as {@see \Woodev_API_Base::handle_response()} would have stored
+	 * them.
+	 *
+	 * @param string $raw_body Raw response body.
+	 * @return void
+	 */
+	public function set_raw_response_body_for_test( string $raw_body ): void {
+		$this->raw_response_body = $raw_body;
+	}
+
+	/**
+	 * Exposes the protected response-body sanitizer under test.
+	 *
+	 * @return string
+	 */
+	public function get_sanitized_response_body_for_test(): string {
+		return $this->get_sanitized_response_body();
+	}
+
+	/**
+	 * Exposes the protected response broadcast payload under test, end to end
+	 * — i.e. through {@see \Woodev_API_Base::get_response_data_for_broadcast()}
+	 * itself, not just the sanitizer it is supposed to call.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_response_data_for_broadcast_for_test(): array {
+		return $this->get_response_data_for_broadcast();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_new_request( $args = [] ) {
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return null
+	 */
+	protected function get_plugin() {
+		return null;
+	}
+}
+
+/**
+ * Class ApiBaseSanitizedResponseBodyTest.
+ */
+final class ApiBaseSanitizedResponseBodyTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $tag, $value = null ) {
+				return $value;
+			}
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// A response body carrying a secret must not reach the log intact.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_unknown_response_class_json_body_secret_is_masked_by_default(): void {
+
+		$secret   = 'super-secret-token-value';
+		$body     = json_encode(
+			[
+				'token'   => $secret,
+				'item_id' => 42,
+			]
+		);
+		$response = new Testable_Unknown_Secret_Carrying_Response( (string) $body );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+
+		$broadcast = $api->get_response_data_for_broadcast_for_test();
+
+		$this->assertArrayHasKey( 'body', $broadcast );
+		$this->assertStringNotContainsString(
+			$secret,
+			$broadcast['body'],
+			'a response body carrying a secret must not reach the broadcast payload intact'
+		);
+		$this->assertStringNotContainsString(
+			$secret,
+			print_r( $broadcast, true ),
+			'the secret leaked into the response broadcast payload'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// #427, second defect: a falsy-but-real to_string_safe() must not fall
+	// back to the raw, never-redacted response body.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * `to_string_safe()` returning `''` used to trigger the raw-body fallback.
+	 * The raw body (what actually came back over the wire) carries a secret;
+	 * the broadcast payload must still not contain it — an empty sanitized
+	 * body must log as empty, never as "fall back to raw".
+	 *
+	 * @return void
+	 */
+	public function test_empty_to_string_safe_does_not_fall_back_to_the_raw_body(): void {
+
+		$secret   = 'super-secret-token-value';
+		$response = new Testable_Falsy_To_String_Safe_Response( '' );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+		$api->set_raw_response_body_for_test( 'token=' . $secret );
+
+		$broadcast = $api->get_response_data_for_broadcast_for_test();
+
+		$this->assertSame( '', $broadcast['body'], 'an empty sanitized body must log as empty, not fall back to the raw body' );
+		$this->assertStringNotContainsString(
+			$secret,
+			$broadcast['body'],
+			'#427: an empty to_string_safe() must not fall back to the raw, unredacted response body'
+		);
+	}
+
+	/**
+	 * `to_string_safe()` returning the string `'0'` is the classic PHP
+	 * falsy-but-valid-value trap (`'0' == false`). The raw body carries a
+	 * secret; the broadcast payload must still not contain it.
+	 *
+	 * @return void
+	 */
+	public function test_falsy_string_zero_to_string_safe_does_not_fall_back_to_the_raw_body(): void {
+
+		$secret   = 'super-secret-token-value';
+		$response = new Testable_Falsy_To_String_Safe_Response( '0' );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+		$api->set_raw_response_body_for_test( 'token=' . $secret );
+
+		$broadcast = $api->get_response_data_for_broadcast_for_test();
+
+		$this->assertStringNotContainsString(
+			$secret,
+			$broadcast['body'],
+			"#427: a to_string_safe() of '0' must not fall back to the raw, unredacted response body"
+		);
+		$this->assertSame(
+			\Woodev_API_Base::UNPARSEABLE_BODY_MASK,
+			$broadcast['body'],
+			"a JSON scalar body ('0' decodes to int 0) is masked in full, same rule as the request side"
+		);
+	}
+
+	/**
+	 * No response object at all (e.g. the transport itself failed, before a
+	 * response was ever parsed) must not fall back to the raw body either.
+	 *
+	 * @return void
+	 */
+	public function test_no_response_object_does_not_fall_back_to_the_raw_body(): void {
+
+		$secret = 'super-secret-token-value';
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_raw_response_body_for_test( 'token=' . $secret );
+
+		$broadcast = $api->get_response_data_for_broadcast_for_test();
+
+		$this->assertSame( '', $broadcast['body'] );
+		$this->assertStringNotContainsString( $secret, $broadcast['body'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// A JSON response object: the secret is redacted at depth, harmless
+	// siblings stay READABLE. A whole-masking regression would pass a naive
+	// test and destroy the log's usefulness — this test would catch it.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_json_response_body_secret_key_is_masked_without_corrupting_the_json(): void {
+
+		$secret = 'super-secret-token-value';
+		$body   = json_encode(
+			[
+				'note'     => 'contact support, token=should-stay-exactly-here for reference',
+				'password' => $secret,
+				'item_id'  => 42,
+			]
+		);
+		$response = new Testable_Unknown_Secret_Carrying_Response( (string) $body );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+
+		$safe_body = $api->get_sanitized_response_body_for_test();
+		$decoded   = json_decode( $safe_body, true );
+
+		$this->assertIsArray( $decoded, 'the redacted response body must still be valid, parseable JSON' );
+		$this->assertStringNotContainsString( $secret, $safe_body, 'the password value must not leak' );
+		$this->assertSame(
+			\Woodev_API_Base::SECRET_VALUE_MASK,
+			$decoded['password'],
+			'the password key must be masked by key, not by scanning the text'
+		);
+		$this->assertSame(
+			'contact support, token=should-stay-exactly-here for reference',
+			$decoded['note'],
+			'a non-secret string value must survive untouched, readable, in the log'
+		);
+		$this->assertSame( 42, $decoded['item_id'], 'a non-secret param must survive untouched' );
+	}
+
+	/**
+	 * A secret nested inside a JSON object (not only at the top level) must
+	 * also be masked, with the non-secret sibling still readable.
+	 *
+	 * @return void
+	 */
+	public function test_json_response_body_nested_secret_key_is_masked(): void {
+
+		$secret = 'super-secret-token-value';
+		$body   = json_encode(
+			[
+				'auth' => [
+					'access_token' => $secret,
+				],
+				'status' => 'active',
+			]
+		);
+		$response = new Testable_Unknown_Secret_Carrying_Response( (string) $body );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+
+		$safe_body = $api->get_sanitized_response_body_for_test();
+		$decoded   = json_decode( $safe_body, true );
+
+		$this->assertIsArray( $decoded, 'the redacted response body must still be valid JSON' );
+		$this->assertStringNotContainsString( $secret, $safe_body );
+		$this->assertSame( \Woodev_API_Base::SECRET_VALUE_MASK, $decoded['auth']['access_token'] );
+		$this->assertSame( 'active', $decoded['status'], 'a non-secret sibling must survive untouched, readable, in the log' );
+	}
+
+	// -------------------------------------------------------------------------
+	// An unparseable response body (XML, print_r(), free text) is whole-masked
+	// — the base has no reliable way to tell a secret-named field apart from a
+	// safe sibling one in a format it cannot parse and walk structurally.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function test_xml_response_body_is_masked_by_default(): void {
+
+		$secret   = 'super-secret-token-value';
+		$response = new Testable_Unknown_Secret_Carrying_Response( '<Token>' . $secret . '</Token><Status>active</Status>' );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+
+		$safe_body = $api->get_sanitized_response_body_for_test();
+
+		$this->assertStringNotContainsString( $secret, $safe_body );
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
+	}
+
+	/**
+	 * A `print_r()`-shaped body — the exact shape a licensing-style response
+	 * class could produce if it ever stopped being JSON — is masked in full.
+	 *
+	 * @return void
+	 */
+	public function test_print_r_shaped_response_body_is_masked_by_default(): void {
+
+		$secret   = 'super-secret-token-value';
+		$response = new Testable_Unknown_Secret_Carrying_Response( print_r( [ 'token' => $secret, 'status' => 'active' ], true ) );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+
+		$safe_body = $api->get_sanitized_response_body_for_test();
+
+		$this->assertStringNotContainsString( $secret, $safe_body );
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_free_text_response_body_is_masked_by_default(): void {
+
+		$secret   = 'super-secret-token-value';
+		$response = new Testable_Unknown_Secret_Carrying_Response( "request failed\ntoken=" . $secret );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+
+		$safe_body = $api->get_sanitized_response_body_for_test();
+
+		$this->assertStringNotContainsString( $secret, $safe_body );
+		$this->assertSame( \Woodev_API_Base::UNPARSEABLE_BODY_MASK, $safe_body );
+	}
+
+	// -------------------------------------------------------------------------
+	// Redaction is a LOG concern only: the response object the caller actually
+	// receives must be byte-for-byte unaffected.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The response object's own `to_string()` — what a caller like
+	 * {@see \Woodev_Licencing_API_Response::get_response_data()} actually
+	 * reads — must still carry the real secret. Only the broadcast (logging)
+	 * payload is redacted.
+	 *
+	 * @return void
+	 */
+	public function test_response_object_to_string_is_unaffected_by_broadcast_masking(): void {
+
+		$secret   = 'super-secret-token-value';
+		$body     = json_encode( [ 'token' => $secret ] );
+		$response = new Testable_Unknown_Secret_Carrying_Response( (string) $body );
+
+		$api = new Testable_Api_Base_For_Response_Body_Test();
+		$api->set_response_for_test( $response );
+
+		$broadcast = $api->get_response_data_for_broadcast_for_test();
+
+		$this->assertStringContainsString(
+			$secret,
+			$response->to_string(),
+			'the actual response object must still carry the real secret — redaction must not touch it'
+		);
+		$this->assertStringNotContainsString(
+			$secret,
+			$broadcast['body'],
+			'only the broadcast (logging) payload may be redacted'
+		);
+	}
+}

--- a/woodev/api/class-api-base.php
+++ b/woodev/api/class-api-base.php
@@ -718,6 +718,11 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *              way, instead of returning it unchanged, because a bare
 		 *              scalar has no key to redact by and may itself BE the
 		 *              secret — #395 Round 6, Blocking 1 & 2.
+		 * @since 2.0.2 also called by {@see self::get_sanitized_response_body()}
+		 *              to redact response bodies — #427. Every rule above is
+		 *              about the body's FORMAT, not which direction it
+		 *              travelled, so no response-specific branch was needed;
+		 *              only the caller changed, not this method.
 		 *
 		 * @param string             $body
 		 * @param array<int, string> $secret_names
@@ -1199,8 +1204,34 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 			return $this->raw_response_body;
 		}
 
-		protected function get_sanitized_response_body() {
-			return is_callable( array( $this->get_response(), 'to_string_safe' ) ) ? $this->get_response()->to_string_safe() : null;
+		/**
+		 * Gets the sanitized response body, for logging.
+		 *
+		 * Symmetric with {@see self::get_sanitized_request_body()} — #427. Before
+		 * this, the response side had no fail-safe pass at all: every concrete
+		 * response class in this codebase ({@see Woodev_API_JSON_Response},
+		 * {@see Woodev_API_XML_Response}) aliases `to_string_safe()` straight onto
+		 * the raw `to_string()`, so whatever came back over the wire reached the
+		 * log unredacted by default — the exact gap {@see self::redact_secret_request_body()}
+		 * already closed on the request side.
+		 *
+		 * Whatever `to_string_safe()` returns — or `''` when there is no response
+		 * yet, or its class does not implement the method at all — is run through
+		 * {@see self::redact_secret_request_body()} unconditionally, exactly like
+		 * the request side: a JSON object/array body is walked and redacted by
+		 * key at any depth, anything else (XML, a `print_r()` dump, free text, a
+		 * bare JSON scalar) is replaced with {@see self::UNPARSEABLE_BODY_MASK} in
+		 * full.
+		 *
+		 * @since 2.0.2
+		 *
+		 * @return string
+		 */
+		protected function get_sanitized_response_body(): string {
+
+			$body = is_callable( [ $this->get_response(), 'to_string_safe' ] ) ? (string) $this->get_response()->to_string_safe() : '';
+
+			return self::redact_secret_request_body( $body, $this->get_secret_param_names() );
 		}
 
 		/**
@@ -1209,17 +1240,30 @@ if ( ! class_exists( 'Woodev_API_Base' ) ) :
 		 *
 		 * @since 2.0.2 `headers` is now {@see self::get_sanitized_response_headers()}
 		 *              instead of the raw {@see self::get_response_headers()} — see #300.
-		 *              The `body` policy is unchanged.
+		 * @since 2.0.2 `body` is now {@see self::get_sanitized_response_body()} taken
+		 *              unconditionally, instead of falling back to the raw
+		 *              {@see self::get_raw_response_body()} whenever the sanitized
+		 *              value was falsy (`''`, `'0'`, ...) — #427. That fallback was
+		 *              exactly the case redaction exists to cover: a response class
+		 *              with no `to_string_safe()`, or one that returns a falsy but
+		 *              real value, fell straight through to the never-redacted
+		 *              bytes off the wire — the second, undocumented leak behind
+		 *              #427. A genuinely empty sanitized body already logs as `''`
+		 *              (see {@see self::get_sanitized_response_body()}, same "empty
+		 *              stays empty" convention {@see self::redact_secret_request_body()}
+		 *              uses for an empty request body), so there is no longer a
+		 *              case where the raw body carries information the sanitized
+		 *              one does not — falling back to raw bytes is never correct.
 		 *
-		 * @return array
+		 * @return array<string, mixed>
 		 */
 		protected function get_response_data_for_broadcast() {
-			return array(
+			return [
 				'code'    => $this->get_response_code(),
 				'message' => $this->get_response_message(),
 				'headers' => $this->get_sanitized_response_headers(),
-				'body'    => $this->get_sanitized_response_body() ? $this->get_sanitized_response_body() : $this->get_raw_response_body(),
-			);
+				'body'    => $this->get_sanitized_response_body(),
+			];
 		}
 
 		public function get_request() {


### PR DESCRIPTION
## What

Makes the response side of the API-request log symmetric with the request side #395 already fixed. Two defects, both in `woodev/api/class-api-base.php`:

1. **The response body reached the log unredacted.** `get_sanitized_response_body()` just returned `to_string_safe()` verbatim, and every concrete response class in this codebase (`Woodev_API_JSON_Response`, `Woodev_API_XML_Response`) aliases `to_string_safe()` straight onto the raw `to_string()`. No re-critic mentioned this one — it was found separately while investigating the card.
2. **The raw-body fallback in `get_response_data_for_broadcast()` defeated redaction precisely when it mattered.** `'body' => get_sanitized_response_body() ? ... : get_raw_response_body()` fell back to the untouched wire bytes whenever the sanitized body was falsy — no response object yet, a response class with no `to_string_safe()`, or one that returns `''`/`'0'`. That fallback is now removed; `get_sanitized_response_body()` always returns a `string`, so there is no falsy case left that needs a fallback.

`get_sanitized_response_body()` now runs whatever `to_string_safe()` returns through the same `redact_secret_request_body()` dispatcher #395 built for requests — no second redactor was written. A JSON object/array body is walked and redacted by key at any depth; anything else (XML, `print_r()`, free text, a bare JSON scalar) is whole-masked via `UNPARSEABLE_BODY_MASK`, same fail-safe rule the request side already gets.

## Two judgement calls

**Should the secret-name denylist be the same for both directions?** Yes — `get_secret_param_names()` is reused unchanged for the response body. This mirrors the existing precedent already in this class: `get_secret_header_names()` is documented as "one list, not two that can drift apart" and is already shared between `get_sanitized_request_headers()` and `get_sanitized_response_headers()`. The default list (`get_default_secret_param_names()`) already includes `access_token`/`refresh_token` — the exact response-only examples in the card — so no entries needed adding. I did not add a response-only name like `signature` speculatively: no concrete response class in this codebase carries one today, and the existing override seam (`get_secret_param_names()`) already lets a future response-carrying class extend the list without a core change, the same extension pattern documented on `get_secret_header_names()`.

**Should the response side skip GET/HEAD like the request side does?** No, and deliberately not. The request-side skip exists because a GET/HEAD *request* conventionally carries no body. That reasoning doesn't transfer to the *response*: a GET's response is the normal case where a body carries the actual payload (that's the point of GET), so skipping redaction there would be exactly backwards — it would exempt the most common body-bearing response from redaction. A HEAD response is bodyless by HTTP semantics regardless (RFC 7231), so it needs no special-casing either — `to_string_safe()` on an empty/absent response body already comes back empty, and `redact_secret_request_body()` already returns an empty body unchanged (its existing "empty stays empty" rule, shared with the request side).

## Tests — all fail on `main`, verified by name

New file: `tests/unit/Api/ApiBaseSanitizedResponseBodyTest.php`, 10 tests / 26 assertions. Verified fail-on-main by reverting `woodev/api/class-api-base.php` to `origin/main`'s version and rerunning this file alone (`.phpunit.result.cache` removed first) — all 10 failed with the pre-fix behavior:

- `test_unknown_response_class_json_body_secret_is_masked_by_default` — secret leaked in `super-secret-token-value` before the fix.
- `test_empty_to_string_safe_does_not_fall_back_to_the_raw_body` — the falsy-`to_string_safe()` defect: before, `broadcast['body']` was `'token=super-secret-token-value'` instead of `''`.
- `test_falsy_string_zero_to_string_safe_does_not_fall_back_to_the_raw_body` — same defect with `to_string_safe()` returning the string `'0'` (the classic `'0' == false` trap).
- `test_no_response_object_does_not_fall_back_to_the_raw_body` — no response object at all still fell back to the raw body before.
- `test_json_response_body_secret_key_is_masked_without_corrupting_the_json` — proves the secret is masked BY KEY, and a harmless sibling string containing `token=...` survives readable — guards against a whole-masking regression that would pass a naive test.
- `test_json_response_body_nested_secret_key_is_masked` — secret nested at depth is masked, sibling stays readable.
- `test_xml_response_body_is_masked_by_default` — unparseable (XML) body whole-masked.
- `test_print_r_shaped_response_body_is_masked_by_default` — unparseable (`print_r()`) body whole-masked.
- `test_free_text_response_body_is_masked_by_default` — unparseable (free text) body whole-masked.
- `test_response_object_to_string_is_unaffected_by_broadcast_masking` — proves redaction is a LOG-only concern: `$response->to_string()` (what a real caller like `Woodev_Licencing_API_Response::get_response_data()` reads) still carries the real secret; only the broadcast payload is redacted.

Reused idiom from `ApiBaseSanitizedHeadersTest.php` / `ApiBaseSecretParamFallbackTest.php`: a minimal `Woodev_API_Response`/`Woodev_API_Base` double exposing the protected surface under test, no HTTP transport pulled in.

## Gates

Baseline on `main` before any change: 2551 tests / 6303 assertions / **66 skipped**.

After this fix (`.phpunit.result.cache` removed before every run):
- `composer test:unit` — 2561 tests / 6329 assertions / **66 skipped** (+10 tests / +26 assertions, skip count unchanged as expected).
- `composer phpcs` — 217/217 clean.
- `composer phpstan` — `[OK] No errors`.
- `npm run test:js -- --roots "<rootDir>/tests/js"` (from bash) — 17 suites / 1260 tests passed (unaffected, PHP-only change).

No `npm run build` was run — this change is PHP-only.

Closes #427
