### PR TITLE
fix(shipping-method): address field no longer inherits the settlement axis mode

### DIFF
--- a/tests/js/location-cascade.test.js
+++ b/tests/js/location-cascade.test.js
@@ -1918,14 +1918,23 @@ describe( 'Task 13 renderer seam (spec D7)', () => {
 		expect( bareMode ).not.toHaveBeenCalled();
 	} );
 
-	it( 'the bare {mode} key serves every level uniformly when no level-specific one is registered', () => {
+	it( 'the bare {mode} key serves the region and settlement levels uniformly when no level-specific one is registered — issue #448: NOT the address level, which never resolves an axis mode at all', () => {
+		// PRE-#448 this asserted `toHaveBeenCalledTimes( 3 )` — the address node used to
+		// inherit whichever axis mode a bare registry key answered to, exactly like region and
+		// settlement, because resolveModeRenderer() had no third branch of its own. That pinned
+		// the defect this issue fixes, not a real contract: the settings UI has never offered a
+		// mode for the address level, so there is no mode for it to inherit. Updated, not
+		// silently — see the #448 PR body for the failing-on-main verification.
 		const bareMode = jest.fn( () => ( { detach: jest.fn() } ) );
 
 		window.WoodevLocationRenderers = { 'custom-mode': bareMode };
 
 		boot( { region: true, settlement: true, address: true, mode: 'custom-mode' } );
 
-		expect( bareMode ).toHaveBeenCalledTimes( 3 );
+		expect( bareMode ).toHaveBeenCalledTimes( 2 );
+		// The address node falls straight through to the baseline typeahead — never a
+		// registry lookup, bare or level-specific.
+		expect( callFor( 'billing_address_1' ) ).toBeDefined();
 	} );
 
 	it( 'a renderer that DECLINES (returns a falsy value) falls back to the baseline typeahead', () => {
@@ -2068,6 +2077,78 @@ describe( 'Task 13 renderer seam (spec D7)', () => {
 			// exception (isRelatedListRegionNode) never engages, and no 'ajax-select2'
 			// call is made FOR the region node (only ever settlement, above).
 			expect( callFor( 'billing_state' ) ).toBeDefined();
+		} );
+	} );
+
+	// -------------------------------------------------------------------
+	// Issue #448 — the address level has NO axis of its own and must never
+	// resolve one: resolveModeRenderer()'s old binary ternary (`region` vs.
+	// "everything else") fed address the SETTLEMENT axis, so a bare registry
+	// key like `ajax-select2` — registered with no level suffix — attached to
+	// address too, turning a text field into a select nobody configured. The
+	// settings UI only ever offers a mode for the region and settlement axes;
+	// address must fall straight through to the baseline typeahead regardless
+	// of what either axis is set to.
+	// -------------------------------------------------------------------
+
+	describe( 'issue #448 — the address level never resolves an axis mode', () => {
+		it( 'does NOT attach the settlement axis\'s ajax-select2 renderer to the address field — falls through to the baseline typeahead instead', () => {
+			const settlementRenderer = jest.fn( () => ( { detach: jest.fn() } ) );
+
+			// The REAL registry shape (location-select-modes.js): 'ajax-select2' is registered
+			// under a bare, level-less key — the exact key that let it attach to any level.
+			window.WoodevLocationRenderers = { 'ajax-select2': settlementRenderer };
+
+			boot( {
+				settlement: true, address: true,
+				mode: { region: 'typeahead', settlement: 'ajax-select2' },
+			} );
+
+			// Attached exactly once — for the settlement node the axis actually governs.
+			expect( settlementRenderer ).toHaveBeenCalledTimes( 1 );
+			expect( settlementRenderer.mock.calls[ 0 ][ 0 ].id ).toBe( 'billing_city' );
+
+			// The address node was never handed to the renderer at all, and falls through to
+			// the baseline typeahead — the D7 floor for every level nothing claims.
+			expect( callFor( 'billing_address_1' ) ).toBeDefined();
+		} );
+
+		it( 'still resolves region and settlement against their OWN axes while address stays on the baseline, all three attached together', () => {
+			const regionRenderer = jest.fn( () => ( { detach: jest.fn() } ) );
+			const settlementRenderer = jest.fn( () => ( { detach: jest.fn() } ) );
+
+			window.WoodevLocationRenderers = {
+				'related-list:region': regionRenderer,
+				'ajax-select2': settlementRenderer,
+			};
+
+			boot( {
+				region: true, settlement: true, address: true,
+				mode: { region: 'related-list', settlement: 'ajax-select2' },
+				levels: { RU: { region: false, settlement: true, address: true } },
+			} );
+
+			expect( regionRenderer ).toHaveBeenCalledTimes( 1 );
+			expect( regionRenderer.mock.calls[ 0 ][ 0 ].id ).toBe( 'billing_state' );
+
+			expect( settlementRenderer ).toHaveBeenCalledTimes( 1 );
+			expect( settlementRenderer.mock.calls[ 0 ][ 0 ].id ).toBe( 'billing_city' );
+
+			// Neither renderer was ever asked about the address node — it went straight to
+			// the baseline typeahead, the operator's rig-observed contract for that level.
+			expect( callFor( 'billing_address_1' ) ).toBeDefined();
+		} );
+
+		it( 'falls through to the baseline typeahead for the address level even when NOTHING is registered for either axis', () => {
+			// window.WoodevLocationRenderers left entirely undefined — as if
+			// location-select-modes.js never loaded (the D7 floor must still hold).
+			boot( {
+				settlement: true, address: true,
+				mode: { region: 'typeahead', settlement: 'typeahead' },
+			} );
+
+			expect( callFor( 'billing_city' ) ).toBeDefined();
+			expect( callFor( 'billing_address_1' ) ).toBeDefined();
 		} );
 	} );
 } );

--- a/woodev/shipping-method/assets/js/frontend/location-cascade.js
+++ b/woodev/shipping-method/assets/js/frontend/location-cascade.js
@@ -10,13 +10,14 @@
  * "WC Address Autocomplete suppression" section below).
  *
  * RENDERER SEAM (Task 13, spec D7 — "mode is presentation, provider is data"; issue #380 —
- * `location.mode` became TWO independent axes, `{ region, settlement }`, resolved PER LEVEL):
- * this module owns exactly ONE renderer itself — the baseline typeahead ({@see attachOne}'s
- * fallback path, gated by the D15 `isLevelServed()` chain) — and otherwise only knows how to
- * ASK for one: {@see resolveModeRenderer} looks up
- * `window.WoodevLocationRenderers[axisMode(+':'+level)]`, where `axisMode` is the REGION axis
- * for the region node and the SETTLEMENT axis for every other node (see that function's own
- * docblock for why address follows settlement) — a registry `location-select-modes.js`
+ * `location.mode` became TWO independent axes, `{ region, settlement }`, resolved PER LEVEL;
+ * issue #448 — the per-level mapping is EXPLICIT, not residual): this module owns exactly ONE
+ * renderer itself — the baseline typeahead ({@see attachOne}'s fallback path, gated by the D15
+ * `isLevelServed()` chain) — and otherwise only knows how to ASK for one:
+ * {@see resolveModeRenderer} looks up `window.WoodevLocationRenderers[axisMode(+':'+level)]`,
+ * where `axisMode` ({@see axisModeForLevel}) is the REGION axis for the region node, the
+ * SETTLEMENT axis for the settlement node, and NO axis at all for address (there is no third
+ * axis to configure — see that function's own docblock) — a registry `location-select-modes.js`
  * populates with the `related-list` and `ajax-select2` renderers, unchanged by the split (this
  * cascade re-keys the LOOKUP, never the registry itself). This file never imports that module,
  * never branches on its presence, and never
@@ -557,36 +558,71 @@
 	}
 
 	/**
+	 * The axis mode that governs `level`'s renderer lookup, or `null` when `level` has no axis
+	 * of its own at all (issue #448).
+	 *
+	 * ONLY `region` and `settlement` are configurable axes (spec D7/issue #380) — the settings
+	 * UI never offers a mode for any other level, `address` included, and there is no field in
+	 * `entry.location.mode` for one. `address`'s own contract is fixed: text, or text-with-
+	 * suggestions when that option is on (see {@see attachOne}'s baseline typeahead path) — it
+	 * is a FLOOR, never a level with a mode of its own to inherit.
+	 *
+	 * Previously this fell through to {@see settlementAxisMode} for "every node that isn't
+	 * region" — a deliberate backward-compatible shim for the OLD single shared mode string
+	 * (see the #448 issue and this function's git history for the reasoning that no longer
+	 * applies). That let a bare registry key like `registry['ajax-select2']` — registered with
+	 * no level suffix, because `ajax-select2`'s widget is the same shape for any field it
+	 * enhances — attach to the address field too, turning it into a select nobody configured
+	 * (operator, rig pass 21.08.2026, issue #448). The mapping is explicit now: `region` takes
+	 * the region axis, `settlement` takes the settlement axis, everything else — currently only
+	 * `address`, since {@see LEVELS} names exactly these three — takes none.
+	 *
+	 * @param {Object} entry
+	 * @param {string} level
+	 * @returns {string|null}
+	 */
+	function axisModeForLevel( entry, level ) {
+		if ( 'region' === level ) {
+			return regionAxisMode( entry );
+		}
+
+		if ( 'settlement' === level ) {
+			return settlementAxisMode( entry );
+		}
+
+		return null;
+	}
+
+	/**
 	 * Resolves the mode-specific renderer for `node`, if Task 13's `location-select-modes.js`
 	 * registered one — spec D7's "mode is presentation, provider is data": this cascade must
 	 * not know WHICH renderer a field uses, only how to ask the registry for one.
 	 *
 	 * MODE RESOLUTION IS PER-LEVEL (issue #380, re-keyed from a single shared mode string to
-	 * two independent axes): the REGION node resolves against {@see regionAxisMode}; every
-	 * OTHER node (settlement, and — with no axis of its own — address, which follows the
-	 * SETTLEMENT axis) resolves against {@see settlementAxisMode}. Address following the
-	 * settlement axis is a deliberate backward-compatible choice, not a spec requirement: under
-	 * the OLD single-mode `ajax-select2`, address got the bare `registry['ajax-select2']`
-	 * fallback exactly like every other level (the same shared mode string reached it too);
-	 * under OLD `related-list`, address got NOTHING registered for it (no `related-list:address`
-	 * key, no bare `related-list` key) and fell straight through to the baseline typeahead below.
-	 * Keying address's lookup off the settlement axis reproduces BOTH outcomes exactly, because
-	 * `related-list` still has no bare-registry entry — only `ajax-select2` does.
+	 * two independent axes) and EXPLICIT, not residual (issue #448) — see
+	 * {@see axisModeForLevel}'s own docblock for which level takes which axis, and why address
+	 * takes none. A node whose level has no axis never reaches the registry at all.
 	 *
-	 * Lookup order per level: `{axisMode}:{level}` (a renderer specific to one field kind under
-	 * one axis value — e.g. `related-list`'s region native-`<select>` watcher, which shares
-	 * nothing with its own settlement renderer) first, then the bare `{axisMode}` (a renderer
-	 * that serves every level uniformly — `ajax-select2`'s select2 widget is the same shape for
-	 * region, settlement, or address). Returns `null` when nothing is registered for either key,
-	 * or when `location-select-modes.js` never loaded at all — {@see attachOne}'s baseline
-	 * typeahead path is the fallback either way, never a special case of this function.
+	 * Lookup order per level, once an axis mode is known: `{axisMode}:{level}` (a renderer
+	 * specific to one field kind under one axis value — e.g. `related-list`'s region native-
+	 * `<select>` watcher, which shares nothing with its own settlement renderer) first, then the
+	 * bare `{axisMode}` (a renderer that serves every level uniformly — `ajax-select2`'s select2
+	 * widget is the same shape for region or settlement). Returns `null` when nothing is
+	 * registered for either key, when `location-select-modes.js` never loaded at all, or when
+	 * the level has no axis to look up in the first place — {@see attachOne}'s baseline
+	 * typeahead path is the fallback in every case, never a special case of this function.
 	 *
 	 * @param {Object} entry
 	 * @param {{level: string}} node
 	 * @returns {function(Element, Object): ({detach: Function}|null)|null}
 	 */
 	function resolveModeRenderer( entry, node ) {
-		var mode = 'region' === node.level ? regionAxisMode( entry ) : settlementAxisMode( entry );
+		var mode = axisModeForLevel( entry, node.level );
+
+		if ( null === mode ) {
+			return null;
+		}
+
 		var registry = window.WoodevLocationRenderers || {};
 
 		if ( 'function' === typeof registry[ mode + ':' + node.level ] ) {


### PR DESCRIPTION
## What

`resolveModeRenderer()` in `location-cascade.js` used a binary ternary — `region` vs.
everything else — to decide which axis mode governs a node's renderer lookup:

```js
var mode = 'region' === node.level ? regionAxisMode( entry ) : settlementAxisMode( entry );
```

The location chain has three levels (`region`, `settlement`, `address`), not two. Every
level that isn't `region` — including `address` — fell into the "everything else" branch and
resolved against the **settlement** axis. Since `location-select-modes.js` registers
`ajax-select2` under a bare, level-less key (`registry['ajax-select2'] = attachAjaxSelect2`,
matching any level), setting the settlement axis to "Список с поиском" made the address field
resolve that same renderer and turn into a select — a state the settings UI has never offered
for address and the field's contract does not support (text, or text-with-suggestions).

Operator-observed on the rig 21.08.2026 (issue #448).

## Fix

Replaced the binary ternary with an explicit per-level mapping
(`axisModeForLevel()`): `region` → region axis, `settlement` → settlement axis, everything
else (currently only `address` — `LEVELS` names exactly these three, and the chain is built
strictly from that constant, so there is no fourth level today) → `null`, i.e. no axis to look
up at all. `resolveModeRenderer()` returns `null` immediately for a level with no axis, which
falls straight through to `attachOne()`'s baseline typeahead — the same fallback path used
when nothing is registered for the axis at all.

Docblocks on `resolveModeRenderer()`, the new `axisModeForLevel()`, and the file's own
RENDERER SEAM section were updated to describe the explicit mapping and retire the old
"address follows settlement for backward compatibility" reasoning, which is what let this bug
exist as a *documented* choice rather than an oversight.

## The bare `ajax-select2` registry key — considered, not changed here

The card asks whether `registry['ajax-select2']` should also become level-scoped
(`ajax-select2:region` / `ajax-select2:settlement`), the way `related-list:region` and
`related-list:settlement` already are — defence in depth, closing the same hole a second way.

I did not make that change. Two reasons:

1. **It isn't needed to close #448.** With the level→axis mapping now explicit, `address`
   never reaches the registry at all, bare key or not — the bug's actual cause (address
   inheriting an axis it has none of) is gone regardless of how `ajax-select2` is keyed.
2. **It's out of my file ownership.** `registry['ajax-select2']` is registered in
   `location-select-modes.js`, which a parallel worker owns for cards #450/#447. Changing the
   registry's key shape is a contract change for that file and would need to be sequenced with
   their work, not made unilaterally here.

My recommendation for whoever picks that up: it's worth doing anyway, purely as defence in
depth — a bare key is inherently level-agnostic by construction, and the only thing that made
it level-safe before this fix was the caller never asking it for the wrong level. Now that the
caller is fixed, the registry doesn't strictly need the same fix, but a future third mode axis
or a refactor of `resolveModeRenderer()` could reintroduce the same class of bug if the bare
key is still there to catch it. Flagging for the coordinator to sequence against #450/#447
rather than doing it here.

## Tests (`tests/js/location-cascade.test.js`)

All new/changed assertions verified to **fail on `main`** (written and run against the
unfixed `resolveModeRenderer()` first, confirmed failing, then the fix was implemented and the
same tests re-run to confirm they pass):

- **`issue #448 — the address level never resolves an axis mode`** (new `describe` block):
  - `does NOT attach the settlement axis's ajax-select2 renderer to the address field — falls
    through to the baseline typeahead instead` — registers `ajax-select2` under the real bare
    key, sets the settlement axis to `ajax-select2`, asserts the renderer is called exactly
    once (for `billing_city`, never `billing_address_1`) and the address field gets the
    baseline typeahead. **Fails on main**: renderer called twice.
  - `still resolves region and settlement against their OWN axes while address stays on the
    baseline, all three attached together` — region on `related-list`, settlement on
    `ajax-select2`, both present alongside address; confirms the fix doesn't just move the bug,
    it removes it, while proving region/settlement keep resolving correctly. **Fails on main**:
    settlement renderer called twice (once for its own level, once for address).
  - `falls through to the baseline typeahead for the address level even when NOTHING is
    registered for either axis` — the pre-existing floor case; passes on both main and the fix
    (included for completeness of the new describe block, not a regression guard).

- **Updated an existing test that pinned the old, wrong behaviour** (did not silently edit it —
  flagging explicitly per the card's instruction): `the bare {mode} key serves every level
  uniformly when no level-specific one is registered` asserted a bare custom-mode renderer was
  called **3 times** (region, settlement, *and* address) — that was asserting the exact defect
  #448 reports, not a real contract (the settings UI never offers address a mode to inherit).
  Renamed and updated to assert **2** calls (region, settlement only) plus an explicit
  assertion that address gets the baseline typeahead. **Fails on main** at the original
  assertion (`toHaveBeenCalledTimes(2)` sees 3).

- Considered whether a level other than `region`/`settlement`/`address` exists or could exist:
  no — `LEVELS` (`location-cascade.js`) is a fixed three-item array and `buildChain()` only
  ever populates the chain from it, so `axisModeForLevel()`'s "everything else → null" branch
  is exercised exclusively by `address` today. No fourth-level test was added since there is no
  fourth level to construct one for; the `null` branch is structured to cover a future one
  without another code change.

No existing test was weakened.

## Gates

Baseline measured first (main moved several times today, per the brief):

- `rm -f .phpunit.result.cache && composer test:unit` — baseline: 2566 tests, 6340 assertions,
  **Skipped: 66**. After the fix: identical (2566/6340/66) — this is a pure JS change, no PHP
  touched.
- `composer phpcs` — clean, 217 files, no violations.
- `composer phpstan` — `[OK] No errors`, 217 files.
- `npm run test:js -- --roots "<rootDir>/tests/js"` (from bash) — full suite: **1270 passed**
  (baseline 1267 + 3 net new). `location-cascade.test.js` alone: 155 passed (152 baseline + 3
  net new, one rewritten in place).

`npm run build` was **not** run. Verified `location-cascade.js` is enqueued directly from
`assets/js/frontend/location-cascade.js` (`class-checkout-handler.php`'s
`enqueue_script_if_built()`, relative path `js/frontend/location-cascade.js` under the assets
dir) — there is no build/dist step in this file's path to source-of-truth.

## Scope note

Per the brief, this PR touches only `location-cascade.js` and its own test file.
`location-select-modes.js` and `location-select-modes.test.js` are untouched — owned by a
parallel worker on cards #450/#447.

Closes #448
