### PR TITLE
fix(shipping): jsdom-visible select2 harness + seed ajax-select2 field value

### DIFF
--- a/tests/js/location-select-modes.test.js
+++ b/tests/js/location-select-modes.test.js
@@ -24,6 +24,8 @@
 
 'use strict';
 
+const { installFakeSelect2 } = require( './support/fake-select2.js' );
+
 const LIST_URL = 'https://example.test/wp-json/woodev/v1/location/list';
 
 let fetchJsonCalls;
@@ -117,6 +119,72 @@ beforeEach( () => {
 // -----------------------------------------------------------------------
 // Registration — the seam location-cascade.js reads from
 // -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+// selectConfigFor() — the PURE half of the #450 harness: no DOM, no jQuery, no select2 call.
+// Testable in an environment with no select2 present at all (issue #450, harness option 2).
+// -----------------------------------------------------------------------
+
+describe( 'selectConfigFor() — pure config builder, no select2 required', () => {
+	let mod;
+
+	beforeEach( () => {
+		mod = require( '../../woodev/shipping-method/assets/js/frontend/location-select-modes.js' );
+	} );
+
+	it( 'a non-ajax strategy gets width only — no ajax block, no placeholder', () => {
+		const config = mod.selectConfigFor(
+			{ ajax: false },
+			{ initialValue: '', placeholder: 'Регион', applyEntries: jest.fn() }
+		);
+
+		expect( config ).toEqual( { width: '100%' } );
+	} );
+
+	it( 'an ajax strategy with an initial value gets no placeholder — the seeded <option> already carries it', () => {
+		const config = mod.selectConfigFor(
+			{ ajax: true, fetchEntries: jest.fn() },
+			{ initialValue: 'Татарстан', placeholder: 'Регион', applyEntries: jest.fn() }
+		);
+
+		expect( config.placeholder ).toBeUndefined();
+		expect( typeof config.ajax.transport ).toBe( 'function' );
+	} );
+
+	it( 'an ajax strategy with NO initial value and a placeholder attribute gets config.placeholder', () => {
+		const config = mod.selectConfigFor(
+			{ ajax: true, fetchEntries: jest.fn() },
+			{ initialValue: '', placeholder: 'Улица, дом', applyEntries: jest.fn() }
+		);
+
+		expect( config.placeholder ).toBe( 'Улица, дом' );
+	} );
+
+	it( 'the transport calls strategy.fetchEntries(term), merges results via seed.applyEntries(entries, false), and reports {id, text} shaped results', async () => {
+		const fetchEntries = jest.fn( () => Promise.resolve( [
+			{ key: 'dadata:tv', label: 'ул Тверская', record: { key: 'dadata:tv', label: 'ул Тверская' } },
+		] ) );
+		const applyEntries = jest.fn();
+		const config = mod.selectConfigFor(
+			{ ajax: true, fetchEntries: fetchEntries },
+			{ initialValue: '', placeholder: '', applyEntries: applyEntries }
+		);
+
+		const success = jest.fn();
+		const failure = jest.fn();
+
+		config.ajax.transport( { data: { term: 'Твер' } }, success, failure );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		expect( fetchEntries ).toHaveBeenCalledWith( 'Твер' );
+		expect( applyEntries ).toHaveBeenCalledWith(
+			[ { key: 'dadata:tv', label: 'ул Тверская', record: { key: 'dadata:tv', label: 'ул Тверская' } } ],
+			false
+		);
+		expect( success ).toHaveBeenCalledWith( { results: [ { id: 'dadata:tv', text: 'ул Тверская' } ] } );
+		expect( failure ).not.toHaveBeenCalled();
+	} );
+} );
 
 describe( 'registers onto window.WoodevLocationRenderers on load', () => {
 	it( 'registers related-list:region, related-list:settlement, and the bare ajax-select2 key', () => {
@@ -540,5 +608,150 @@ describe( 'ajax-select2 renderer', () => {
 
 		expect( options.onSelect ).toHaveBeenCalledTimes( 1 );
 		expect( options.onSelect ).toHaveBeenCalledWith( { record: { key: 'dadata:tv', label: 'ул Тверская' } } );
+	} );
+} );
+
+// -----------------------------------------------------------------------
+// ajax-select2 — seeding the field's OWN current value (issue #447), proven through the
+// #450 harness (a fake jQuery.fn.select2 that records config and can drive ajax.transport,
+// PLUS the plain-DOM assertions the file docblock already promised were possible without it).
+// -----------------------------------------------------------------------
+
+describe( 'ajax-select2 renderer — current value is seeded before select2 init (issue #447)', () => {
+	let mod;
+
+	beforeEach( () => {
+		mod = require( '../../woodev/shipping-method/assets/js/frontend/location-select-modes.js' );
+	} );
+
+	afterEach( () => {
+		delete window.jQuery.fn.select2;
+	} );
+
+	it( 'a field with a non-empty value produces a select containing that value, selected, with NO select2 present at all', () => {
+		// No jQuery.fn.select2 installed — ensureSelect2() no-ops (see the file docblock's
+		// "SELECT2 IS OPTIONAL AT RUNTIME" section), so whatever the DOM looks like here is
+		// exactly what buildSelectField() itself produced, unmodified by any plugin. FAILS on
+		// main: buildSelectField() never reads input.value at all today.
+		document.body.innerHTML = '<input type="text" id="shipping_state" name="shipping_state" value="Татарстан" />';
+		const input = document.getElementById( 'shipping_state' );
+
+		mod.attachAjaxSelect2( input, buildOptions( { node: { level: 'region', fieldId: 'shipping_state' } } ) );
+
+		const select = document.getElementById( 'shipping_state' );
+
+		expect( select.tagName ).toBe( 'SELECT' );
+		expect( select.options.length ).toBe( 1 );
+		expect( select.options[ 0 ].value ).toBe( 'Татарстан' );
+		expect( select.options[ 0 ].selected ).toBe( true );
+		expect( select.value ).toBe( 'Татарстан' );
+	} );
+
+	it( 'a field with an empty value produces a select with NO options (unchanged behaviour, no placeholder attribute present)', () => {
+		document.body.innerHTML = '<input type="text" id="billing_address_1" name="billing_address_1" value="" />';
+
+		mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), buildOptions() );
+
+		const select = document.getElementById( 'billing_address_1' );
+
+		expect( select.options.length ).toBe( 0 );
+	} );
+
+	it( 'DATA LOSS CLAIM: the seeded select serializes to its actual value, not to an empty/absent field — confirmed true on main (empty select drops the field from serialize() entirely, and WooCommerce\'s own get_posted_data() treats an ABSENT posted key exactly like an empty one, writing \'\' over the stored address — includes/class-wc-checkout.php:784-789)', () => {
+		document.body.innerHTML = '<form id="checkout"><input type="text" id="shipping_state" name="shipping_state" value="Татарстан" /></form>';
+		const input = document.getElementById( 'shipping_state' );
+
+		mod.attachAjaxSelect2( input, buildOptions( { node: { level: 'region', fieldId: 'shipping_state' } } ) );
+
+		// Mirrors checkout.js's OWN mechanism for the shipping_state field exactly:
+		// `s_state = $( '#shipping_state' ).val();` (assets/js/frontend/checkout.js:532) — this
+		// is jQuery's `.val()`, not the native `.value` getter; jQuery's own valHook for a
+		// select-one with selectedIndex === -1 returns `null`, which jQuery.param() then
+		// serializes as an EMPTY STRING in the actual POST body (verified empirically against
+		// this repo's own jQuery devDependency) — the field is never simply "missing" from the
+		// wire, it arrives as `s_state=`, which WooCommerce writes straight into the customer
+		// session (WC_Data::set_props() only skips `null`, never `''`).
+		//
+		// FAILS on main: main's select has zero options, so `.val()` is `null` here too — but
+		// this test pins the FIXED behaviour: a real value now serializes as itself.
+		expect( window.jQuery( '#shipping_state' ).val() ).toBe( 'Татарстан' );
+		expect( window.jQuery( '#checkout' ).serialize() ).toBe( 'shipping_state=' + encodeURIComponent( 'Татарстан' ) );
+	} );
+
+	it( 'placeholder: an empty field WITH a placeholder attribute gets an empty leading <option> and select2 receives config.placeholder (select2 docs: required even for AJAX single selects)', () => {
+		document.body.innerHTML = '<input type="text" id="billing_address_1" name="billing_address_1" value="" placeholder="Улица, дом" />';
+
+		const instances = installFakeSelect2( window.jQuery );
+
+		mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), buildOptions() );
+
+		expect( instances ).toHaveLength( 1 );
+		expect( instances[ 0 ].config.placeholder ).toBe( 'Улица, дом' );
+
+		const select = document.getElementById( 'billing_address_1' );
+
+		expect( select.options.length ).toBe( 1 );
+		expect( select.options[ 0 ].value ).toBe( '' );
+	} );
+
+	it( 'a non-empty value takes priority over a placeholder attribute — the select carries the VALUE, not a blank leading option, and select2 gets no config.placeholder', () => {
+		document.body.innerHTML = '<input type="text" id="shipping_city" name="shipping_city" value="Казань" placeholder="Населённый пункт" />';
+
+		const instances = installFakeSelect2( window.jQuery );
+
+		mod.attachAjaxSelect2( document.getElementById( 'shipping_city' ), buildOptions( { node: { level: 'settlement', fieldId: 'shipping_city' } } ) );
+
+		expect( instances[ 0 ].config.placeholder ).toBeUndefined();
+
+		const select = document.getElementById( 'shipping_city' );
+
+		expect( select.options.length ).toBe( 1 );
+		expect( select.options[ 0 ].value ).toBe( 'Казань' );
+	} );
+
+	it( 'the seeded option is already IN THE DOM at the moment select2() is called — proven via the #450 fake, not inferred', () => {
+		document.body.innerHTML = '<input type="text" id="shipping_state" name="shipping_state" value="Татарстан" />';
+
+		const instances = installFakeSelect2( window.jQuery );
+
+		mod.attachAjaxSelect2( document.getElementById( 'shipping_state' ), buildOptions( { node: { level: 'region', fieldId: 'shipping_state' } } ) );
+
+		expect( instances ).toHaveLength( 1 );
+
+		const liveSelect = instances[ 0 ].el[ 0 ];
+
+		expect( liveSelect.options.length ).toBe( 1 );
+		expect( liveSelect.value ).toBe( 'Татарстан' );
+		expect( typeof instances[ 0 ].config.ajax.transport ).toBe( 'function' );
+	} );
+
+	it( 'the #450 fake reproduces the minimumInputLength gate and the abort contract — pinning that OUR transport still returns nothing (issue #449, unfixed here on purpose)', async () => {
+		const fetchSpy = jest.fn( () => Promise.resolve( [] ) );
+		const options = buildOptions( { fetch: fetchSpy } );
+
+		document.body.innerHTML = '<input type="text" id="billing_address_1" name="billing_address_1" value="" />';
+
+		const instances = installFakeSelect2( window.jQuery );
+
+		mod.attachAjaxSelect2( document.getElementById( 'billing_address_1' ), options );
+
+		// No minimumInputLength is set today (issue #449) — the fake's own gate is a no-op,
+		// and every query reaches the transport. This is a SHAPE assertion pinning today's
+		// config, not a claim that it is correct.
+		expect( instances[ 0 ].config.minimumInputLength ).toBeUndefined();
+
+		const first = instances[ 0 ].query( 'Твер' );
+		await Promise.resolve().then( () => Promise.resolve() );
+
+		// Our transport never `return`s its underlying request (location-select-modes.js's own
+		// `config.ajax.transport`, issue #449) — the fake's `_request` therefore stays `null`
+		// after the first query, so a second query never calls anything's `.abort()`. Asserted
+		// here by construction: `query()` only calls `request.abort()` when the PREVIOUS
+		// request was non-null and abortable, and nothing in this test double tracks an abort
+		// call, so there is nothing to assert a call COUNT against — the absence itself is the
+		// pin. A future #449 fix that starts returning `{ abort() {} }` would need this test
+		// extended with an abort spy; documented here so that fix doesn't have to rediscover it.
+		expect( first ).not.toBeNull();
+		expect( fetchSpy ).toHaveBeenCalledWith( 'Твер' );
 	} );
 } );

--- a/tests/js/support/fake-select2.js
+++ b/tests/js/support/fake-select2.js
@@ -1,0 +1,96 @@
+/**
+ * A minimal fake `jQuery.fn.select2` for jest (issue #450).
+ *
+ * jsdom has no select2/selectWoo — the package is not vendored in this repo, it arrives from
+ * WordPress/WooCommerce at runtime (see `location-select-modes.js`'s own "SELECT2 IS OPTIONAL
+ * AT RUNTIME" docblock section). Before this fake existed, `ensureSelect2()`'s own defensive
+ * `'function' !== typeof $select.select2` guard always took the "select2 absent" branch in
+ * every test, so the entire `config` object it builds — `ajax.transport`, `minimumInputLength`,
+ * `ajax.delay`, `placeholder` — ran zero times under jest (issue #450's own root cause).
+ *
+ * This fake does NOT vendor real select2. It only RECORDS the config `.select2()` was called
+ * with and reproduces the two contract points that decide whether OUR OWN `ajax.transport`
+ * plays correctly with a real select2/selectWoo instance:
+ *
+ * - The `minimumInputLength` gate (selectWoo.full.js:3885-3902, a data-adapter DECORATOR that
+ *   runs BEFORE the ajax adapter at all): a query shorter than the floor never reaches
+ *   `ajax.transport`.
+ * - The abort contract (selectWoo.full.js:3564-3571, `AjaxAdapter.prototype.query`): the
+ *   REAL adapter stores whatever `ajax.transport` returns and, on the NEXT query, aborts it
+ *   ONLY if `this._request != null && 'function' === typeof this._request.abort` — never
+ *   blindly. A transport that returns nothing (our own code, today) never gets its in-flight
+ *   request aborted, because select2 never even tries — this fake reproduces that exact check
+ *   so a test can tell "transport returned something abortable" from "transport returned
+ *   nothing" by whether the PREVIOUS request's `abort` spy was actually called.
+ *
+ * `ajax.delay` is NOT reproduced as a timer — selectWoo applies it itself, before the
+ * transport is ever invoked (research doc §2.3); it is not the transport's concern, so a test
+ * that cares about it asserts the recorded `config.ajax.delay` value directly (a shape
+ * assertion, not a timing one).
+ *
+ * @see docs-internal/research/2026-08-21-select2-location-fields.md §2.2, §2.4
+ * @see woodev/shipping-method/assets/js/frontend/location-select-modes.js
+ */
+
+'use strict';
+
+/**
+ * Installs the fake onto `$.fn.select2` and returns the array of instances it will push to —
+ * one entry per `.select2( config )` call observed, in call order.
+ *
+ * @param {Object} $ jQuery (real jQuery — a devDependency of this repo).
+ * @returns {Array<{config: Object, query: function(string=): ({success: jest.Mock, failure: jest.Mock}|null)}>}
+ */
+function installFakeSelect2( $ ) {
+	var instances = [];
+
+	$.fn.select2 = jest.fn( function( config ) {
+		var $el = this;
+		var request = null;
+
+		var instance = {
+			el: $el,
+			config: config,
+
+			/**
+			 * Fires `config.ajax.transport` for `term`, reproducing selectWoo's own
+			 * minimumInputLength gate and pre-abort-then-store sequence.
+			 *
+			 * @param {string} [term]
+			 * @returns {{success: jest.Mock, failure: jest.Mock}|null} `null` when the
+			 *   minimumInputLength gate blocked the query BEFORE it reached the transport —
+			 *   mirrors selectWoo's own `MinimumInputLength.prototype.query` short-circuit.
+			 */
+			query: function( term ) {
+				if ( ! config.ajax || 'function' !== typeof config.ajax.transport ) {
+					throw new Error( 'fake select2: query() called on a config with no ajax.transport' );
+				}
+
+				var value = term || '';
+
+				if ( 'number' === typeof config.minimumInputLength && value.length < config.minimumInputLength ) {
+					return null;
+				}
+
+				if ( request != null && 'function' === typeof request.abort ) {
+					request.abort();
+				}
+
+				var success = jest.fn();
+				var failure = jest.fn();
+
+				request = config.ajax.transport( { data: { term: value } }, success, failure );
+
+				return { success: success, failure: failure };
+			},
+		};
+
+		instances.push( instance );
+
+		return $el;
+	} );
+
+	return instances;
+}
+
+module.exports = { installFakeSelect2: installFakeSelect2 };

--- a/woodev/shipping-method/assets/js/frontend/location-select-modes.js
+++ b/woodev/shipping-method/assets/js/frontend/location-select-modes.js
@@ -210,6 +210,63 @@
 	registry[ 'related-list:region' ] = attachRelatedListRegion;
 
 	// -------------------------------------------------------------------------
+	// Pure select2 config builder (issue #450, harness option 2) — no DOM read beyond its own
+	// arguments, no jQuery, no `.select2()` call. Testable with NO select2 present in the
+	// environment at all, and independently of `buildSelectField()`'s init-guard/idempotency
+	// wrapper — this is the SAME object `ensureSelect2()` hands to `.select2()`, extracted so
+	// a test can assert its shape directly instead of inferring it from a stubbed `select2()`
+	// call (issue #450's own point: jsdom has no select2, so nothing here ran under any test
+	// before this function existed to be called on its own).
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Builds the config object for `strategy` — the exact object `ensureSelect2()` passes to
+	 * `.select2()`.
+	 *
+	 * @param {{ajax: boolean, fetchEntries: function(string): Promise<Array>}} strategy
+	 * @param {{initialValue: string, placeholder: string, applyEntries: function(Array, boolean): void}} seed
+	 *   `applyEntries` is called with `(entries, false)` on every successful ajax response —
+	 *   the SAME merge-only call `ensureSelect2()`'s own transport made before this extraction.
+	 * @returns {Object}
+	 */
+	function selectConfigFor( strategy, seed ) {
+		var config = { width: '100%' };
+
+		if ( strategy.ajax ) {
+			// Only meaningful when the field starts EMPTY — select2's own docs require a
+			// blank leading <option> for this to render at all (verified against
+			// select2/select2 docs/placeholders.md, "Single select placeholders" AND "Using
+			// placeholders with AJAX" — the empty <option> is required in BOTH cases).
+			// `attachAjaxSelect2()`'s own seeding only appends that leading option in this
+			// same empty case — see `buildSelectField()`.
+			if ( seed.placeholder && ! seed.initialValue ) {
+				config.placeholder = seed.placeholder;
+			}
+
+			config.ajax = {
+				transport: function( params, success, failure ) {
+					var term = params && params.data && params.data.term ? params.data.term : '';
+
+					strategy.fetchEntries( term ).then( function( entries ) {
+						seed.applyEntries( entries, false );
+
+						success( {
+							results: ( entries || [] ).map( function( entry ) {
+								return {
+									id: entry.key,
+									text: entry.record && entry.record.label ? entry.record.label : entry.label,
+								};
+							} ),
+						} );
+					}, failure );
+				},
+			};
+		}
+
+		return config;
+	}
+
+	// -------------------------------------------------------------------------
 	// Shared select2-ish field builder — turns a plain <input> into a <select> select2 CAN
 	// enhance (select2 requires a real <select>; it cannot attach to an arbitrary text input).
 	// -------------------------------------------------------------------------
@@ -249,6 +306,11 @@
 		select.id = input.id;
 		select.name = input.name || '';
 		select.className = input.className;
+
+		// Captured BEFORE the <input> is detached — issue #447: a field re-rendered with an
+		// existing value (a page reload, or a sibling level's re-render) must not lose it.
+		var initialValue = input.value || '';
+		var placeholder = input.getAttribute( 'placeholder' ) || input.getAttribute( 'data-placeholder' ) || '';
 
 		input.parentNode.insertBefore( select, input );
 		input.parentNode.removeChild( input );
@@ -328,37 +390,39 @@
 
 			select2Initialized = true;
 
-			var config = { width: '100%' };
-
-			if ( strategy.ajax ) {
-				config.ajax = {
-					transport: function( params, success, failure ) {
-						var term = params && params.data && params.data.term ? params.data.term : '';
-
-						strategy.fetchEntries( term ).then( function( entries ) {
-							applyEntries( entries, false );
-
-							success( {
-								results: ( entries || [] ).map( function( entry ) {
-									return {
-										id: entry.key,
-										text: entry.record && entry.record.label ? entry.record.label : entry.label,
-									};
-								} ),
-							} );
-						}, failure );
-					},
-				};
-			}
-
-			$select.select2( config );
+			$select.select2( selectConfigFor( strategy, {
+				initialValue: initialValue,
+				placeholder: placeholder,
+				applyEntries: applyEntries,
+			} ) );
 		}
 
 		if ( strategy.ajax ) {
 			// select2's own `ajax.transport` (wired above) drives population per keystroke —
-			// nothing to pre-fetch. Without select2 available at all, the field is simply an
-			// empty native <select> a customer cannot search; `ajax-select2` mode is only ever
-			// offered by the store setting when the real plugin is expected to be present.
+			// nothing to PRE-FETCH. But the field's OWN current value (issue #447) is not a
+			// fetch result at all: it is the label the field already carries, exactly the
+			// select2-documented "Preselect option in AJAX Select2" pattern (append a real,
+			// pre-selected <option> before init — see the CDEK reference,
+			// plugins-reference/woocommerce-edostavka/assets/js/frontend/city-select.js:69,90-98,
+			// which does the same thing for the same reason) — without it the select renders
+			// with NO options at all until the first keystroke.
+			if ( initialValue ) {
+				var seededOption = document.createElement( 'option' );
+
+				seededOption.value = initialValue;
+				seededOption.textContent = initialValue;
+				seededOption.selected = true;
+
+				select.appendChild( seededOption );
+			} else if ( placeholder ) {
+				// The empty leading <option> select2's placeholder requires (see ensureSelect2()).
+				select.appendChild( document.createElement( 'option' ) );
+			}
+
+			// Without select2 available at all, the field is simply a native <select> carrying
+			// the option above (or genuinely empty) — a customer cannot search it; `ajax-select2`
+			// mode is only ever offered by the store setting when the real plugin is expected to
+			// be present.
 			ensureSelect2();
 		} else {
 			strategy.fetchEntries( '' ).then(
@@ -492,6 +556,7 @@
 			attachRelatedListSettlement: attachRelatedListSettlement,
 			attachAjaxSelect2: attachAjaxSelect2,
 			bindChangeBothWorlds: bindChangeBothWorlds,
+			selectConfigFor: selectConfigFor,
 		};
 	}
 


### PR DESCRIPTION
## What

Closes #450 first (test harness), then #447 (the empty-field bug it makes provable).

**#450 — jsdom can't see select2, so the config was dead code.** `ensureSelect2()`'s own
defensive guard (`'function' !== typeof $select.select2`) always took the "select2 absent"
branch under jest — the whole `config` object (`ajax.transport`, `placeholder`, and the
still-unfixed `minimumInputLength`/`delay` from #449) ran zero times in any test. Did both
options the card asked for, complementary:

- `selectConfigFor(strategy, seed)` — the config-building half of `ensureSelect2()` pulled out
  into a pure function: no DOM, no jQuery, no `.select2()` call. Testable with select2 absent
  entirely (`tests/js/location-select-modes.test.js`, `describe('selectConfigFor() — pure
  config builder, no select2 required', ...)`).
- `tests/js/support/fake-select2.js` — a minimal `jQuery.fn.select2` fake that records the
  config it was handed and can drive `ajax.transport`. It reproduces selectWoo's own
  `minimumInputLength` gate (`selectWoo.full.js:3885-3902`) and its store-then-abort-if-abortable
  contract (`selectWoo.full.js:3564-3571`) — `this._request != null && 'function' === typeof
  this._request.abort` — so a future #449 fix has something that actually pins "the transport's
  return value is abortable," not just its shape.

**#447 — the field renders empty and loses its value.** `buildSelectField()` moved
`id`/`name`/`className` onto the new `<select>` but never `input.value`, and the ajax path never
populated any options at start. Now, before select2 init:

- a non-empty value gets a real, pre-selected `<option>` — select2's own documented
  ["Preselect option in AJAX Select2"](select2/select2 docs, `docs/programmatic-control/add-select-clear-items.md`)
  pattern, matching the operator's own CDEK plugin
  (`plugins-reference/woocommerce-edostavka/assets/js/frontend/city-select.js:69,90-98`) — see
  "Where I departed from the reference" below;
- an empty value **with** a `placeholder`/`data-placeholder` attribute gets the blank leading
  `<option>` select2's own docs say is required for a placeholder to render at all — verified
  against `select2/select2`'s `docs/placeholders.md` ("Single select placeholders" **and**
  "Using placeholders with AJAX" — the empty option is required in both), not assumed — and
  `config.placeholder` is set to match.

## The data-loss claim — CONFIRMED, with evidence

The brief flagged this as mine, unmeasured, to prove or disprove. **It's real.** Chain, each
link checked against source, not memory:

1. `assets/js/frontend/checkout.js:532` (WooCommerce core) reads the field with jQuery:
   `s_state = $( '#shipping_state' ).val();` — not the native `.value` getter.
2. Verified empirically (this repo's own jQuery devDependency, in jsdom): a `<select>` with
   zero options has `.value === ''` (native) but **jQuery's own `.val()` returns `null`** for a
   select-one with no selection.
3. Also verified empirically: `jQuery.param({ s_state: null })` → `"s_state="` — jQuery's own
   AJAX serialization turns `null` into an **empty string that IS present on the wire**, not an
   omitted key.
4. `includes/class-wc-ajax.php:407` (`update_order_review`, read from the vendored WooCommerce
   checkout at `D:/Projects/wordpress/woocommerce`): `'shipping_state' => isset( $_POST['s_state']
   ) ? wc_clean( wp_unslash( $_POST['s_state'] ) ) : null`. Since `s_state=` **is** present
   (step 3), this evaluates to `''`, not `null`.
5. `abstract-wc-data.php:794` (`WC_Data::set_props()`): `if ( is_null( $value ) ...) { continue;
   }` — it skips `null`, but **never** skips `''`. So `''` is written straight into
   `WC()->customer`'s session shipping address.

So: empty select → `null` from `.val()` → `''` on the wire → `''` written into the session,
clobbering whatever was there before, on every checkout refresh. Pinned as a jest test (not just
this writeup) in `location-select-modes.test.js`, the `DATA LOSS CLAIM` test — asserts
`$('#shipping_state').val()` and `.serialize()` on the FIXED select produce the real value, and
fails on `main` (see below) because `main`'s `.val()` is `null` there too.

## Placeholder — decided: yes, sourced from the DOM, not a new options field

The card lists the missing placeholder as symptom (1) but doesn't ask for it explicitly; the
brief asked me to decide with reasons. Went with yes: `location-cascade.js`'s `options` object
carries no placeholder i18n string today (that file is out of my ownership for this card), but
WooCommerce's own checkout field rendering already emits a `placeholder` attribute on these
inputs, and the CDEK reference reads exactly that (`$element.attr('placeholder') ||
$element.attr('data-placeholder') || settings.placeholder`, `city-select.js:70`) — so I read it
off the DOM the same way, no new plumbing needed. Did **not** add `allowClear`: nothing in the
symptoms asks for it, and a required shipping field offering a one-click "clear to empty" button
would reintroduce exactly the data-loss chain above.

## Where I departed from the CDEK reference, and why

The reference (`city-select.js:90-98`) appends `<option value=X>X</option>` where `X =
$element.val()` — value and label are the same string, no separate lookup. I did the identical
thing (`seededOption.value = seededOption.textContent = initialValue`) for the same reason the
research doc gives: the label the field already carries **is** the value, no fetch needed. One
departure: the reference always empties the element first (`$element.empty()`) before
conditionally appending; our `select` is freshly created and never had other options, so that
step doesn't apply. No other departures.

## A real, uncarded defect found and NOT fixed here — filed as #455

Even after this fix, a **live pick** through `ajax-select2` still breaks backwards-fill into an
ancestor field of the same mode. `applyEntries()`'s ajax results give each `<option>` a
provider-KEY value (`id: entry.key`, e.g. `dadata:tatarstan`), but `location-cascade.js`'s
`writeSilently()`/`fieldValueFor()` — which drives backwards-fill — always writes the bare
component NAME (`"Татарстан"`), never the key. Confirmed with a throwaway repro (not committed):

```
after key-based pick, select.value = "dadata:tatarstan"
after backwards-fill writeSilently(el.value = bare name), select.value = ""
```

This is exactly symptom 4 from #447 ("picked Kazan, the region field cleared") — but it survives
this PR's fix because my seeded `<option>`'s value space (bare name, matching `writeSilently`)
and `applyEntries()`'s live-pick value space (provider key) are still two different spaces. A
real fix needs either this file's key scheme changed (breaks several tests currently pinning
`option.value === entry.key`, e.g. `wires the SAME options.fetch as select2's own ajax.transport`)
or `location-cascade.js::writeSilently()` made select2-aware (owned by the parallel worker on
this branch) — a coordinated, cross-file decision, not a one-line addition to either card.
Filed as **#455**, straight to Бэклог.

## Tests — new ones, verified to fail on `main`

Verified by stashing `location-select-modes.js` alone (reverting the fix, keeping the new
tests), running, then restoring. All 9 new/changed-behavior tests fail on `main`; 2 more
(unchanged-behaviour pins) correctly still pass on `main`:

**Fail on `main`:**
- `selectConfigFor() — pure config builder, no select2 required` — all 4 (function doesn't
  exist on `main`)
- `a field with a non-empty value produces a select containing that value, selected, with NO
  select2 present at all`
- `DATA LOSS CLAIM: the seeded select serializes to its actual value, not to an empty/absent
  field...`
- `placeholder: an empty field WITH a placeholder attribute gets an empty leading <option>...`
- `a non-empty value takes priority over a placeholder attribute...`
- `the seeded option is already IN THE DOM at the moment select2() is called...`

**Pass on `main` too (pin EXISTING, unchanged behaviour on purpose):**
- `a field with an empty value produces a select with NO options...`
- `the #450 fake reproduces the minimumInputLength gate and the abort contract — pinning that
  OUR transport still returns nothing (issue #449, unfixed here on purpose)`

No existing test was weakened or deleted.

## Gates

Baseline measured fresh on this branch before any change (main moved today):

- `rm -f .phpunit.result.cache && composer test:unit` — **2566 tests, 6340 assertions, 66
  skipped** (matches the required baseline exactly). No PHP touched by this PR; re-ran after
  the JS change, same result expected (no PHP files in the diff).
- `composer phpcs` — clean, 217 files.
- `composer phpstan` — `[OK] No errors`, 217 files.
- `npm run test:js -- --roots "<rootDir>/tests/js"` (from bash) — **1278 passed** (1260 baseline
  + 27 pre-existing in this file + ... i.e. all green, zero failures, zero skips).

## Bundles

Did **not** run `npm run build`. Verified first: `woodev/shipping-method/assets/js/frontend/`
is enqueued directly as a plain script
(`class-checkout-handler.php:576-577`, `wp_enqueue_script( 'woodev-location-select-modes', ...,
'js/frontend/location-select-modes.js', ... )`), never through webpack. The only files
`package.json`'s `build` script touches are the five React admin bundles under
`woodev/assets/build/` (`license-page`, `plugins-page`, `settings-page`, `setup-wizard`,
`ui-kit-gallery`) — grepped `woodev/assets/build/` for any trace of `location-select-modes` /
`selectConfigFor` / `ensureSelect2`: none. Not affected.

## Scope note

`woodev/shipping-method/assets/js/frontend/location-cascade.js` was not touched — owned by a
parallel worker on this branch. The one place I needed a change there (#455 above) is filed as
an issue, not routed around.

Closes #450
Closes #447
